### PR TITLE
Feature/merge unmerge channels

### DIFF
--- a/app/Filament/Resources/ChannelResource.php
+++ b/app/Filament/Resources/ChannelResource.php
@@ -507,6 +507,101 @@ class ChannelResource extends Resource
                         ->modalIcon('heroicon-o-arrows-pointing-in')
                         ->modalDescription('Merge all selected channels with the same ID into a single channel with failover.')
                         ->modalSubmitActionLabel('Merge now'),
+                    Tables\Actions\BulkAction::make('failover')
+                        ->label('Add as failover')
+                        ->form(function (Collection $records) {
+                            $existingFailoverIds = $records->pluck('id')->toArray();
+                            $initialMasterOptions = [];
+                            foreach ($records as $record) {
+                                $displayTitle = $record->title_custom ?: $record->title;
+                                $playlistName = $record->getEffectivePlaylist()->name ?? 'Unknown';
+                                $initialMasterOptions[$record->id] = "{$displayTitle} [{$playlistName}]";
+                            }
+                            return [
+                                Forms\Components\ToggleButtons::make('master_source')
+                                    ->label('Choose master from?')
+                                    ->options([
+                                        'selected' => 'Selected Channels',
+                                        'searched' => 'Channel Search',
+                                    ])
+                                    ->icons([
+                                        'selected' => 'heroicon-o-check',
+                                        'searched' => 'heroicon-o-magnifying-glass',
+                                    ])
+                                    ->default('selected')
+                                    ->live()
+                                    ->grouped(),
+                                Forms\Components\Select::make('selected_master_id')
+                                    ->label('Select master channel')
+                                    ->helperText('From the selected channels')
+                                    ->options($initialMasterOptions)
+                                    ->required()
+                                    ->hidden(fn(Get $get) => $get('master_source') !== 'selected')
+                                    ->searchable(),
+                                Forms\Components\Select::make('master_channel_id')
+                                    ->label('Search for master channel')
+                                    ->searchable()
+                                    ->required()
+                                    ->hidden(fn(Get $get) => $get('master_source') !== 'searched')
+                                    ->getSearchResultsUsing(function (string $search) use ($existingFailoverIds) {
+                                        $searchLower = strtolower($search);
+                                        $channels = Auth::user()->channels()
+                                            ->withoutEagerLoads()
+                                            ->with('playlist')
+                                            ->whereNotIn('id', $existingFailoverIds)
+                                            ->where(function ($query) use ($searchLower) {
+                                                $query->whereRaw('LOWER(title) LIKE ?', ["%{$searchLower}%"])
+                                                    ->orWhereRaw('LOWER(title_custom) LIKE ?', ["%{$searchLower}%"])
+                                                    ->orWhereRaw('LOWER(name) LIKE ?', ["%{$searchLower}%"])
+                                                    ->orWhereRaw('LOWER(name_custom) LIKE ?', ["%{$searchLower}%"])
+                                                    ->orWhereRaw('LOWER(stream_id) LIKE ?', ["%{$searchLower}%"])
+                                                    ->orWhereRaw('LOWER(stream_id_custom) LIKE ?', ["%{$searchLower}%"]);
+                                            })
+                                            ->limit(50) // Keep a reasonable limit
+                                            ->get();
+
+                                        // Create options array
+                                        $options = [];
+                                        foreach ($channels as $channel) {
+                                            $displayTitle = $channel->title_custom ?: $channel->title;
+                                            $playlistName = $channel->getEffectivePlaylist()->name ?? 'Unknown';
+                                            $options[$channel->id] = "{$displayTitle} [{$playlistName}]";
+                                        }
+
+                                        return $options;
+                                    })
+                                    ->helperText('To use as the master for the selected channel.')
+                                    ->required(),
+                            ];
+                        })
+                        ->action(function (Collection $records, array $data): void {
+                            // Filter out the master channel from the records to be added as failovers
+                            $masterRecordId = $data['master_source'] === 'selected'
+                                ? $data['selected_master_id']
+                                : $data['master_channel_id'];
+                            $failoverRecords = $records->filter(function ($record) use ($masterRecordId) {
+                                return (int)$record->id !== (int)$masterRecordId;
+                            });
+
+                            foreach ($failoverRecords as $record) {
+                                ChannelFailover::updateOrCreate([
+                                    'channel_id' => $masterRecordId,
+                                    'channel_failover_id' => $record->id,
+                                ]);
+                            }
+                        })->after(function () {
+                            Notification::make()
+                                ->success()
+                                ->title('Channels as failover')
+                                ->body('The selected channels have been added as failovers.')
+                                ->send();
+                        })
+                        ->deselectRecordsAfterCompletion()
+                        ->requiresConfirmation()
+                        ->icon('heroicon-o-arrow-path-rounded-square')
+                        ->modalIcon('heroicon-o-arrow-path-rounded-square')
+                        ->modalDescription('Add the selected channel(s) to the chosen channel as failover sources.')
+                        ->modalSubmitActionLabel('Add failovers now'),
                     Tables\Actions\BulkAction::make('unmerge')
                         ->label('Unmerge Same ID')
                         ->action(function (Collection $records): void {

--- a/app/Filament/Resources/ChannelResource.php
+++ b/app/Filament/Resources/ChannelResource.php
@@ -491,9 +491,15 @@ class ChannelResource extends Resource
                         ->modalSubmitActionLabel('Update now'),
                     Tables\Actions\BulkAction::make('merge')
                         ->label('Merge Same ID')
-                        ->action(function (Collection $records): void {
+                        ->form([
+                            Forms\Components\Select::make('playlist_id')
+                                ->label('Preferred Playlist')
+                                ->options(Playlist::where('user_id', auth()->id())->pluck('name', 'id'))
+                                ->helperText('Select a playlist to prioritize as the master during the merge process.')
+                        ])
+                        ->action(function (Collection $records, array $data): void {
                             app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new \App\Jobs\MergeChannels($records));
+                                ->dispatch(new \App\Jobs\MergeChannels($records, auth()->user(), $data['playlist_id'] ?? null));
                         })->after(function () {
                             Notification::make()
                                 ->success()
@@ -606,7 +612,7 @@ class ChannelResource extends Resource
                         ->label('Unmerge Same ID')
                         ->action(function (Collection $records): void {
                             app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new \App\Jobs\UnmergeChannels($records));
+                                ->dispatch(new \App\Jobs\UnmergeChannels($records, auth()->user()));
                         })->after(function () {
                             Notification::make()
                                 ->success()

--- a/app/Filament/Resources/ChannelResource.php
+++ b/app/Filament/Resources/ChannelResource.php
@@ -489,102 +489,42 @@ class ChannelResource extends Resource
                         ->modalIcon('heroicon-o-photo')
                         ->modalDescription('Update the preferred icon for the selected channel(s).')
                         ->modalSubmitActionLabel('Update now'),
-                    Tables\Actions\BulkAction::make('failover')
-                        ->label('Add as failover')
-                        ->form(function (Collection $records) {
-                            $existingFailoverIds = $records->pluck('id')->toArray();
-                            $initialMasterOptions = [];
-                            foreach ($records as $record) {
-                                $displayTitle = $record->title_custom ?: $record->title;
-                                $playlistName = $record->getEffectivePlaylist()->name ?? 'Unknown';
-                                $initialMasterOptions[$record->id] = "{$displayTitle} [{$playlistName}]";
-                            }
-                            return [
-                                Forms\Components\ToggleButtons::make('master_source')
-                                    ->label('Choose master from?')
-                                    ->options([
-                                        'selected' => 'Selected Channels',
-                                        'searched' => 'Channel Search',
-                                    ])
-                                    ->icons([
-                                        'selected' => 'heroicon-o-check',
-                                        'searched' => 'heroicon-o-magnifying-glass',
-                                    ])
-                                    ->default('selected')
-                                    ->live()
-                                    ->grouped(),
-                                Forms\Components\Select::make('selected_master_id')
-                                    ->label('Select master channel')
-                                    ->helperText('From the selected channels')
-                                    ->options($initialMasterOptions)
-                                    ->required()
-                                    ->hidden(fn(Get $get) => $get('master_source') !== 'selected')
-                                    ->searchable(),
-                                Forms\Components\Select::make('master_channel_id')
-                                    ->label('Search for master channel')
-                                    ->searchable()
-                                    ->required()
-                                    ->hidden(fn(Get $get) => $get('master_source') !== 'searched')
-                                    ->getSearchResultsUsing(function (string $search) use ($existingFailoverIds) {
-                                        $searchLower = strtolower($search);
-                                        $channels = Auth::user()->channels()
-                                            ->withoutEagerLoads()
-                                            ->with('playlist')
-                                            ->whereNotIn('id', $existingFailoverIds)
-                                            ->where(function ($query) use ($searchLower) {
-                                                $query->whereRaw('LOWER(title) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(title_custom) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(name) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(name_custom) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(stream_id) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(stream_id_custom) LIKE ?', ["%{$searchLower}%"]);
-                                            })
-                                            ->limit(50) // Keep a reasonable limit
-                                            ->get();
-
-                                        // Create options array
-                                        $options = [];
-                                        foreach ($channels as $channel) {
-                                            $displayTitle = $channel->title_custom ?: $channel->title;
-                                            $playlistName = $channel->getEffectivePlaylist()->name ?? 'Unknown';
-                                            $options[$channel->id] = "{$displayTitle} [{$playlistName}]";
-                                        }
-
-                                        return $options;
-                                    })
-                                    ->helperText('To use as the master for the selected channel.')
-                                    ->required(),
-                            ];
-                        })
-                        ->action(function (Collection $records, array $data): void {
-                            // Filter out the master channel from the records to be added as failovers
-                            $masterRecordId = $data['master_source'] === 'selected'
-                                ? $data['selected_master_id']
-                                : $data['master_channel_id'];
-                            $failoverRecords = $records->filter(function ($record) use ($masterRecordId) {
-                                return (int)$record->id !== (int)$masterRecordId;
-                            });
-
-                            foreach ($failoverRecords as $record) {
-                                ChannelFailover::updateOrCreate([
-                                    'channel_id' => $masterRecordId,
-                                    'channel_failover_id' => $record->id,
-                                ]);
-                            }
+                    Tables\Actions\BulkAction::make('merge')
+                        ->label('Merge Same ID')
+                        ->action(function (Collection $records): void {
+                            app('Illuminate\Contracts\Bus\Dispatcher')
+                                ->dispatch(new \App\Jobs\MergeChannels($records));
                         })->after(function () {
                             Notification::make()
                                 ->success()
-                                ->title('Channels as failover')
-                                ->body('The selected channels have been added as failovers.')
+                                ->title('Channel merge started')
+                                ->body('Merging channels in the background. You will be notified once the process is complete.')
                                 ->send();
                         })
-                        ->deselectRecordsAfterCompletion()
                         ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-path-rounded-square')
-                        ->modalIcon('heroicon-o-arrow-path-rounded-square')
-                        ->modalDescription('Add the selected channel(s) to the chosen channel as failover sources.')
-                        ->modalSubmitActionLabel('Add failovers now'),
-
+                        ->icon('heroicon-o-arrows-pointing-in')
+                        ->color('primary')
+                        ->modalIcon('heroicon-o-arrows-pointing-in')
+                        ->modalDescription('Merge all selected channels with the same ID into a single channel with failover.')
+                        ->modalSubmitActionLabel('Merge now'),
+                    Tables\Actions\BulkAction::make('unmerge')
+                        ->label('Unmerge Same ID')
+                        ->action(function (Collection $records): void {
+                            app('Illuminate\Contracts\Bus\Dispatcher')
+                                ->dispatch(new \App\Jobs\UnmergeChannels($records));
+                        })->after(function () {
+                            Notification::make()
+                                ->success()
+                                ->title('Channel unmerge started')
+                                ->body('Unmerging channels in the background. You will be notified once the process is complete.')
+                                ->send();
+                        })
+                        ->requiresConfirmation()
+                        ->icon('heroicon-o-arrows-pointing-out')
+                        ->color('warning')
+                        ->modalIcon('heroicon-o-arrows-pointing-out')
+                        ->modalDescription('Unmerge all selected channels with the same ID, removing all failover relationships.')
+                        ->modalSubmitActionLabel('Unmerge now'),
                     Tables\Actions\BulkAction::make('find-replace')
                         ->label('Find & Replace')
                         ->form([

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -33,9 +33,6 @@ class MergeChannels implements ShouldQueue
      */
     public function handle(): void
     {
-        $total = $this->channels->count();
-        $processed = 0;
-
         // Group channels by their effective stream ID
         $groupedChannels = $this->channels->groupBy(function ($channel) {
             return $channel->stream_id_custom ?: $channel->stream_id;
@@ -71,22 +68,10 @@ class MergeChannels implements ShouldQueue
                         ]
                     );
                     $processed++;
-                    $this->updateProgress($processed, $total);
                 }
             }
         }
         $this->sendCompletionNotification();
-    }
-
-    protected function updateProgress($processed, $total)
-    {
-        $progress = round(($processed / $total) * 100);
-        Notification::make()
-            ->title('Merging channels...')
-            ->body("Processed {$processed} of {$total} channels.")
-            ->success()
-            ->progress($progress)
-            ->sendToDatabase($this->user);
     }
 
     protected function sendCompletionNotification()

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -38,6 +38,7 @@ class MergeChannels implements ShouldQueue
             return $channel->stream_id_custom ?: $channel->stream_id;
         });
 
+        $processed = 0;
         foreach ($groupedChannels as $group) {
             if ($group->count() > 1) {
                 // Designate the first channel as the master
@@ -71,14 +72,16 @@ class MergeChannels implements ShouldQueue
                 }
             }
         }
-        $this->sendCompletionNotification();
+        $this->sendCompletionNotification($processed);
     }
 
-    protected function sendCompletionNotification()
+    protected function sendCompletionNotification($processed)
     {
+        $body = $processed > 0 ? "Merged {$processed} channels successfully." : 'No channels were merged.';
+
         Notification::make()
             ->title('Merge complete')
-            ->body('All channels have been merged successfully.')
+            ->body($body)
             ->success()
             ->sendToDatabase($this->user);
     }

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -35,7 +35,8 @@ class MergeChannels implements ShouldQueue
     {
         $processed = 0;
         $groupedChannels = $this->channels->groupBy(function ($channel) {
-            return $channel->stream_id_custom ?: $channel->stream_id;
+            $streamId = $channel->stream_id_custom ?: $channel->stream_id;
+            return strtolower($streamId);
         });
 
         foreach ($groupedChannels as $group) {

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -40,10 +40,15 @@ class MergeChannels implements ShouldQueue
 
                 // The rest are failovers
                 foreach ($group as $failover) {
-                    ChannelFailover::updateOrCreate([
-                        'channel_id' => $master->id,
-                        'channel_failover_id' => $failover->id,
-                    ]);
+                    ChannelFailover::updateOrCreate(
+                        [
+                            'channel_id' => $master->id,
+                            'channel_failover_id' => $failover->id,
+                        ],
+                        [
+                            'user_id' => $master->user_id,
+                        ]
+                    );
                 }
             }
         }

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
+use Filament\Notifications\Notification;
 
 class MergeChannels implements ShouldQueue
 {

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -35,8 +35,13 @@ class MergeChannels implements ShouldQueue
     {
         $processed = 0;
         if ($this->channels->count() > 1) {
-            // Find the channel with the highest resolution
-            $master = $this->channels->reduce(function ($highest, $channel) {
+            $preferredChannels = $this->channels;
+            if ($this->playlistId) {
+                $preferredChannels = $this->channels->where('playlist_id', $this->playlistId);
+            }
+
+            // Find the channel with the highest resolution in the preferred playlist
+            $master = $preferredChannels->reduce(function ($highest, $channel) {
                 if (!$highest) {
                     return $channel;
                 }

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Channel;
+use App\Models\ChannelFailover;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class MergeChannels implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public Collection $channels)
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        // Group channels by their effective stream ID
+        $groupedChannels = $this->channels->groupBy(function ($channel) {
+            return $channel->stream_id_custom ?: $channel->stream_id;
+        });
+
+        foreach ($groupedChannels as $group) {
+            if ($group->count() > 1) {
+                // Designate the first channel as the master
+                $master = $group->shift();
+
+                // The rest are failovers
+                foreach ($group as $failover) {
+                    ChannelFailover::updateOrCreate([
+                        'channel_id' => $master->id,
+                        'channel_failover_id' => $failover->id,
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/app/Jobs/UnmergeChannels.php
+++ b/app/Jobs/UnmergeChannels.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\ChannelFailover;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class UnmergeChannels implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public Collection $channels)
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $channelIds = $this->channels->pluck('id');
+
+        // Delete all failover records where the selected channels are either the master or the failover
+        ChannelFailover::whereIn('channel_id', $channelIds)
+            ->orWhereIn('channel_failover_id', $channelIds)
+            ->delete();
+    }
+}

--- a/app/Jobs/UnmergeChannels.php
+++ b/app/Jobs/UnmergeChannels.php
@@ -35,10 +35,6 @@ class UnmergeChannels implements ShouldQueue
             ->orWhereIn('channel_failover_id', $channelIds)
             ->delete();
 
-        foreach ($this->channels as $channel) {
-            $processed++;
-        }
-
         $this->sendCompletionNotification();
     }
 

--- a/app/Jobs/UnmergeChannels.php
+++ b/app/Jobs/UnmergeChannels.php
@@ -15,12 +15,14 @@ class UnmergeChannels implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    public $user;
+
     /**
      * Create a new job instance.
      */
-    public function __construct(public Collection $channels)
+    public function __construct(public Collection $channels, $user)
     {
-        //
+        $this->user = $user;
     }
 
     /**

--- a/app/Jobs/UnmergeChannels.php
+++ b/app/Jobs/UnmergeChannels.php
@@ -28,9 +28,6 @@ class UnmergeChannels implements ShouldQueue
      */
     public function handle(): void
     {
-        $total = $this->channels->count();
-        $processed = 0;
-
         $channelIds = $this->channels->pluck('id');
 
         // Delete all failover records where the selected channels are either the master or the failover
@@ -40,21 +37,9 @@ class UnmergeChannels implements ShouldQueue
 
         foreach ($this->channels as $channel) {
             $processed++;
-            $this->updateProgress($processed, $total);
         }
 
         $this->sendCompletionNotification();
-    }
-
-    protected function updateProgress($processed, $total)
-    {
-        $progress = round(($processed / $total) * 100);
-        Notification::make()
-            ->title('Unmerging channels...')
-            ->body("Processed {$processed} of {$total} channels.")
-            ->success()
-            ->progress($progress)
-            ->sendToDatabase($this->user);
     }
 
     protected function sendCompletionNotification()

--- a/app/Jobs/UnmergeChannels.php
+++ b/app/Jobs/UnmergeChannels.php
@@ -27,11 +27,41 @@ class UnmergeChannels implements ShouldQueue
      */
     public function handle(): void
     {
+        $total = $this->channels->count();
+        $processed = 0;
+
         $channelIds = $this->channels->pluck('id');
 
         // Delete all failover records where the selected channels are either the master or the failover
         ChannelFailover::whereIn('channel_id', $channelIds)
             ->orWhereIn('channel_failover_id', $channelIds)
             ->delete();
+
+        foreach ($this->channels as $channel) {
+            $processed++;
+            $this->updateProgress($processed, $total);
+        }
+
+        $this->sendCompletionNotification();
+    }
+
+    protected function updateProgress($processed, $total)
+    {
+        $progress = round(($processed / $total) * 100);
+        Notification::make()
+            ->title('Unmerging channels...')
+            ->body("Processed {$processed} of {$total} channels.")
+            ->success()
+            ->progress($progress)
+            ->sendToDatabase($this->user);
+    }
+
+    protected function sendCompletionNotification()
+    {
+        Notification::make()
+            ->title('Unmerge complete')
+            ->body('All channels have been unmerged successfully.')
+            ->success()
+            ->sendToDatabase($this->user);
     }
 }

--- a/app/Jobs/UnmergeChannels.php
+++ b/app/Jobs/UnmergeChannels.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Collection;
+use Filament\Notifications\Notification;
 
 class UnmergeChannels implements ShouldQueue
 {

--- a/app/Models/ChannelFailover.php
+++ b/app/Models/ChannelFailover.php
@@ -15,6 +15,13 @@ class ChannelFailover extends Model
      *
      * @var array
      */
+    protected $fillable = [
+        'user_id',
+        'channel_id',
+        'channel_failover_id',
+        'metadata',
+    ];
+
     protected $casts = [
         'id' => 'integer',
         'user_id' => 'integer',


### PR DESCRIPTION
feat: Add merge and unmerge actions for channels
This commit introduces two new bulk actions for channels:

- **Merge Same ID:** This action merges all selected channels with the same `stream_id` into a single channel with failover. The first channel in the selection becomes the master, and the rest are added as failovers.
- **Unmerge Same ID:** This action removes all failover relationships for the selected channels.

These actions are handled by two new jobs, `MergeChannels` and `UnmergeChannels`, which run in the background to avoid timeouts and improve your experience.