### PR TITLE
fix: use DB_CONNECTION instead of ENABLE_POSTGRES for worker count

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -185,7 +185,7 @@ return [
             'queue' => ['default', 'import'],
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
-            'maxProcesses' => (bool) env('ENABLE_POSTGRES', false) ? 10 : 1,
+            'maxProcesses' => env('DB_CONNECTION', 'sqlite') === 'pgsql' ? 10 : 1,
             'maxTime' => 0,
             'maxJobs' => 0,
             'memory' => 512, // MB


### PR DESCRIPTION
ENABLE_POSTGRES controls whether to start internal Postgres container, not whether Postgres is used at all. Both internal and external Postgres users should get 10 workers, not just internal.

Changed from:
  'maxProcesses' => (bool) env('ENABLE_POSTGRES', false) ? 10 : 1

To:
  'maxProcesses' => env('DB_CONNECTION', 'sqlite') === 'pgsql' ? 10 : 1

This gives:
- SQLite users: 1 worker (SQLite has lock limitations)
- PostgreSQL users: 10 workers (regardless of internal/external)