### PR TITLE
feat: Add name filtering option for STRM file sync

### DIFF
--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -673,6 +673,22 @@ class Preferences extends SettingsPage
                                                     ]),
                                             ])
                                             ->hidden(fn($get) => ! $get('stream_file_sync_enabled')),
+                                        Fieldset::make('Name Filtering')
+                                            ->columnSpanFull()
+                                            ->schema([
+                                                Toggle::make('stream_file_sync_name_filter_enabled')
+                                                    ->label('Enable name filtering')
+                                                    ->helperText('Remove specific words or symbols from folder and file names (e.g. "DE • " from "DE • Action" → "Action")')
+                                                    ->inline(false)
+                                                    ->live(),
+                                                Forms\Components\TagsInput::make('stream_file_sync_name_filter_patterns')
+                                                    ->label('Patterns to remove')
+                                                    ->placeholder('Add pattern (e.g. "DE • " or "EN |")')
+                                                    ->helperText('Enter words, symbols or prefixes to remove from category, series and episode names. Press Enter after each pattern.')
+                                                    ->columnSpanFull()
+                                                    ->hidden(fn($get) => ! $get('stream_file_sync_name_filter_enabled')),
+                                            ])
+                                            ->hidden(fn($get) => ! $get('stream_file_sync_enabled')),
                                     ]),
                                 Section::make('VOD stream file settings')
                                     ->description('Generate .strm files and sync them to a local file path. Options can be overriden per VOD in the VOD edit panel.')
@@ -797,6 +813,22 @@ class Preferences extends SettingsPage
                                                         'period' => '.',
                                                         'remove' => 'Remove',
                                                     ]),
+                                            ])
+                                            ->hidden(fn($get) => ! $get('vod_stream_file_sync_enabled')),
+                                        Fieldset::make('Name Filtering')
+                                            ->columnSpanFull()
+                                            ->schema([
+                                                Toggle::make('vod_stream_file_sync_name_filter_enabled')
+                                                    ->label('Enable name filtering')
+                                                    ->helperText('Remove specific words or symbols from folder and file names (e.g. "DE • " from "DE • Action" → "Action")')
+                                                    ->inline(false)
+                                                    ->live(),
+                                                Forms\Components\TagsInput::make('vod_stream_file_sync_name_filter_patterns')
+                                                    ->label('Patterns to remove')
+                                                    ->placeholder('Add pattern (e.g. "DE • " or "EN |")')
+                                                    ->helperText('Enter words, symbols or prefixes to remove from group and file names. Press Enter after each pattern.')
+                                                    ->columnSpanFull()
+                                                    ->hidden(fn($get) => ! $get('vod_stream_file_sync_name_filter_enabled')),
                                             ])
                                             ->hidden(fn($get) => ! $get('vod_stream_file_sync_enabled')),
                                     ]),

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -64,6 +64,11 @@ class GeneralSettings extends Settings
     public ?string $stream_file_sync_replace_char = 'space';
 
 
+    // Stream file sync name filtering options
+    public ?bool $stream_file_sync_name_filter_enabled = false;
+    public ?array $stream_file_sync_name_filter_patterns = null;
+
+
     // VOD stream file sync options
     public ?bool $vod_stream_file_sync_enabled = false;
     public ?bool $vod_stream_file_sync_include_series = false;
@@ -82,6 +87,11 @@ class GeneralSettings extends Settings
     public ?bool $vod_stream_file_sync_clean_special_chars = true;
     public ?bool $vod_stream_file_sync_remove_consecutive_chars = true;
     public ?string $vod_stream_file_sync_replace_char = 'space';
+
+
+    // VOD stream file sync name filtering options
+    public ?bool $vod_stream_file_sync_name_filter_enabled = false;
+    public ?array $vod_stream_file_sync_name_filter_patterns = null;
 
 
     // Video player proxy options

--- a/database/settings/2025_12_15_000000_add_name_filter_options_to_stream_sync.php
+++ b/database/settings/2025_12_15_000000_add_name_filter_options_to_stream_sync.php
@@ -1,0 +1,25 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        // Series stream file sync name filtering options
+        if (!$this->migrator->exists('general.stream_file_sync_name_filter_enabled')) {
+            $this->migrator->add('general.stream_file_sync_name_filter_enabled', false);
+        }
+        if (!$this->migrator->exists('general.stream_file_sync_name_filter_patterns')) {
+            $this->migrator->add('general.stream_file_sync_name_filter_patterns', null);
+        }
+
+        // VOD stream file sync name filtering options
+        if (!$this->migrator->exists('general.vod_stream_file_sync_name_filter_enabled')) {
+            $this->migrator->add('general.vod_stream_file_sync_name_filter_enabled', false);
+        }
+        if (!$this->migrator->exists('general.vod_stream_file_sync_name_filter_patterns')) {
+            $this->migrator->add('general.vod_stream_file_sync_name_filter_patterns', null);
+        }
+    }
+};


### PR DESCRIPTION
Add ability to remove specific words/symbols from folder and file names when generating .strm files for Series and VOD content.

Features:
- New 'Name Filtering' section in Preferences > Sync Options
- Configurable patterns to remove (e.g. 'DE • ', 'EN |', '[HD]')
- Applies to category names, series names, episode titles (Series)
- Applies to group names and VOD titles (VOD)
- Disabled by default, can be enabled per content type

Use case: Remove country prefixes like 'DE • Action' -> 'Action'

Files changed:
- app/Settings/GeneralSettings.php: New settings properties
- app/Filament/Pages/Preferences.php: UI for name filtering
- app/Jobs/SyncSeriesStrmFiles.php: Apply filtering logic
- app/Jobs/SyncVodStrmFiles.php: Apply filtering logic
- database/settings/2025_12_15_*: Migration for new settings