### PR TITLE
feat: Add separate VOD sync progress tracking and chunked processing

### DIFF
--- a/app/Console/Commands/ResetSyncProcess.php
+++ b/app/Console/Commands/ResetSyncProcess.php
@@ -59,6 +59,7 @@ class ResetSyncProcess extends Command
                     'errors' => null,
                     'progress' => 0,
                     'series_progress' => 0,
+                    'vod_progress' => 0,
                 ]);
             }
 

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -207,6 +207,11 @@ class PlaylistResource extends Resource
                     ->sortable()
                     ->poll(fn($record) => $record->status === Status::Processing || $record->status === Status::Pending ? '3s' : null)
                     ->toggleable(),
+                ProgressColumn::make('vod_progress')
+                    ->label('VOD Sync')
+                    ->sortable()
+                    ->poll(fn($record) => $record->vod_progress < 100 ? '3s' : null)
+                    ->toggleable(),
                 ToggleColumn::make('enable_proxy')
                     ->label('Proxy')
                     ->toggleable()
@@ -324,7 +329,8 @@ class PlaylistResource extends Resource
                         ->action(function ($record) {
                             $record->update([
                                 'status' => Status::Processing,
-                                'progress' => 0,
+                                'processing' => true,
+                                'vod_progress' => 0,
                             ]);
                             app('Illuminate\Contracts\Bus\Dispatcher')
                                 ->dispatch(new ProcessVodChannels(playlist: $record));
@@ -540,6 +546,7 @@ class PlaylistResource extends Resource
                                 'processing' => false,
                                 'progress' => 0,
                                 'series_progress' => 0,
+                                'vod_progress' => 0,
                                 'channels' => 0,
                                 'synced' => null,
                                 'errors' => null,
@@ -614,6 +621,7 @@ class PlaylistResource extends Resource
                                     'processing' => false,
                                     'progress' => 0,
                                     'series_progress' => 0,
+                                    'vod_progress' => 0,
                                     'channels' => 0,
                                     'synced' => null,
                                     'errors' => null,
@@ -717,7 +725,8 @@ class PlaylistResource extends Resource
                     ->action(function ($record) {
                         $record->update([
                             'status' => Status::Processing,
-                            'progress' => 0,
+                            'processing' => true,
+                            'vod_progress' => 0,
                         ]);
                         app('Illuminate\Contracts\Bus\Dispatcher')
                             ->dispatch(new ProcessVodChannels(playlist: $record));
@@ -819,6 +828,7 @@ class PlaylistResource extends Resource
                             'processing' => false,
                             'progress' => 0,
                             'series_progress' => 0,
+                            'vod_progress' => 0,
                             'channels' => 0,
                             'synced' => null,
                             'errors' => null,

--- a/app/Filament/Resources/Playlists/Widgets/ImportProgress.php
+++ b/app/Filament/Resources/Playlists/Widgets/ImportProgress.php
@@ -30,6 +30,7 @@ class ImportProgress extends Widget
             'processing' => $isProcessing,
             'progress' => round($record->progress ?? 100, 2), // default to complete if no record
             'seriesProgress' => round($record->series_progress ?? 100, 2), // default to complete if no record
+            'vodProgress' => round($record->vod_progress ?? 100, 2), // default to complete if no record
         ];
     }
 }

--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -132,6 +132,7 @@ class ProcessM3uImport implements ShouldQueue
             'errors' => null,
             'progress' => 0,
             'series_progress' => 0,
+            'vod_progress' => 0,
         ]);
 
         // Determine if using Xtream API or M3U+

--- a/app/Jobs/ProcessM3uImportVod.php
+++ b/app/Jobs/ProcessM3uImportVod.php
@@ -33,7 +33,7 @@ class ProcessM3uImportVod implements ShouldQueue
             dispatch(new ProcessVodChannels(
                 playlist: $playlist,
                 updateProgress: false // Don't update playlist progress
-            ));
+            ))->onConnection('redis')->onQueue('import');
         }
 
         // Sync stream files, if enabled
@@ -41,7 +41,7 @@ class ProcessM3uImportVod implements ShouldQueue
             // Process stream file syncing
             dispatch(new SyncVodStrmFiles(
                 playlist: $playlist
-            ));
+            ))->onConnection('redis')->onQueue('import');
         }
 
         // All done! Nothing else to do ;)

