### PR TITLE
Dev

### DIFF
--- a/app/Console/Commands/PruneStaleHlsProcesses.php
+++ b/app/Console/Commands/PruneStaleHlsProcesses.php
@@ -40,10 +40,10 @@ class PruneStaleHlsProcesses extends Command
             }
             $lastSeen = Carbon::createFromTimestamp((int) $ts);
             if ($lastSeen->addSeconds($threshold)->isPast()) {
-                $wasRunning = $this->hlsService->stopStream(type: 'channel', id: $channelId);
+                $wasRunning = $this->hlsService->stopStream(type: 'channel', id: $channelId, reason: 'stale_process_pruned_channel');
                 if ($wasRunning) {
                     $stoppedChannels++;
-                    $this->info("🛑 Stopped stale channel {$channelId}");
+                    $this->info("🛑 Stopped stale channel {$channelId} (pruned due to inactivity)");
                 }
             }
         }
@@ -56,10 +56,10 @@ class PruneStaleHlsProcesses extends Command
             }
             $lastSeen = Carbon::createFromTimestamp((int) $ts);
             if ($lastSeen->addSeconds($threshold)->isPast()) {
-                $wasRunning = $this->hlsService->stopStream(type: 'episode', id: $episodeId);
+                $wasRunning = $this->hlsService->stopStream(type: 'episode', id: $episodeId, reason: 'stale_process_pruned_episode');
                 if ($wasRunning) {
                     $stoppedEpisodes++;
-                    $this->info("🛑 Stopped stale episode {$episodeId}");
+                    $this->info("🛑 Stopped stale episode {$episodeId} (pruned due to inactivity)");
                 }
             }
         }

