### PR TITLE
Improve Playlist Alias provider selection UI and stability

### DIFF
--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -739,22 +739,43 @@ class Preferences extends SettingsPage
                                                 $pathStructure = $get('vod_stream_file_sync_path_structure') ?? [];
                                                 $filenameMetadata = $get('vod_stream_file_sync_filename_metadata') ?? [];
                                                 $tmdbIdFormat = $get('vod_stream_file_sync_tmdb_id_format') ?? 'square';
+                                                $replaceChar = $get('vod_stream_file_sync_replace_char') ?? ' ';
+                                                $titleFolderEnabled = in_array('title', $pathStructure);
 
                                                 // Build path preview
                                                 $preview = 'Preview: ' . $path;
 
                                                 if (in_array('group', $pathStructure)) {
-                                                    $preview .= '/' . $vodExample->group;
+                                                    $groupName = $vodExample->group->name ?? $vodExample->group ?? 'Uncategorized';
+                                                    $preview .= '/' . PlaylistService::makeFilesystemSafe($groupName, $replaceChar);
                                                 }
-                                                if (in_array('title', $pathStructure)) {
-                                                    $preview .= '/' . PlaylistService::makeFilesystemSafe($vodExample->title, $get('vod_stream_file_sync_replace_char') ?? ' ');
+                                                if ($titleFolderEnabled) {
+                                                    $titleFolder = PlaylistService::makeFilesystemSafe($vodExample->title, $replaceChar);
+                                                    // Add year to folder if available
+                                                    if (! empty($vodExample->year) && strpos($titleFolder, "({$vodExample->year})") === false) {
+                                                        $titleFolder .= " ({$vodExample->year})";
+                                                    }
+                                                    // Add TMDB ID to folder for Trash Guides compatibility
+                                                    $tmdbId = $vodExample->info['tmdb_id'] ?? $vodExample->movie_data['tmdb_id'] ?? null;
+                                                    if (! empty($tmdbId)) {
+                                                        $titleFolder .= " {tmdb-{$tmdbId}}";
+                                                    }
+                                                    $preview .= '/' . $titleFolder;
                                                 }
 
                                                 // Build filename preview
-                                                $filename = PlaylistService::makeFilesystemSafe($vodExample->title, $get('vod_stream_file_sync_replace_char') ?? ' ');
+                                                $filename = PlaylistService::makeFilesystemSafe($vodExample->title, $replaceChar);
 
-                                                // Add metadata to filename (year might already be in title, but we'll add others)
-                                                if (in_array('tmdb_id', $filenameMetadata) && ! empty($vodExample->info['tmdb_id'])) {
+                                                // Add year to filename
+                                                if (in_array('year', $filenameMetadata) && ! empty($vodExample->year)) {
+                                                    if (strpos($filename, "({$vodExample->year})") === false) {
+                                                        $filename .= " ({$vodExample->year})";
+                                                    }
+                                                }
+
+                                                // Only add TMDB ID to filename if title folder is NOT enabled
+                                                // (If title folder exists, TMDB ID is already in the folder name)
+                                                if (in_array('tmdb_id', $filenameMetadata) && ! $titleFolderEnabled && ! empty($vodExample->info['tmdb_id'])) {
                                                     $bracket = $tmdbIdFormat === 'curly' ? ['{', '}'] : ['[', ']'];
                                                     $filename .= " {$bracket[0]}tmdb-{$vodExample->info['tmdb_id']}{$bracket[1]}";
                                                 }

--- a/app/Filament/Resources/Epgs/EpgResource.php
+++ b/app/Filament/Resources/Epgs/EpgResource.php
@@ -684,6 +684,7 @@ class EpgResource extends Resource
                                 ->label('Disable SSL verification')
                                 ->helperText('Only disable this if you are having issues.')
                                 ->columnSpan(1)
+                                ->onColor('danger')
                                 ->inline(false)
                                 ->default(false),
                         ])

--- a/app/Filament/Resources/PlaylistAliases/PlaylistAliasResource.php
+++ b/app/Filament/Resources/PlaylistAliases/PlaylistAliasResource.php
@@ -317,7 +317,7 @@ class PlaylistAliasResource extends Resource
                         ->live()
                         ->helperText(text: 'Enter the full URL using <url>:<port> format - without trailing slash (/).')
                         ->prefixIcon('heroicon-m-globe-alt')
-                        ->maxLength(255)
+                        ->maxLength(4000)
                         ->url()
                         ->columnSpan(2)
                         ->required(),

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -963,7 +963,7 @@ class PlaylistResource extends Resource
                         ->live()
                         ->helperText('Enter the full url, using <url>:<port> format - without trailing slash (/).')
                         ->prefixIcon('heroicon-m-globe-alt')
-                        ->maxLength(2000)
+                        ->maxLength(4000)
                         ->url()
                         ->columnSpan(2)
                         ->required()

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -1027,11 +1027,15 @@ class XtreamApiController extends Controller
                             ->whereIn('taggable_id', $channelIds);
                     })->get();
 
-                foreach ($tags as $tag) {
+                // Sort tags by order_column
+                $sortedTags = $tags->sortBy('order_column')->values();
+
+                foreach ($sortedTags as $tag) {
                     $liveCategories[] = [
                         'category_id' => (string)$tag->id, // Use tag ID instead of name
                         'category_name' => $tag->name,
                         'parent_id' => 0,
+                        'sort_order' => $tag->order_column ?? 999999,
                     ];
                 }
 
@@ -1050,7 +1054,7 @@ class XtreamApiController extends Controller
                             ->from('channels')
                             ->whereIn('id', $channelsWithoutTags)
                             ->whereNotNull('group_id');
-                    })->get();
+                    })->orderBy('sort_order')->get();
 
                     foreach ($fallbackGroups as $group) {
                         // Avoid duplicate category_ids
@@ -1060,10 +1064,22 @@ class XtreamApiController extends Controller
                                 'category_id' => (string)$group->id,
                                 'category_name' => $group->name,
                                 'parent_id' => 0,
+                                'sort_order' => $group->sort_order ?? 999999,
                             ];
                         }
                     }
                 }
+
+                // Sort all categories by sort_order to ensure proper ordering
+                usort($liveCategories, function ($a, $b) {
+                    return ($a['sort_order'] ?? 999999) <=> ($b['sort_order'] ?? 999999);
+                });
+
+                // Remove sort_order from output
+                $liveCategories = array_map(function ($cat) {
+                    unset($cat['sort_order']);
+                    return $cat;
+                }, $liveCategories);
             } else {
                 // For regular Playlist and MergedPlaylist, use the groups() relationship
                 $groups = $playlist->groups()
@@ -1111,11 +1127,15 @@ class XtreamApiController extends Controller
                             ->whereIn('taggable_id', $channelIds);
                     })->get();
 
