### PR TITLE
Update PlaylistUrlService.php

### DIFF
--- a/app/Services/PlaylistUrlService.php
+++ b/app/Services/PlaylistUrlService.php
@@ -12,7 +12,7 @@ class PlaylistUrlService
 {
     /**
      * Get URLs for the given playlist
-     * 
+     *
      * @param  Playlist|MergedPlaylist|CustomPlaylist $playlist
      * @return array
      */
@@ -28,10 +28,16 @@ class PlaylistUrlService
         // Get the base URLs
         if ($playlist->short_urls_enabled) {
             $shortUrls = collect($playlist->short_urls)->keyBy('type');
-            $m3uUrl = url('/s/' . $shortUrls->get('m3u')['key']);
-            $hdhrUrl = url('/s/' . $shortUrls->get('hdhr')['key']);
-            $epgUrl = url('/s/' . $shortUrls->get('epg')['key']);
-            $epgZipUrl = url('/s/' . $shortUrls->get('epg_zip')['key']);
+
+            $m3uData = $shortUrls->get('m3u');
+            $hdhrData = $shortUrls->get('hdhr');
+            $epgData = $shortUrls->get('epg');
+            $epgZipData = $shortUrls->get('epg_zip');
+
+            $m3uUrl = $m3uData ? url('/s/' . $m3uData['key']) : null;
+            $hdhrUrl = $hdhrData ? url('/s/' . $hdhrData['key']) : null;
+            $epgUrl = $epgData ? url('/s/' . $epgData['key']) : null;
+            $epgZipUrl = $epgZipData ? url('/s/' . $epgZipData['key']) : null;
         } else {
             $m3uUrl = route('playlist.generate', ['uuid' => $playlist->uuid]);
             $hdhrUrl = route('playlist.hdhr.overview', ['uuid' => $playlist->uuid]);
@@ -41,8 +47,8 @@ class PlaylistUrlService
 
         // If auth set, append auth parameters to the URLs
         if ($auth) {
-            $m3uUrl .= $auth;
-            $hdhrUrl .= $auth;
+            if ($m3uUrl) $m3uUrl .= $auth;
+            if ($hdhrUrl) $hdhrUrl .= $auth;
         }
 
         // Return the results
@@ -57,7 +63,7 @@ class PlaylistUrlService
 
     /**
      * Get the media flow proxy server URL
-     * 
+     *
      * @return string
      */
     public function getMediaFlowProxyServerUrl()
@@ -72,7 +78,7 @@ class PlaylistUrlService
 
     /**
      * Get the media flow proxy URLs for the given playlist
-     * 
+     *
      * @param  Playlist|MergedPlaylist|CustomPlaylist $playlist
      * @return array
      */
@@ -117,7 +123,7 @@ class PlaylistUrlService
 
     /**
      * Determine if the media flow proxy is enabled
-     * 
+     *
      * @return boolean
      */
     public function mediaFlowProxyEnabled()
@@ -127,7 +133,7 @@ class PlaylistUrlService
 
     /**
      * Get the media flow settings
-     * 
+     *
      * @return array
      */
     public function getMediaFlowSettings(): array


### PR DESCRIPTION
Description of Changes:

1.  Added null checks to the getUrls method in PlaylistUrlService to prevent "Trying to access array offset on null" errors.

2.  Now, before accessing ['key'] on each short URL type (m3u, hdhr, epg, epg_zip), the code verifies that the entry exists and is not null.

3. This improves the stability of the URL generation and prevents view exceptions when certain short URLs are missing.