### PR TITLE
feat: Parallelize Docker builds and add manifest lists

### DIFF
--- a/.github/workflows/publish_dev.yml
+++ b/.github/workflows/publish_dev.yml
@@ -4,8 +4,8 @@ on:
     branches: [dev]
 
 jobs:
-  push:
-    name: Publish dev m3u-editor Docker image
+  push-amd64:
+    name: Publish dev m3u-editor Docker image (amd64)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,9 +20,61 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
-      - name: Build and push
+      - name: Build and push amd64
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: sparkison/m3u-editor:dev
+          tags: sparkison/m3u-editor:dev-amd64
+
+  push-arm64:
+    name: Publish dev m3u-editor Docker image (arm64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push arm64
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/arm64
+          push: true
+          tags: sparkison/m3u-editor:dev-arm64
+
+  push-manifest:
+    name: Push Docker Manifest for dev
+    runs-on: ubuntu-latest
+    needs: [push-amd64, push-arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list
+        run: |
+          docker manifest create sparkison/m3u-editor:dev \
+            sparkison/m3u-editor:dev-amd64 \
+            sparkison/m3u-editor:dev-arm64
+      
+      - name: Push manifest list
+        run: docker manifest push sparkison/m3u-editor:dev

--- a/.github/workflows/publish_experimental.yml
+++ b/.github/workflows/publish_experimental.yml
@@ -4,8 +4,8 @@ on:
     branches: [experimental]
 
 jobs:
-  push:
-    name: Publish experimental m3u-editor Docker image
+  push-amd64:
+    name: Publish experimental m3u-editor Docker image (amd64)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,9 +20,61 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
-      - name: Build and push
+      - name: Build and push amd64
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: sparkison/m3u-editor:experimental
+          tags: sparkison/m3u-editor:experimental-amd64
+
+  push-arm64:
+    name: Publish experimental m3u-editor Docker image (arm64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push arm64
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/arm64
+          push: true
+          tags: sparkison/m3u-editor:experimental-arm64
+
+  push-manifest:
+    name: Push Docker Manifest for experimental
+    runs-on: ubuntu-latest
+    needs: [push-amd64, push-arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list
+        run: |
+          docker manifest create sparkison/m3u-editor:experimental \
+            sparkison/m3u-editor:experimental-amd64 \
+            sparkison/m3u-editor:experimental-arm64
+      
+      - name: Push manifest list
+        run: docker manifest push sparkison/m3u-editor:experimental

--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -4,8 +4,8 @@ on:
     types: [published]
 
 jobs:
-  release:
-    name: Publish m3u-editor Docker image
+  release-amd64:
+    name: Publish m3u-editor Docker image (amd64)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,19 +20,96 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - name: Extract metadata (tags, labels) for amd64
+        id: meta-amd64
+        uses: docker/metadata-action@v5
+        with:
+          images: sparkison/m3u-editor
+          tags: |
+            type=semver,pattern={{version}},suffix=-amd64
+            type=raw,value=latest,suffix=-amd64
+
+      - name: Build and push amd64
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta-amd64.outputs.tags }}
+          labels: ${{ steps.meta-amd64.outputs.labels }}
+
+  release-arm64:
+    name: Publish m3u-editor Docker image (arm64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for arm64
+        id: meta-arm64
+        uses: docker/metadata-action@v5
+        with:
+          images: sparkison/m3u-editor
+          tags: |
+            type=semver,pattern={{version}},suffix=-arm64
+            type=raw,value=latest,suffix=-arm64
+
+      - name: Build and push arm64
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta-arm64.outputs.tags }}
+          labels: ${{ steps.meta-arm64.outputs.labels }}
+
+  push-manifest:
+    name: Push Docker Manifest for release
+    runs-on: ubuntu-latest
+    needs: [release-amd64, release-arm64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for manifest
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: sparkison/m3u-editor
           tags: |
             type=semver,pattern={{version}}
-            latest
+            type=raw,value=latest 
+            # The 'latest' tag for the manifest will combine 'latest-amd64' and 'latest-arm64'
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create and push semver manifest list
+        run: |
+          docker manifest create sparkison/m3u-editor:${{ steps.meta.outputs.version }} \
+            sparkison/m3u-editor:${{ steps.meta.outputs.version }}-amd64 \
+            sparkison/m3u-editor:${{ steps.meta.outputs.version }}-arm64
+          docker manifest push sparkison/m3u-editor:${{ steps.meta.outputs.version }}
+      
+      - name: Create and push latest manifest list
+        run: |
+          docker manifest create sparkison/m3u-editor:latest \
+            sparkison/m3u-editor:latest-amd64 \
+            sparkison/m3u-editor:latest-arm64
+          docker manifest push sparkison/m3u-editor:latest


### PR DESCRIPTION
I've refactored the GitHub Actions workflows for Docker image publishing (`dev`, `experimental`, `master`) to improve efficiency and your experience.

Key changes:

1.  **Parallelized Platform Builds:**
    *   The `docker/build-push-action` for `linux/amd64` and `linux/arm64` platforms are now split into separate, parallel jobs in each workflow (`publish_dev.yml`, `publish_experimental.yml`, `publish_master.yml`).
    *   This significantly reduces the total build time as both platforms are built concurrently.
    *   Platform-specific tags are used for these individual builds (e.g., `dev-amd64`, `dev-arm64`, `{{version}}-amd64`, `latest-amd64`).

2.  **Manifest List Creation:**
    *   A new job (`push-manifest`) is added to each workflow, which runs after the platform-specific builds complete.
    *   This job creates and pushes a Docker manifest list.
    *   This allows you to use generic tags (e.g., `sparkison/m3u-editor:dev`, `sparkison/m3u-editor:latest`, `sparkison/m3u-editor:{{version}}`) and have Docker automatically pull the image matching your architecture.
    *   The `publish_master.yml` workflow correctly handles both the semantic version tag and the `latest` tag for manifest creation.

These changes make the Docker image publishing process faster and simplify image consumption for you by providing architecture-agnostic tags.