### PR TITLE
feat(strm): improve STRM file naming with Trash Guides format support

### DIFF
--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -739,22 +739,43 @@ class Preferences extends SettingsPage
                                                 $pathStructure = $get('vod_stream_file_sync_path_structure') ?? [];
                                                 $filenameMetadata = $get('vod_stream_file_sync_filename_metadata') ?? [];
                                                 $tmdbIdFormat = $get('vod_stream_file_sync_tmdb_id_format') ?? 'square';
+                                                $replaceChar = $get('vod_stream_file_sync_replace_char') ?? ' ';
+                                                $titleFolderEnabled = in_array('title', $pathStructure);
 
                                                 // Build path preview
                                                 $preview = 'Preview: ' . $path;
 
                                                 if (in_array('group', $pathStructure)) {
-                                                    $preview .= '/' . $vodExample->group;
+                                                    $groupName = $vodExample->group->name ?? $vodExample->group ?? 'Uncategorized';
+                                                    $preview .= '/' . PlaylistService::makeFilesystemSafe($groupName, $replaceChar);
                                                 }
-                                                if (in_array('title', $pathStructure)) {
-                                                    $preview .= '/' . PlaylistService::makeFilesystemSafe($vodExample->title, $get('vod_stream_file_sync_replace_char') ?? ' ');
+                                                if ($titleFolderEnabled) {
+                                                    $titleFolder = PlaylistService::makeFilesystemSafe($vodExample->title, $replaceChar);
+                                                    // Add year to folder if available
+                                                    if (! empty($vodExample->year) && strpos($titleFolder, "({$vodExample->year})") === false) {
+                                                        $titleFolder .= " ({$vodExample->year})";
+                                                    }
+                                                    // Add TMDB ID to folder for Trash Guides compatibility
+                                                    $tmdbId = $vodExample->info['tmdb_id'] ?? $vodExample->movie_data['tmdb_id'] ?? null;
+                                                    if (! empty($tmdbId)) {
+                                                        $titleFolder .= " {tmdb-{$tmdbId}}";
+                                                    }
+                                                    $preview .= '/' . $titleFolder;
                                                 }
 
                                                 // Build filename preview
-                                                $filename = PlaylistService::makeFilesystemSafe($vodExample->title, $get('vod_stream_file_sync_replace_char') ?? ' ');
+                                                $filename = PlaylistService::makeFilesystemSafe($vodExample->title, $replaceChar);
 
-                                                // Add metadata to filename (year might already be in title, but we'll add others)
-                                                if (in_array('tmdb_id', $filenameMetadata) && ! empty($vodExample->info['tmdb_id'])) {
+                                                // Add year to filename
+                                                if (in_array('year', $filenameMetadata) && ! empty($vodExample->year)) {
+                                                    if (strpos($filename, "({$vodExample->year})") === false) {
+                                                        $filename .= " ({$vodExample->year})";
+                                                    }
+                                                }
+
+                                                // Only add TMDB ID to filename if title folder is NOT enabled
+                                                // (If title folder exists, TMDB ID is already in the folder name)
+                                                if (in_array('tmdb_id', $filenameMetadata) && ! $titleFolderEnabled && ! empty($vodExample->info['tmdb_id'])) {
                                                     $bracket = $tmdbIdFormat === 'curly' ? ['{', '}'] : ['[', ']'];
                                                     $filename .= " {$bracket[0]}tmdb-{$vodExample->info['tmdb_id']}{$bracket[1]}";
                                                 }

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -189,12 +189,34 @@ class SyncSeriesStrmFiles implements ShouldQueue
 
             // See if the series is enabled, if not, skip, else create the folder
             if (in_array('series', $pathStructure)) {
-                // Create the series folder
+                // Create the series folder with Trash Guides format support
                 // Remove any special characters from the series name
                 $seriesName = $applyNameFilter($series->name);
+                $seriesFolder = $seriesName;
+
+                // Add year to folder name if available
+                if (! empty($series->release_date)) {
+                    $year = substr($series->release_date, 0, 4);
+                    if (strpos($seriesFolder, "({$year})") === false) {
+                        $seriesFolder .= " ({$year})";
+                    }
+                }
+
+                // Add TVDB/TMDB ID to folder name for Trash Guides compatibility
+                $tvdbId = $series->metadata['tvdb_id'] ?? $series->metadata['tvdb'] ?? null;
+                $tmdbId = $series->metadata['tmdb_id'] ?? $series->metadata['tmdb'] ?? null;
+                $imdbId = $series->metadata['imdb_id'] ?? $series->metadata['imdb'] ?? null;
+                if (! empty($tvdbId)) {
+                    $seriesFolder .= " {tvdb-{$tvdbId}}";
+                } elseif (! empty($tmdbId)) {
+                    $seriesFolder .= " {tmdb-{$tmdbId}}";
+                } elseif (! empty($imdbId)) {
+                    $seriesFolder .= " {imdb-{$imdbId}}";
+                }
+
                 $cleanName = $cleanSpecialChars
-                    ? PlaylistService::makeFilesystemSafe($seriesName, $replaceChar)
-                    : PlaylistService::makeFilesystemSafe($seriesName);
+                    ? PlaylistService::makeFilesystemSafe($seriesFolder, $replaceChar)
+                    : PlaylistService::makeFilesystemSafe($seriesFolder);
                 $path .= '/' . $cleanName;
                 if (! is_dir($path)) {
                     mkdir($path, 0777, true);


### PR DESCRIPTION
- Fix VOD name filtering bug: use group->name instead of group model object
- Add TMDB ID to VOD title folder for Trash Guides compatibility
- Add TVDB/TMDB/IMDB ID to Series folder names (priority: TVDB > TMDB > IMDB)
- Smart TMDB ID placement: folder name when title folder enabled, filename otherwise
- Update Preferences preview to reflect actual naming logic
- Fix group name preview to use group->name instead of model object