### PR TITLE
Fix: Prevent Undefined Array Key Error in Preferences Page

### DIFF
--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -34,9 +34,9 @@ class Preferences extends SettingsPage
 
         $codecs = app(FfmpegCodecService::class)->getEncoders();
 
-        $this->videoCodecs = $codecs['video'];
-        $this->audioCodecs = $codecs['audio'];
-        $this->subtitleCodecs = $codecs['subtitle'];
+        $this->videoCodecs = $codecs['video'] ?? [];
+        $this->audioCodecs = $codecs['audio'] ?? [];
+        $this->subtitleCodecs = $codecs['subtitle'] ?? [];
     }
 
     public function form(Form $form): Form


### PR DESCRIPTION
## 🐛 Fix: Handle Missing Codec Keys in Preferences

**Summary**

This PR addresses an "Undefined array key" error that could occur on the `/preferences` page if the `FfmpegCodecService` failed to return expected codec keys (e.g., 'video', 'audio', 'subtitle').

**The Issue**

In `app/Filament/Pages/Preferences.php`, the `mount()` method retrieves available FFmpeg encoders using `app(FfmpegCodecService::class)->getEncoders()`. If the underlying `ffmpeg -encoders` command fails or returns an unexpected output, the resulting `$codecs` array might not contain the 'video', 'audio', or 'subtitle' keys. This would lead to an `ErrorException: Undefined array key` when trying to access these keys directly (e.g., `$codecs['video']`). This occurs in local dev environment.

**The Fix**

The `mount()` method in `app/Filament/Pages/Preferences.php` has been updated to use the null coalescing operator (`??`) when assigning video, audio, and subtitle codecs. This change ensures that if a codec key is missing from the `$codecs` array, the corresponding property (`$this->videoCodecs`, etc.) will be initialized as an empty array instead of throwing an error. This makes the preferences page more resilient to issues with FFmpeg codec discovery.