-                foreach ($tags as $tag) {
+                // Sort tags by order_column
+                $sortedTags = $tags->sortBy('order_column')->values();
+
+                foreach ($sortedTags as $tag) {
                     $vodCategories[] = [
                         'category_id' => (string)$tag->id, // Use tag ID instead of name
                         'category_name' => $tag->name,
                         'parent_id' => 0,
+                        'sort_order' => $tag->order_column ?? 999999,
                     ];
                 }
 
@@ -1134,7 +1154,7 @@ class XtreamApiController extends Controller
                             ->from('channels')
                             ->whereIn('id', $channelsWithoutTags)
                             ->whereNotNull('group_id');
-                    })->get();
+                    })->orderBy('sort_order')->get();
 
                     foreach ($fallbackGroups as $group) {
                         // Avoid duplicate category_ids
@@ -1144,10 +1164,22 @@ class XtreamApiController extends Controller
                                 'category_id' => (string)$group->id,
                                 'category_name' => $group->name,
                                 'parent_id' => 0,
+                                'sort_order' => $group->sort_order ?? 999999,
                             ];
                         }
                     }
                 }
+
+                // Sort all categories by sort_order to ensure proper ordering
+                usort($vodCategories, function ($a, $b) {
+                    return ($a['sort_order'] ?? 999999) <=> ($b['sort_order'] ?? 999999);
+                });
+
+                // Remove sort_order from output
+                $vodCategories = array_map(function ($cat) {
+                    unset($cat['sort_order']);
+                    return $cat;
+                }, $vodCategories);
             } else {
                 // For regular Playlist and MergedPlaylist, use the groups() relationship
                 $vodGroups = $playlist->groups()
@@ -1195,11 +1227,15 @@ class XtreamApiController extends Controller
                             ->whereIn('taggable_id', $seriesIds);
                     })->get();
 
-                foreach ($tags as $tag) {
+                // Sort tags by order_column
+                $sortedTags = $tags->sortBy('order_column')->values();
+
+                foreach ($sortedTags as $tag) {
                     $seriesCategories[] = [
                         'category_id' => (string)$tag->id, // Use tag ID instead of name
                         'category_name' => $tag->name,
                         'parent_id' => 0,
+                        'sort_order' => $tag->order_column ?? 999999,
                     ];
                 }
 
@@ -1218,7 +1254,7 @@ class XtreamApiController extends Controller
                             ->from('series')
                             ->whereIn('id', $seriesWithoutTags)
                             ->whereNotNull('category_id');
-                    })->get();
+                    })->orderBy('sort_order')->get();
 
                     foreach ($fallbackCategories as $category) {
                         // Avoid duplicate category_ids
@@ -1228,10 +1264,22 @@ class XtreamApiController extends Controller
                                 'category_id' => (string)$category->id,
                                 'category_name' => $category->name,
                                 'parent_id' => 0,
+                                'sort_order' => $category->sort_order ?? 999999,
                             ];
                         }
                     }
                 }