--- a/app/Console/Commands/PruneStaleHlsProcesses.php
+++ b/app/Console/Commands/PruneStaleHlsProcesses.php
@@ -34,39 +34,94 @@ class PruneStaleHlsProcesses extends Command
 
         // For each active channel, check staleness
         foreach ($activeChannelIds as $channelId) {
-            $ts = Redis::get("hls:channel_last_seen:{$channelId}");
-            if (! $ts) {
-                continue;
-            }
-            $lastSeen = Carbon::createFromTimestamp((int) $ts);
-            if ($lastSeen->addSeconds($threshold)->isPast()) {
-                $wasRunning = $this->hlsService->stopStream(type: 'channel', id: $channelId, reason: 'stale_process_pruned_channel');
-                if ($wasRunning) {
-                    $stoppedChannels++;
-                    $this->info("🛑 Stopped stale channel {$channelId} (pruned due to inactivity)");
-                }
-            }
+            $this->processStaleStream('channel', $channelId, $threshold, $stoppedChannels);
         }
 
         // For each active episode, check staleness
         foreach ($activeEspisodeIds as $episodeId) {
-            $ts = Redis::get("hls:episode_last_seen:{$episodeId}");
-            if (! $ts) {
-                continue;
-            }
-            $lastSeen = Carbon::createFromTimestamp((int) $ts);
-            if ($lastSeen->addSeconds($threshold)->isPast()) {
-                $wasRunning = $this->hlsService->stopStream(type: 'episode', id: $episodeId, reason: 'stale_process_pruned_episode');
-                if ($wasRunning) {
-                    $stoppedEpisodes++;
-                    $this->info("🛑 Stopped stale episode {$episodeId} (pruned due to inactivity)");
-                }
-            }
+            $this->processStaleStream('episode', $episodeId, $threshold, $stoppedEpisodes);
         }
 
         // Only output summary if there was activity
         if ($stoppedChannels > 0 || $stoppedEpisodes > 0) {
             $this->info("HLS Prune: Stopped {$stoppedChannels} channels and {$stoppedEpisodes} episodes");
+        }
+    }
+
+    private function processStaleStream(string $type, string $id, int $threshold, int &$stoppedCounter)
+    {
+        $originalIdLastSeenTs = Redis::get("hls:{$type}_last_seen:{$id}");
+
+        if (!$originalIdLastSeenTs) {
+            // If there's no last_seen for this ID, it might be an orphaned active_id or already cleaned up.
+            // Try to stop it just in case to clean up any lingering PID cache or files if HlsStreamService allows.
+            // HlsStreamService::stopStream is idempotent.
+            $wasRunning = $this->hlsService->stopStream($type, $id, "stale_process_pruned_{$type}_no_last_seen");
+            if ($wasRunning) {
+                $stoppedCounter++;
+                $this->info("🛑 Stopped {$type} {$id} (pruned due to missing last_seen timestamp, but was running)");
+            } else {
+                // If not running and no last_seen, ensure it's removed from active set if it's somehow still there
+                Redis::srem("hls:active_{$type}_ids", $id);
+            }
+            return;
+        }
+
+        $originalIdLastSeen = Carbon::createFromTimestamp((int) $originalIdLastSeenTs);
+
+        // Check if this ID is an original ID that has an active failover mapping
+        $streamMappingKey = "hls:stream_mapping:{$type}:{$id}";
+        $mappedStreamingId = Cache::get($streamMappingKey);
+
+        if ($mappedStreamingId && $mappedStreamingId != $id) {
+            // A failover has occurred. The current $id is the original, $mappedStreamingId is the actual one.
+            // We should check the staleness of the $mappedStreamingId.
+            $mappedIdLastSeenTs = Redis::get("hls:{$type}_last_seen:{$mappedStreamingId}");
+
+            if ($mappedIdLastSeenTs) {
+                $mappedIdLastSeen = Carbon::createFromTimestamp((int) $mappedIdLastSeenTs);
+                if ($mappedIdLastSeen->addSeconds($threshold)->isPast()) {
+                    // The *actual* streaming ID (failover) is stale. Stop it.
+                    // And also stop/cleanup the original ID's resources.
+                    $this->info("🔎 {$type} {$id} mapped to {$mappedStreamingId}. Mapped stream is stale.");
+                    $wasRunningMapped = $this->hlsService->stopStream($type, $mappedStreamingId, "stale_process_pruned_mapped_{$type}");
+                    if ($wasRunningMapped) {
+                        $stoppedCounter++; // Count as one stopped logical stream
+                        $this->info("🛑 Stopped stale mapped {$type} {$mappedStreamingId}");
+                    }
+                    // Now, also ensure the original ID is cleaned up.
+                    // The reason here is slightly different to indicate it's part of a stale mapped cleanup.
+                    $this->hlsService->stopStream($type, $id, "stale_process_pruned_original_of_stale_mapped_{$type}");
+                    Cache::forget($streamMappingKey); // Clean up the mapping as it's stale
+                } else {
+                    // Mapped stream is active, so the original $id (logical stream) is considered active. Don't prune.
+                    $this->info("🔎 {$type} {$id} mapped to {$mappedStreamingId}. Mapped stream is still active. Skipping prune for {$id}.");
+                    return;
+                }
+            } else {
+                // Mapped stream has no last_seen. This is unusual. Treat as stale.
+                // Stop the mapped stream and the original.
+                $this->info("🔎 {$type} {$id} mapped to {$mappedStreamingId}, but mapped stream has no last_seen. Treating as stale.");
+                $this->hlsService->stopStream($type, $mappedStreamingId, "stale_process_pruned_mapped_{$type}_no_last_seen");
+                $this->hlsService->stopStream($type, $id, "stale_process_pruned_original_of_unseen_mapped_{$type}");
+                Cache::forget($streamMappingKey);
+                // We don't increment counter here if mapped wasn't "running" per se, stopStream handles logging.
+                // But it's good to ensure the original is also stopped.
+            }
+        } else {
+            // No mapping, or mapped to itself. This $id is the one we check directly.
+            if ($originalIdLastSeen->addSeconds($threshold)->isPast()) {
+                $reason = "stale_process_pruned_{$type}";
+                $wasRunning = $this->hlsService->stopStream($type, $id, $reason);
+                if ($wasRunning) {
+                    $stoppedCounter++;
+                    $this->info("🛑 Stopped stale {$type} {$id} (pruned due to inactivity)");
+                }
+                // If there was a mapping to itself, clean it up if it's stale
+                if ($mappedStreamingId && $mappedStreamingId == $id) {
+                    Cache::forget($streamMappingKey);
+                }
+            }
         }
     }
 }

