### PR TITLE
Auto match

### DIFF
--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -886,6 +886,34 @@ class PlaylistResource extends Resource
                                 ->helperText('When enabled, a backup will be created before syncing.')
                                 ->inline(false)
                                 ->default(false),
+                            Toggle::make('auto_merge_channels_enabled')
+                                ->label('Auto-merge channels after sync')
+                                ->helperText('When enabled, channels with the same stream ID will be automatically merged with failover relationships after each sync.')
+                                ->live()
+                                ->inline(false)
+                                ->default(false),
+                            Toggle::make('auto_merge_deactivate_failover')
+                                ->label('Deactivate failover channels')
+                                ->helperText('When enabled, all failover channels will be automatically deactivated during the merge process, keeping only the master channel active.')
+                                ->inline(false)
+                                ->default(false)
+                                ->hidden(fn(Get $get): bool => !$get('auto_merge_channels_enabled')),
+                        ]),
+
+                    Fieldset::make('Auto-Merge Advanced Settings')
+                        ->columnSpanFull()
+                        ->hidden(fn(Get $get): bool => !$get('auto_merge_channels_enabled'))
+                        ->schema([
+                            Toggle::make('auto_merge_config.check_resolution')
+                                ->label('Prioritize by resolution')
+                                ->helperText('When enabled, channels with higher resolution will be prioritized as master channels during merge. This process takes longer as stream resolution needs to be analyzed.')
+                                ->inline(false)
+                                ->default(false),
+                            Toggle::make('auto_merge_config.force_complete_remerge')
+                                ->label('Force complete re-merge')
+                                ->helperText('When enabled, all channels will be re-evaluated during merge, including existing failover relationships. Disable this for better performance if you only want to merge new channels.')
+                                ->inline(false)
+                                ->default(false),
                         ]),
 
                     TextInput::make('sync_interval')

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -904,16 +904,12 @@ class PlaylistResource extends Resource
                         ->columnSpanFull()
                         ->hidden(fn(Get $get): bool => !$get('auto_merge_channels_enabled'))
                         ->schema([
-                            Toggle::make('auto_merge_config.check_resolution')
+                            static::makeToggle('auto_merge_config.check_resolution')
                                 ->label('Prioritize by resolution')
-                                ->helperText('When enabled, channels with higher resolution will be prioritized as master channels during merge. This process takes longer as stream resolution needs to be analyzed.')
-                                ->inline(false)
-                                ->default(false),
-                            Toggle::make('auto_merge_config.force_complete_remerge')
+                                ->helperText('When enabled, channels with higher resolution will be prioritized as master channels during merge. This process takes longer as stream resolution needs to be analyzed.'),
+                            static::makeToggle('auto_merge_config.force_complete_remerge')
                                 ->label('Force complete re-merge')
-                                ->helperText('When enabled, all channels will be re-evaluated during merge, including existing failover relationships. Disable this for better performance if you only want to merge new channels.')
-                                ->inline(false)
-                                ->default(false),
+                                ->helperText('When enabled, all channels will be re-evaluated during merge, including existing failover relationships. Disable this for better performance if you only want to merge new channels.'),
                         ]),
 
                     TextInput::make('sync_interval')
@@ -1424,5 +1420,15 @@ class PlaylistResource extends Resource
             }
         }
         return $wizard;
+    }
+
+    /**
+     * Create a toggle with consistent default configuration.
+     */
+    private static function makeToggle(string $name): Toggle
+    {
+        return Toggle::make($name)
+            ->inline(false)
+            ->default(false);
     }
 }

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -60,13 +60,15 @@ class MergeChannels implements ShouldQueue
 
         // Get all channels with stream IDs in a single efficient query
         // Exclude channels that are already configured as failovers (unless we're re-merging everything)
+        $shouldExcludeExistingFailovers = !empty($existingFailoverChannelIds) && !$this->forceCompleteRemerge;
+        
         $allChannels = Channel::where('user_id', $this->user->id)
             ->whereIn('playlist_id', $playlistIds)
             ->where(function ($query) {
                 $query->where('stream_id_custom', '!=', '')
                     ->orWhere('stream_id', '!=', '');
             })
