### PR TITLE
Add duplicate channel finder and similarity matching features

### DIFF
--- a/app/Filament/Resources/ChannelResource/Pages/DuplicateFinder.php
+++ b/app/Filament/Resources/ChannelResource/Pages/DuplicateFinder.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace App\Filament\Resources\ChannelResource\Pages;
+
+use App\Filament\Resources\ChannelResource;
+use App\Models\Channel;
+use App\Models\ChannelFailover;
+use App\Services\ChannelSimilarityMatchingService;
+use Filament\Actions;
+use Filament\Forms;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\Page;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+class DuplicateFinder extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string $resource = ChannelResource::class;
+
+    protected static string $view = 'filament.resources.channel-resource.pages.duplicate-finder';
+
+    protected static ?string $title = 'Channel Duplicate Finder';
+
+    protected static ?string $navigationLabel = 'Find Duplicates';
+
+    public $duplicateGroups = [];
+    public $similarityThreshold = 0.75;
+    
+    public function mount(): void
+    {
+        $this->loadDuplicateGroups();
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\Action::make('refresh')
+                ->label('Refresh Analysis')
+                ->icon('heroicon-o-arrow-path')
+                ->action(function () {
+                    $this->loadDuplicateGroups();
+                    Notification::make()
+                        ->success()
+                        ->title('Analysis Refreshed')
+                        ->body('Duplicate channel analysis has been updated.')
+                        ->send();
+                }),
+            Actions\Action::make('configure')
+                ->label('Configure')
+                ->icon('heroicon-o-cog-6-tooth')
+                ->form([
+                    Forms\Components\Slider::make('similarity_threshold')
+                        ->label('Similarity Threshold')
+                        ->default($this->similarityThreshold)
+                        ->min(0.5)
+                        ->max(1.0)
+                        ->step(0.05)
+                        ->helperText('Higher values require more exact matches'),
+                ])
+                ->action(function (array $data) {
+                    $this->similarityThreshold = $data['similarity_threshold'];
+                    $this->loadDuplicateGroups();
+                    Notification::make()
+                        ->success()
+                        ->title('Settings Updated')
+                        ->body('Similarity threshold updated and analysis refreshed.')
+                        ->send();
+                }),
+        ];
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query($this->getTableQuery())
+            ->columns([
+                Tables\Columns\TextColumn::make('group_id')
+                    ->label('Group')
+                    ->badge()
+                    ->color('primary'),
+                Tables\Columns\ImageColumn::make('logo')
+                    ->label('Icon')
+                    ->checkFileExistence(false)
+                    ->height(30)
+                    ->width('auto'),
+                Tables\Columns\TextColumn::make('display_title')
+                    ->label('Title')
+                    ->getStateUsing(fn ($record) => $record->title_custom ?: $record->title),
+                Tables\Columns\TextColumn::make('display_name')
+                    ->label('Name')
+                    ->getStateUsing(fn ($record) => $record->name_custom ?: $record->name),
+                Tables\Columns\TextColumn::make('playlist.name')
+                    ->label('Playlist'),
+                Tables\Columns\ToggleColumn::make('is_fallback_candidate')
+                    ->label('Fallback')
+                    ->tooltip('Toggle fallback candidate status'),
+                Tables\Columns\TextColumn::make('similarity_score')
+                    ->label('Similarity')
+                    ->getStateUsing(function ($record) {
+                        return isset($record->similarity_score) 
+                            ? number_format($record->similarity_score * 100, 1) . '%' 
+                            : 'N/A';
+                    })
+                    ->badge()
+                    ->color(function ($state) {
+                        $numeric = floatval(str_replace('%', '', $state)) / 100;
+                        if ($numeric >= 0.9) return 'success';
+                        if ($numeric >= 0.8) return 'warning';
+                        return 'danger';
+                    }),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('playlist')
+                    ->relationship('playlist', 'name')
+                    ->multiple()
+                    ->preload(),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('set_primary')
+                    ->label('Set Primary')
+                    ->icon('heroicon-o-star')
+                    ->color('warning')
+                    ->action(function ($record) {
+                        // Mark this channel as NOT a fallback candidate
+                        $record->update(['is_fallback_candidate' => false]);
+                        
+                        // Mark other channels in the same group as fallback candidates
+                        $groupChannels = $this->getChannelsInGroup($record->group_id);
+                        foreach ($groupChannels as $channel) {
+                            if ($channel->id !== $record->id) {
+                                $channel->update(['is_fallback_candidate' => true]);
+                            }
+                        }
+                        
+                        $this->loadDuplicateGroups();
+                        
+                        Notification::make()
+                            ->success()
+                            ->title('Primary Channel Set')
+                            ->body('Channel marked as primary and others set as fallback candidates.')
+                            ->send();
+                    })
+                    ->requiresConfirmation(),
+                Tables\Actions\Action::make('create_failovers')
+                    ->label('Auto-Create Failovers')
+                    ->icon('heroicon-o-link')
+                    ->color('success')
+                    ->action(function ($record) {
+                        $groupChannels = $this->getChannelsInGroup($record->group_id);
+                        $primaryChannel = $groupChannels->where('is_fallback_candidate', false)->first();
+                        
+                        if (!$primaryChannel) {
+                            Notification::make()
+                                ->danger()
+                                ->title('No Primary Channel')
+                                ->body('Please set a primary channel first.')
+                                ->send();
+                            return;
+                        }
+                        
+                        $created = 0;
+                        foreach ($groupChannels as $channel) {
+                            if ($channel->id !== $primaryChannel->id && $channel->is_fallback_candidate) {
+                                ChannelFailover::updateOrCreate([
+                                    'channel_id' => $primaryChannel->id,
+                                    'channel_failover_id' => $channel->id,
+                                ], [
+                                    'user_id' => auth()->id(),
+                                    'auto_matched' => true,
+                                    'match_quality' => $channel->similarity_score ?? 0.8,
+                                    'match_type' => 'duplicate_finder'
+                                ]);
+                                $created++;
+                            }
+                        }
+                        
+                        Notification::make()
+                            ->success()
+                            ->title('Failovers Created')
+                            ->body("Created {$created} failover relationships.")
+                            ->send();
+                    })
+                    ->requiresConfirmation(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkAction::make('mark_fallback_candidates')
+                    ->label('Mark as Fallback Candidates')
+                    ->action(function (Collection $records) {
+                        $records->each->update(['is_fallback_candidate' => true]);
+                        
+                        Notification::make()
+                            ->success()
+                            ->title('Channels Updated')
+                            ->body('Selected channels marked as fallback candidates.')
+                            ->send();
+                    })
+                    ->requiresConfirmation(),
+            ]);
+    }
+
+    protected function getTableQuery(): Builder
+    {
+        // Return channels that are part of duplicate groups
+        $channelIds = collect($this->duplicateGroups)->flatten(1)->pluck('id');
+        
+        return Channel::query()
+            ->whereIn('id', $channelIds)
+            ->with(['playlist'])
+            ->where('user_id', auth()->id());
+    }
+
+    private function loadDuplicateGroups(): void
+    {
+        $similarityService = new ChannelSimilarityMatchingService();
+        
+        $channels = Channel::where('user_id', auth()->id())
+            ->with(['playlist'])
+            ->get();
+            
+        $duplicateGroups = [];
+        $processedChannels = [];
+        $groupId = 1;
+        
+        foreach ($channels as $channel) {
+            if (in_array($channel->id, $processedChannels)) {
+                continue;
+            }
+            
+            // Find similar channels
+            $similarChannels = $similarityService->findSimilarChannels(
+                $channel,
+                $channels->except($channel->id),
+                false
+            );
+            
+            // Filter by threshold
+            $matches = $similarChannels->filter(function ($match) {
+                return $match['similarity'] >= $this->similarityThreshold;
+            });
+            
+            if ($matches->isNotEmpty()) {
+                // Create a group with the original channel and its matches
+                $group = collect([$channel]);
+                
+                foreach ($matches as $match) {
+                    $matchChannel = $match['channel'];
+                    $matchChannel->similarity_score = $match['similarity'];
+                    $group->push($matchChannel);
+                    $processedChannels[] = $matchChannel->id;
+                }
+                
+                // Assign group ID to all channels in the group
+                $group->each(function ($ch) use ($groupId) {
+                    $ch->group_id = $groupId;
+                });
+                
+                $duplicateGroups[$groupId] = $group;
+                $processedChannels[] = $channel->id;
+                $groupId++;
+            }
+        }
+        
+        $this->duplicateGroups = $duplicateGroups;
+    }
+    
+    private function getChannelsInGroup(int $groupId): Collection
+    {
+        return collect($this->duplicateGroups[$groupId] ?? []);
+    }
+}

