### PR TITLE
Update HlsStreamService.php

### DIFF
--- a/app/Services/HlsStreamService.php
+++ b/app/Services/HlsStreamService.php
@@ -588,7 +588,7 @@ class HlsStreamService
             if ($vaapiEnabled || $isVaapiCodec) {
                 $outputVideoCodec = $isVaapiCodec ? $finalVideoCodec : 'h264_vaapi'; // Default to h264_vaapi if only toggle is on
 
-                $hwaccelInitArgs = "-init_hw_device vaapi=va_device:{$vaapiDevice} -filter_hw_device va_device:{$vaapiDevice} ";
+                $hwaccelInitArgs = "-init_hw_device vaapi=va_device:{$vaapiDevice} -filter_hw_device va_device ";
 
                 // These args are for full hardware acceleration (decode using VA-API)
                 $hwaccelInputArgs = "-hwaccel vaapi -hwaccel_device va_device -hwaccel_output_format vaapi ";


### PR DESCRIPTION
Fix: Correct -filter_hw_device argument for VAAPI FFmpeg commands The -filter_hw_device option for VAAPI was incorrectly being formatted with the device path (e.g., `va_device:/dev/dri/renderD128`) instead of just the device name (e.g., `va_device`) as required by FFmpeg.

This change corrects the argument construction in `HlsStreamService::buildCmd` to use the proper device name, resolving "Invalid filter device" errors when VAAPI hardware acceleration is enabled without a custom command template.