### PR TITLE
Custom playlist - View channels within groups from the group page

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+

--- a/app/Filament/Resources/ChannelResource.php
+++ b/app/Filament/Resources/ChannelResource.php
@@ -98,7 +98,8 @@ class ChannelResource extends Resource
             ->columns(self::getTableColumns(showGroup: !$relationId, showPlaylist: !$relationId))
             ->filters(self::getTableFilters(showPlaylist: !$relationId))
             ->actions(self::getTableActions(), position: Tables\Enums\ActionsPosition::BeforeCells)
-            ->bulkActions(self::getTableBulkActions());
+            ->bulkActions(self::getTableBulkActions())
+            ->reorderable('sort'); // Enable drag-and-drop sorting
     }
 
     public static function getTableColumns($showGroup = true, $showPlaylist = true): array
@@ -133,14 +134,9 @@ class ChannelResource extends Resource
                 })
                 ->extraAttributes(['style' => 'min-width: 350px;'])
                 ->toggleable(),
-            Tables\Columns\TextInputColumn::make('sort')
+            Tables\Columns\TextColumn::make('sort')
                 ->label('Sort Order')
-                ->rules(['min:0'])
-                ->type('number')
-                ->placeholder('Sort Order')
                 ->sortable()
-                ->tooltip(fn($record) => !$record->is_custom && $record->playlist?->auto_sort ? 'Playlist auto-sort enabled; disable to change' : 'Channel sort order')
-                ->disabled(fn($record) => !$record->is_custom && $record->playlist?->auto_sort)
                 ->toggleable(),
             Tables\Columns\TextColumn::make('failovers_count')
                 ->label('Failovers')
@@ -747,7 +743,7 @@ class ChannelResource extends Resource
     public static function getRelations(): array
     {
         return [
-            // 
+            //
         ];
     }
 
@@ -1140,9 +1136,9 @@ class ChannelResource extends Resource
 
     /**
      * Create a custom channel with the provided data.
-     * 
+     *
      * This method is used to create a channel with custom data, typically for a Custom Playlist.
-     * 
+     *
      * @param array $data The data for the channel.
      * @param string $model The model class to use for creating the channel.
      * @return Model The created channel model.

--- a/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylistResource/RelationManagers/ChannelsRelationManager.php
@@ -119,6 +119,7 @@ class ChannelsRelationManager extends RelationManager
             ->persistFiltersInSession()
             ->persistSortInSession()
             ->recordTitleAttribute('title')
+            ->reorderable('sort') // Enable drag-and-drop sorting by 'sort' column
             ->filtersTriggerAction(function ($action) {
                 return $action->button()->label('Filters');
             })

--- a/app/Filament/Resources/GroupResource/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/GroupResource/RelationManagers/ChannelsRelationManager.php
@@ -27,7 +27,7 @@ class ChannelsRelationManager extends RelationManager
     {
         return false;
     }
-    
+
     public function form(Form $form): Form
     {
         return $form

--- a/app/Http/Controllers/ChannelOrderController.php
+++ b/app/Http/Controllers/ChannelOrderController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Channel;
+
+class ChannelOrderController extends Controller
+{
+    public function reorder(Request $request)
+    {
+        $channelIds = $request->input('ids', []);
+        if (empty($channelIds) || !is_array($channelIds)) {
+            if ($request->expectsJson()) {
+                return response()->json(['success' => false, 'message' => 'No channels provided for sorting.'], 422);
+            }
+            return back()->with('error', 'No channels provided for sorting.');
+        }
+
+        foreach ($channelIds as $index => $id) {
+            Channel::where('id', $id)->update(['sort' => $index]);
+        }
+
+        if ($request->expectsJson()) {
+            return response()->json(['success' => true, 'message' => 'Channels order updated.']);
+        }
+        return back()->with('success', 'Channels order updated.');
+    }
+}
+

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -104,7 +104,7 @@ class Channel extends Model
 
     /**
      * Check if the channel has metadata.
-     * 
+     *
      * @return bool
      */
     public function getHasMetadataAttribute(): bool

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Spatie\Tags\Tag as SpatieTag;
+
+class Tag extends SpatieTag
+{
+    /**
+     * Get all channels associated with this tag (group).
+     */
+    public function channels(): BelongsToMany
+    {
+        return $this->morphedByMany(Channel::class, 'taggable', 'taggables');
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "m3u-proxy-editor",
+    "name": "m3u-editor",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
@@ -8,6 +8,7 @@
                 "easyqrcodejs": "^4.6.2",
                 "hls.js": "^1.6.7",
                 "mpegts.js": "^1.8.0",
+                "sortablejs": "^1.15.6",
                 "video.js": "^8.23.3"
             },
             "devDependencies": {
@@ -2974,6 +2975,11 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/sortablejs": {
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
+            "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A=="
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5577,6 +5583,11 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true
+        },
+        "sortablejs": {
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
+            "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A=="
         },
         "source-map-js": {
             "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "easyqrcodejs": "^4.6.2",
         "hls.js": "^1.6.7",
         "mpegts.js": "^1.8.0",
+        "sortablejs": "^1.15.6",
         "video.js": "^8.23.3"
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -30,3 +30,44 @@ document.addEventListener('error', event => {
         }
     }
 }, true);