--- a/app/Jobs/ProcessVodChannelsChunk.php
+++ b/app/Jobs/ProcessVodChannelsChunk.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Services\XtreamService;
+use Filament\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class ProcessVodChannelsChunk implements ShouldQueue
+{
+    use Queueable;
+
+    // Don't retry the job on failure
+    public $tries = 1;
+
+    // Giving a timeout of 10 minutes per chunk
+    public $timeout = 60 * 10;
+
+    // Default user agent
+    public $userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36';
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public array $channelIds,
+        public int $playlistId,
+        public int $chunkIndex,
+        public int $totalChunks,
+        public bool $force = false,
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(XtreamService $xtream): void
+    {
+        $playlist = Playlist::find($this->playlistId);
+        if (!$playlist) {
+            Log::error('ProcessVodChannelsChunk: Playlist not found', ['playlist_id' => $this->playlistId]);
+            return;
+        }
+
+        // Initialize Xtream service
+        $xtream = $xtream->init(
+            playlist: $playlist,
+            retryLimit: 3
+        );
+        if (!$xtream) {
+            Log::error('ProcessVodChannelsChunk: Xtream service initialization failed', ['playlist_id' => $playlist->id]);
+            return;
+        }
+
+        // If this is the first chunk, notify user and reset progress
+        if ($this->chunkIndex === 0) {
+            Notification::make()
+                ->info()
+                ->title('Processing VOD Metadata')
+                ->body('Fetching VOD metadata now. This may take a while depending on the number of VOD channels.')
+                ->broadcast($playlist->user)
+                ->sendToDatabase($playlist->user);
+            
+            $playlist->update([
+                'vod_progress' => 0,
+            ]);
+        }
+
+        // Get the channels for this chunk
+        $channels = Channel::whereIn('id', $this->channelIds)->get(['id', 'name', 'source_id']);
+        
+        $processedCount = 0;
+        $errorCount = 0;
+
+        foreach ($channels as $channel) {
+            try {
+                $channel->fetchMetadata($xtream);
+                $processedCount++;
+            } catch (\Exception $e) {
+                $errorCount++;
+                Log::warning('ProcessVodChannelsChunk: Failed to fetch metadata for channel', [
+                    'channel_id' => $channel->id,
+                    'channel_name' => $channel->name,
+                    'error' => $e->getMessage(),
+                ]);
+                // Continue processing other channels instead of stopping
+            }
+            
+            // Small delay to avoid overwhelming the API
+            usleep(50000); // 50ms delay
+        }
+
+        // Update progress based on chunks completed
+        $progress = min(99, (($this->chunkIndex + 1) / $this->totalChunks) * 100);
+        $playlist->update(['vod_progress' => round($progress)]);
+
+        Log::debug('ProcessVodChannelsChunk completed', [
+            'playlist_id' => $playlist->id,
+            'chunk' => $this->chunkIndex + 1,
+            'total_chunks' => $this->totalChunks,
+            'processed' => $processedCount,
+            'errors' => $errorCount,
+            'progress' => $progress,
+        ]);
+    }
+}

--- a/app/Jobs/ProcessVodChannelsComplete.php
+++ b/app/Jobs/ProcessVodChannelsComplete.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\Status;
+use App\Events\SyncCompleted;
+use App\Models\Playlist;
+use Filament\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class ProcessVodChannelsComplete implements ShouldQueue
+{
+    use Queueable;
+
+    // Don't retry the job on failure
+    public $tries = 1;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public int $playlistId,
+        public int $totalChannels,
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $playlist = Playlist::find($this->playlistId);
+        if (!$playlist) {
+            Log::error('ProcessVodChannelsComplete: Playlist not found', ['playlist_id' => $this->playlistId]);
+            return;
+        }
+
+        // Check if anything else is still running
+        $channelSyncRunning = $playlist->progress < 100;
+        $seriesSyncRunning = $playlist->series_progress < 100;
+        $anythingElseRunning = $channelSyncRunning || $seriesSyncRunning;
+
+        // Update the VOD progress and set final status if nothing else is running
+        $updateData = [
+            'vod_progress' => 100,
+        ];
+        
+        if (!$anythingElseRunning) {
+            $updateData['processing'] = false;
+            $updateData['status'] = Status::Completed;
+        }
+        
+        $playlist->update($updateData);
+
+        Log::info('Completed processing VOD channels for playlist', [
+            'playlist_id' => $playlist->id,
+            'total_channels' => $this->totalChannels,
+            'set_final_status' => !$anythingElseRunning,
+        ]);
+
+        Notification::make()
+            ->success()
+            ->title('VOD Metadata Processed')
+            ->body("Successfully processed metadata for {$this->totalChannels} VOD channels in playlist \"{$playlist->name}\".")
+            ->broadcast($playlist->user)
+            ->sendToDatabase($playlist->user);
+
+        // Fire the sync completed event if this is the final step
+        if (!$anythingElseRunning) {
+            event(new SyncCompleted($playlist));
+        }
+    }
+}

