### PR TITLE
Fixed issue where series episodes were missing

### DIFF
--- a/database/migrations/2025_12_15_000001_change_source_ids_to_bigint.php
+++ b/database/migrations/2025_12_15_000001_change_source_ids_to_bigint.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Change source_*_id columns from integer to bigint.
+ *
+ * The crc32() function returns values from 0 to 4,294,967,295 (unsigned 32-bit).
+ * PostgreSQL's integer type is signed (-2,147,483,648 to 2,147,483,647), so values
+ * above 2,147,483,647 cause "Numeric value out of range" errors.
+ *
+ * This migration changes the affected columns to bigint to accommodate the full
+ * range of crc32() values.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Change episodes.source_episode_id to bigint
+        Schema::table('episodes', function (Blueprint $table) {
+            $table->unsignedBigInteger('source_episode_id')->nullable()->change();
+        });
+
+        // Change series.source_series_id to bigint (same issue)
+        Schema::table('series', function (Blueprint $table) {
+            $table->unsignedBigInteger('source_series_id')->nullable()->change();
+        });
+
+        // Change seasons.source_season_id to bigint if it exists and uses crc32
+        if (Schema::hasColumn('seasons', 'source_season_id')) {
+            Schema::table('seasons', function (Blueprint $table) {
+                $table->unsignedBigInteger('source_season_id')->nullable()->change();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Revert to unsigned integer (may cause data loss for large values)
+        Schema::table('episodes', function (Blueprint $table) {
+            $table->unsignedInteger('source_episode_id')->nullable()->change();
+        });
+
+        Schema::table('series', function (Blueprint $table) {
+            $table->unsignedInteger('source_series_id')->nullable()->change();
+        });
+
+        if (Schema::hasColumn('seasons', 'source_season_id')) {
+            Schema::table('seasons', function (Blueprint $table) {
+                $table->unsignedInteger('source_season_id')->nullable()->change();
+            });
+        }
+    }
+};


### PR DESCRIPTION
The issue was that crc32() returns unsigned 32-bit values (0 to 4,294,967,295), but PostgreSQL's integer type is signed 32-bit (max 2,147,483,647). Values above that caused "Numeric value out of range" errors.

The migration I created changes source_episode_id, source_series_id, and source_season_id to bigint to accommodate the full crc32 range.