### PR TITLE
Add options to Channels api

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -75,6 +75,7 @@ class ChannelController extends Controller
                     'name' => $channel->name_custom ?? $channel->name,
                     'logo' => $channel->logo ?? $channel->logo_internal,
                     'url' => $channel->url_custom ?? $channel->url,
+                    'stream_id' => $channel->stream_id_custom ?? $channel->stream_id,
                 ];
             });
 
@@ -157,6 +158,7 @@ class ChannelController extends Controller
             'name' => 'sometimes|string|max:500',
             'logo' => 'sometimes|nullable|string|max:2500',
             'url' => 'sometimes|nullable|url|max:2500',
+            'stream_id' => 'sometimes|string|max:500',
         ]);
 
         // Update the channel fields
@@ -184,6 +186,11 @@ class ChannelController extends Controller
             $updated = true;
         }
 
+        if (array_key_exists('stream_id', $validated)) {
+            $channel->stream_id_custom = $validated['stream_id'];
+            $updated = true;
+        }
+
         // Save if any updates were made
         if ($updated) {
             $channel->save();
@@ -198,6 +205,7 @@ class ChannelController extends Controller
                 'name' => $channel->name_custom ?? $channel->name,
                 'logo' => $channel->logo ?? $channel->logo_internal,
                 'url' => $channel->url_custom ?? $channel->url,
+                'stream_id' => $channel->stream_id_custom ?? $channel->stream_id
             ],
         ]);
     }

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -76,6 +76,7 @@ class ChannelController extends Controller
                     'logo' => $channel->logo ?? $channel->logo_internal,
                     'url' => $channel->url_custom ?? $channel->url,
                     'stream_id' => $channel->stream_id_custom ?? $channel->stream_id,
+                    'enabled'=> $channel->enabled,
                 ];
             });
 
@@ -159,6 +160,7 @@ class ChannelController extends Controller
             'logo' => 'sometimes|nullable|string|max:2500',
             'url' => 'sometimes|nullable|url|max:2500',
             'stream_id' => 'sometimes|string|max:500',
+            'enabled' => 'sometimes|boolean',
         ]);
 
         // Update the channel fields
@@ -191,6 +193,11 @@ class ChannelController extends Controller
             $updated = true;
         }
 
+        if (array_key_exists('enabled', $validated)) {
+            $channel->enabled = $validated['enabled'];
+            $updated = true;
+        }
+
         // Save if any updates were made
         if ($updated) {
             $channel->save();
@@ -205,7 +212,8 @@ class ChannelController extends Controller
                 'name' => $channel->name_custom ?? $channel->name,
                 'logo' => $channel->logo ?? $channel->logo_internal,
                 'url' => $channel->url_custom ?? $channel->url,
-                'stream_id' => $channel->stream_id_custom ?? $channel->stream_id
+                'stream_id' => $channel->stream_id_custom ?? $channel->stream_id,
+                'enabled'=> $channel->enabled,
             ],
         ]);
     }


### PR DESCRIPTION
This change enables the "stream_id" to be modified via the new Channels API, using the same method as already implemented for name/logo/url.

Not a developer, so hopefully this change makes sense.

EDIT:
Additionally added the ability to enable or disable a channel via the same Channels API.