### PR TITLE
Option to use jellyfin-ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk update && apk --no-cache add \
     nodejs \
     npm \
     ffmpeg \
+    jellyfin-ffmpeg \
     redis \
     git \
     bash \

--- a/app/Services/FfmpegCodecService.php
+++ b/app/Services/FfmpegCodecService.php
@@ -12,7 +12,10 @@ class FfmpegCodecService
     public function getEncoders(): array
     {
         return Cache::remember('ffmpeg_encoders', 3600, function () {
-            $process = new Process(['ffmpeg', '-hide_banner', '-encoders']);
+
+            $ffmpegPath = getenv('FFMPEG_PATH') ?: 'ffmpeg';
+
+            $process = new Process([$ffmpegPath, '-hide_banner', '-encoders']);
 
             try {
                 $process->mustRun();

--- a/app/Services/HlsStreamService.php
+++ b/app/Services/HlsStreamService.php
@@ -21,6 +21,8 @@ class HlsStreamService
      */
     public function startStream($id, $streamUrl): int
     {
+        $ffmpegPath = getenv('FFMPEG_PATH') ?: 'ffmpeg';
+
         // Only start one FFmpeg per channel at a time
         $cacheKey = "hls:pid:{$id}";
         $pid = Cache::get($cacheKey);
@@ -73,7 +75,7 @@ class HlsStreamService
             $segmentBaseUrl = url("/api/stream/{$id}") . '/';
 
             $cmd = sprintf(
-                'ffmpeg ' .
+                $ffmpegPath . ' ' .
                     // Optimization options:
                     '-fflags nobuffer -flags low_delay ' .
 
@@ -107,7 +109,7 @@ class HlsStreamService
                 $userArgs,                    // user defined options
                 $streamUrl,                   // input URL
                 $outputFormat,                // output format
-                $segment,                     // segment filename 
+                $segment,                     // segment filename
                 $segmentBaseUrl,              // base URL for segments (want to make sure routed through the proxy to track active users)
                 $playlist,                    // playlist filename
                 $settings['ffmpeg_debug'] ? '' : '-hide_banner -nostats -loglevel error'

--- a/start-container
+++ b/start-container
@@ -31,6 +31,15 @@ if [ "$BROADCAST_CONNECTION" = "null" ]; then
     export VITE_WEBSOCKETS_DISABLED="true"
 fi
 
+# FFMPEG
+# Alternatively use jellyfin-ffmpeg if enabled
+export FFMPEG_USE_JELLYFIN="${FFMPEG_USE_JELLYFIN:-false}"
+if [ "$FFMPEG_USE_JELLYFIN" = "true" ]; then
+    export FFMPEG_PATH="/usr/lib/jellyfin-ffmpeg/ffmpeg"
+else
+    export FFMPEG_PATH="/usr/bin/ffmpeg"
+fi
+
 # Set timezone, default to UTC
 export TZ="${TZ:-UTC}"
 
@@ -196,7 +205,7 @@ if [ "${ENABLE_POSTGRES}" = "true" ]; then
   # Create socket dir and start Postgres
   mkdir -p /run/postgresql && chown $WWWUSER:$WWWGROUP /run/postgresql
   su-exec $WWWUSER postgres -D "$PGDATA" -h 0.0.0.0 -p "$PG_PORT" >> "${postgres_log_file}" 2>&1 &
-  
+
   # Wait until it's ready
   dots=""
   until su-exec $WWWUSER pg_isready -h localhost -p "$PG_PORT" --quiet; do


### PR DESCRIPTION
The current `ffmpeg` in alpine is 6.x and has issues handling some streams.  Jellyfin ships a `jellyfin-ffmpeg` package based on 7.x which seems to do better for these streams.

This installs the `jellyfin-ffmpeg` package in the Dockerfile, and adds an option to set the environment variable `FFMPEG_USE_JELLYFIN=true` which will cause that ffmpeg to be set as the `FFMPEG_PATH` environment variable which is then used in the streaming code later.