### PR TITLE
Proxy all programme artwork images when proxyEnabled is true

### DIFF
--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -295,7 +295,12 @@ class EpgGenerateController extends Controller
                                 // Program artwork images (NEW)
                                 if (!empty($programme['images'] ?? null) && is_array($programme['images'])) {
                                     foreach ($programme['images'] as $image) {
-                                        $url = htmlspecialchars($image['url'], ENT_XML1);
+                                        $rawUrl = $image['url'] ?? '';
+                                        $proxiedUrl = $proxyEnabled && $rawUrl
+                                            ? LogoProxyController::generateProxyUrl($rawUrl)
+                                            : $rawUrl;
+
+                                        $url = htmlspecialchars($proxiedUrl, ENT_XML1);
                                         $type = htmlspecialchars($image['type'], ENT_XML1);
                                         $width = htmlspecialchars($image['width'], ENT_XML1);
                                         $height = htmlspecialchars($image['height'], ENT_XML1);


### PR DESCRIPTION
This update ensures that all programme artwork images are proxied when proxyEnabled is enabled. Previously, only the main $programme['icon'] URL was proxied, while additional images under $programme['images'] were always returned as direct URLs.

No breaking changes expected.