+
+// Import SortableJS
+import Sortable from 'sortablejs';
+
+// Initialize SortableJS for channel reordering
+function initChannelSortable() {
+    const tbody = document.getElementById('channels-tbody');
+    console.log('Initializing channel sortable...', tbody);
+    if (tbody && !tbody.dataset.sortableInitialized) {
+        new Sortable(tbody, {
+            handle: '.cursor-move',
+            animation: 150,
+            onEnd: function () {
+                const rows = Array.from(tbody.querySelectorAll('tr'));
+                const ids = rows.map(row => row.getAttribute('data-id'));
+                fetch(window.channelReorderUrl || '/channels/reorder', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                    },
+                    body: JSON.stringify({ ids })
+                }).then(response => {
+                    if (response.ok) {
+                        // Update the sort order column in the DOM
+                        rows.forEach((row, idx) => {
+                            // Find the correct cell for sort order (last cell)
+                            const sortCell = row.querySelectorAll('td')[row.querySelectorAll('td').length - 1];
+                            if (sortCell) {
+                                sortCell.textContent = (idx + 1).toString();
+                            }
+                        });
+                    }
+                });
+            }
+        });
+        tbody.dataset.sortableInitialized = '1';
+    }
+}
+
+window.initChannelSortable = initChannelSortable;

