### PR TITLE
Gitignore DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ config/database
 config/logs
 config/env
 data/
+.DS_Store
 
 # Analysis and summary reports - never commit these
 *_ANALYSIS.md


### PR DESCRIPTION
Convenience for OSX devs, ignore the attributes file OSX sprinkles everywhere.