### PR TITLE
Fix null-safe operator for group/category name access

### DIFF
--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -175,7 +175,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 // Create the category folder
                 // Remove any special characters from the category name
                 $category = $series->category;
-                $catName = $category->name ?? $category->name_internal ?? 'Uncategorized';
+                $catName = $category?->name ?? $category?->name_internal ?? 'Uncategorized';
                 // Apply name filtering
                 $catName = $applyNameFilter($catName);
                 $cleanName = $cleanSpecialChars

--- a/app/Jobs/SyncVodStrmFiles.php
+++ b/app/Jobs/SyncVodStrmFiles.php
@@ -113,7 +113,8 @@ class SyncVodStrmFiles implements ShouldQueue
 
                 // Create the group folder if enabled
                 if (in_array('group', $pathStructure)) {
-                    $groupName = $channel->group->name ?? $channel->group->name_internal ?? 'Uncategorized';
+                    $group = $channel->group;
+                    $groupName = $group?->name ?? $group?->name_internal ?? 'Uncategorized';
                     $groupName = $applyNameFilter($groupName);
                     $group = $cleanSpecialChars
                         ? PlaylistService::makeFilesystemSafe($groupName, $replaceChar)


### PR DESCRIPTION
- Use null-safe operator (?->) when accessing group->name in SyncVodStrmFiles
- Use null-safe operator (?->) when accessing category->name in SyncSeriesStrmFiles
- Prevents 'Uncategorized' fallback from not working when group/category is null