### PR TITLE
Add configurable ffprobe_path and consolidate logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,6 +124,7 @@ RUN composer install --no-dev --no-interaction --no-progress -o
 
 # Symlink jellyfin-ffmpeg to usr/bin
 RUN ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin/jellyfin-ffmpeg
+RUN ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/bin/jellyfin-ffprobe
 
 # Setup user, group and permissions
 RUN addgroup $WWWGROUP \

--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -78,6 +78,21 @@ class Preferences extends SettingsPage
                                             ->hint(fn() => !empty($ffmpegPath) ? 'Already set by environment variable!' : null)
                                             ->dehydrated(fn() => empty($ffmpegPath))
                                             ->placeholder(fn() => empty($ffmpegPath) ? 'jellyfin-ffmpeg' : $ffmpegPath),
+                                        Forms\Components\Select::make('ffprobe_path')
+                                            ->label('FFprobe')
+                                            ->columnSpan(2)
+                                            ->helperText('Which ffprobe variant would you like to use.')
+                                            ->options([
+                                                'jellyfin-ffprobe' => 'jellyfin-ffprobe (default)',
+                                                'ffprobe' => 'ffprobe',
+                                            ])
+                                            ->searchable()
+                                            // Assuming similar logic for ffprobe path being set by env var
+                                            ->suffixIcon(fn() => !empty(config('proxy.ffprobe_path')) ? 'heroicon-m-lock-closed' : null)
+                                            ->disabled(fn() => !empty(config('proxy.ffprobe_path')))
+                                            ->hint(fn() => !empty(config('proxy.ffprobe_path')) ? 'Already set by environment variable!' : null)
+                                            ->dehydrated(fn() => empty(config('proxy.ffprobe_path')))
+                                            ->placeholder(fn() => empty(config('proxy.ffprobe_path')) ? 'jellyfin-ffprobe' : config('proxy.ffprobe_path')),
                                         Forms\Components\TextInput::make('ffmpeg_max_tries')
                                             ->label('Max tries')
                                             ->columnSpan(1)
@@ -457,7 +472,8 @@ class Preferences extends SettingsPage
             // mediaflow fields were removed, but if others exist that are text & nullable, add here
             // 'mediaflow_proxy_url', 'mediaflow_proxy_port', 'mediaflow_proxy_password',
             // 'mediaflow_proxy_user_agent', 