--- a/app/Filament/Resources/ChannelResource/Pages/ListChannels.php
+++ b/app/Filament/Resources/ChannelResource/Pages/ListChannels.php
@@ -227,6 +227,14 @@ class ListChannels extends ListRecords
                         //     });
                     })
             ])->button()->label('Actions'),
+            Actions\Action::make('duplicate_finder')
+                ->label('Find Duplicates')
+                ->icon('heroicon-o-document-duplicate')
+                ->color('warning')
+                ->action(function () {
+                    $this->redirectRoute('filament.admin.resources.channels.duplicate-finder');
+                })
+                ->button(),
         ];
     }
 

--- a/app/Jobs/BulkChannelSimilarityMatchingJob.php
+++ b/app/Jobs/BulkChannelSimilarityMatchingJob.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Channel;
+use App\Models\ChannelFailover;
+use App\Services\ChannelSimilarityMatchingService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
+use Filament\Notifications\Notification as FilamentNotification;
+
+class BulkChannelSimilarityMatchingJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        private array $channelIds,
+        private int $userId,
+        private array $options = []
+    ) {
+        $this->onQueue('default');
+    }
+
+    public function handle(): void
+    {
+        $similarityService = new ChannelSimilarityMatchingService();
+        
+        // Get primary channels (those not marked as fallback candidates)
+        $primaryChannels = Channel::whereIn('id', $this->channelIds)
+            ->where('user_id', $this->userId)
+            ->where('is_fallback_candidate', false)
+            ->get();
+            
+        // Get all fallback candidate channels for this user
+        $fallbackCandidates = Channel::where('user_id', $this->userId)
+            ->where('is_fallback_candidate', true)
+            ->get();
+
+        $matchesCreated = 0;
+        $matchesSkipped = 0;
+        
+        $minThreshold = $this->options['min_threshold'] ?? 0.75;
+        $overwriteExisting = $this->options['overwrite_existing'] ?? false;
+
+        foreach ($primaryChannels as $primaryChannel) {
+            try {
+                // Skip if already has failovers and not overwriting
+                if (!$overwriteExisting && $primaryChannel->failovers()->exists()) {
+                    $matchesSkipped++;
+                    continue;
+                }
+
+                // Find similar channels
+                $similarChannels = $similarityService->findSimilarChannels(
+                    $primaryChannel, 
+                    $fallbackCandidates,
+                    false // debug
+                );
+
+                // Filter by threshold
+                $filteredMatches = $similarChannels->filter(function ($match) use ($minThreshold) {
+                    return $match['similarity'] >= $minThreshold;
+                });
+
+                if ($filteredMatches->isEmpty()) {
+                    continue;
+                }
+
+                // If overwriting, remove existing failovers first
+                if ($overwriteExisting) {
+                    ChannelFailover::where('channel_id', $primaryChannel->id)->delete();
+                }
+
+                // Create failover relationships for matches above threshold
+                foreach ($filteredMatches as $match) {
+                    ChannelFailover::updateOrCreate([
+                        'channel_id' => $primaryChannel->id,
+                        'channel_failover_id' => $match['channel']->id,
+                    ], [
+                        'auto_matched' => true,
+                        'match_quality' => $match['similarity'],
+                        'match_type' => $match['match_type'] ?? 'similarity'
+                    ]);
+                    
+                    $matchesCreated++;
+                }
+
+            } catch (\Exception $e) {
+                Log::error("Error processing channel {$primaryChannel->id} in bulk similarity matching", [
+                    'error' => $e->getMessage(),
+                    'channel_id' => $primaryChannel->id
+                ]);
+            }
+        }
+
+        // Send notification to user
+        FilamentNotification::make()
+            ->success()
+            ->title('Channel Similarity Matching Complete')
+            ->body("Created {$matchesCreated} fallover relationships. Skipped {$matchesSkipped} channels with existing failovers.")
+            ->persistent()
+            ->sendToDatabase(\App\Models\User::find($this->userId));
+
+        Log::info("Bulk channel similarity matching completed", [
+            'user_id' => $this->userId,
+            'matches_created' => $matchesCreated,
+            'matches_skipped' => $matchesSkipped,
+            'primary_channels_processed' => $primaryChannels->count(),
+            'fallback_candidates_available' => $fallbackCandidates->count()
+        ]);
+    }
+}

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -34,6 +34,7 @@ class Channel extends Model
         'extvlcopt' => 'array',
         'kodidrop' => 'array',
         'logo_type' => ChannelLogoType::class,
