### PR TITLE
Fix/failover cache key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,11 +110,7 @@ COPY start-container /usr/local/bin/start-container
 RUN chmod +x /usr/local/bin/start-container
 
 # Pull app code
-RUN git clone https://github.com/sparkison/m3u-editor.git /tmp/m3u-editor \
-    && mv /tmp/m3u-editor/* /var/www/html \
-    && mv /tmp/m3u-editor/.git /var/www/html/.git \
-    && mv /tmp/m3u-editor/.env.example /var/www/html/.env.example \
-    && rm -rf /tmp/m3u-editor
+COPY . /var/www/html
 
 # Configure git
 RUN git config --global --add safe.directory /var/www/html

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -52,7 +52,7 @@ class StreamController extends Controller
             $title = strip_tags($title);
 
             // Make sure we have a valid source channel
-            $badSourceCacheKey = ProxyService::BAD_SOURCE_CACHE_PREFIX . $stream->id;
+            $badSourceCacheKey = ProxyService::BAD_SOURCE_CACHE_PREFIX . $stream->id . ':' . $playlist->id;
             if (Redis::exists($badSourceCacheKey)) {
                 if ($sourceChannel->id === $stream->id) {
                     Log::channel('ffmpeg')->info("Skipping source ID {$title} ({$sourceChannel->id}) for as it was recently marked as bad. Reason: " . (Redis::get($badSourceCacheKey) ?: 'N/A'));

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -89,7 +89,7 @@ class StreamController extends Controller
             }
 
             // Setup streams array
-            $streamUrl = $stream->url_custom ?? $channel->url;
+            $streamUrl = $stream->url_custom ?? $stream->url;
 
             // Determine the output format
             $ip = $request->ip();

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -522,8 +522,8 @@ class StreamController extends Controller
                 if (!empty($settings['ffmpeg_qsv_video_filter'])) {
                     $videoFilterArgs = "-vf " . escapeshellarg(trim($settings['ffmpeg_qsv_video_filter'], "'\",")) . " ";
                 } else {
-                    // Simplified filter chain for QSV
-                    $videoFilterArgs = "-vf 'format=nv12,hwupload=extra_hw_frames=64' ";
+                    // Default QSV video filter, matches user's working example
+                    $videoFilterArgs = "-vf 'hwupload=extra_hw_frames=64,scale_qsv=format=nv12' ";
                 }
 
                 // Additional QSV specific options
@@ -559,9 +559,6 @@ class StreamController extends Controller
 
             // User defined general options:
             $cmd .= $userArgs;
-
-            // Codec specific additional arguments (e.g. QSV specific):
-            $cmd .= $codecSpecificArgs;
 
             // Input:
             if ($format === 'ts') {

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -52,7 +52,7 @@ class StreamController extends Controller
             $title = strip_tags($title);
 
             // Make sure we have a valid source channel
-            $badSourceCacheKey = ProxyService::BAD_SOURCE_CACHE_PREFIX . $stream->id . ':' . $playlist->id;
+            $badSourceCacheKey = ProxyService::BAD_SOURCE_CACHE_PREFIX . $stream->id . ':' . $stream->playlist->id;
             if (Redis::exists($badSourceCacheKey)) {
                 if ($sourceChannel->id === $stream->id) {
                     Log::channel('ffmpeg')->info("Skipping source ID {$title} ({$sourceChannel->id}) for as it was recently marked as bad. Reason: " . (Redis::get($badSourceCacheKey) ?: 'N/A'));

--- a/app/Services/HlsStreamService.php
+++ b/app/Services/HlsStreamService.php
@@ -117,7 +117,7 @@ class HlsStreamService
         // Get the failover channels (if any)
         $streams = collect([$model]);
         if ($type === 'channel') {
-            $streams->concat($model->failoverChannels);
+            $streams = $streams->concat($model->failoverChannels);
         }
 
         // Record timestamp in Redis (never expires until we prune)

--- a/app/Services/HlsStreamService.php
+++ b/app/Services/HlsStreamService.php
@@ -543,9 +543,15 @@ class HlsStreamService
                 if (!empty($qsvFilterFromSettings)) {
                     // This filter is applied to frames already in QSV format
                     $videoFilterArgs = "-vf '" . trim($qsvFilterFromSettings, "'") . "' ";
+                } else {
+                    // Add default QSV video filter for HLS if not set by user
+                    $videoFilterArgs = "-vf 'hwupload=extra_hw_frames=64,scale_qsv=format=nv12' ";
                 }
-                if (!empty($qsvEncoderOptions)) {
+                if (!empty($qsvEncoderOptions)) { // $qsvEncoderOptions = $settings['ffmpeg_qsv_encoder_options']
                     $codecSpecificArgs = trim($qsvEncoderOptions) . " ";
+                } else {
+                    // Default QSV encoder options for HLS if not set by user
+                    $codecSpecificArgs = "-preset medium -global_quality 23 "; // Ensure trailing space
                 }
                 if (!empty($qsvAdditionalArgs)) {
                     $userArgs = trim($qsvAdditionalArgs) . ($userArgs ? " " . $userArgs : "");

--- a/app/Services/HlsStreamService.php
+++ b/app/Services/HlsStreamService.php
@@ -134,8 +134,11 @@ class HlsStreamService
 
         // Loop over the failover channels and grab the first one that works.
         foreach ($streams as $stream) {
+            // Check if playlist is specified
+            $playlist = $stream->playlist; // Moved $playlist assignment here
+
             // Make sure we have a valid source channel
-            $badSourceCacheKey = ProxyService::BAD_SOURCE_CACHE_PREFIX . $stream->id . ':' . $playlist->id;
+            $badSourceCacheKey = ProxyService::BAD_SOURCE_CACHE_PREFIX . $stream->id . ':' . $playlist->id; // Now $playlist is defined
             if (Redis::exists($badSourceCacheKey)) {
                 if ($model->id === $stream->id) {
                     Log::channel('ffmpeg')->info("Skipping source ID {$title} ({$model->id}) for as it was recently marked as bad. Reason: " . (Redis::get($badSourceCacheKey) ?: 'N/A'));
@@ -144,9 +147,6 @@ class HlsStreamService
                 }
                 continue;
             }
-
-            // Check if playlist is specified
-            $playlist = $stream->playlist;
 
             // Keep track of the active streams for this playlist using optimistic locking pattern
             $activeStreamsKey = "active_streams:{$playlist->id}";

--- a/app/Services/HlsStreamService.php
+++ b/app/Services/HlsStreamService.php
@@ -135,7 +135,7 @@ class HlsStreamService
         // Loop over the failover channels and grab the first one that works.
         foreach ($streams as $stream) {
             // Make sure we have a valid source channel
-            $badSourceCacheKey = ProxyService::BAD_SOURCE_CACHE_PREFIX . $stream->id;
+            $badSourceCacheKey = ProxyService::BAD_SOURCE_CACHE_PREFIX . $stream->id . ':' . $playlist->id;
             if (Redis::exists($badSourceCacheKey)) {
                 if ($model->id === $stream->id) {
                     Log::channel('ffmpeg')->info("Skipping source ID {$title} ({$model->id}) for as it was recently marked as bad. Reason: " . (Redis::get($badSourceCacheKey) ?: 'N/A'));


### PR DESCRIPTION
Fix: Ensure StreamController uses correct URL for failover channels

This commit addresses a critical bug in `StreamController.php` that prevented the failover mechanism from working correctly for standard (non-HLS) streams.

Previously, in the `__invoke` method, when iterating through the streams (primary and its failovers), the `$streamUrl` was determined by:
`$streamUrl = $stream->url_custom ?? $channel->url;`

The issue was that if `$stream->url_custom` (for the current iterated stream, which could be a failover) was `null`, it would incorrectly fall back to `$channel->url` (the URL of the *original* primary channel). This meant that if the primary channel's URL failed, subsequent attempts to use failover channels (that didn't have `url_custom` set) would re-probe and attempt to stream the same, already failed, primary URL.

When this incorrect probe failed, the failover channel itself (identified by `$stream->id` and `$stream->playlist->id`) would be marked as bad in the Redis cache. This led to logs showing "Skipping Failover Channel ... as it was recently marked as bad," even though the failover channel's own URL was never actually tested.

The fix changes the line to:
`$streamUrl = $stream->url_custom ?? $stream->url;`

This ensures that if `$stream->url_custom` is not set, the system correctly uses the `$stream->url` property of the *current* iterated stream (be it the primary or a failover channel). This allows each failover channel to be tested using its own distinct URL.

This change, combined with previous fixes for HLS stream handling, should now allow the failover mechanism to function as intended for all stream types.