+
+                // Sort all categories by sort_order to ensure proper ordering
+                usort($seriesCategories, function ($a, $b) {
+                    return ($a['sort_order'] ?? 999999) <=> ($b['sort_order'] ?? 999999);
+                });
+
+                // Remove sort_order from output
+                $seriesCategories = array_map(function ($cat) {
+                    unset($cat['sort_order']);
+                    return $cat;
+                }, $seriesCategories);
             } else {
                 // Get categories from series only
                 $categories = $playlist->series()

--- a/app/Jobs/ProcessM3uImportComplete.php
+++ b/app/Jobs/ProcessM3uImportComplete.php
@@ -257,12 +257,12 @@ class ProcessM3uImportComplete implements ShouldQueue
                     $verify = !$playlist->disable_ssl_verification;
                     $userAgent = empty($playlist->user_agent) ? $this->userAgent : $playlist->user_agent;
 
-                    // Let's check if the EPG url is valid
+                    // Let's check if the EPG url is valid (using HEAD to avoid downloading the entire file)
                     $results = Http::withUserAgent($userAgent)
                         ->withOptions(['verify' => $verify])
                         ->timeout(30)
-                        ->throw()->get($epgUrl);
-                    if ($results->accepted()) {
+                        ->head($epgUrl);
+                    if ($results->successful()) {
                         // EPG found, create it
                         $epg = $user->epgs()->create([
                             'name' => $playlist->name . ' EPG',

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -175,7 +175,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 // Create the category folder
                 // Remove any special characters from the category name
                 $category = $series->category;
-                $catName = $category->name ?? $category->name_internal ?? 'Uncategorized';
+                $catName = $category?->name ?? $category?->name_internal ?? 'Uncategorized';
                 // Apply name filtering
                 $catName = $applyNameFilter($catName);
                 $cleanName = $cleanSpecialChars

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -298,6 +298,12 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 );
             }
 
+            // Clean up orphaned files for disabled/deleted episodes
+            StrmFileMapping::cleanupOrphaned(
+                SeriesEpisode::class,
+                $syncLocation
+            );
+
             // Notify the user
             if ($this->notify) {
                 Notification::make()

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -189,12 +189,34 @@ class SyncSeriesStrmFiles implements ShouldQueue
 
             // See if the series is enabled, if not, skip, else create the folder
             if (in_array('series', $pathStructure)) {
-                // Create the series folder
+                // Create the series folder with Trash Guides format support
                 // Remove any special characters from the series name
                 $seriesName = $applyNameFilter($series->name);
+                $seriesFolder = $seriesName;
+
+                // Add year to folder name if available
+                if (! empty($series->release_date)) {
+                    $year = substr($series->release_date, 0, 4);
+                    if (strpos($seriesFolder, "({$year})") === false) {
+                        $seriesFolder .= " ({$year})";
+                    }
+                }
+
+                // Add TVDB/TMDB ID to folder name for Trash Guides compatibility
+                $tvdbId = $series->metadata['tvdb_id'] ?? $series->metadata['tvdb'] ?? null;
+                $tmdbId = $series->metadata['tmdb_id'] ?? $series->metadata['tmdb'] ?? null;
+                $imdbId = $series->metadata['imdb_id'] ?? $series->metadata['imdb'] ?? null;
+                if (! empty($tvdbId)) {
+                    $seriesFolder .= " {tvdb-{$tvdbId}}";
+                } elseif (! empty($tmdbId)) {
+                    $seriesFolder .= " {tmdb-{$tmdbId}}";
+                } elseif (! empty($imdbId)) {
+                    $seriesFolder .= " {imdb-{$imdbId}}";
+                }
+
                 $cleanName = $cleanSpecialChars
-                    ? PlaylistService::makeFilesystemSafe($seriesName, $replaceChar)
-                    : PlaylistService::makeFilesystemSafe($seriesName);
+                    ? PlaylistService::makeFilesystemSafe($seriesFolder, $replaceChar)
+                    : PlaylistService::makeFilesystemSafe($seriesFolder);
                 $path .= '/' . $cleanName;
                 if (! is_dir($path)) {
                     mkdir($path, 0777, true);

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -77,6 +77,10 @@ class SyncSeriesStrmFiles implements ShouldQueue
 
     private function fetchMetadataForSeries(Series $series, $settings)
     {
+        if (!$series->enabled) {
+            return;  // Skip processing for disabled series
+        }
+        
         $series->load('enabled_episodes', 'playlist', 'user', 'category');
 
         $playlist = $series->playlist;

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -3,8 +3,8 @@
 namespace App\Jobs;
 
 use App\Facades\ProxyFacade;
+use App\Models\Episode;
 use App\Models\Series;
-use App\Models\SeriesEpisode;
 use App\Models\StrmFileMapping;
 use App\Models\User;
 use App\Services\PlaylistService;
@@ -300,7 +300,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
 
             // Clean up orphaned files for disabled/deleted episodes
             StrmFileMapping::cleanupOrphaned(
-                SeriesEpisode::class,
+                Episode::class,
                 $syncLocation
             );
 

--- a/app/Jobs/SyncVodStrmFiles.php
+++ b/app/Jobs/SyncVodStrmFiles.php
@@ -113,7 +113,8 @@ class SyncVodStrmFiles implements ShouldQueue
 
                 // Create the group folder if enabled
                 if (in_array('group', $pathStructure)) {
-                    $groupName = $channel->group->name ?? $channel->group->name_internal ?? 'Uncategorized';
+                    $group = $channel->group;
+                    $groupName = $group?->name ?? $group?->name_internal ?? 'Uncategorized';
                     $groupName = $applyNameFilter($groupName);
                     $group = $cleanSpecialChars
                         ? PlaylistService::makeFilesystemSafe($groupName, $replaceChar)

--- a/app/Jobs/SyncVodStrmFiles.php
+++ b/app/Jobs/SyncVodStrmFiles.php
@@ -155,10 +155,6 @@ class SyncVodStrmFiles implements ShouldQueue
                         mkdir($titlePath, 0777, true);
                     }
 
-                    $titleFolder = $cleanSpecialChars
-                        ? PlaylistService::makeFilesystemSafe($titleFolder, $replaceChar)
-                        : PlaylistService::makeFilesystemSafe($titleFolder);
-                    $titlePath = $path . '/' . $titleFolder;
                     $path = $titlePath;
                 }
 
@@ -223,10 +219,11 @@ class SyncVodStrmFiles implements ShouldQueue
             }
 
             // Clean up orphaned files for disabled/deleted channels
-            if ($this->playlist) {
+            // Run cleanup whenever we're syncing with a valid sync location
+            if ($syncLocation = $global_sync_settings['sync_location'] ?? null) {
                 StrmFileMapping::cleanupOrphaned(
                     Channel::class,
-                    $global_sync_settings['sync_location'] ?? ''
+                    $syncLocation
                 );
             }
         } catch (\Exception $e) {

--- a/app/Jobs/SyncVodStrmFiles.php
+++ b/app/Jobs/SyncVodStrmFiles.php
@@ -221,6 +221,14 @@ class SyncVodStrmFiles implements ShouldQueue
                     $pathOptions
                 );
             }
+
+            // Clean up orphaned files for disabled/deleted channels
+            if ($this->playlist) {
+                StrmFileMapping::cleanupOrphaned(
+                    Channel::class,
+                    $global_sync_settings['sync_location'] ?? ''
+                );
+            }
         } catch (\Exception $e) {
             // Log the exception or handle it as needed
             Log::error('Error syncing VOD .strm files: ' . $e->getMessage());

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Spatie\Tags\HasTags;
@@ -93,6 +94,14 @@ class Channel extends Model
     public function failovers()
     {
         return $this->hasMany(ChannelFailover::class, 'channel_id');
+    }
+
+    /**
+     * Get all STRM file mappings for this channel
+     */
+    public function strmFileMappings(): MorphMany
+    {
+        return $this->morphMany(StrmFileMapping::class, 'syncable');
     }
 
     public function failoverChannels(): HasManyThrough

--- a/app/Models/Episode.php
+++ b/app/Models/Episode.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process as SymfonyProcess;
 use Illuminate\Support\Str;
@@ -62,6 +63,14 @@ class Episode extends Model
     public function season(): BelongsTo
     {
         return $this->belongsTo(Season::class);
+    }
+
+    /**
+     * Get all STRM file mappings for this episode
+     */
+    public function strmFileMappings(): MorphMany
+    {
+        return $this->morphMany(StrmFileMapping::class, 'syncable');
     }
 
     public function getFloatingPlayerAttributes(): array

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -20,7 +20,6 @@ class Group extends Model
         'id' => 'integer',
         'user_id' => 'integer',
         'playlist_id' => 'integer',
-        'sort_order' => 'integer',
     ];
 
     public function user(): BelongsTo

--- a/app/Models/PlaylistAlias.php
+++ b/app/Models/PlaylistAlias.php
@@ -70,7 +70,7 @@ class PlaylistAlias extends Model
         foreach ($this->getXtreamConfigs() as $cfg) {
             // Normalize config URL
             $cfgUrl = rtrim((string) strtolower($cfg['url'] ?? ''), '/');
-            
+
             // If URLs match, return this config
             if ($cfgUrl !== '' && $cfgUrl === $needle) {
                 return $cfg;
@@ -194,7 +194,7 @@ class PlaylistAlias extends Model
     public function channels(): BelongsToMany|HasManyThrough
     {
         if ($this->custom_playlist_id) {
-            return $this->belongsToMany(Channel::class, 'channel_custom_playlist', 'custom_playlist_id', 'channel_id');
+            return $this->belongsToMany(Channel::class, 'channel_custom_playlist', 'custom_playlist_id', 'channel_id', 'custom_playlist_id', 'id');
         }
         return $this->hasManyThrough(
             Channel::class,
@@ -209,7 +209,7 @@ class PlaylistAlias extends Model
     public function series(): BelongsToMany|HasManyThrough
     {
         if ($this->custom_playlist_id) {
-            return $this->belongsToMany(Series::class, 'series_custom_playlist', 'custom_playlist_id', 'series_id');
+            return $this->belongsToMany(Series::class, 'series_custom_playlist', 'custom_playlist_id', 'series_id', 'custom_playlist_id', 'id');
         }
         return $this->hasManyThrough(
             Series::class,

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -233,7 +233,7 @@ class Series extends Model
                 // Update last fetched timestamp for the series
                 $this->update($update);
 
-                if ($sync) {
+                if ($sync && $this->enabled) {
                     // Dispatch the job to sync .strm files
                     dispatch(new SyncSeriesStrmFiles(series: $this, notify: false));
                 }

--- a/app/Models/StrmFileMapping.php
+++ b/app/Models/StrmFileMapping.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Facades\Log;
+
+class StrmFileMapping extends Model
+{
+    protected $fillable = [
+        'syncable_type',
+        'syncable_id',
+        'sync_location',
+        'current_path',
+        'current_url',
+        'path_options',
+    ];
+
+    protected $casts = [
+        'path_options' => 'array',
+    ];
+
+    /**
+     * Get the parent syncable model (Channel for VOD, Series Episode, etc.)
+     */
+    public function syncable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Find or create a mapping for a syncable item
+     */
+    public static function findForSyncable(Model $syncable, string $syncLocation): ?self
+    {
+        return self::where('syncable_type', get_class($syncable))
+            ->where('syncable_id', $syncable->id)
+            ->where('sync_location', $syncLocation)
+            ->first();
+    }
+
+    /**
+     * Sync the .strm file - handles create, rename, and URL updates
+     * 
+     * @param Model $syncable The model being synced (Channel, Episode, etc.)
+     * @param string $syncLocation Base sync location path
+     * @param string $expectedPath The expected full path for the .strm file
+     * @param string $url The URL to store in the .strm file
+     * @param array $pathOptions The options used to generate the path (for tracking changes)
+     * @return self The mapping record
+     */
+    public static function syncFile(
+        Model $syncable,
+        string $syncLocation,
+        string $expectedPath,
+        string $url,
+        array $pathOptions = []
+    ): self {
+        $mapping = self::findForSyncable($syncable, $syncLocation);
+
+        // Case 1: No existing mapping - create new file
+        if (! $mapping) {
+            return self::createNewFile($syncable, $syncLocation, $expectedPath, $url, $pathOptions);
+        }
+
+        // Case 2: Path changed - rename the file
+        if ($mapping->current_path !== $expectedPath) {
+            return self::renameFile($mapping, $expectedPath, $url, $pathOptions);
+        }
+
+        // Case 3: URL changed - update the file content
+        if ($mapping->current_url !== $url) {
+            return self::updateFileUrl($mapping, $url);
+        }
+
+        // Case 4: Nothing changed - just return the mapping
+        return $mapping;
+    }
+
+    /**
+     * Create a new .strm file and mapping
+     */
+    protected static function createNewFile(
+        Model $syncable,
+        string $syncLocation,
+        string $path,
+        string $url,
+        array $pathOptions
+    ): self {
+        // Ensure directory exists
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        // Write the file
+        file_put_contents($path, $url);
+
+        Log::debug("STRM Sync: Created new file", ['path' => $path]);
+
+        // Create and return the mapping
+        return self::create([
+            'syncable_type' => get_class($syncable),
+            'syncable_id' => $syncable->id,
+            'sync_location' => $syncLocation,
+            'current_path' => $path,
+            'current_url' => $url,
+            'path_options' => $pathOptions,
+        ]);
+    }
+
+    /**
+     * Rename an existing .strm file
+     */
+    protected static function renameFile(
+        self $mapping,
+        string $newPath,
+        string $url,
+        array $pathOptions
+    ): self {
+        $oldPath = $mapping->current_path;
+        $oldDirectory = dirname($oldPath);
+
+        // Ensure new directory exists
+        $newDirectory = dirname($newPath);
+        if (! is_dir($newDirectory)) {
+            mkdir($newDirectory, 0777, true);
+        }
+
+        // Rename or create the file
+        if (file_exists($oldPath)) {
+            // Rename the file
+            rename($oldPath, $newPath);
+            Log::info("STRM Sync: Renamed file", ['from' => $oldPath, 'to' => $newPath]);
+
+            // Update URL if it changed
+            if ($mapping->current_url !== $url) {
+                file_put_contents($newPath, $url);
+            }
+
+            // Clean up empty old directories
+            self::cleanupEmptyDirectories($oldDirectory, $mapping->sync_location);
+        } else {
+            // Old file doesn't exist, create new one
+            file_put_contents($newPath, $url);
+            Log::debug("STRM Sync: Created file (old file missing)", ['path' => $newPath]);
+        }
+
+        // Update the mapping
+        $mapping->update([
+            'current_path' => $newPath,
+            'current_url' => $url,
+            'path_options' => $pathOptions,
+        ]);
+
+        return $mapping;
+    }
+
+    /**
+     * Update the URL in an existing .strm file
+     */
+    protected static function updateFileUrl(self $mapping, string $url): self
+    {
+        if (file_exists($mapping->current_path)) {
+            file_put_contents($mapping->current_path, $url);
+            Log::debug("STRM Sync: Updated URL", ['path' => $mapping->current_path]);
+        } else {
+            // File doesn't exist, create it
+            $directory = dirname($mapping->current_path);
+            if (! is_dir($directory)) {
+                mkdir($directory, 0777, true);
+            }
+            file_put_contents($mapping->current_path, $url);
+            Log::debug("STRM Sync: Recreated file with new URL", ['path' => $mapping->current_path]);
+        }
+
+        $mapping->update(['current_url' => $url]);
+
+        return $mapping;
+    }
+
+    /**
+     * Delete the .strm file and its mapping
+     */
+    public function deleteFile(): void
+    {
+        if (file_exists($this->current_path)) {
+            unlink($this->current_path);
+            Log::debug("STRM Sync: Deleted file", ['path' => $this->current_path]);
+
+            // Clean up empty directories
+            self::cleanupEmptyDirectories(dirname($this->current_path), $this->sync_location);
+        }
+
+        $this->delete();
+    }
+
+    /**
+     * Clean up empty directories up to the sync location
+     */
+    protected static function cleanupEmptyDirectories(string $directory, string $syncLocation): void
+    {
+        $syncLocation = rtrim($syncLocation, '/');
+        
+        // Don't delete the sync location itself
+        while ($directory !== $syncLocation && strlen($directory) > strlen($syncLocation)) {
+            if (is_dir($directory) && self::isDirectoryEmpty($directory)) {
+                rmdir($directory);
+                Log::debug("STRM Sync: Removed empty directory", ['path' => $directory]);
+                $directory = dirname($directory);
+            } else {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Check if a directory is empty
+     */
+    protected static function isDirectoryEmpty(string $directory): bool
+    {
+        if (! is_dir($directory)) {
+            return false;
+        }
+        
+        $files = scandir($directory);
+        return count($files) <= 2; // Only . and ..
+    }
+
+    /**
+     * Delete all mappings and files for a syncable that no longer exist
+     */
+    public static function cleanupOrphaned(string $syncableType, string $syncLocation): int
+    {
+        $count = 0;
+        
+        self::where('syncable_type', $syncableType)
+            ->where('sync_location', $syncLocation)
+            ->chunk(100, function ($mappings) use (&$count) {
+                foreach ($mappings as $mapping) {
+                    // Check if the syncable still exists and is enabled
+                    $syncable = $mapping->syncable;
+                    if (! $syncable || ! ($syncable->enabled ?? true)) {
+                        $mapping->deleteFile();
+                        $count++;
+                    }
+                }
+            });
+
+        return $count;
+    }
+}

--- a/app/Models/StrmFileMapping.php
+++ b/app/Models/StrmFileMapping.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 
 class StrmFileMapping extends Model
 {
@@ -42,12 +43,12 @@ class StrmFileMapping extends Model
 
     /**
      * Sync the .strm file - handles create, rename, and URL updates
-     * 
-     * @param Model $syncable The model being synced (Channel, Episode, etc.)
-     * @param string $syncLocation Base sync location path
-     * @param string $expectedPath The expected full path for the .strm file
-     * @param string $url The URL to store in the .strm file
-     * @param array $pathOptions The options used to generate the path (for tracking changes)
+     *
+     * @param  Model  $syncable  The model being synced (Channel, Episode, etc.)
+     * @param  string  $syncLocation  Base sync location path
+     * @param  string  $expectedPath  The expected full path for the .strm file
+     * @param  string  $url  The URL to store in the .strm file
+     * @param  array  $pathOptions  The options used to generate the path (for tracking changes)
      * @return self The mapping record
      */
     public static function syncFile(
@@ -80,6 +81,8 @@ class StrmFileMapping extends Model
 
     /**
      * Create a new .strm file and mapping
+     *
+     * @throws RuntimeException If file creation fails
      */
     protected static function createNewFile(
         Model $syncable,
@@ -88,16 +91,21 @@ class StrmFileMapping extends Model
         string $url,
         array $pathOptions
     ): self {
-        // Ensure directory exists
+        // Ensure directory exists (0755 = owner full, others read+execute)
         $directory = dirname($path);
         if (! is_dir($directory)) {
-            mkdir($directory, 0777, true);
+            if (! mkdir($directory, 0755, true)) {
+                throw new RuntimeException("STRM Sync: Failed to create directory: {$directory}");
+            }
         }
 
-        // Write the file
-        file_put_contents($path, $url);
+        // Write the file and check for errors
+        $result = file_put_contents($path, $url);
+        if ($result === false) {
+            throw new RuntimeException("STRM Sync: Failed to write file: {$path}");
+        }
 
-        Log::debug("STRM Sync: Created new file", ['path' => $path]);
+        Log::debug('STRM Sync: Created new file', ['path' => $path]);
 
         // Create and return the mapping
         return self::create([
@@ -112,6 +120,8 @@ class StrmFileMapping extends Model
 
     /**
      * Rename an existing .strm file
+     *
+     * @throws RuntimeException If rename or file creation fails
      */
     protected static function renameFile(
         self $mapping,
@@ -122,29 +132,48 @@ class StrmFileMapping extends Model
         $oldPath = $mapping->current_path;
         $oldDirectory = dirname($oldPath);
 
-        // Ensure new directory exists
+        // Ensure new directory exists (0755 = owner full, others read+execute)
         $newDirectory = dirname($newPath);
         if (! is_dir($newDirectory)) {
-            mkdir($newDirectory, 0777, true);
+            if (! mkdir($newDirectory, 0755, true)) {
+                throw new RuntimeException("STRM Sync: Failed to create directory: {$newDirectory}");
+            }
         }
 
         // Rename or create the file
         if (file_exists($oldPath)) {
-            // Rename the file
-            rename($oldPath, $newPath);
-            Log::info("STRM Sync: Renamed file", ['from' => $oldPath, 'to' => $newPath]);
+            // Try to rename the file
+            if (! @rename($oldPath, $newPath)) {
+                // Rename failed - try copy + delete as fallback (handles cross-device moves)
+                if (! @copy($oldPath, $newPath)) {
+                    throw new RuntimeException("STRM Sync: Failed to rename/copy file from {$oldPath} to {$newPath}");
+                }
+                // Copy succeeded, try to delete old file (non-critical if it fails)
+                if (! @unlink($oldPath)) {
+                    Log::warning('STRM Sync: Failed to delete old file after copy', ['path' => $oldPath]);
+                }
+                Log::info('STRM Sync: Moved file (copy+delete)', ['from' => $oldPath, 'to' => $newPath]);
+            } else {
+                Log::info('STRM Sync: Renamed file', ['from' => $oldPath, 'to' => $newPath]);
+            }
 
             // Update URL if it changed
             if ($mapping->current_url !== $url) {
-                file_put_contents($newPath, $url);
+                $result = file_put_contents($newPath, $url);
+                if ($result === false) {
+                    Log::warning('STRM Sync: Failed to update URL in renamed file', ['path' => $newPath]);
+                }
             }
 
             // Clean up empty old directories
             self::cleanupEmptyDirectories($oldDirectory, $mapping->sync_location);
         } else {
             // Old file doesn't exist, create new one
-            file_put_contents($newPath, $url);
-            Log::debug("STRM Sync: Created file (old file missing)", ['path' => $newPath]);
+            $result = file_put_contents($newPath, $url);
+            if ($result === false) {
+                throw new RuntimeException("STRM Sync: Failed to create file: {$newPath}");
+            }
+            Log::debug('STRM Sync: Created file (old file missing)', ['path' => $newPath]);
         }
 
         // Update the mapping
@@ -163,16 +192,29 @@ class StrmFileMapping extends Model
     protected static function updateFileUrl(self $mapping, string $url): self
     {
         if (file_exists($mapping->current_path)) {
-            file_put_contents($mapping->current_path, $url);
-            Log::debug("STRM Sync: Updated URL", ['path' => $mapping->current_path]);
+            $result = file_put_contents($mapping->current_path, $url);
+            if ($result === false) {
+                Log::warning('STRM Sync: Failed to update URL', ['path' => $mapping->current_path]);
+            } else {
+                Log::debug('STRM Sync: Updated URL', ['path' => $mapping->current_path]);
+            }
         } else {
             // File doesn't exist, create it
             $directory = dirname($mapping->current_path);
             if (! is_dir($directory)) {
-                mkdir($directory, 0777, true);
+                if (! mkdir($directory, 0755, true)) {
+                    Log::warning('STRM Sync: Failed to create directory for URL update', ['directory' => $directory]);
+
+                    return $mapping;
+                }
             }
-            file_put_contents($mapping->current_path, $url);
-            Log::debug("STRM Sync: Recreated file with new URL", ['path' => $mapping->current_path]);
+            $result = file_put_contents($mapping->current_path, $url);
+            if ($result === false) {
+                Log::warning('STRM Sync: Failed to recreate file with new URL', ['path' => $mapping->current_path]);
+
+                return $mapping;
+            }
+            Log::debug('STRM Sync: Recreated file with new URL', ['path' => $mapping->current_path]);
         }
 
         $mapping->update(['current_url' => $url]);
@@ -186,8 +228,12 @@ class StrmFileMapping extends Model
     public function deleteFile(): void
     {
         if (file_exists($this->current_path)) {
-            unlink($this->current_path);
-            Log::debug("STRM Sync: Deleted file", ['path' => $this->current_path]);
+            if (! @unlink($this->current_path)) {
+                Log::warning('STRM Sync: Failed to delete file', ['path' => $this->current_path]);
+                // Still delete the mapping to avoid retrying endlessly
+            } else {
+                Log::debug('STRM Sync: Deleted file', ['path' => $this->current_path]);
+            }
 
             // Clean up empty directories
             self::cleanupEmptyDirectories(dirname($this->current_path), $this->sync_location);
@@ -202,12 +248,15 @@ class StrmFileMapping extends Model
     protected static function cleanupEmptyDirectories(string $directory, string $syncLocation): void
     {
         $syncLocation = rtrim($syncLocation, '/');
-        
+
         // Don't delete the sync location itself
         while ($directory !== $syncLocation && strlen($directory) > strlen($syncLocation)) {
             if (is_dir($directory) && self::isDirectoryEmpty($directory)) {
-                rmdir($directory);
-                Log::debug("STRM Sync: Removed empty directory", ['path' => $directory]);
+                if (! @rmdir($directory)) {
+                    Log::debug('STRM Sync: Failed to remove empty directory (may be in use)', ['path' => $directory]);
+                    break;
+                }
+                Log::debug('STRM Sync: Removed empty directory', ['path' => $directory]);
                 $directory = dirname($directory);
             } else {
                 break;
@@ -216,25 +265,39 @@ class StrmFileMapping extends Model
     }
 
     /**
-     * Check if a directory is empty
+     * Check if a directory is empty using efficient early-exit approach
      */
     protected static function isDirectoryEmpty(string $directory): bool
     {
         if (! is_dir($directory)) {
             return false;
         }
-        
-        $files = scandir($directory);
-        return count($files) <= 2; // Only . and ..
+
+        $handle = opendir($directory);
+        if ($handle === false) {
+            return false;
+        }
+
+        while (($entry = readdir($handle)) !== false) {
+            if ($entry !== '.' && $entry !== '..') {
+                closedir($handle);
+
+                return false;
+            }
+        }
+
+        closedir($handle);
+
+        return true;
     }
 
     /**
-     * Delete all mappings and files for a syncable that no longer exist
+     * Delete all mappings and files for syncables that no longer exist or are disabled
      */
     public static function cleanupOrphaned(string $syncableType, string $syncLocation): int
     {
         $count = 0;
-        
+
         self::where('syncable_type', $syncableType)
             ->where('sync_location', $syncLocation)
             ->chunk(100, function ($mappings) use (&$count) {
@@ -249,5 +312,31 @@ class StrmFileMapping extends Model
             });
 
         return $count;
+    }
+
+    /**
+     * Clean up all orphaned files for all sync locations
+     */
+    public static function cleanupAllOrphaned(): array
+    {
+        $results = [];
+
+        // Get unique sync locations and types
+        $locations = self::select('syncable_type', 'sync_location')
+            ->distinct()
+            ->get();
+
+        foreach ($locations as $location) {
+            $count = self::cleanupOrphaned($location->syncable_type, $location->sync_location);
+            if ($count > 0) {
+                $results[] = [
+                    'type' => $location->syncable_type,
+                    'location' => $location->sync_location,
+                    'cleaned' => $count,
+                ];
+            }
+        }
+
+        return $results;
     }
 }

--- a/app/Models/StrmFileMapping.php
+++ b/app/Models/StrmFileMapping.php
@@ -79,7 +79,12 @@ class StrmFileMapping extends Model
             return self::updateFileUrl($mapping, $url);
         }
 
-        // Case 4: Nothing changed - just return the mapping
+        // Case 4: Nothing changed - ensure path_options stay in sync
+        if ($mapping->path_options != $pathOptions) {
+            $mapping->path_options = $pathOptions;
+            $mapping->save();
+        }
+
         return $mapping;
     }
 

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -249,7 +249,7 @@ class PlaylistService
     public static function getChannelBaseUrl(Playlist|PlaylistAlias $source, $channelId): string
     {
         $config = $source instanceof PlaylistAlias
-            ? $source->getEffectiveXtreamConfig()
+            ? $source->getPrimaryXtreamConfig()
             : $source->xtream_config;
 
         if (!$config) {
@@ -266,7 +266,7 @@ class PlaylistService
     public static function getSeriesBaseUrl(Playlist|PlaylistAlias $source, $seriesId): string
     {
         $config = $source instanceof PlaylistAlias
-            ? $source->getEffectiveXtreamConfig()
+            ? $source->getPrimaryXtreamConfig()
             : $source->xtream_config;
 
         if (!$config) {

--- a/config/dev.php
+++ b/config/dev.php
@@ -3,8 +3,8 @@
 return [
     'author' => 'Shaun Parkison',
     'version' => '0.8.19',
-    'dev_version' => '0.8.21-dev',
-    'experimental_version' => '0.8.22-exp',
+    'dev_version' => '0.8.22-dev',
+    'experimental_version' => '0.8.23-exp',
     'repo' => 'sparkison/m3u-editor',
     'docs_url' => 'https://sparkison.github.io/m3u-editor-docs',
     'donate' => 'https://buymeacoffee.com/shparkison',

--- a/config/dev.php
+++ b/config/dev.php
@@ -3,8 +3,8 @@
 return [
     'author' => 'Shaun Parkison',
     'version' => '0.8.19',
-    'dev_version' => '0.8.20-dev',
-    'experimental_version' => '0.8.21-exp',
+    'dev_version' => '0.8.21-dev',
+    'experimental_version' => '0.8.22-exp',
     'repo' => 'sparkison/m3u-editor',
     'docs_url' => 'https://sparkison.github.io/m3u-editor-docs',
     'donate' => 'https://buymeacoffee.com/shparkison',

--- a/database/factories/StrmFileMappingFactory.php
+++ b/database/factories/StrmFileMappingFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Channel;
+use App\Models\StrmFileMapping;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class StrmFileMappingFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = StrmFileMapping::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        $channel = Channel::factory()->create();
+
+        return [
+            'syncable_type' => Channel::class,
+            'syncable_id' => $channel->id,
+            'sync_location' => '/tmp/strm-test',
+            'current_path' => '/tmp/strm-test/' . $this->faker->word() . '.strm',
+            'current_url' => $this->faker->url(),
+            'path_options' => [
+                'use_group_folders' => true,
+                'use_title_folders' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Configure the model to use an existing syncable model.
+     */
+    public function forSyncable($syncable): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'syncable_type' => get_class($syncable),
+            'syncable_id' => $syncable->id,
+        ]);
+    }
+
+    /**
+     * Configure the sync location.
+     */
+    public function syncLocation(string $location): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'sync_location' => $location,
+        ]);
+    }
+
+    /**
+     * Configure the current path.
+     */
+    public function path(string $path): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'current_path' => $path,
+        ]);
+    }
+
+    /**
+     * Configure the current URL.
+     */
+    public function url(string $url): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'current_url' => $url,
+        ]);
+    }
+}

--- a/database/factories/StrmFileMappingFactory.php
+++ b/database/factories/StrmFileMappingFactory.php
@@ -20,11 +20,9 @@ class StrmFileMappingFactory extends Factory
      */
     public function definition(): array
     {
-        $channel = Channel::factory()->create();
-
         return [
             'syncable_type' => Channel::class,
-            'syncable_id' => $channel->id,
+            'syncable_id' => fn (array $attributes) => Channel::factory()->create()->id,
             'sync_location' => '/tmp/strm-test',
             'current_path' => '/tmp/strm-test/' . $this->faker->word() . '.strm',
             'current_url' => $this->faker->url(),

--- a/database/migrations/2024_12_16_000001_create_strm_file_mappings_table.php
+++ b/database/migrations/2024_12_16_000001_create_strm_file_mappings_table.php
@@ -13,10 +13,10 @@ return new class extends Migration
     {
         Schema::create('strm_file_mappings', function (Blueprint $table) {
             $table->id();
-            $table->morphs('syncable'); // Can be Channel (VOD) or SeriesEpisode
-            $table->string('sync_location', 500); // Base sync location
-            $table->string('current_path', 1000); // Full path to the .strm file
-            $table->string('current_url', 1000)->nullable(); // URL stored in the file
+            $table->morphs('syncable'); // Can be Channel (VOD) or Episode
+            $table->text('sync_location'); // Base sync location
+            $table->text('current_path'); // Full path to the .strm file
+            $table->text('current_url')->nullable(); // URL stored in the file
             $table->json('path_options')->nullable(); // Naming options used to generate path
             $table->timestamps();
 

--- a/database/migrations/2024_12_16_000001_create_strm_file_mappings_table.php
+++ b/database/migrations/2024_12_16_000001_create_strm_file_mappings_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('strm_file_mappings', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('syncable'); // Can be Channel (VOD) or Series
+            $table->string('sync_location', 500); // Base sync location
+            $table->string('current_path', 1000); // Full path to the .strm file
+            $table->string('current_url', 1000)->nullable(); // URL stored in the file
+            $table->json('path_options')->nullable(); // Naming options used to generate path
+            $table->timestamps();
+            
+            // Index for quick lookups
+            $table->index(['syncable_type', 'syncable_id', 'sync_location']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('strm_file_mappings');
+    }
+};

--- a/database/migrations/2024_12_16_000001_create_strm_file_mappings_table.php
+++ b/database/migrations/2024_12_16_000001_create_strm_file_mappings_table.php
@@ -13,15 +13,17 @@ return new class extends Migration
     {
         Schema::create('strm_file_mappings', function (Blueprint $table) {
             $table->id();
-            $table->morphs('syncable'); // Can be Channel (VOD) or Series
+            $table->morphs('syncable'); // Can be Channel (VOD) or SeriesEpisode
             $table->string('sync_location', 500); // Base sync location
             $table->string('current_path', 1000); // Full path to the .strm file
             $table->string('current_url', 1000)->nullable(); // URL stored in the file
             $table->json('path_options')->nullable(); // Naming options used to generate path
             $table->timestamps();
-            
-            // Index for quick lookups
-            $table->index(['syncable_type', 'syncable_id', 'sync_location']);
+
+            // Index for quick lookups by syncable
+            $table->index(['syncable_type', 'syncable_id', 'sync_location'], 'strm_syncable_location_idx');
+            // Index for path lookups and comparisons
+            $table->index('current_path', 'strm_current_path_idx');
         });
     }
 

--- a/database/migrations/2025_12_16_213335_add_source_group_id_to_source_groups.php
+++ b/database/migrations/2025_12_16_213335_add_source_group_id_to_source_groups.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('source_groups', function (Blueprint $table) {
+            $table->unsignedBigInteger('source_group_id')->nullable()->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('source_groups', function (Blueprint $table) {
+            $table->dropColumn('source_group_id');
+        });
+    }
+};

--- a/tests/Feature/StrmFileMappingTest.php
+++ b/tests/Feature/StrmFileMappingTest.php
@@ -1,0 +1,311 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Episode;
+use App\Models\StrmFileMapping;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    $this->testDir = sys_get_temp_dir() . '/strm-test-' . uniqid();
+    @mkdir($this->testDir, 0755, true);
+});
+
+afterEach(function () {
+    // Clean up test directory
+    if (isset($this->testDir) && is_dir($this->testDir)) {
+        $this->recursiveDelete($this->testDir);
+    }
+});
+
+// Helper function to recursively delete a directory
+function recursiveDelete(string $dir): void
+{
+    if (is_dir($dir)) {
+        $objects = scandir($dir);
+        foreach ($objects as $object) {
+            if ($object !== '.' && $object !== '..') {
+                $path = $dir . '/' . $object;
+                if (is_dir($path)) {
+                    recursiveDelete($path);
+                } else {
+                    @unlink($path);
+                }
+            }
+        }
+        @rmdir($dir);
+    }
+}
+
+// Make recursiveDelete available on $this
+beforeEach(function () {
+    $this->recursiveDelete = function (string $dir): void {
+        if (is_dir($dir)) {
+            $objects = scandir($dir);
+            foreach ($objects as $object) {
+                if ($object !== '.' && $object !== '..') {
+                    $path = $dir . '/' . $object;
+                    if (is_dir($path)) {
+                        ($this->recursiveDelete)($path);
+                    } else {
+                        @unlink($path);
+                    }
+                }
+            }
+            @rmdir($dir);
+        }
+    };
+});
+
+describe('StrmFileMapping', function () {
+    it('can create a new strm file', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path = $this->testDir . '/Movies/Test Movie.strm';
+        $url = 'http://example.com/stream.ts';
+
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $path, $url, ['test' => true]);
+
+        expect($mapping)->toBeInstanceOf(StrmFileMapping::class);
+        expect($mapping->syncable_type)->toBe(Channel::class);
+        expect($mapping->syncable_id)->toBe($channel->id);
+        expect($mapping->sync_location)->toBe($this->testDir);
+        expect($mapping->current_path)->toBe($path);
+        expect($mapping->current_url)->toBe($url);
+        expect($mapping->path_options)->toBe(['test' => true]);
+        expect(file_exists($path))->toBeTrue();
+        expect(file_get_contents($path))->toBe($url);
+    });
+
+    it('can rename an existing strm file when path changes', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $oldPath = $this->testDir . '/Movies/Old Name.strm';
+        $newPath = $this->testDir . '/Movies/New Name.strm';
+        $url = 'http://example.com/stream.ts';
+
+        // Create initial file
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $oldPath, $url);
+        expect(file_exists($oldPath))->toBeTrue();
+
+        // Rename by syncing with new path
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $newPath, $url);
+
+        expect($mapping->current_path)->toBe($newPath);
+        expect(file_exists($newPath))->toBeTrue();
+        expect(file_exists($oldPath))->toBeFalse();
+    });
+
+    it('can update url without renaming file', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path = $this->testDir . '/Movies/Test Movie.strm';
+        $oldUrl = 'http://example.com/old-stream.ts';
+        $newUrl = 'http://example.com/new-stream.ts';
+
+        // Create initial file
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $path, $oldUrl);
+        expect(file_get_contents($path))->toBe($oldUrl);
+
+        // Update URL
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $path, $newUrl);
+
+        expect($mapping->current_url)->toBe($newUrl);
+        expect(file_get_contents($path))->toBe($newUrl);
+    });
+
+    it('can delete strm file and mapping', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path = $this->testDir . '/Movies/Test Movie.strm';
+        $url = 'http://example.com/stream.ts';
+
+        // Create file
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $path, $url);
+        $mappingId = $mapping->id;
+        expect(file_exists($path))->toBeTrue();
+
+        // Delete file
+        $mapping->deleteFile();
+
+        expect(file_exists($path))->toBeFalse();
+        expect(StrmFileMapping::find($mappingId))->toBeNull();
+    });
+
+    it('cleans up empty directories after file deletion', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path = $this->testDir . '/Movies/SubFolder/Test Movie.strm';
+        $url = 'http://example.com/stream.ts';
+
+        // Create file (creates directories)
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $path, $url);
+        expect(is_dir($this->testDir . '/Movies/SubFolder'))->toBeTrue();
+
+        // Delete file
+        $mapping->deleteFile();
+
+        expect(is_dir($this->testDir . '/Movies/SubFolder'))->toBeFalse();
+        expect(is_dir($this->testDir . '/Movies'))->toBeFalse();
+        // Sync location should still exist
+        expect(is_dir($this->testDir))->toBeTrue();
+    });
+
+    it('cleans up empty directories after file rename', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $oldPath = $this->testDir . '/OldFolder/Test Movie.strm';
+        $newPath = $this->testDir . '/NewFolder/Test Movie.strm';
+        $url = 'http://example.com/stream.ts';
+
+        // Create initial file
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $oldPath, $url);
+        expect(is_dir($this->testDir . '/OldFolder'))->toBeTrue();
+
+        // Rename to new folder
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $newPath, $url);
+
+        expect(is_dir($this->testDir . '/NewFolder'))->toBeTrue();
+        expect(is_dir($this->testDir . '/OldFolder'))->toBeFalse();
+    });
+
+    it('does not delete sync location when cleaning up', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path = $this->testDir . '/Test Movie.strm';
+        $url = 'http://example.com/stream.ts';
+
+        // Create file directly in sync location
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $path, $url);
+
+        // Delete file
+        $mapping->deleteFile();
+
+        // Sync location should still exist
+        expect(is_dir($this->testDir))->toBeTrue();
+    });
+
+    it('returns existing mapping without changes when nothing changed', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path = $this->testDir . '/Movies/Test Movie.strm';
+        $url = 'http://example.com/stream.ts';
+
+        // Create initial file
+        $mapping1 = StrmFileMapping::syncFile($channel, $this->testDir, $path, $url, ['option' => 'value']);
+
+        // Sync again with same values
+        $mapping2 = StrmFileMapping::syncFile($channel, $this->testDir, $path, $url, ['option' => 'value']);
+
+        expect($mapping1->id)->toBe($mapping2->id);
+        expect(StrmFileMapping::count())->toBe(1);
+    });
+
+    it('recreates file if it was externally deleted', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path = $this->testDir . '/Movies/Test Movie.strm';
+        $url = 'http://example.com/stream.ts';
+        $newUrl = 'http://example.com/new-stream.ts';
+
+        // Create initial file
+        StrmFileMapping::syncFile($channel, $this->testDir, $path, $url);
+
+        // Externally delete the file
+        @unlink($path);
+        expect(file_exists($path))->toBeFalse();
+
+        // Sync with new URL should recreate the file
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $path, $newUrl);
+
+        expect(file_exists($path))->toBeTrue();
+        expect(file_get_contents($path))->toBe($newUrl);
+    });
+});
+
+describe('StrmFileMapping relationships', function () {
+    it('has morphTo syncable relationship', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path = $this->testDir . '/Test.strm';
+        $url = 'http://example.com/stream.ts';
+
+        $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $path, $url);
+
+        expect($mapping->syncable)->toBeInstanceOf(Channel::class);
+        expect($mapping->syncable->id)->toBe($channel->id);
+    });
+
+    it('channel has morphMany strmFileMappings relationship', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path1 = $this->testDir . '/location1/Test.strm';
+        $path2 = $this->testDir . '/location2/Test.strm';
+        $url = 'http://example.com/stream.ts';
+
+        StrmFileMapping::syncFile($channel, $this->testDir . '/location1', $path1, $url);
+        StrmFileMapping::syncFile($channel, $this->testDir . '/location2', $path2, $url);
+
+        expect($channel->strmFileMappings)->toHaveCount(2);
+    });
+});
+
+describe('StrmFileMapping cleanup', function () {
+    it('can clean up orphaned mappings', function () {
+        $channel = Channel::factory()->create([
+            'user_id' => $this->user->id,
+            'enabled' => true,
+        ]);
+        $disabledChannel = Channel::factory()->create([
+            'user_id' => $this->user->id,
+            'enabled' => false,
+        ]);
+
+        $path1 = $this->testDir . '/enabled.strm';
+        $path2 = $this->testDir . '/disabled.strm';
+        $url = 'http://example.com/stream.ts';
+
+        StrmFileMapping::syncFile($channel, $this->testDir, $path1, $url);
+        StrmFileMapping::syncFile($disabledChannel, $this->testDir, $path2, $url);
+
+        expect(StrmFileMapping::count())->toBe(2);
+
+        // Clean up orphaned (disabled channels)
+        $count = StrmFileMapping::cleanupOrphaned(Channel::class, $this->testDir);
+
+        expect($count)->toBe(1);
+        expect(StrmFileMapping::count())->toBe(1);
+        expect(file_exists($path1))->toBeTrue();
+        expect(file_exists($path2))->toBeFalse();
+    });
+
+    it('cleans up mappings when syncable is deleted', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path = $this->testDir . '/Test.strm';
+        $url = 'http://example.com/stream.ts';
+
+        StrmFileMapping::syncFile($channel, $this->testDir, $path, $url);
+        expect(StrmFileMapping::count())->toBe(1);
+
+        // Delete the channel
+        $channel->delete();
+
+        // Clean up orphaned
+        $count = StrmFileMapping::cleanupOrphaned(Channel::class, $this->testDir);
+
+        expect($count)->toBe(1);
+        expect(StrmFileMapping::count())->toBe(0);
+    });
+});
+
+describe('StrmFileMapping findForSyncable', function () {
+    it('finds mapping by syncable and location', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $path = $this->testDir . '/Test.strm';
+        $url = 'http://example.com/stream.ts';
+
+        $created = StrmFileMapping::syncFile($channel, $this->testDir, $path, $url);
+        $found = StrmFileMapping::findForSyncable($channel, $this->testDir);
+
+        expect($found)->not->toBeNull();
+        expect($found->id)->toBe($created->id);
+    });
+
+    it('returns null when mapping not found', function () {
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+
+        $found = StrmFileMapping::findForSyncable($channel, $this->testDir);
+
+        expect($found)->toBeNull();
+    });
+});