-            'ffmpeg_path'
+            'ffmpeg_path',
+            'ffprobe_path'
         ];
 
         foreach ($nullableTextfields as $field) {

--- a/app/Http/Controllers/StreamController.php
+++ b/app/Http/Controllers/StreamController.php
@@ -355,10 +355,12 @@ class StreamController extends Controller
             if (empty($ffmpegExecutable)) {
                 $ffmpegExecutable = 'jellyfin-ffmpeg'; // Default ffmpeg command
             }
-            $ffprobePath = str_contains($ffmpegExecutable, '/') ? dirname($ffmpegExecutable) . '/ffprobe' : 'ffprobe';
+
+            // Determine ffprobe path using the consolidated service method
+            $ffprobePath = ProxyService::getEffectiveFfprobePath($settings);
             $ffprobeTimeout = $settings['ffmpeg_ffprobe_timeout'] ?? 5;
 
-            $precheckCmd = "$ffprobePath -v quiet -print_format json -show_streams -show_format -user_agent " . $escapedUserAgent . " " . escapeshellarg($streamUrl);
+            $precheckCmd = escapeshellcmd($ffprobePath) . " -v quiet -print_format json -show_streams -show_format -user_agent " . $escapedUserAgent . " " . escapeshellarg($streamUrl);
             Log::channel('ffmpeg')->debug("[PRE-CHECK] Executing ffprobe command for [{$title}] with timeout {$ffprobeTimeout}s: {$precheckCmd}");
             $precheckProcess = SymfonyProcess::fromShellCommandline($precheckCmd);
             $precheckProcess->setTimeout($ffprobeTimeout);

--- a/app/Services/HlsStreamService.php
+++ b/app/Services/HlsStreamService.php
@@ -370,10 +370,13 @@ class HlsStreamService
      */
     private function runPreCheck(string $modelType, $modelId, $streamUrl, $userAgent, $title, int $ffprobeTimeout)
     {
-        $ffprobePath = config('proxy.ffprobe_path', 'ffprobe');
+        $settings = ProxyService::getStreamSettings(); // Get general settings
+
+        // Determine ffprobe path using the consolidated service method
+        $ffprobePath = ProxyService::getEffectiveFfprobePath($settings);
 
         // Updated command to include -show_format and remove -select_streams to get all streams for detailed info
-        $cmd = "$ffprobePath -v quiet -print_format json -show_streams -show_format -user_agent " . escapeshellarg($userAgent) . " " . escapeshellarg($streamUrl);
+        $cmd = escapeshellcmd($ffprobePath) . " -v quiet -print_format json -show_streams -show_format -user_agent " . escapeshellarg($userAgent) . " " . escapeshellarg($streamUrl);
 
         Log::channel('ffmpeg')->debug("[PRE-CHECK] Executing ffprobe command for [{$title}] with timeout {$ffprobeTimeout}s: {$cmd}");
         $precheckProcess = SymfonyProcess::fromShellCommandline($cmd);

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -25,6 +25,7 @@ class GeneralSettings extends Settings
     public ?string $mediaflow_proxy_user_agent = null;
     public ?bool $mediaflow_proxy_playlist_user_agent = false;
     public ?string $ffmpeg_path = null;
+    public ?string $ffprobe_path = null;
     public ?int $ffmpeg_hls_time = 4;
     public ?int $ffmpeg_ffprobe_timeout = 5;
     public ?int $hls_playlist_max_attempts = 10;

--- a/config/proxy.php
+++ b/config/proxy.php
@@ -4,6 +4,7 @@ return [
     'url_override' => env('PROXY_URL_OVERRIDE', null),
     'proxy_format' => env('PROXY_FORMAT', 'mpts'), // 'mpts' or 'hls'
     'ffmpeg_path' => env('PROXY_FFMPEG_PATH', null),
+    'ffprobe_path' => env('PROXY_FFPROBE_PATH', null),
     'ffmpeg_additional_args' => env('PROXY_FFMPEG_ADDITIONAL_ARGS', ''),
     'ffmpeg_codec_video' => env('PROXY_FFMPEG_CODEC_VIDEO', null),
     'ffmpeg_codec_audio' => env('PROXY_FFMPEG_CODEC_AUDIO', null),

--- a/database/settings/2025_07_22_000000_add_ffprobe_path_select_option.php
+++ b/database/settings/2025_07_22_000000_add_ffprobe_path_select_option.php
@@ -1,0 +1,13 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        if (!$this->migrator->exists('general.ffprobe_path')) {
+            $this->migrator->add('general.ffprobe_path', config('proxy.ffprobe_path') ?? 'jellyfin-ffprobe');
+        }
+    }
+};


### PR DESCRIPTION
This pull request includes several updates to enhance the application's functionality, improve code structure, and add new features. Key changes include the addition of new exception classes, updates to shared streaming functionality, enhancements to the HLS pruning process, and modifications to the preferences form. Below is a breakdown of the most significant changes grouped by theme:

### Application Functionality Enhancements:
* Added detailed instructions for the M3U Editor project and shared streaming functionality, including descriptions of features like proxy functionality, buffered streaming, and channel failover. (`.github/instructions/project-details.instructions.md` - [[1]](diffhunk://#diff-ceeec05cb6bc4a99288ca1387e4f66659d192be978f1e345a35b28e70cc9d684R1-R14) `.github/instructions/shared-streaming-details.instructions.md` - [[2]](diffhunk://#diff-024e1b4040a94403aa96ffb0bce988ed1d02e2dd4481857e7010c9620cd2564fR1-R24)
* Enhanced the `Preferences` page to include a selectable `ffprobe_path` option, allowing users to choose between different ffprobe variants. (`app/Filament/Pages/Preferences.php` - [[1]](diffhunk://#diff-62de19abc0fcf48b2fd3aec845807351950ff51536c959e2f803eba1dd45dc48R81-R95) [[2]](diffhunk://#diff-62de19abc0fcf48b2fd3aec845807351950ff51536c959e2f803eba1dd45dc48L460-R476)

### Codebase Improvements:
* Refactored the `PruneStaleHlsProcesses` command to streamline the handling of stale streams, including logic for failover mappings and enhanced cleanup processes. (`app/Console/Commands/PruneStaleHlsProcesses.php` - [[1]](diffhunk://#diff-e158a83671bf4db75db4f3217c97f0b4aaa5783ca247b09680175522e769d949R9) [[2]](diffhunk://#diff-e158a83671bf4db75db4f3217c97f0b4aaa5783ca247b09680175522e769d949L37-L69)
* Added new exception classes (`AllPlaylistsExhaustedException`, `FatalStreamContentException`, and `MaxRetriesReachedException`) to improve error handling and provide more specific exception types. (`app/Exceptions/AllPlaylistsExhaustedException.php` - [[1]](diffhunk://#diff-86f315c0c28ba2b363c8a751ed6aa1ebf9186d670c18176317f2d748e86d8255R1-R38) `app/Exceptions/FatalStreamContentException.php` - [[2]](diffhunk://#diff-1ab7486d3c09589d157b1b6f4029e0fd56d5f40aa7418f1ee1c53698efd92c23R1-R10) `app/Exceptions/MaxRetriesReachedException.php` - [[3]](diffhunk://#diff-d70743a78307f7311f6aaa65edad905d12b59adc7de11209f464f20e0e7457eeR1-R10)

### Streaming and Testing Enhancements:
* Updated the `TestXtream` command to support fetching all live streams and added logic for handling Xtream user information. (`app/Console/Commands/TestXtream.php` - [[1]](diffhunk://#diff-ed30548f7ce483493470b11d3a583eafe13243ffe037df478dac86ff3c5ed230L69-R72) [[2]](diffhunk://#diff-ed30548f7ce483493470b11d3a583eafe13243ffe037df478dac86ff3c5ed230L83-R84) [[3]](diffhunk://#diff-ed30548f7ce483493470b11d3a583eafe13243ffe037df478dac86ff3c5ed230L146-R155) [[4]](diffhunk://#diff-ed30548f7ce483493470b11d3a583eafe13243ffe037df478dac86ff3c5ed230R172)
* Introduced the `TestSystemStats` command to test and output system statistics, including memory usage, disk space, and load average. (`app/Console/Commands/TestSystemStats.php` - [app/Console/Commands/TestSystemStats.phpR1-R45](diffhunk://#diff-a8bf28b28ddb53ecdeb716ca49e67c39a255f0354d40854da24f9f2ccbd3d1f3R1-R45))

### Docker Configuration Update:
* Added a symbolic link for `ffprobe` in the `Dockerfile` to ensure compatibility with the Jellyfin ffmpeg setup. (`Dockerfile` - [DockerfileR127](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R127))
This pull request introduces support for configuring the `ffprobe` executable path alongside `ffmpeg` in the application. The changes ensure flexibility in specifying `ffprobe` paths via environment variables, user preferences, or defaults, and streamline how these paths are derived and used across the codebase.

### Configuration Updates:
* Added `ffprobe_path` configuration in `config/proxy.php` to allow specifying the `ffprobe` executable path via environment variables.
* Introduced a new database migration to add `ffprobe_path` as a configurable option in the `general` settings table, defaulting to `jellyfin-ffprobe`.

### User Preferences:
* Updated `GeneralSettings` to include `ffprobe_path` as a nullable property for user configuration.
* Enhanced the `Preferences` page to allow users to select their preferred `ffprobe` path, with options for `jellyfin-ffprobe` (default) or `ffprobe`. Logic for handling environment variable overrides and placeholders was added. [[1]](diffhunk://#diff-62de19abc0fcf48b2fd3aec845807351950ff51536c959e2f803eba1dd45dc48R81-R95) [[2]](diffhunk://#diff-62de19abc0fcf48b2fd3aec845807351950ff51536c959e2f803eba1dd45dc48L460-R476)

### Path Derivation Logic:
* Added `getEffectiveFfprobePath` method in `ProxyService` to determine the `ffprobe` executable path based on environment variables, user preferences, or derived defaults. This ensures consistency in path resolution across the application.

### Code Integration:
* Updated the `StreamController` and `HlsStreamService` to use the new `getEffectiveFfprobePath` method for determining the `ffprobe` path, replacing hardcoded logic. [[1]](diffhunk://#diff-113330d8e323ab718e5ad95db31520ee71367f700b89c141c3317816798e3b79L358-R363) [[2]](diffhunk://#diff-4c90e1ff83a696326c10f90a7cda4fd85e5e030a55fd95537addd8621861bbcaL373-R379)
* Modified `Dockerfile` to create a symlink for `jellyfin-ffprobe`, ensuring compatibility with the default configuration.