-            ->when(!empty($existingFailoverChannelIds) && !$this->forceCompleteRemerge, function ($query) use ($existingFailoverChannelIds) {
+            ->when($shouldExcludeExistingFailovers, function ($query) use ($existingFailoverChannelIds) {
                 // Only exclude existing failovers if we're not forcing a complete re-merge
                 $query->whereNotIn('id', $existingFailoverChannelIds);
             })

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -24,6 +24,8 @@ class MergeChannels implements ShouldQueue
         public Collection $playlists,
         public int $playlistId,
         public bool $checkResolution = false,
+        public bool $deactivateFailoverChannels = false,
+        public bool $forceCompleteRemerge = false,
     ) {}
 
     /**
@@ -32,6 +34,7 @@ class MergeChannels implements ShouldQueue
     public function handle(): void
     {
         $processed = 0;
+        $deactivatedCount = 0;
 
         // Build unified playlist IDs array and create priority lookup
         $playlistIds = $this->playlists->map(function ($item) {
@@ -47,13 +50,27 @@ class MergeChannels implements ShouldQueue
         // Create playlist priority lookup for efficient sorting
         $playlistPriority = $playlistIds ? array_flip($playlistIds) : [];
 
+        // Get existing failover channel IDs to exclude them from being masters
+        $existingFailoverChannelIds = ChannelFailover::where('user_id', $this->user->id)
+            ->whereHas('channelFailover', function ($query) use ($playlistIds) {
+                $query->whereIn('playlist_id', $playlistIds);
+            })
+            ->pluck('channel_failover_id')
+            ->toArray();
+
         // Get all channels with stream IDs in a single efficient query
+        // Exclude channels that are already configured as failovers (unless we're re-merging everything)
         $allChannels = Channel::where('user_id', $this->user->id)
             ->whereIn('playlist_id', $playlistIds)
             ->where(function ($query) {
                 $query->where('stream_id_custom', '!=', '')
                     ->orWhere('stream_id', '!=', '');
-            })->cursor();
+            })
+            ->when(!empty($existingFailoverChannelIds) && !$this->forceCompleteRemerge, function ($query) use ($existingFailoverChannelIds) {
+                // Only exclude existing failovers if we're not forcing a complete re-merge
+                $query->whereNotIn('id', $existingFailoverChannelIds);
+            })
+            ->cursor();
 
         // Group channels by stream ID using LazyCollection
         $groupedChannels = $allChannels->groupBy(function ($channel) {
@@ -90,11 +107,18 @@ class MergeChannels implements ShouldQueue
                     ],
                     ['user_id' => $this->user->id]
                 );
+                
+                // Deactivate failover channel if requested
+                if ($this->deactivateFailoverChannels && $failover->enabled) {
+                    $failover->update(['enabled' => false]);
+                    $deactivatedCount++;
+                }
+                
                 $processed++;
             }
         }
 
-        $this->sendCompletionNotification($processed);
+        $this->sendCompletionNotification($processed, $deactivatedCount);
     }
 
     /**
@@ -144,12 +168,19 @@ class MergeChannels implements ShouldQueue
         return 0;
     }
 
-    protected function sendCompletionNotification($processed)
+    protected function sendCompletionNotification($processed, $deactivatedCount = 0)
     {
-        $body = $processed > 0 ? "Merged {$processed} channels successfully." : 'No channels were merged.';
+        if ($processed > 0) {
+            $body = "Merged {$processed} channels successfully.";
+            if ($deactivatedCount > 0) {
+                $body .= " {$deactivatedCount} failover channels were deactivated.";
+            }
+        } else {
+            $body = 'No channels were merged.';
+        }
 
         Notification::make()
-            ->title('Merge complete')
+            ->title('Channel merge complete')
             ->body($body)
             ->success()
             ->broadcast($this->user)

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -47,6 +47,9 @@ class Playlist extends Model
         'sync_logs_enabled' => 'boolean',
         'include_series_in_m3u' => 'boolean',
         'auto_fetch_series_metadata' => 'boolean',
+        'auto_merge_channels_enabled' => 'boolean',
+        'auto_merge_deactivate_failover' => 'boolean',
+        'auto_merge_config' => 'array',
         'status' => Status::class,
         'id_channel_by' => PlaylistChannelId::class
     ];

--- a/database/migrations/2025_09_30_094734_add_auto_merge_settings_to_playlists.php
+++ b/database/migrations/2025_09_30_094734_add_auto_merge_settings_to_playlists.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->boolean('auto_merge_channels_enabled')->default(false)->after('auto_sync');
+            $table->boolean('auto_merge_deactivate_failover')->default(false)->after('auto_merge_channels_enabled');
+            $table->json('auto_merge_config')->nullable()->after('auto_merge_deactivate_failover');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->dropColumn(['auto_merge_channels_enabled', 'auto_merge_deactivate_failover', 'auto_merge_config']);
+        });
+    }
+};

--- a/docs/auto-merge-channels.md
+++ b/docs/auto-merge-channels.md
@@ -1,0 +1,223 @@
+# Auto-Merge Channels Functionality
+
+## Overview
+
+The Auto-Merge Channels functionality automatically merges channels with the same stream ID into a single master channel with failover relationships after each playlist sync. This feature helps streamline playlist management and improves streaming reliability.
+
+## Features
+
+### Core Functionality
+- **Automatic Channel Merging**: Channels with identical stream IDs are automatically merged
+- **Failover Channel Deactivation**: Option to automatically disable failover channels 
+- **Smart Optimization**: Excludes already processed channels for better performance
+- **Resolution-Based Prioritization**: Option to prioritize channels based on stream resolution
+- **Complete Re-merge**: Force full reprocessing of all channels when needed
+
+### Configuration Options
+
+#### Playlist Settings
+- **Auto-merge channels after sync**: Enable/disable the auto-merge functionality
+- **Deactivate failover channels**: Automatically disable channels used as failovers
+- **Prioritize by resolution**: Use stream resolution to determine master channel priority
+- **Force complete re-merge**: Reprocess all channels instead of just new ones
+
+## How It Works
+
+### 1. Trigger Mechanism
+The auto-merge process is triggered automatically when:
+- A playlist sync completes successfully (`SyncCompleted` event)
+- The playlist has `auto_merge_channels_enabled = true`
+- The playlist sync status is `Status::Completed`
+
+### 2. Channel Selection Logic
+The system identifies channels for merging by:
+- Grouping channels by their stream ID (either `stream_id_custom` or `stream_id`)
+- Excluding channels that are already configured as failovers (unless force re-merge is enabled)
+- Processing only channels within the specified playlists
+
+### 3. Master Channel Selection
+Priority rules for selecting the master channel:
+1. **With Resolution Check**: Channel with highest resolution from preferred playlist, then highest resolution overall
+2. **Without Resolution Check**: Channel from preferred playlist with earliest order, then earliest playlist order overall
+
+### 4. Failover Management
+- Remaining channels become failovers for the master channel
+- Failovers are sorted by resolution (descending) or playlist priority
+- If deactivation is enabled, failover channels are automatically disabled
+- Existing failover relationships are updated or created as needed
+
+## Performance Optimizations
+
+### Smart Channel Filtering
+- Excludes channels already configured as failovers from master selection
+- Reduces processing time for playlists with existing merge relationships
+- Can be overridden with "Force complete re-merge" option
+
+### Efficient Database Queries
+- Uses cursor-based iteration for large channel sets
+- Bulk operations for creating failover relationships
+- Single query to identify existing failover channels
+
+## Configuration
+
+### Database Fields
+New fields added to the `playlists` table:
+- `auto_merge_channels_enabled` (boolean): Enable auto-merge functionality
+- `auto_merge_deactivate_failover` (boolean): Deactivate failover channels
+- `auto_merge_config` (JSON): Advanced configuration options
+
+### Example Configuration
+```php
+$playlist->update([
+    'auto_merge_channels_enabled' => true,
+    'auto_merge_deactivate_failover' => true,
+    'auto_merge_config' => [
+        'check_resolution' => false,
+        'force_complete_remerge' => false
+    ]
+]);
+```
+
+## User Interface
+
+### Playlist Form Fields
+Located in the sync settings section of playlist creation/editing:
+
+1. **Auto-merge channels after sync** toggle
+   - Main enable/disable switch
+   - Helper text explains functionality
+
+2. **Deactivate failover channels** toggle
+   - Visible only when auto-merge is enabled
+   - Controls whether failover channels are disabled
+
+3. **Advanced Settings** (expandable section)
+   - **Prioritize by resolution**: Use stream analysis for master selection
+   - **Force complete re-merge**: Reprocess all channels regardless of existing state
+
+## Testing Locally
+
+### Prerequisites
+1. Laravel application running locally
+2. Database with playlists and channels
+3. Queue worker running (for background job processing)
+
+### Manual Testing Steps
+
+1. **Setup Test Data**
+   ```bash
+   php test_auto_merge.php
+   ```
+
+2. **Verify Settings in UI**
+   - Navigate to Playlists → Edit [Playlist Name]
+   - Check auto-merge settings are visible and functional
+   - Enable the desired options
+
+3. **Test Sync Trigger**
+   - Manually sync the playlist from the UI
+   - Monitor queue workers and logs
+   - Check notifications for merge results
+
+4. **Verify Results**
+   - Check Channels section
+   - Look for master/failover relationships
+   - Verify channel enabled/disabled states
+
+### Expected Results
+- Channels with same stream ID grouped under one master
+- Failover channels disabled if option is enabled
+- Notification showing merge results
+- Proper failover relationships in database
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Auto-merge not triggering**
+   - Verify `auto_merge_channels_enabled` is true
+   - Check playlist sync completed successfully
+   - Ensure queue workers are running
+
+2. **No channels being merged**
+   - Check channels have matching stream IDs
+   - Verify channels are not already in failover relationships
+   - Try enabling "Force complete re-merge"
+
+3. **Performance issues**
+   - Consider disabling resolution checking for large playlists
+   - Ensure database indexes on stream_id columns
+   - Monitor queue worker memory usage
+
+### Debugging
+
+Enable detailed logging by checking:
+- Laravel logs in `storage/logs/`
+- Queue job failures in Horizon dashboard
+- Database changes in `channel_failovers` table
+
+## API Integration
+
+### Job Dispatch
+```php
+use App\Jobs\MergeChannels;
+
+dispatch(new MergeChannels(
+    user: $user,
+    playlists: collect([['playlist_failover_id' => $playlist->id]]),
+    playlistId: $playlist->id,
+    checkResolution: false,
+    deactivateFailoverChannels: true,
+    forceCompleteRemerge: false
+));
+```
+
+### Event Listener
+The auto-merge is triggered via the `SyncListener` which handles `SyncCompleted` events:
+
+```php
+// In app/Listeners/SyncListener.php
+private function handleAutoMergeChannels(\App\Models\Playlist $playlist): void
+{
+    // Configuration and job dispatch logic
+}
+```
+
+## Migration
+
+The database migration adds the required fields:
+
+```bash
+php artisan migrate
+```
+
+This adds:
+- `auto_merge_channels_enabled` boolean field
+- `auto_merge_deactivate_failover` boolean field  
+- `auto_merge_config` JSON field
+
+## Security Considerations
+
+- Auto-merge only processes channels owned by the playlist user
+- All database operations include user_id constraints
+- Job parameters are validated and sanitized
+- Failover relationships maintain proper foreign key constraints
+
+## Performance Impact
+
+### Minimal Impact Scenarios
+- Small playlists (< 1000 channels)
+- Playlists with few duplicate stream IDs
+- Existing merge relationships in place
+
+### Higher Impact Scenarios
+- Large playlists (> 10000 channels) 
+- Resolution checking enabled
+- Force complete re-merge enabled
+- Many channels with duplicate stream IDs
+
+### Mitigation Strategies
+- Process during off-peak hours
+- Use queue workers with appropriate memory limits
+- Enable optimizations (disable force re-merge)
+- Monitor database performance during processing


### PR DESCRIPTION
This pull request introduces a new "Auto-Merge Channels" feature for playlists, allowing channels with the same stream ID to be automatically merged after each sync. The feature is highly configurable, supporting options such as failover channel deactivation, prioritization by stream resolution, and forced complete re-merging. The implementation includes UI updates, backend logic, database migrations, event-driven job dispatching, and comprehensive documentation.

**Key changes:**

**Feature Implementation & Configuration:**
- Added new form fields in the playlist resource (`PlaylistResource.php`) for enabling auto-merge, deactivating failover channels, and advanced settings (resolution prioritization and force re-merge). These settings are conditionally displayed and stored in new database fields.
- Updated the `Playlist` model to cast the new settings fields (`auto_merge_channels_enabled`, `auto_merge_deactivate_failover`, `auto_merge_config`) appropriately.
- Added a migration to create the new columns in the `playlists` table: `auto_merge_channels_enabled`, `auto_merge_deactivate_failover`, and `auto_merge_config`.

**Backend Logic & Automation:**
- Enhanced the `MergeChannels` job to support the new options: deactivating failover channels, forcing complete re-merges, and sending improved notifications showing how many channels were merged and deactivated. [[1]](diffhunk://#diff-f7b699f40d858524ffef06f63fdbefdfd022ebaa33a2a34e24a27cbf212c4412R27-R28) [[2]](diffhunk://#diff-f7b699f40d858524ffef06f63fdbefdfd022ebaa33a2a34e24a27cbf212c4412R37) [[3]](diffhunk://#diff-f7b699f40d858524ffef06f63fdbefdfd022ebaa33a2a34e24a27cbf212c4412R53-R73) [[4]](diffhunk://#diff-f7b699f40d858524ffef06f63fdbefdfd022ebaa33a2a34e24a27cbf212c4412R110-R121) [[5]](diffhunk://#diff-f7b699f40d858524ffef06f63fdbefdfd022ebaa33a2a34e24a27cbf212c4412L147-R183)
- Modified the `SyncListener` to automatically dispatch the merge job with the correct configuration after a successful playlist sync, including error handling and user notifications. [[1]](diffhunk://#diff-34e641560d452abaaf9a5d90140884c1cec4e71bcc7150e035bf172de8c0bca5R10) [[2]](diffhunk://#diff-34e641560d452abaaf9a5d90140884c1cec4e71bcc7150e035bf172de8c0bca5L26-R42) [[3]](diffhunk://#diff-34e641560d452abaaf9a5d90140884c1cec4e71bcc7150e035bf172de8c0bca5R65-R105)

**Documentation:**
- Added a detailed `auto-merge-channels.md` document describing the feature, configuration options, workflow, UI, troubleshooting, and performance considerations.