--- a/app/Jobs/RestartQueue.php
+++ b/app/Jobs/RestartQueue.php
@@ -41,6 +41,7 @@ class RestartQueue implements ShouldQueue
                     'processing' => false,
                     'progress' => 0,
                     'series_progress' => 0,
+                    'vod_progress' => 0,
                     'channels' => 0,
                     'synced' => null,
                     'errors' => null,

--- a/database/migrations/2025_12_04_080932_add_vod_progress_to_playlists.php
+++ b/database/migrations/2025_12_04_080932_add_vod_progress_to_playlists.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->float('vod_progress')
+                ->default(100)
+                ->after('series_progress');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->dropColumn('vod_progress');
+        });
+    }
+};

--- a/resources/views/filament/resources/playlist-resource/widgets/import-progress.blade.php
+++ b/resources/views/filament/resources/playlist-resource/widgets/import-progress.blade.php
@@ -10,10 +10,18 @@
         </div>
         @endif
         @if($data['processing'] && $data['seriesProgress'] < 100)
-            <div class="w-full h-5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden relative">
+            <div class="w-full h-5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden relative mb-2">
                 <div class="absolute left-0 top-0 h-5 bg-primary-600 transition-all duration-700 ease-in-out" style="width: {{ $data['seriesProgress'] }}%"></div>
                 <div class="absolute left-0 top-0 w-full h-5 flex items-center justify-center">
                     <span class="text-xs font-medium text-primary-900 dark:text-primary-100 select-none">Series Sync Progress: <strong>{{ $data['seriesProgress'] }}%</strong></span>
+                </div>
+            </div>
+        @endif
+        @if($data['vodProgress'] < 100)
+            <div class="w-full h-5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden relative">
+                <div class="absolute left-0 top-0 h-5 bg-primary-600 transition-all duration-700 ease-in-out" style="width: {{ $data['vodProgress'] }}%"></div>
+                <div class="absolute left-0 top-0 w-full h-5 flex items-center justify-center">
+                    <span class="text-xs font-medium text-primary-900 dark:text-primary-100 select-none">VOD Sync Progress: <strong>{{ $data['vodProgress'] }}%</strong></span>
                 </div>
             </div>
         @endif


### PR DESCRIPTION
- Add vod_progress column to playlists table for independent VOD tracking
- Add VOD Sync column to playlist table view with real-time progress
- Refactor VOD processing into chunked jobs (100 channels per chunk)
  - ProcessVodChannels: Dispatches job chain for bulk processing
  - ProcessVodChannelsChunk: Processes individual chunks with progress updates
  - ProcessVodChannelsComplete: Finalizes VOD sync and sets completion status
- Update status logic: Status stays 'processing' until ALL syncs complete
  - Channel, Series, and VOD must all finish before status becomes 'completed'
  - Each completion job checks if other syncs are still running
- Make manual 'Fetch VOD Metadata' action consistent with Series action
  - Sets status to 'processing' when started
  - Sets status to 'completed' when finished (if nothing else running)
- Add VOD progress to ImportProgress widget in playlist edit view
- Dispatch VOD jobs on 'import' queue for sequential processing
- Add vod_progress reset to all relevant reset actions

This prevents timeouts with large VOD libraries (16k+ channels) and provides clear visibility into what's currently syncing.