+        'is_fallback_candidate' => 'boolean',
     ];
 
     public function user(): BelongsTo

--- a/app/Models/ChannelFailover.php
+++ b/app/Models/ChannelFailover.php
@@ -10,6 +10,17 @@ class ChannelFailover extends Model
 {
     use HasFactory;
 
+    protected $fillable = [
+        'user_id',
+        'channel_id', 
+        'channel_failover_id',
+        'sort',
+        'metadata',
+        'auto_matched',
+        'match_quality',
+        'match_type'
+    ];
+
     /**
      * The attributes that should be cast to native types.
      *
@@ -21,6 +32,8 @@ class ChannelFailover extends Model
         'channel_id' => 'integer',
         'channel_failover_id' => 'integer',
         'metadata' => 'array',
+        'auto_matched' => 'boolean',
+        'match_quality' => 'decimal:4',
     ];
 
     public function user(): BelongsTo

--- a/app/Services/ChannelSimilarityMatchingService.php
+++ b/app/Services/ChannelSimilarityMatchingService.php
@@ -1,0 +1,354 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Channel;
+use App\Models\ChannelFailover;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+class ChannelSimilarityMatchingService
+{
+    // Configurable parameters for matching
+    private $bestMatchThreshold = 3;        // Levenshtein distance threshold for best matches
+    private $goodMatchThreshold = 5;        // Levenshtein distance threshold for good matches
+    private $cosineSimilarityThreshold = 0.75; // Cosine similarity threshold
+
+    // Words to ignore when normalizing channel names
+    private $stopWords = [
+        'tv', 'channel', 'network', 'television', 'hd', 'uhd', 'fhd', 'sd',
+        'us', 'usa', 'uk', 'ca', 'de', 'fr', 'it', 'es', 'nl', 'be', 'au',
+        '1080p', '720p', '540p', '480p', '360p', '4k', 'live', 'stream',
+        'online', 'web', 'digital', 'plus', 'premium', 'max', 'pro', 'super'
+    ];
+
+    /**
+     * Find potential fallback channels for a given channel based on name similarity
+     *
+     * @param Channel $primaryChannel
+     * @param Collection $candidateChannels
+     * @param bool $debug
+     * @return Collection
+     */
+    public function findSimilarChannels(Channel $primaryChannel, Collection $candidateChannels, bool $debug = false): Collection
+    {
+        $primaryName = $this->normalizeChannelName($primaryChannel->title_custom ?? $primaryChannel->title ?? '');
+        $primaryNameAlt = $this->normalizeChannelName($primaryChannel->name_custom ?? $primaryChannel->name ?? '');
+        
+        if (empty($primaryName) && empty($primaryNameAlt)) {
+            if ($debug) {
+                Log::info("Channel {$primaryChannel->id} has no valid names for matching");
+            }
+            return collect();
+        }
+
+        $matches = collect();
+
+        foreach ($candidateChannels as $candidate) {
+            if ($candidate->id === $primaryChannel->id) {
+                continue; // Skip self
+            }
+
+            $candidateName = $this->normalizeChannelName($candidate->title_custom ?? $candidate->title ?? '');
+            $candidateNameAlt = $this->normalizeChannelName($candidate->name_custom ?? $candidate->name ?? '');
+
+            // Calculate similarity scores for all name combinations
+            $scores = [];
+            
+            if (!empty($primaryName) && !empty($candidateName)) {
+                $scores[] = $this->calculateSimilarityScore($primaryName, $candidateName);
+            }
+            if (!empty($primaryName) && !empty($candidateNameAlt)) {
+                $scores[] = $this->calculateSimilarityScore($primaryName, $candidateNameAlt);
+            }
+            if (!empty($primaryNameAlt) && !empty($candidateName)) {
+                $scores[] = $this->calculateSimilarityScore($primaryNameAlt, $candidateName);
+            }
+            if (!empty($primaryNameAlt) && !empty($candidateNameAlt)) {
+                $scores[] = $this->calculateSimilarityScore($primaryNameAlt, $candidateNameAlt);
+            }
+
+            if (empty($scores)) {
+                continue;
+            }
+
+            // Use the best (lowest) Levenshtein score
+            $bestScore = min(array_column($scores, 'levenshtein'));
+            $bestMatch = collect($scores)->firstWhere('levenshtein', $bestScore);
+
+            // Only consider channels that meet our similarity threshold
+            if ($bestScore <= $this->goodMatchThreshold) {
+                $matches->push([
+                    'channel' => $candidate,
+                    'similarity_score' => $bestScore,
+                    'cosine_similarity' => $bestMatch['cosine'],
+                    'match_quality' => $this->getMatchQuality($bestScore, $bestMatch['cosine']),
+                    'matched_names' => [
+                        'primary' => $bestMatch['primary_name'],
+                        'candidate' => $bestMatch['candidate_name']
+                    ]
+                ]);
+
+                if ($debug) {
+                    $quality = $this->getMatchQuality($bestScore, $bestMatch['cosine']);
+                    Log::info("Channel {$primaryChannel->id} '{$primaryName}' matched with {$candidate->id} '{$candidateName}' - Score: {$bestScore}, Quality: {$quality}");
+                }
+            }
+        }
+
+        // Sort by similarity score (lower is better for Levenshtein)
+        return $matches->sortBy('similarity_score');
+    }
+
+    /**
+     * Calculate similarity score between two normalized channel names
+     *
+     * @param string $name1
+     * @param string $name2
+     * @return array
+     */
+    private function calculateSimilarityScore(string $name1, string $name2): array
+    {
+        // Calculate Levenshtein distance
+        $levenshtein = levenshtein($name1, $name2);
+        
+        // Calculate cosine similarity
+        $cosine = $this->cosineSimilarity(
+            $this->textToVector($name1),
+            $this->textToVector($name2)
+        );
+
+        return [
+            'levenshtein' => $levenshtein,
+            'cosine' => $cosine,
+            'primary_name' => $name1,
+            'candidate_name' => $name2
+        ];
+    }
+
+    /**
+     * Determine match quality based on scores
+     *
+     * @param int $levenshteinScore
+     * @param float $cosineSimilarity
+     * @return string
+     */
+    private function getMatchQuality(int $levenshteinScore, float $cosineSimilarity): string
+    {
+        if ($levenshteinScore <= $this->bestMatchThreshold && $cosineSimilarity >= $this->cosineSimilarityThreshold) {
+            return 'excellent';
+        } elseif ($levenshteinScore <= $this->bestMatchThreshold) {
+            return 'very_good';
+        } elseif ($levenshteinScore <= $this->goodMatchThreshold && $cosineSimilarity >= $this->cosineSimilarityThreshold) {
+            return 'good';
+        } elseif ($levenshteinScore <= $this->goodMatchThreshold) {
+            return 'fair';
+        }
+        return 'poor';
+    }
+
+    /**
+     * Automatically create failover relationships for similar channels
+     *
+     * @param Channel $primaryChannel
+     * @param Collection $similarChannels
+     * @param string $minQuality
+     * @return int Number of failovers created
+     */
+    public function createFailoverRelationships(Channel $primaryChannel, Collection $similarChannels, string $minQuality = 'good'): int
+    {
+        $qualityOrder = ['excellent', 'very_good', 'good', 'fair', 'poor'];
+        $minQualityIndex = array_search($minQuality, $qualityOrder);
+        
+        if ($minQualityIndex === false) {
+            $minQualityIndex = 2; // Default to 'good'
+        }
+
+        $created = 0;
+        $sortOrder = 1;
+
+        foreach ($similarChannels as $match) {
+            $qualityIndex = array_search($match['match_quality'], $qualityOrder);
+            
+            if ($qualityIndex !== false && $qualityIndex <= $minQualityIndex) {
+                // Check if failover relationship already exists
+                $exists = ChannelFailover::where([
+                    'channel_id' => $primaryChannel->id,
+                    'channel_failover_id' => $match['channel']->id,
+                ])->exists();
+
+                if (!$exists) {
+                    ChannelFailover::create([
+                        'user_id' => $primaryChannel->user_id,
+                        'channel_id' => $primaryChannel->id,
+                        'channel_failover_id' => $match['channel']->id,
+                        'sort' => $sortOrder++,
+                        'metadata' => [
+                            'auto_matched' => true,
+                            'similarity_score' => $match['similarity_score'],
+                            'cosine_similarity' => $match['cosine_similarity'],
+                            'match_quality' => $match['match_quality'],
+                            'matched_names' => $match['matched_names'],
+                            'created_at' => now()->toISOString(),
+                        ]
+                    ]);
+                    $created++;
+                }
+            }
+        }
+
+        return $created;
+    }
+
+    /**
+     * Find and group duplicate channels (channels with very similar names)
+     *
+     * @param Collection $channels
+     * @param bool $debug
+     * @return Collection
+     */
+    public function findDuplicateGroups(Collection $channels, bool $debug = false): Collection
+    {
+        $groups = collect();
+        $processedChannels = collect();
+
+        foreach ($channels as $channel) {
+            if ($processedChannels->contains($channel->id)) {
+                continue; // Already processed in a group
+            }
+
+            // Find all similar channels for this channel
+            $similarChannels = $this->findSimilarChannels($channel, $channels, $debug);
+            
+            // Only create a group if we have excellent or very good matches
+            $excellentMatches = $similarChannels->filter(function ($match) {
+                return in_array($match['match_quality'], ['excellent', 'very_good']);
+            });
+
+            if ($excellentMatches->isNotEmpty()) {
+                $group = collect([$channel]);
+                $group = $group->concat($excellentMatches->pluck('channel'));
+                
+                $groups->push([
+                    'primary_channel' => $channel,
+                    'channels' => $group,
+                    'total_channels' => $group->count(),
+                    'best_match_quality' => $excellentMatches->first()['match_quality'] ?? 'none'
+                ]);
+
+                // Mark all channels in this group as processed
+                $processedChannels = $processedChannels->concat($group->pluck('id'));
+
+                if ($debug) {
+                    $channelNames = $group->map(fn($c) => $c->title_custom ?? $c->title)->implode(', ');
+                    Log::info("Found duplicate group with {$group->count()} channels: {$channelNames}");
+                }
+            }
+        }
+
+        return $groups;
+    }
+
+    /**
+     * Public method to calculate similarity between two channel names
+     *
+     * @param string $name1
+     * @param string $name2
+     * @return float
+     */
+    public function calculateSimilarity(string $name1, string $name2): float
+    {
+        $normalized1 = $this->normalizeChannelName($name1);
+        $normalized2 = $this->normalizeChannelName($name2);
+        
+        $score = $this->calculateSimilarityScore($normalized1, $normalized2);
+        
+        // Return a combined score (lower levenshtein is better, higher cosine is better)
+        // Normalize to 0-1 scale where 1 is perfect match
+        $maxLen = max(strlen($normalized1), strlen($normalized2));
+        $levenshteinNormalized = $maxLen > 0 ? 1 - ($score['levenshtein'] / $maxLen) : 1;
+        
+        // Combine levenshtein and cosine (weighted average)
+        return ($levenshteinNormalized * 0.6) + ($score['cosine'] * 0.4);
+    }
+
+
+
+    /**
+     * Normalize a channel name for comparison
+     *
+     * @param string $name
+     * @return string
+     */
+    private function normalizeChannelName(string $name): string
+    {
+        if (empty($name)) {
+            return '';
+        }
+
+        $name = strtolower(trim($name));
+        
+        // Remove content in brackets and parentheses
+        $name = preg_replace('/\[.*?\]|\(.*?\)/', '', $name);
+        
+        // Remove special characters and extra spaces
+        $name = preg_replace('/[^\w\s]/', ' ', $name);
+        $name = preg_replace('/\s+/', ' ', $name);
+        
+        // Remove stop words
+        $words = explode(' ', $name);
+        $words = array_diff($words, $this->stopWords);
+        
+        return trim(implode(' ', $words));
+    }
+
+    /**
+     * Convert text to word frequency vector
+     *
+     * @param string $text
+     * @return array
+     */
+    private function textToVector(string $text): array
+    {
+        $words = explode(' ', $text);
+        return array_count_values($words);
+    }
+
+    /**
+     * Calculate cosine similarity between two vectors
+     *
+     * @param array $vecA
+     * @param array $vecB
+     * @return float
+     */
+    private function cosineSimilarity(array $vecA, array $vecB): float
+    {
+        if (empty($vecA) || empty($vecB)) {
+            return 0.0;
+        }
+
+        $dotProduct = 0;
+        $magA = 0;
+        $magB = 0;
+
+        // Calculate dot product and magnitude of A
+        foreach ($vecA as $word => $countA) {
+            $countB = $vecB[$word] ?? 0;
+            $dotProduct += $countA * $countB;
+            $magA += $countA ** 2;
+        }
+
+        // Calculate magnitude of B
+        foreach ($vecB as $countB) {
+            $magB += $countB ** 2;
+        }
+
+        $magnitude = sqrt($magA) * sqrt($magB);
+        
+        if ($magnitude == 0) {
+            return 0.0;
+        }
+
+        return $dotProduct / $magnitude;
+    }
+}

