### PR TITLE
EPG playlist view respects configured sort order

### DIFF
--- a/resources/views/livewire/epg-viewer.blade.php
+++ b/resources/views/livewire/epg-viewer.blade.php
@@ -167,7 +167,7 @@
                                         <span x-show="!isMobile">Channels</span>
                                         <span x-show="isMobile">Ch.</span>
                                     </span>
-                                    <span class="text-xs text-gray-500 dark:text-gray-400 ml-1" x-text="`(${Object.keys(epgData?.channels || {}).length})`"></span>
+                                    <span class="text-xs text-gray-500 dark:text-gray-400 ml-1" x-text="`(${channelOrder.length})`"></span>
                                 </div>
                                 <!-- Search Status Indicator -->
                                 <div x-show="isSearchActive && !isMobile" class="flex items-center space-x-1">
@@ -213,15 +213,15 @@
                     virtualScrollTop: 0,
                     get itemHeight() { return isMobile ? 48 : 60; },
                     get containerHeight() { return isMobile ? 452 : 552; },
-                    get totalChannels() { return Object.keys(epgData?.channels || {}).length; },
+                    get totalChannels() { return channelOrder.length; },
                     get startIndex() { return Math.max(0, Math.floor(this.virtualScrollTop / this.itemHeight) - 5); },
                     get endIndex() { return Math.min(this.totalChannels, this.startIndex + Math.ceil(this.containerHeight / this.itemHeight) + 15); },
                     get visibleChannels() {
                         if (!epgData?.channels) return [];
-                        const channelEntries = Object.entries(epgData.channels);
-                        return channelEntries.slice(this.startIndex, this.endIndex).map(([id, channel], index) => ({
+                        const orderedIds = channelOrder.slice(this.startIndex, this.endIndex);
+                        return orderedIds.map((id, index) => ({
                             id,
-                            channel,
+                            channel: epgData.channels[id],
                             absoluteIndex: this.startIndex + index,
                             top: (this.startIndex + index) * this.itemHeight
                         }));
@@ -306,7 +306,7 @@
                             </div>
 
                             <!-- No Results Message -->
-                            <div x-show="isSearchActive && Object.keys(epgData?.channels || {}).length === 0 && !loadingMore && !loading" :class="isMobile ? 'px-2 py-6' : 'px-4 py-8'" class="text-center">
+                            <div x-show="isSearchActive && channelOrder.length === 0 && !loadingMore && !loading" :class="isMobile ? 'px-2 py-6' : 'px-4 py-8'" class="text-center">
                                 <div class="flex flex-col items-center space-y-2">
                                     <x-heroicon-m-magnifying-glass :class="isMobile ? 'w-6 h-6' : 'w-8 h-8'" class="text-gray-400 dark:text-gray-500" />
                                     <div :class="isMobile ? 'text-xs' : 'text-sm'" class="font-medium text-gray-600 dark:text-gray-400">No channels found</div>


### PR DESCRIPTION
This one needs a quick visual test/review before merge.

The core issue was that the EPG view wasn't actually reflecting the sort order promised elsewhere (defined under the 'Live Channels' tab as below): 

`NOTE: Playlist channel output order is based on: 1 Sort order, 2 Channel no. and 3 Channel title - in that order. You can edit your Playlist output to auto sort as well, which will define the sort order based on the playlist order.`


Original issue: playlist/EPG API responses keyed channels by channel_no, so JSON became an object and JS re-ordered keys numerically, making the guide appear sorted by channel number instead of the documented DB sort order.

Specifically-- 

app/Http/Controllers/Api/EpgApiController.php (lines 343-358) builds $playlistChannelData with the playlist’s sort-aware SQL order, but it stores each channel in an associative array keyed by $channelNo. When the controller later returns 'channels' => $channels (app/Http/Controllers/Api/EpgApiController.php (lines 375-523)), PHP encodes that structure as a JSON object whose keys are integers. JavaScript enumerates integer-like object keys in ascending numeric order, so the UI receives the right payload but iterating over it reorders everything by channelNo, defeating the “sort order, channel number, channel title” promise. This is why the guide appears to respect channel numbers first even though the SQL query is already sorted correctly.

EpgGenerateController still orders its cursor by sort → channel → title (app/Http/Controllers/EpgGenerateController.php (lines 90-108)), so the XML export honors the intended priority; the mismatch only happens in the API response consumed by the guide.


Fix summary: add sequential sort_index metadata when building channel payloads, update the Alpine viewer to keep a channelOrder array sorted by that index, and drive counts/virtual scroll from it so UI rows follow the intended order even with numeric IDs.