### PR TITLE
corrected naming of webhook routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -41,9 +41,9 @@ Route::get('epgs/{uuid}/epg.xml', EpgFileController::class)
 
 // Test webhook endpoint
 Route::post('/webhook/test', \App\Http\Controllers\WebhookTestController::class)
-    ->name('webhook.test.get');
-Route::get('/webhook/test', \App\Http\Controllers\WebhookTestController::class)
     ->name('webhook.test.post');
+Route::get('/webhook/test', \App\Http\Controllers\WebhookTestController::class)
+    ->name('webhook.test.get');
 
 // If local env, show PHP info screen
 Route::get('/phpinfo', function () {


### PR DESCRIPTION
Corrected the naming of webhook routes.
POST endpoint uses webhook.test.post, GET endpoint uses webhook.test.get