--- a/app/Console/Commands/PruneStaleHlsProcesses.php
+++ b/app/Console/Commands/PruneStaleHlsProcesses.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use App\Services\HlsStreamService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Facades\Cache; // Added this line
 
 class PruneStaleHlsProcesses extends Command
 {

--- a/app/Exceptions/AllPlaylistsExhaustedException.php
+++ b/app/Exceptions/AllPlaylistsExhaustedException.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class AllPlaylistsExhaustedException extends Exception
+{
+    /**
+     * Report the exception.
+     *
+     * @return bool|null
+     */
+    public function report()
+    {
+        // You can add custom logging here if needed,
+        // but the controller will likely log it as well.
+        return false; // Returning false prevents default logging if you handle it elsewhere.
+    }
+
+    /**
+     * Render the exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     */
+    public function render($request)
+    {
+        if ($request->expectsJson()) {
+            return response()->json(['message' => $this->getMessage()], 429);
+        }
+
+        // For web requests, you could return a view here,
+        // but we'll handle it in the controller for more flexibility.
+        // Or, you can use abort() which Laravel's handler will turn into a nice error page.
+        return response($this->getMessage(), 429);
+    }
+}

--- a/app/Exceptions/FatalStreamContentException.php
+++ b/app/Exceptions/FatalStreamContentException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class FatalStreamContentException extends Exception
+{
+    // You can add custom properties or methods if needed
+}

--- a/app/Services/HlsStreamService.php
+++ b/app/Services/HlsStreamService.php
@@ -441,10 +441,14 @@ class HlsStreamService
      *
      * @param string $type
      * @param string $id
+     * @param string|null $reason Optional reason for stopping the stream
      * @return bool
      */
-    public function stopStream($type, $id): bool
+    public function stopStream($type, $id, $reason = null): bool
     {
+        $logReason = $reason ? " (Reason: {$reason})" : "";
+        Log::channel('ffmpeg')->info("Attempting to stop HLS stream for {$type} ID {$id}{$logReason}");
+
         $cacheKey = "hls:pid:{$type}:{$id}";
         $pid = Cache::get($cacheKey);
         $wasRunning = false;

--- a/app/Services/HlsStreamService.php
+++ b/app/Services/HlsStreamService.php
@@ -7,6 +7,7 @@ use App\Models\Channel;
 use App\Models\Episode;
 use App\Exceptions\SourceNotResponding;
 use App\Exceptions\FatalStreamContentException; // Added
+use App\Exceptions\AllPlaylistsExhaustedException;
 use App\Traits\TracksActiveStreams;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
@@ -27,10 +28,6 @@ class HlsStreamService
      * @param Channel|Episode $model The Channel model instance
      * @param string $title The title of the channel
      */
-use App\Exceptions\AllPlaylistsExhaustedException;
-
-// ... (other use statements) ...
-
     public function startStream(
         string $type,
         Channel|Episode $model, // This $model is the *original* requested channel/episode

--- a/app/Services/ProxyService.php
+++ b/app/Services/ProxyService.php
@@ -8,7 +8,8 @@ use Exception;
 class ProxyService
 {
     // Cache configuration for bad sources
-    public const BAD_SOURCE_CACHE_SECONDS = 10;
+    public const BAD_SOURCE_CACHE_SECONDS = 10; // Default for ffprobe/general errors
+    public const BAD_SOURCE_CACHE_SECONDS_CONTENT_ERROR = 10; // For fatal stream content errors
     public const BAD_SOURCE_CACHE_PREFIX = 'failover:bad_source:';
 
     /**

--- a/app/Traits/TracksActiveStreams.php
+++ b/app/Traits/TracksActiveStreams.php
@@ -38,7 +38,7 @@ trait TracksActiveStreams
         // Fire event
         event(new StreamingStarted($playlistId));
 
-        Log::channel('ffmpeg')->debug("Active streams for playlist {$playlistId}: {$activeStreams} (after increment)");
+        Log::channel('ffmpeg')->debug("Playlist {$playlistId} active streams now: {$activeStreams} (after increment; may be for new stream attempt or confirmed start)");
 
         return $activeStreams;
     }
@@ -65,7 +65,7 @@ trait TracksActiveStreams
         // Fire event
         event(new StreamingStopped($playlistId));
 
-        Log::channel('ffmpeg')->debug("Active streams for playlist {$playlistId}: {$activeStreams} (after decrement)");
+        Log::channel('ffmpeg')->debug("Playlist {$playlistId} active streams now: {$activeStreams} (after decrement; may be for failed/skipped attempt or confirmed stop)");
 
         return $activeStreams;
     }

--- a/resources/views/errors/429.blade.php
+++ b/resources/views/errors/429.blade.php
@@ -1,0 +1,12 @@
+@extends('errors::minimal')
+
+@section('title', __('Too Many Requests'))
+@section('code', '429')
+@section('message')
+    {{ $exception->getMessage() ?: __('Too Many Requests. Please try again later.') }}
+@endsection
+
+@section('sub_message')
+    You have made too many requests or the system is currently at its maximum capacity for this resource.
+    Please wait a short while before trying again. If the problem persists, please contact support.
+@endsection

--- a/resources/views/errors/429.blade.php
+++ b/resources/views/errors/429.blade.php
@@ -1,12 +1,13 @@
 @extends('errors::minimal')
 
-@section('title', __('Too Many Requests'))
+@section('title', __('Max Streams Reached'))
 @section('code', '429')
 @section('message')
-    {{ $exception->getMessage() ?: __('Too Many Requests. Please try again later.') }}
+    {{-- Prefer the specific message from the abort() call via the exception --}}
+    {{ $exception->getMessage() ?: __('Maximum stream limits have been reached. Please try again later.') }}
 @endsection
 
 @section('sub_message')
-    You have made too many requests or the system is currently at its maximum capacity for this resource.
+    The system is currently at its maximum capacity for this channel or playlist.
     Please wait a short while before trying again. If the problem persists, please contact support.
 @endsection

--- a/start-container
+++ b/start-container
@@ -201,48 +201,95 @@ echo "📡 Starting Redis server..."
 # Start Redis in background and suppress memory overcommit warning
 redis-server /etc/redis/redis.conf 2>&1 | grep -v "Memory overcommit must be enabled" &
 
+# Give Redis a moment to initialize before the first check
+sleep 0.5
+
 # If postgres is enabled, start it
 if [ "${ENABLE_POSTGRES}" = "true" ]; then
-  echo "📡 Starting Postgres..."
+  # Check if DB_HOST is set from the environment (passed by Docker)
+  # and is not localhost or 127.0.0.1, indicating an external DB.
+  # Note: Ensure DB_HOST is actually passed to the container's environment.
+  # Your docker-compose.yml shows it is.
+  if [ -n "${DB_HOST}" ] && [ "${DB_HOST}" != "localhost" ] && [ "${DB_HOST}" != "127.0.0.1" ]; then
+    echo "📡 Using external Postgres server configured at ${DB_HOST}. Skipping local Postgres setup."
+    # Even if external, ensure the log file directory exists for other potential logs
+    [ ! -f "${postgres_log_file}" ] && touch "${postgres_log_file}"
+    echo "" > "${postgres_log_file}" # Clear it or add a note about external DB
+    echo "INFO: Configured to use external PostgreSQL at ${DB_HOST}:${DB_PORT:-5432}" >> "${postgres_log_file}"
+    chown $WWWUSER:$WWWGROUP "${postgres_log_file}"
+  else
+    echo "📡 Starting local Postgres server setup..."
 
-  # Create log file
-  [ ! -f "${postgres_log_file}" ] && touch "${postgres_log_file}"
-  echo "" > "${postgres_log_file}"
-  chown -R $WWWUSER:$WWWGROUP "${postgres_log_file}"
+    # Create log file for local Postgres
+    [ ! -f "${postgres_log_file}" ] && touch "${postgres_log_file}"
+    echo "" > "${postgres_log_file}"
+    chown $WWWUSER:$WWWGROUP "${postgres_log_file}"
 
-  # Make sure permissions are correct
-  chown -R $WWWUSER:$WWWGROUP "$PGDATA"
-  chmod -R 700 "$PGDATA"
+    # Make sure permissions are correct for $PGDATA *if it exists*
+    # These lines were causing issues if $PGDATA (e.g. /var/lib/postgresql/data) didn't exist.
+    # initdb is responsible for creating $PGDATA if it's not there.
+    # The parent directory /var/lib/postgresql is created in Dockerfile and chowned.
+    if [ -d "$PGDATA" ]; then
+      echo "ℹ️ $PGDATA directory exists. Ensuring correct permissions..."
+      chown -R $WWWUSER:$WWWGROUP "$PGDATA"
+      chmod -R 700 "$PGDATA"
+    else
+      echo "ℹ️ $PGDATA does not exist. 'initdb' will attempt to create it."
+    fi
 
-  # Ensure data & run initdb on first-run
-  if [ ! -f "$PGDATA/PG_VERSION" ]; then
-    pwfile="/tmp/.pg_pwfile"
-    echo "$PG_PASSWORD" > "$pwfile"
-    chown $WWWUSER:$WWWGROUP "$pwfile" && chmod 600 "$pwfile"
-    su-exec $WWWUSER initdb --username=postgres --pwfile="$pwfile" -D "$PGDATA"
-    rm -f "$pwfile"
-  fi
+    # Ensure data & run initdb on first-run
+    if [ ! -f "$PGDATA/PG_VERSION" ]; then
+      pwfile="/tmp/.pg_pwfile"
+      echo "$PG_PASSWORD" > "$pwfile"
+      chown $WWWUSER:$WWWGROUP "$pwfile" && chmod 600 "$pwfile"
+      echo "🚀 Initializing local Postgres database in $PGDATA (User: $WWWUSER, DB: $PG_DATABASE)..."
+      # Ensure the parent directory of $PGDATA exists and is writable by $WWWUSER
+      # Dockerfile creates and chowns /var/lib/postgresql to $WWWUSER:$WWWGROUP
+      if ! su-exec $WWWUSER initdb --username=postgres --pwfile="$pwfile" -D "$PGDATA"; then
+        echo "❌ FATAL: Failed to initialize local Postgres database. Check permissions on /var/lib/postgresql and logs at ${postgres_log_file}."
+        exit 1
+      fi
+      rm -f "$pwfile"
+      echo "✅ Local Postgres database initialized."
+    else
+      echo "ℹ️ Local Postgres database already initialized at $PGDATA."
+    fi
 
-  # Create socket dir and start Postgres
-  mkdir -p /run/postgresql && chown $WWWUSER:$WWWGROUP /run/postgresql
-  su-exec $WWWUSER postgres -D "$PGDATA" -h 0.0.0.0 -p "$PG_PORT" >> "${postgres_log_file}" 2>&1 &
+    # Create socket dir and start Postgres
+    mkdir -p /run/postgresql && chown $WWWUSER:$WWWGROUP /run/postgresql
+    echo "🚀 Starting local Postgres process..."
+    su-exec $WWWUSER postgres -D "$PGDATA" -h 0.0.0.0 -p "$PG_PORT" >> "${postgres_log_file}" 2>&1 &
 
-  # Wait until it's ready
-  dots=""
-  until su-exec $WWWUSER pg_isready -h localhost -p "$PG_PORT" --quiet; do
-    dots+="."
-    echo "⏳ Waiting for Postgres${dots}"
-    sleep 1
-  done
-  echo ""
+    # Wait until it's ready
+    dots=""
+    max_wait_seconds=30
+    wait_interval=1
+    elapsed_wait=0
+    echo "⏳ Waiting for local Postgres to be ready (max ${max_wait_seconds}s)..."
+    until su-exec $WWWUSER pg_isready -h localhost -p "$PG_PORT" --quiet; do
+      dots+="."
+      echo "⏳ Waiting for local Postgres${dots}"
+      sleep $wait_interval
+      elapsed_wait=$((elapsed_wait + wait_interval))
+      if [ $elapsed_wait -ge $max_wait_seconds ]; then
+        echo "❌ FATAL: Local Postgres failed to start within ${max_wait_seconds} seconds. Check logs: ${postgres_log_file}"
+        exit 1
+      fi
+    done
+    echo "✅ Local Postgres is ready."
+    echo ""
 
-  # Idempotent role + database creation
-  su-exec $WWWUSER psql \
-  --quiet \
-  --tuples-only \
-  --no-align \
-  -U postgres \
-  <<-EOSQL
+    # Idempotent role + database creation for local postgres
+    echo "⚙️ Configuring local Postgres roles and database (User: ${PG_USER}, DB: ${PG_DATABASE})..."
+    # Note: PG_USER, PG_PASSWORD, PG_DATABASE are used here for the local instance.
+    # For external DB, these would be DB_USER, DB_PASSWORD, DB_DATABASE from .env
+    su-exec $WWWUSER psql \
+    --quiet \
+    --tuples-only \
+    --no-align \
+    -U postgres \
+    -h localhost -p "$PG_PORT" \
+    <<-EOSQL
 DO \$\$
 BEGIN
   -- ensure your app user exists and has the right password
@@ -254,15 +301,16 @@ BEGIN
     ALTER ROLE "${PG_USER}" WITH PASSWORD '${PG_PASSWORD}';
   END IF;
 
-  -- ensure the postgres superuser also has the password
+  -- ensure the postgres superuser also has the password (using PG_PASSWORD for local setup)
   ALTER ROLE postgres WITH PASSWORD '${PG_PASSWORD}';
 END
 \$\$;
 EOSQL
 
-  # If the database exists but is owned by someone else, reassign it
-  if su-exec $WWWUSER psql -U postgres --quiet -tAc "SELECT 1 FROM pg_database WHERE datname='${PG_DATABASE}'" | grep -q 1; then
-    su-exec $WWWUSER psql -U postgres --quiet <<-EOSQL
+    # If the database exists but is owned by someone else, reassign it (for local postgres)
+    if su-exec $WWWUSER psql -U postgres -h localhost -p "$PG_PORT" --quiet -tAc "SELECT 1 FROM pg_database WHERE datname='${PG_DATABASE}'" | grep -q 1; then
+      echo "ℹ️ Database '${PG_DATABASE}' exists. Ensuring correct owner ('${PG_USER}')."
+      su-exec $WWWUSER psql -U postgres -h localhost -p "$PG_PORT" --quiet <<-EOSQL
 -- change the database owner
 ALTER DATABASE "${PG_DATABASE}" OWNER TO "${PG_USER}";
 
@@ -288,8 +336,9 @@ BEGIN
 END
 \$\$;
 EOSQL
-  else
-    su-exec $WWWUSER psql -U postgres --quiet -v ON_ERROR_STOP=1 <<-EOSQL
+    else
+      echo "ℹ️ Database '${PG_DATABASE}' does not exist. Creating it with owner '${PG_USER}'."
+      su-exec $WWWUSER psql -U postgres -h localhost -p "$PG_PORT" --quiet -v ON_ERROR_STOP=1 <<-EOSQL
 CREATE DATABASE "${PG_DATABASE}"
   OWNER = "${PG_USER}"
   ENCODING = 'UTF8'
@@ -297,16 +346,40 @@ CREATE DATABASE "${PG_DATABASE}"
   LC_CTYPE = 'C.UTF-8'
   TEMPLATE = template0;
 EOSQL
+    fi
+    echo "✅ Local Postgres setup and configuration complete."
   fi
 fi
 
 # Wait until Redis is ready
+echo "⏳ Waiting for Redis to be ready..."
 dots=""
+max_wait_seconds_redis=30
+elapsed_wait_redis=0
+wait_interval_redis=1
+
 until redis-cli -p "$REDIS_SERVER_PORT" ping | grep -q PONG; do
-  dots+="."
-  echo "⏳ Waiting for Redis${dots}"
-  sleep 1
+  # Output from redis-cli on failure (like "Connection refused") will go to stderr,
+  # which is fine for the loop condition. We just want to control our own "Waiting..." message.
+  if [ $elapsed_wait_redis -gt 0 ]; then # Print dots only after the first attempt (which is silent from our script's perspective)
+    dots+="."
+    echo "⏳ Waiting for Redis${dots}"
+  fi
+  sleep $wait_interval_redis
+  elapsed_wait_redis=$((elapsed_wait_redis + wait_interval_redis))
+  if [ $elapsed_wait_redis -ge $max_wait_seconds_redis ]; then
+    echo "❌ FATAL: Redis failed to start within ${max_wait_seconds_redis} seconds. Check Redis logs if available."
+    # Decide if to exit: exit 1
+    break # Exit loop, subsequent parts of script might fail
+  fi
 done
+
+if redis-cli -p "$REDIS_SERVER_PORT" ping | grep -q PONG; then # Final check after the loop
+  echo "✅ Redis is ready."
+else
+  echo "⚠️ Redis did not become ready after waiting."
+  # Consider exiting if Redis is critical: exit 1
+fi
 echo ""
 
 # Flush FFmpeg process cache and prune HLS


### PR DESCRIPTION
Implement FFmpeg error detection for stream failover
- Added active monitoring of FFmpeg stderr in `startStreamingProcess`.
- If critical errors (SPS/PPS, decode issues) are detected, FFmpeg is terminated.
- A new `FatalStreamContentException` is thrown in such cases.
- `startStream` now catches this exception, logs it, and proceeds with failover logic.
- Ensures stream counts and active stream IDs in Redis are correctly decremented in all relevant error paths.
- Adds a short bad-source cache for content-specific errors to prevent immediate retries of the same problematic stream URL during failover.


Update start-container
Fix: Skip local Postgres setup when external DB_HOST is configured
The start-container script was attempting to initialize and manage a
local PostgreSQL instance even when the environment was configured
to use an external database via DB_HOST. This caused errors like
'chown: cannot access /var/lib/postgresql/data' because the
data directory for the external database is not managed by this container.

This commit modifies the start-container script to check the DB_HOST
environment variable. If DB_HOST is set and is not 'localhost' or
'127.0.0.1', the script will now bypass all local PostgreSQL
initialization steps (chown, chmod, initdb, local server start).
It also adds logging to indicate whether a local or external
PostgreSQL configuration is detecte