--- a/resources/views/filament/custom-playlist/group-channels-list.blade.php
+++ b/resources/views/filament/custom-playlist/group-channels-list.blade.php
@@ -1,0 +1,99 @@
+<div class="p-4" x-data="{
+    channels: @js($channels->map(fn($c) => [
+        'id' => $c->id,
+        'title' => $c->title,
+        'title_custom' => $c->title_custom,
+        'stream_id' => $c->stream_id,
+        'stream_id_custom' => $c->stream_id_custom,
+        'enabled' => $c->enabled,
+        'sort' => $c->sort,
+    ])),
+    message: '',
+    messageType: '',
+    sortAZ() {
+        this.channels.sort((a, b) => {
+            const tA = (a.title_custom || a.title || '').toLowerCase();
+            const tB = (b.title_custom || b.title || '').toLowerCase();
+            return tA.localeCompare(tB);
+        });
+        this.persistSortOrder();
+        var channels = [...this.channels]; // Force Alpine to update the DOM
+        this.channels = [];
+        this.$nextTick(() => this.channels = channels); // Re-assign to trigger reactivity
+    },
+    persistSortOrder() {
+        fetch('{{ route('channels.reorder') }}', {
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({ ids: this.channels.map(c => c.id) }),
+        })
+        .then(response => response.json())
+        .then(data => {
+            this.message = data.message;
+            this.messageType = data.success ? 'success' : 'error';
+        })
+        .catch(() => {
+            this.message = 'An error occurred while saving the order.';
+            this.messageType = 'error';
+        });
+    }
+}" x-init="initChannelSortable()">
+    <div class="flex justify-end mb-2">
+        <template x-if="message">
+            <div :class="messageType === 'success' ? 'mr-4 text-green-600 dark:text-green-400' : 'mr-4 text-red-600 dark:text-red-400'" class="text-xs font-semibold flex items-center">
+                <x-heroicon-o-check-circle class="w-4 h-4 mr-1" x-show="messageType === 'success'" />
+                <x-heroicon-o-x-circle class="w-4 h-4 mr-1" x-show="messageType === 'error'" />
+                <span x-text="message"></span>
+            </div>
+        </template>
+        <button
+            type="button"
+            class="inline-flex items-center px-3 py-1.5 bg-blue-600 text-white text-xs font-semibold rounded hover:bg-blue-700 transition"
+            x-on:click="sortAZ()"
+        >
+            Sort A-Z
+            <x-heroicon-o-arrow-up class="ml-1 w-4 h-4" />
+        </button>
+    </div>
+    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+        <thead>
+            <tr>
+                <th class="w-8"></th> <!-- Drag handle column -->
+                @php
+                    $currentSort = request('sort', 'title');
+                    $currentDirection = request('direction', 'asc');
+                @endphp
+                <th class="px-2 py-1 text-left text-xs font-medium text-gray-500 dark:text-gray-300">
+                    <a href="#" class="hover:underline">Title</a>
+                </th>
+                <th class="px-2 py-1 text-left text-xs font-medium text-gray-500 dark:text-gray-300">Stream ID</th>
+                <th class="px-2 py-1 text-left text-xs font-medium text-gray-500 dark:text-gray-300">Status</th>
+                <th class="px-2 py-1 text-left text-xs font-medium text-gray-500 dark:text-gray-300">Sort Order</th>
+            </tr>
+        </thead>
+        <tbody id="channels-tbody" class="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+            <template x-for="channel in channels" :key="channel.id">
+                <tr :data-id="channel.id">
+                    <td class="cursor-move text-gray-400 dark:text-gray-500">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" /></svg>
+                    </td>
+                    <td class="px-2 py-1 text-sm text-gray-900 dark:text-gray-100" x-text="channel.title_custom || channel.title"></td>
+                    <td class="px-2 py-1 text-sm text-gray-900 dark:text-gray-100" x-text="channel.stream_id_custom || channel.stream_id"></td>
+                    <td class="px-2 py-1 text-sm">
+                        <template x-if="channel.enabled">
+                            <span class="text-green-600 dark:text-green-400">Enabled</span>
+                        </template>
+                        <template x-if="!channel.enabled">
+                            <span class="text-red-600 dark:text-red-400">Disabled</span>
+                        </template>
+                    </td>
+                    <td class="px-2 py-1 text-sm text-gray-900 dark:text-gray-100" x-text="channel.sort"></td>
+                </tr>
+            </template>
+        </tbody>
+    </table>
+</div>

--- a/resources/views/filament/custom-playlist/no-channels.blade.php
+++ b/resources/views/filament/custom-playlist/no-channels.blade.php
@@ -1,0 +1,4 @@
+<div class="p-4 text-center text-gray-500 dark:text-gray-400">
+    No channels in this group.
+</div>
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ChannelOrderController;
 use App\Http\Controllers\EpgFileController;
 use App\Http\Controllers\EpgGenerateController;
 use App\Http\Controllers\PlaylistGenerateController;
@@ -7,6 +8,7 @@ use App\Http\Controllers\XtreamApiController;
 use AshAllenDesign\ShortURL\Controllers\ShortURLController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\GroupChannelSortController;
 
 // Handle short URLs with optional path forwarding (e.g. /s/{key}/device.xml)
 Route::get('/s/{shortUrlKey}/{path?}', function (Request $request, string $shortUrlKey, string $path = null) {
@@ -173,3 +175,6 @@ Route::get('/series/{username}/{password}/{streamId}.{format}', [App\Http\Contro
 // Timeshift endpoints
 Route::get('/timeshift/{username}/{password}/{duration}/{date}/{streamId}.{format}', [App\Http\Controllers\XtreamStreamController::class, 'handleTimeshift'])
     ->name('xtream.stream.timeshift.root');
+
+// Channel reordering
+Route::post('/channels/reorder', [ChannelOrderController::class, 'reorder'])->name('channels.reorder');


### PR DESCRIPTION
Sort channels within groups by drag/drop and alphabetically

This will add a "view" icon to the group page within a custom playlist. The view icon pops up a modal in which the channels can be sorted, either by dragging or by a button: alphabetically. 

In the end, it would be nice to not use the "sort" column of the channel, but create a pivot table so you can sort the same channels differently within multiple groups. But I don't know exactly how the whole export to m3u works, so didn't touch that. 

Disclaimer: I had help from Copilot since I'm not familiar with Lavarel framework:) So, if I coded any anti patterns, I'm sorry, please let me know. 