### PR TITLE
Fix/failover cache key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,11 +110,7 @@ COPY start-container /usr/local/bin/start-container
 RUN chmod +x /usr/local/bin/start-container
 
 # Pull app code
-RUN git clone https://github.com/sparkison/m3u-editor.git /tmp/m3u-editor \
-    && mv /tmp/m3u-editor/* /var/www/html \
-    && mv /tmp/m3u-editor/.git /var/www/html/.git \
-    && mv /tmp/m3u-editor/.env.example /var/www/html/.env.example \
-    && rm -rf /tmp/m3u-editor
+COPY . /var/www/html
 
 # Configure git
 RUN git config --global --add safe.directory /var/www/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN apk update && apk --no-cache add \
 
 # Add architecture-specific packages conditionally
 RUN if [ "$(uname -m)" = "x86_64" ]; then \
-        apk add --no-cache intel-media-driver libva-intel-driver; \
+        apk add --no-cache intel-media-driver intel-media-sdk libva-intel-driver; \
     else \
         echo "Skipping Intel-specific packages on $(uname -m) architecture"; \
     fi
@@ -110,7 +110,11 @@ COPY start-container /usr/local/bin/start-container
 RUN chmod +x /usr/local/bin/start-container
 
 # Pull app code
-COPY . /var/www/html
+RUN git clone https://github.com/sparkison/m3u-editor.git /tmp/m3u-editor \
+    && mv /tmp/m3u-editor/* /var/www/html \
+    && mv /tmp/m3u-editor/.git /var/www/html/.git \
+    && mv /tmp/m3u-editor/.env.example /var/www/html/.env.example \
+    && rm -rf /tmp/m3u-editor
 
 # Configure git
 RUN git config --global --add safe.directory /var/www/html

--- a/app/Filament/Resources/SeriesResource.php
+++ b/app/Filament/Resources/SeriesResource.php
@@ -468,19 +468,6 @@ class SeriesResource extends Resource
                 ]),
             Forms\Components\Wizard\Step::make('Series to Import')
                 ->schema([
-                    Forms\Components\Toggle::make('import_all')
-                        ->label('Import All Series')
-                        ->onColor('warning')
-                        ->hint('Use with caution')
-                        ->live()
-                        ->helperText('If enabled, all series in the selected category will be imported. Use with caution as this will make a lot of requests to your provider. It is recomended to import only the series you want to watch.')
-                        ->default(false)
-                        ->columnSpanFull()
-                        ->afterStateUpdated(function (Get $get, $set) {
-                            if ($get('import_all')) {
-                                $set('series', []);
-                            }
-                        }),
                     Forms\Components\CheckboxList::make('series')
                         ->label('Series to Import')
                         ->required()
@@ -499,7 +486,8 @@ class SeriesResource extends Resource
                             $xtreamPass = $xtreamConfig['password'] ?? '';
                             $cacheKey = 'xtream_category_series' . md5($xtremeUrl . $xtreamUser . $xtreamPass . $category);
                             $cachedCategories = Cache::remember($cacheKey, 60 * 1, function () use ($xtremeUrl, $xtreamUser, $xtreamPass, $category) {
-                                $xtream = XtreamService::make(xtream_config: [
+                                $service = new XtreamService();
+                                $xtream = $service->init(xtream_config: [
                                     'url' => $xtremeUrl,
                                     'username' => $xtreamUser,
                                     'password' => $xtreamPass,
@@ -524,8 +512,8 @@ class SeriesResource extends Resource
                                 ? 'Which series would you like to import.'
                                 : 'You must select a playlist and category first.'
                         )
-                        ->disabled(fn(Get $get): bool => ! $get('playlist') || ! $get('category') || $get('import_all'))
-                        ->hidden(fn(Get $get): bool => ! $get('playlist') || ! $get('category') || $get('import_all')),
+                        ->disabled(fn(Get $get): bool => ! $get('playlist') || ! $get('category'))
+                        ->hidden(fn(Get $get): bool => ! $get('playlist') || ! $get('category')),
                 ])
         ];
     }

--- a/app/Filament/Resources/SeriesResource/Pages/ListSeries.php
+++ b/app/Filament/Resources/SeriesResource/Pages/ListSeries.php
@@ -28,8 +28,7 @@ class ListSeries extends ListRecords
                             playlist: $data['playlist'],
                             catId: $data['category'],
                             catName: $data['category_name'],
-                            series: $data['series'] ?? [],
-                            importAll: $data['import_all'] ?? false,
+                            series: $data['series'],
                         ));
                 })->after(function () {
                     Notification::make()

--- a/app/Jobs/SyncXtreamSeries.php
+++ b/app/Jobs/SyncXtreamSeries.php
@@ -20,7 +20,6 @@ class SyncXtreamSeries implements ShouldQueue
         public int $catId,
         public string $catName,
         public array $series,
-        public bool $importAll = false,
     ) {}
 
     /**
@@ -59,12 +58,6 @@ class SyncXtreamSeries implements ShouldQueue
                 ]);
         }
 
-        if ($this->importAll) {
-            // If importAll is true, we need to import all series from the category
-            $this->series = collect($xtream->getSeries($this->catId))
-                ->pluck('series_id')
-                ->toArray();
-        }
         foreach ($this->series as $seriesId) {
             // Check if the series exists for the playlist
             $playlistSeries = $playlist->series()

--- a/app/Services/XtreamService.php
+++ b/app/Services/XtreamService.php
@@ -15,31 +15,6 @@ class XtreamService
     protected Playlist|null $playlist;
     protected array|null $xtream_config;
 
-    /**
-     * Factory method to create an instance of XtreamService.
-     *
-     * @param Playlist|null $playlist
-     * @param array|null $xtream_config
-     * @param int $retryLimit Number of retries for HTTP requests
-     * @return XtreamService
-     */
-    public static function make(
-        Playlist|null $playlist = null,
-        array|null $xtream_config = null,
-        $retryLimit = 5
-    ): self {
-        $instance = new self();
-        return $instance->init($playlist, $xtream_config, $retryLimit);
-    }
-
-    /**
-     * Initialize the XtreamService with a Playlist or Xtream config.
-     *
-     * @param Playlist|null $playlist
-     * @param array|null $xtream_config
-     * @param int $retryLimit Number of retries for HTTP requests
-     * @return bool|self Returns false if initialization fails, otherwise returns the instance.
-     */
     public function init(
         Playlist|null $playlist = null,
         array|null $xtream_config = null,


### PR DESCRIPTION
This commit addresses several issues in the construction of FFmpeg commands when Intel Quick Sync Video (QSV) hardware acceleration is enabled, affecting both standard (TS/MP4) and HLS streaming.

**Key Changes:**

1.  **`StreamController.php` (`buildCmd` method for standard streams):**
    *   **Removed Misplaced Encoder Options:** QSV-specific encoder options (e.g., `-preset`, `-global_quality` held in `$codecSpecificArgs`) were incorrectly being added to the command string *before* the `-i` (input) option. This caused FFmpeg to error with "Codec AVOption ... is not a decoding option." This redundant addition has been removed. These options are already correctly applied to the output video codec.
    *   **Corrected Default QSV Video Filter:** The default video filter for QSV (when no specific filter is set by you in `ffmpeg_qsv_video_filter`) has been changed from `-vf 'format=nv12,hwupload=extra_hw_frames=64'` to `-vf 'hwupload=extra_hw_frames=64,scale_qsv=format=nv12'`. This aligns with known working QSV filter chains that use `scale_qsv` for hardware-accelerated scaling and pixel format conversion.

2.  **`HlsStreamService.php` (`buildCmd` method for HLS streams):**
    *   **Added Default QSV Video Filter:** If no `ffmpeg_qsv_video_filter` is provided in settings, the service will now apply a default filter: `-vf 'hwupload=extra_hw_frames=64,scale_qsv=format=nv12'`. Previously, no default QSV-specific filter was applied, potentially leading to transcoding failures or suboptimal performance.
    *   **Added Default QSV Encoder Options:** If no `ffmpeg_qsv_encoder_options` are provided in settings, the service will now apply default encoder options: `-preset medium -global_quality 23`. This provides a sensible baseline for QSV encoding quality and performance for HLS, consistent with the defaults in `StreamController`.

These changes ensure that:
- Output-specific encoder options are not incorrectly applied to the input.
- A more appropriate and effective default video filter is used for QSV operations.
- HLS streams benefit from default QSV encoder options and video filters when not explicitly configured by you, leading to more reliable QSV transcoding.