### PR TITLE
Update XtreamStreamController.php

### DIFF
--- a/app/Http/Controllers/XtreamStreamController.php
+++ b/app/Http/Controllers/XtreamStreamController.php
@@ -197,8 +197,8 @@ class XtreamStreamController extends Controller
         if ($channel instanceof Channel) {
             if ($playlist->enable_proxy) {
                 return app()->call('App\\Http\\Controllers\\Api\\M3uProxyApiController@channel', [
-                    'id' => $streamId,
-                    'playlist' => $playlist,
+                    'id'   => $streamId,
+                    'uuid' => $playlist->uuid,   // ← CAMBIO CLAVE
                 ]);
             } else {
                 return Redirect::to(PlaylistUrlService::getChannelUrl($channel, $playlist));
@@ -218,8 +218,8 @@ class XtreamStreamController extends Controller
         if ($channel instanceof Channel) {
             if ($playlist->enable_proxy) {
                 return app()->call('App\\Http\\Controllers\\Api\\M3uProxyApiController@channel', [
-                    'id' => $streamId,
-                    'playlist' => $playlist,
+                    'id'   => $streamId,
+                    'uuid' => $playlist->uuid,   // ← CAMBIO CLAVE
                 ]);
             } else {
                 return Redirect::to(PlaylistUrlService::getChannelUrl($channel, $playlist));
@@ -239,8 +239,8 @@ class XtreamStreamController extends Controller
         if ($episode instanceof Episode) {
             if ($playlist->enable_proxy) {
                 return app()->call('App\\Http\\Controllers\\Api\\M3uProxyApiController@episode', [
-                    'id' => $streamId,
-                    'playlist' => $playlist,
+                    'id'   => $streamId,
+                    'uuid' => $playlist->uuid,   // ← CAMBIO CLAVE
                 ]);
             } else {
                 return Redirect::to(PlaylistUrlService::getEpisodeUrl($episode, $playlist));
@@ -295,14 +295,13 @@ class XtreamStreamController extends Controller
 
         if ($playlist->enable_proxy) {
             return app()->call('App\\Http\\Controllers\\Api\\M3uProxyApiController@channel', [
-                'id' => $streamId,
-                'playlist' => $playlist,
+                'id'   => $streamId,
+                'uuid' => $playlist->uuid,   // ← CAMBIO CLAVE
             ]);
         } else {
-            // If proxy is not enabled, simply return the timeshift URL
             $streamUrl = PlaylistUrlService::getChannelUrl($channel, $playlist);
             $streamUrl = PlaylistService::generateTimeshiftUrl($request, $streamUrl, $playlist);
             return Redirect::to($streamUrl);
-        }
+}
     }
 }


### PR DESCRIPTION
fix(proxy): ensure PlaylistAlias Xtream config is used when proxy is enabled

Previously, when streaming through the proxy, PlaylistAlias authentication was ignored and the proxy defaulted to using the original playlist's Xtream credentials. This occurred because XtreamStreamController passed a `playlist` parameter that M3uProxyApiController does not accept, and no UUID was provided for playlist resolution.

This fix passes the correct `uuid` of the authenticated playlist (including PlaylistAlias) to the proxy controller, ensuring that the proxy loads and uses the correct Xtream configuration.