### PR TITLE
Update PlaylistGenerateController.php

### DIFF
--- a/app/Http/Controllers/PlaylistGenerateController.php
+++ b/app/Http/Controllers/PlaylistGenerateController.php
@@ -55,9 +55,12 @@ class PlaylistGenerateController extends Controller
         if ($auths->isNotEmpty()) {
             $authenticated = false;
             foreach ($auths as $auth) {
+                $authUsername = is_array($auth) ? $auth['username'] : $auth->username;
+                $authPassword = is_array($auth) ? $auth['password'] : $auth->password;
+
                 if (
-                    $request->get('username') === $auth->username &&
-                    $request->get('password') === $auth->password
+                    $request->get('username') === $authUsername &&
+                    $request->get('password') === $authPassword
                 ) {
                     $authenticated = true;
                     $usedAuth = $auth;
@@ -101,8 +104,8 @@ class PlaylistGenerateController extends Controller
 
                 // Set the auth details
                 if ($usedAuth) {
-                    $username = $usedAuth->username;
-                    $password = $usedAuth->password;
+                    $username = is_array($usedAuth) ? $usedAuth['username'] : $usedAuth->username;
+                    $password = is_array($usedAuth) ? $usedAuth['password'] : $usedAuth->password;
                 } else {
                     $username = $playlist->user->name;
                     $password = $playlist->uuid;
@@ -351,11 +354,15 @@ class PlaylistGenerateController extends Controller
         if ($auths->isNotEmpty()) {
             $authenticated = false;
             foreach ($auths as $auth) {
+                $authUsername = is_array($auth) ? $auth['username'] : $auth->username;
+                $authPassword = is_array($auth) ? $auth['password'] : $auth->password;
+
                 if (
-                    $request->get('username') === $auth->username &&
-                    $request->get('password') === $auth->password
+                    $request->get('username') === $authUsername &&
+                    $request->get('password') === $authPassword
                 ) {
                     $authenticated = true;
+                    $usedAuth = $auth;
                     break;
                 }
             }


### PR DESCRIPTION
## Extended Description

This update resolves a runtime error that occurred during M3U playlist generation and when accessing HDHR endpoints. The error being triggered was:

`Attempt to read property "username" on array`

### Root Cause

Some playlist types — especially `PlaylistAlias` — provide authentication data using `only(['username', 'password'])`, which returns an **array** instead of an Eloquent model. However, the code later attempted to access these fields as object properties, such as:

`$usedAuth->username`  
`$usedAuth->password`

When `$usedAuth` was an array, this resulted in a fatal error.

### What Was Fixed

A unified accessor was implemented to safely handle both arrays and objects. The updated logic checks whether the authentication object is an array and retrieves the values accordingly. This prevents type errors and ensures consistent behaviour across all playlist types.

The authentication validation loops were also updated to follow the same array/object-safe pattern.

### Key Improvements

- Prevents crashes during playlist generation for `PlaylistAlias` items.
- Ensures correct handling of authentication values regardless of whether they originate from arrays or Eloquent models.
- Removes all known occurrences of the `"Attempt to read property on array"` error.
- Improves reliability for M3U generation, HDHR discovery, and HDHR overview endpoints.
- No functional logic was changed—only safer handling of dynamic data structures.

### Result

Playlist generation now works reliably with all playlist sources.   HDHR endpoints load normally.  
Authentication remains consistent across `Playlist`, `MergedPlaylist`, `CustomPlaylist`, and `PlaylistAlias` models.