### PR TITLE
Dev

### DIFF
--- a/app/Exceptions/FatalStreamContentException.php
+++ b/app/Exceptions/FatalStreamContentException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class FatalStreamContentException extends Exception
+{
+    // You can add custom properties or methods if needed
+}

--- a/app/Services/ProxyService.php
+++ b/app/Services/ProxyService.php
@@ -8,7 +8,8 @@ use Exception;
 class ProxyService
 {
     // Cache configuration for bad sources
-    public const BAD_SOURCE_CACHE_SECONDS = 10;
+    public const BAD_SOURCE_CACHE_SECONDS = 10; // Default for ffprobe/general errors
+    public const BAD_SOURCE_CACHE_SECONDS_CONTENT_ERROR = 10; // For fatal stream content errors
     public const BAD_SOURCE_CACHE_PREFIX = 'failover:bad_source:';
 
     /**

--- a/start-container
+++ b/start-container
@@ -201,48 +201,95 @@ echo "📡 Starting Redis server..."
 # Start Redis in background and suppress memory overcommit warning
 redis-server /etc/redis/redis.conf 2>&1 | grep -v "Memory overcommit must be enabled" &
 
+# Give Redis a moment to initialize before the first check
+sleep 0.5
+
 # If postgres is enabled, start it
 if [ "${ENABLE_POSTGRES}" = "true" ]; then
-  echo "📡 Starting Postgres..."
+  # Check if DB_HOST is set from the environment (passed by Docker)
+  # and is not localhost or 127.0.0.1, indicating an external DB.
+  # Note: Ensure DB_HOST is actually passed to the container's environment.
+  # Your docker-compose.yml shows it is.
+  if [ -n "${DB_HOST}" ] && [ "${DB_HOST}" != "localhost" ] && [ "${DB_HOST}" != "127.0.0.1" ]; then
+    echo "📡 Using external Postgres server configured at ${DB_HOST}. Skipping local Postgres setup."
+    # Even if external, ensure the log file directory exists for other potential logs
+    [ ! -f "${postgres_log_file}" ] && touch "${postgres_log_file}"
+    echo "" > "${postgres_log_file}" # Clear it or add a note about external DB
+    echo "INFO: Configured to use external PostgreSQL at ${DB_HOST}:${DB_PORT:-5432}" >> "${postgres_log_file}"
+    chown $WWWUSER:$WWWGROUP "${postgres_log_file}"
+  else
+    echo "📡 Starting local Postgres server setup..."
 
-  # Create log file
-  [ ! -f "${postgres_log_file}" ] && touch "${postgres_log_file}"
-  echo "" > "${postgres_log_file}"
-  chown -R $WWWUSER:$WWWGROUP "${postgres_log_file}"
+    # Create log file for local Postgres
+    [ ! -f "${postgres_log_file}" ] && touch "${postgres_log_file}"
+    echo "" > "${postgres_log_file}"
+    chown $WWWUSER:$WWWGROUP "${postgres_log_file}"
 
-  # Make sure permissions are correct
-  chown -R $WWWUSER:$WWWGROUP "$PGDATA"
-  chmod -R 700 "$PGDATA"
+    # Make sure permissions are correct for $PGDATA *if it exists*
+    # These lines were causing issues if $PGDATA (e.g. /var/lib/postgresql/data) didn't exist.
+    # initdb is responsible for creating $PGDATA if it's not there.
+    # The parent directory /var/lib/postgresql is created in Dockerfile and chowned.
+    if [ -d "$PGDATA" ]; then
+      echo "ℹ️ $PGDATA directory exists. Ensuring correct permissions..."
+      chown -R $WWWUSER:$WWWGROUP "$PGDATA"
+      chmod -R 700 "$PGDATA"
+    else
+      echo "ℹ️ $PGDATA does not exist. 'initdb' will attempt to create it."
+    fi
 
-  # Ensure data & run initdb on first-run
-  if [ ! -f "$PGDATA/PG_VERSION" ]; then
-    pwfile="/tmp/.pg_pwfile"
-    echo "$PG_PASSWORD" > "$pwfile"
-    chown $WWWUSER:$WWWGROUP "$pwfile" && chmod 600 "$pwfile"
-    su-exec $WWWUSER initdb --username=postgres --pwfile="$pwfile" -D "$PGDATA"
-    rm -f "$pwfile"
-  fi
+    # Ensure data & run initdb on first-run
+    if [ ! -f "$PGDATA/PG_VERSION" ]; then
+      pwfile="/tmp/.pg_pwfile"
+      echo "$PG_PASSWORD" > "$pwfile"
+      chown $WWWUSER:$WWWGROUP "$pwfile" && chmod 600 "$pwfile"
+      echo "🚀 Initializing local Postgres database in $PGDATA (User: $WWWUSER, DB: $PG_DATABASE)..."
+      # Ensure the parent directory of $PGDATA exists and is writable by $WWWUSER
+      # Dockerfile creates and chowns /var/lib/postgresql to $WWWUSER:$WWWGROUP
+      if ! su-exec $WWWUSER initdb --username=postgres --pwfile="$pwfile" -D "$PGDATA"; then
+        echo "❌ FATAL: Failed to initialize local Postgres database. Check permissions on /var/lib/postgresql and logs at ${postgres_log_file}."
+        exit 1
+      fi
+      rm -f "$pwfile"
+      echo "✅ Local Postgres database initialized."
+    else
+      echo "ℹ️ Local Postgres database already initialized at $PGDATA."
+    fi
 
-  # Create socket dir and start Postgres
-  mkdir -p /run/postgresql && chown $WWWUSER:$WWWGROUP /run/postgresql
-  su-exec $WWWUSER postgres -D "$PGDATA" -h 0.0.0.0 -p "$PG_PORT" >> "${postgres_log_file}" 2>&1 &
+    # Create socket dir and start Postgres
+    mkdir -p /run/postgresql && chown $WWWUSER:$WWWGROUP /run/postgresql
+    echo "🚀 Starting local Postgres process..."
+    su-exec $WWWUSER postgres -D "$PGDATA" -h 0.0.0.0 -p "$PG_PORT" >> "${postgres_log_file}" 2>&1 &
 
-  # Wait until it's ready
-  dots=""
-  until su-exec $WWWUSER pg_isready -h localhost -p "$PG_PORT" --quiet; do
-    dots+="."
-    echo "⏳ Waiting for Postgres${dots}"
-    sleep 1
-  done
-  echo ""
+    # Wait until it's ready
+    dots=""
+    max_wait_seconds=30
+    wait_interval=1
+    elapsed_wait=0
+    echo "⏳ Waiting for local Postgres to be ready (max ${max_wait_seconds}s)..."
+    until su-exec $WWWUSER pg_isready -h localhost -p "$PG_PORT" --quiet; do
+      dots+="."
+      echo "⏳ Waiting for local Postgres${dots}"
+      sleep $wait_interval
+      elapsed_wait=$((elapsed_wait + wait_interval))
+      if [ $elapsed_wait -ge $max_wait_seconds ]; then
+        echo "❌ FATAL: Local Postgres failed to start within ${max_wait_seconds} seconds. Check logs: ${postgres_log_file}"
+        exit 1
+      fi
+    done
+    echo "✅ Local Postgres is ready."
+    echo ""
 
-  # Idempotent role + database creation
-  su-exec $WWWUSER psql \
-  --quiet \
-  --tuples-only \
-  --no-align \
-  -U postgres \
-  <<-EOSQL
+    # Idempotent role + database creation for local postgres
+    echo "⚙️ Configuring local Postgres roles and database (User: ${PG_USER}, DB: ${PG_DATABASE})..."
+    # Note: PG_USER, PG_PASSWORD, PG_DATABASE are used here for the local instance.
+    # For external DB, these would be DB_USER, DB_PASSWORD, DB_DATABASE from .env
+    su-exec $WWWUSER psql \
+    --quiet \
+    --tuples-only \
+    --no-align \
+    -U postgres \
+    -h localhost -p "$PG_PORT" \
+    <<-EOSQL
 DO \$\$
 BEGIN
   -- ensure your app user exists and has the right password
@@ -254,15 +301,16 @@ BEGIN
     ALTER ROLE "${PG_USER}" WITH PASSWORD '${PG_PASSWORD}';
   END IF;
 
-  -- ensure the postgres superuser also has the password
+  -- ensure the postgres superuser also has the password (using PG_PASSWORD for local setup)
   ALTER ROLE postgres WITH PASSWORD '${PG_PASSWORD}';
 END
 \$\$;
 EOSQL
 
-  # If the database exists but is owned by someone else, reassign it
-  if su-exec $WWWUSER psql -U postgres --quiet -tAc "SELECT 1 FROM pg_database WHERE datname='${PG_DATABASE}'" | grep -q 1; then
-    su-exec $WWWUSER psql -U postgres --quiet <<-EOSQL
+    # If the database exists but is owned by someone else, reassign it (for local postgres)
+    if su-exec $WWWUSER psql -U postgres -h localhost -p "$PG_PORT" --quiet -tAc "SELECT 1 FROM pg_database WHERE datname='${PG_DATABASE}'" | grep -q 1; then
+      echo "ℹ️ Database '${PG_DATABASE}' exists. Ensuring correct owner ('${PG_USER}')."
+      su-exec $WWWUSER psql -U postgres -h localhost -p "$PG_PORT" --quiet <<-EOSQL
 -- change the database owner
 ALTER DATABASE "${PG_DATABASE}" OWNER TO "${PG_USER}";
 
@@ -288,8 +336,9 @@ BEGIN
 END
 \$\$;
 EOSQL
-  else
-    su-exec $WWWUSER psql -U postgres --quiet -v ON_ERROR_STOP=1 <<-EOSQL
+    else
+      echo "ℹ️ Database '${PG_DATABASE}' does not exist. Creating it with owner '${PG_USER}'."
+      su-exec $WWWUSER psql -U postgres -h localhost -p "$PG_PORT" --quiet -v ON_ERROR_STOP=1 <<-EOSQL
 CREATE DATABASE "${PG_DATABASE}"
   OWNER = "${PG_USER}"
   ENCODING = 'UTF8'
@@ -297,16 +346,40 @@ CREATE DATABASE "${PG_DATABASE}"
   LC_CTYPE = 'C.UTF-8'
   TEMPLATE = template0;
 EOSQL
+    fi
+    echo "✅ Local Postgres setup and configuration complete."
   fi
 fi
 
 # Wait until Redis is ready
+echo "⏳ Waiting for Redis to be ready..."
 dots=""
+max_wait_seconds_redis=30
+elapsed_wait_redis=0
+wait_interval_redis=1
+
 until redis-cli -p "$REDIS_SERVER_PORT" ping | grep -q PONG; do
-  dots+="."
-  echo "⏳ Waiting for Redis${dots}"
-  sleep 1
+  # Output from redis-cli on failure (like "Connection refused") will go to stderr,
+  # which is fine for the loop condition. We just want to control our own "Waiting..." message.
+  if [ $elapsed_wait_redis -gt 0 ]; then # Print dots only after the first attempt (which is silent from our script's perspective)
+    dots+="."
+    echo "⏳ Waiting for Redis${dots}"
+  fi
+  sleep $wait_interval_redis
+  elapsed_wait_redis=$((elapsed_wait_redis + wait_interval_redis))
+  if [ $elapsed_wait_redis -ge $max_wait_seconds_redis ]; then
+    echo "❌ FATAL: Redis failed to start within ${max_wait_seconds_redis} seconds. Check Redis logs if available."
+    # Decide if to exit: exit 1
+    break # Exit loop, subsequent parts of script might fail
+  fi
 done
+
+if redis-cli -p "$REDIS_SERVER_PORT" ping | grep -q PONG; then # Final check after the loop
+  echo "✅ Redis is ready."
+else
+  echo "⚠️ Redis did not become ready after waiting."
+  # Consider exiting if Redis is critical: exit 1
+fi
 echo ""
 
 # Flush FFmpeg process cache and prune HLS


### PR DESCRIPTION
Implement FFmpeg error detection for stream failover
- Added active monitoring of FFmpeg stderr in `startStreamingProcess`.
- If critical errors (SPS/PPS, decode issues) are detected, FFmpeg is terminated.
- A new `FatalStreamContentException` is thrown in such cases.
- `startStream` now catches this exception, logs it, and proceeds with failover logic.
- Ensures stream counts and active stream IDs in Redis are correctly decremented in all relevant error paths.
- Adds a short bad-source cache for content-specific errors to prevent immediate retries of the same problematic stream URL during failover.