--- a/database/migrations/2025_06_05_120000_add_is_fallback_candidate_to_channels_table.php
+++ b/database/migrations/2025_06_05_120000_add_is_fallback_candidate_to_channels_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->boolean('is_fallback_candidate')->default(false)->after('kodi_drop');
+            $table->index('is_fallback_candidate');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropIndex(['is_fallback_candidate']);
+            $table->dropColumn('is_fallback_candidate');
+        });
+    }
+};

--- a/database/migrations/2025_06_05_121000_add_auto_matching_fields_to_channel_failovers_table.php
+++ b/database/migrations/2025_06_05_121000_add_auto_matching_fields_to_channel_failovers_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channel_failovers', function (Blueprint $table) {
+            $table->boolean('auto_matched')->default(false)->after('sort');
+            $table->decimal('match_quality', 5, 4)->nullable()->after('auto_matched');
+            $table->string('match_type')->nullable()->after('match_quality');
+            
+            $table->index('auto_matched');
+            $table->index('match_quality');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channel_failovers', function (Blueprint $table) {
+            $table->dropIndex(['auto_matched']);
+            $table->dropIndex(['match_quality']);
+            $table->dropColumn(['auto_matched', 'match_quality', 'match_type']);
+        });
+    }
+};

--- a/resources/views/filament/resources/channel-resource/pages/duplicate-finder.blade.php
+++ b/resources/views/filament/resources/channel-resource/pages/duplicate-finder.blade.php
@@ -1,0 +1,93 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        @if (count($this->duplicateGroups) > 0)
+            <div class="bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+                <div class="flex items-center space-x-2">
+                    <x-heroicon-o-information-circle class="w-5 h-5 text-blue-600 dark:text-blue-400" />
+                    <div>
+                        <h3 class="text-sm font-medium text-blue-800 dark:text-blue-200">
+                            Found {{ count($this->duplicateGroups) }} duplicate groups with {{ collect($this->duplicateGroups)->flatten(1)->count() }} total channels
+                        </h3>
+                        <p class="text-sm text-blue-600 dark:text-blue-300 mt-1">
+                            Review the groups below and set primary channels, then use "Auto-Create Failovers" to establish fallback relationships.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="space-y-4">
+                @foreach ($this->duplicateGroups as $groupId => $channels)
+                    <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+                        <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+                            <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                                Duplicate Group #{{ $groupId }}
+                                <span class="ml-2 text-xs text-gray-500 dark:text-gray-400">
+                                    ({{ $channels->count() }} channels)
+                                </span>
+                            </h4>
+                        </div>
+                        
+                        <div class="divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach ($channels as $channel)
+                                <div class="p-4 flex items-center justify-between">
+                                    <div class="flex items-center space-x-4">
+                                        @if ($channel->logo)
+                                            <img src="{{ $channel->logo }}" alt="{{ $channel->title }}" class="w-8 h-8 rounded object-cover">
+                                        @else
+                                            <div class="w-8 h-8 bg-gray-200 dark:bg-gray-700 rounded flex items-center justify-center">
+                                                <x-heroicon-o-tv class="w-4 h-4 text-gray-400" />
+                                            </div>
+                                        @endif
+                                        
+                                        <div>
+                                            <div class="font-medium text-gray-900 dark:text-gray-100">
+                                                {{ $channel->title_custom ?: $channel->title }}
+                                            </div>
+                                            <div class="text-sm text-gray-500 dark:text-gray-400">
+                                                {{ $channel->playlist->name ?? 'Unknown Playlist' }}
+                                                @if (isset($channel->similarity_score))
+                                                    • {{ number_format($channel->similarity_score * 100, 1) }}% match
+                                                @endif
+                                            </div>
+                                        </div>
+                                    </div>
+                                    
+                                    <div class="flex items-center space-x-2">
+                                        @if ($channel->is_fallback_candidate)
+                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
+                                                Fallback Candidate
+                                            </span>
+                                        @else
+                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                                                Primary
+                                            </span>
+                                        @endif
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @else
+            <div class="text-center py-12">
+                <x-heroicon-o-document-duplicate class="mx-auto h-12 w-12 text-gray-400" />
+                <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">No duplicate channels found</h3>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    No channels with similarity above {{ number_format($this->similarityThreshold * 100, 0) }}% were found.
+                </p>
+                <div class="mt-6">
+                    <button 
+                        type="button" 
+                        wire:click="$set('similarityThreshold', 0.6)"
+                        class="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                    >
+                        Try Lower Threshold (60%)
+                    </button>
+                </div>
+            </div>
+        @endif
+
+        {{ $this->table }}
+    </div>
+</x-filament-panels::page>


### PR DESCRIPTION
- Introduced a new DuplicateFinder page for identifying duplicate channels.
- Added functionality to mark channels as fallback candidates.
- Implemented bulk similarity matching job for automatic failover creation.
- Enhanced Channel and ChannelFailover models with new fields for fallback candidates and matching quality.
- Created ChannelSimilarityMatchingService for similarity calculations.
- Updated migrations to include new fields in channels and channel_failovers tables.
- Added a new view for displaying duplicate channels and their details.