--- a/tests/Feature/StrmFileMappingTest.php
+++ b/tests/Feature/StrmFileMappingTest.php
@@ -19,26 +19,7 @@ afterEach(function () {
     }
 });
 
-// Helper function to recursively delete a directory
-function recursiveDelete(string $dir): void
-{
-    if (is_dir($dir)) {
-        $objects = scandir($dir);
-        foreach ($objects as $object) {
-            if ($object !== '.' && $object !== '..') {
-                $path = $dir . '/' . $object;
-                if (is_dir($path)) {
-                    recursiveDelete($path);
-                } else {
-                    @unlink($path);
-                }
-            }
-        }
-        @rmdir($dir);
-    }
-}
-
-// Make recursiveDelete available on $this
+// Helper closure to recursively delete a directory, available on $this
 beforeEach(function () {
     $this->recursiveDelete = function (string $dir): void {
         if (is_dir($dir)) {
@@ -86,10 +67,12 @@ describe('StrmFileMapping', function () {
         // Create initial file
         $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $oldPath, $url);
         expect(file_exists($oldPath))->toBeTrue();
+        $originalId = $mapping->id;
 
         // Rename by syncing with new path
         $mapping = StrmFileMapping::syncFile($channel, $this->testDir, $newPath, $url);
 
+        expect($mapping->id)->toBe($originalId);
         expect($mapping->current_path)->toBe($newPath);
         expect(file_exists($newPath))->toBeTrue();
         expect(file_exists($oldPath))->toBeFalse();


### PR DESCRIPTION
Enhance the Playlist Alias edit form to properly support multiple Xtream
providers in a clear and stable way.

Changes:
- Added an explicit selector to choose the active Xtream provider using
  human-readable playlist names.
- Fixed issues where provider options could collapse after saving or editing.
- Normalized xtream_config state when loading existing aliases to prevent
  credential loss.
- Ensured the active provider selection resets safely to the default
  when providers are added or removed.

Result:
Editing Playlist Aliases no longer requires re-selecting Custom Playlists
or re-entering provider credentials, and the active provider selection
remains consistent across edits.
