### PR TITLE
Fix/series categories not saving

### DIFF
--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -1310,7 +1310,7 @@ class PlaylistResource extends Resource
                                 ->dehydrateStateUsing(function ($state, $record) {
                                     // Convert IDs back to names for storage
                                     if (is_array($state) && !empty($state)) {
-                                        return Category::where('playlist_id', $record?->id)
+                                        return SourceCategory::where('playlist_id', $record?->id)
                                             ->whereIn('id', $state)
                                             ->pluck('name')
                                             ->unique()

--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -853,7 +853,8 @@ class ProcessM3uImport implements ShouldQueue
         string         $batchNo,
         int            $userId,
         Carbon         $start,
-        ?Collection    $seriesCategories = null
+        ?Collection    $seriesCategories = null,
+        bool           $importSeries = false
     ) {
         // Get the playlist ID
         $playlistId = $playlist->id;

--- a/app/Jobs/ProcessM3uImportSeriesComplete.php
+++ b/app/Jobs/ProcessM3uImportSeriesComplete.php
@@ -35,6 +35,7 @@ class ProcessM3uImportSeriesComplete implements ShouldQueue
             'processing' => false,
             'status' => Status::Completed,
             'errors' => null,
+            'progress' => 100,
             'series_progress' => 100,
         ]);
         $message = "Series sync completed successfully for playlist \"{$this->playlist->name}\".";


### PR DESCRIPTION
This pull request introduces a few targeted improvements to playlist category handling and import job processing. The changes focus on correctly mapping category sources, improving import job tracking, and updating status reporting.

**Category Source Handling:**

* Updated the category mapping in the playlist form dehydration logic to use `SourceCategory` instead of `Category`, ensuring that category names are sourced from the correct model during form processing.

**Import Job Processing Enhancements:**

* Added an `importSeries` boolean parameter to the `processChannelCollection` method in `ProcessM3uImport.php`, providing more control over series import behavior during batch processing.
* Set the `progress` field to `100` in the completion handler of `ProcessM3uImportSeriesComplete.php`, ensuring that playlist import status reflects full completion when series sync is done.