### PR TITLE
feat: Add Background Jobs transparency feature

### DIFF
--- a/app/Filament/Pages/Jobs.php
+++ b/app/Filament/Pages/Jobs.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\JobProgress;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Contracts\Support\Htmlable;
+use RyanChandler\FilamentProgressColumn\ProgressColumn;
+
+class Jobs extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-queue-list';
+
+    protected string $view = 'filament.pages.jobs';
+
+    protected static ?string $navigationLabel = 'Background Jobs';
+
+    protected static ?string $title = 'Background Jobs';
+
+    protected ?string $subheading = 'Monitor the progress of background jobs like playlist syncs, EPG imports, and metadata fetching.';
+
+    public static function getNavigationSort(): ?int
+    {
+        return 1;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return 'Tools';
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        $count = JobProgress::active()->count();
+
+        return $count > 0 ? (string) $count : null;
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'primary';
+    }
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Background Jobs';
+    }
+
+    protected function getActions(): array
+    {
+        return [
+            Action::make('refresh')
+                ->label('Refresh')
+                ->icon(Heroicon::ArrowPath)
+                ->action(fn () => $this->resetTable())
+                ->color('gray'),
+            Action::make('clear_completed')
+                ->label('Clear Completed')
+                ->icon(Heroicon::Trash)
+                ->action(function () {
+                    JobProgress::finished()
+                        ->where('completed_at', '<', now()->subHours(1))
+                        ->delete();
+
+                    Notification::make()
+                        ->success()
+                        ->title('Completed jobs cleared')
+                        ->body('Jobs completed more than 1 hour ago have been removed.')
+                        ->send();
+
+                    $this->resetTable();
+                })
+                ->requiresConfirmation()
+                ->modalDescription('This will remove all completed, failed, and cancelled jobs that finished more than 1 hour ago.')
+                ->color('danger'),
+        ];
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(JobProgress::query()->latest())
+            ->poll('5s')
+            ->columns([
+                TextColumn::make('name')
+                    ->label('Job')
+                    ->searchable()
+                    ->sortable()
+                    ->description(fn (JobProgress $record): ?string => $record->trackable?->name ?? null),
+                TextColumn::make('job_type')
+                    ->label('Type')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => str($state)->afterLast('\\')->toString())
+                    ->color('gray'),
+                ProgressColumn::make('progress_percent')
+                    ->label('Progress')
+                    ->progress(fn (JobProgress $record): float => $record->progress_percent)
+                    ->color(fn (JobProgress $record): string => match ($record->status) {
+                        JobProgress::STATUS_COMPLETED => 'success',
+                        JobProgress::STATUS_FAILED => 'danger',
+                        JobProgress::STATUS_CANCELLED => 'warning',
+                        JobProgress::STATUS_RUNNING => 'primary',
+                        default => 'gray',
+                    }),
+                TextColumn::make('processed_items')
+                    ->label('Items')
+                    ->formatStateUsing(fn (JobProgress $record): string => $record->total_items > 0
+                        ? "{$record->processed_items} / {$record->total_items}"
+                        : (string) $record->processed_items
+                    )
+                    ->alignCenter(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        JobProgress::STATUS_COMPLETED => 'success',
+                        JobProgress::STATUS_FAILED => 'danger',
+                        JobProgress::STATUS_CANCELLED => 'warning',
+                        JobProgress::STATUS_RUNNING => 'primary',
+                        JobProgress::STATUS_PENDING => 'gray',
+                        default => 'gray',
+                    }),
+                TextColumn::make('message')
+                    ->label('Status Message')
+                    ->limit(50)
+                    ->tooltip(fn (JobProgress $record): ?string => $record->message)
+                    ->placeholder('—'),
+                TextColumn::make('started_at')
+                    ->label('Started')
+                    ->dateTime('M j, H:i:s')
+                    ->sortable()
+                    ->placeholder('Not started'),
+                TextColumn::make('completed_at')
+                    ->label('Finished')
+                    ->dateTime('M j, H:i:s')
+                    ->sortable()
+                    ->placeholder('—'),
+                TextColumn::make('created_at')
+                    ->label('Queued')
+                    ->dateTime('M j, H:i:s')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                //
+            ])
+            ->bulkActions([
+                //
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->emptyStateHeading('No background jobs')
+            ->emptyStateDescription('Background jobs will appear here when playlist syncs, EPG imports, or other long-running tasks are started.')
+            ->emptyStateIcon('heroicon-o-queue-list');
+    }
+}

--- a/app/Jobs/MapEpgToChannelsComplete.php
+++ b/app/Jobs/MapEpgToChannelsComplete.php
@@ -6,6 +6,7 @@ use App\Enums\Status;
 use App\Models\Epg;
 use App\Models\EpgMap;
 use App\Models\Job;
+use App\Models\JobProgress;
 use App\Models\Playlist;
 use Carbon\Carbon;
 use Filament\Notifications\Notification;
@@ -73,6 +74,12 @@ class MapEpgToChannelsComplete implements ShouldQueue
                 'processing' => false,
             ]);
         }
+
+        // Mark job progress as completed for EPG mapping jobs
+        JobProgress::forTrackable($this->epg)
+            ->where('job_type', MapPlaylistChannelsToEpg::class)
+            ->active()
+            ->each(fn (JobProgress $job) => $job->complete("EPG mapping completed. Mapped {$actualMappedCount} of {$this->channelCount} channels."));
 
         // Notify the user
         $epg = $this->epg;

--- a/app/Jobs/ProcessM3uImportComplete.php
+++ b/app/Jobs/ProcessM3uImportComplete.php
@@ -2,18 +2,19 @@
 
 namespace App\Jobs;
 
-use Exception;
 use App\Enums\Status;
 use App\Events\SyncCompleted;
 use App\Models\Channel;
 use App\Models\Group;
 use App\Models\Job;
+use App\Models\JobProgress;
 use App\Models\PlaylistSyncStatus;
 use App\Models\PlaylistSyncStatusLog;
 use App\Models\User;
 use App\Services\EpgCacheService;
 use App\Settings\GeneralSettings;
 use Carbon\Carbon;
+use Exception;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -37,6 +38,7 @@ class ProcessM3uImportComplete implements ShouldQueue
 
     // Whether to invalidate the import if the number of new channels is less than the current count
     public $invalidateImport = false;
+
     public $invalidateImportThreshold = 100; // Default threshold for invalidating import
 
     // Default user agent to use for HTTP requests
@@ -109,12 +111,12 @@ class ProcessM3uImportComplete implements ShouldQueue
 
         // See if sync logs are disabled
         $syncLogsDisabled = config('dev.disable_sync_logs', false);
-        if (!$playlist->sync_logs_enabled) {
+        if (! $playlist->sync_logs_enabled) {
             $syncLogsDisabled = true;
         }
 
         // If not a new playlist create a new playlst sync status!
-        if (!$this->isNew) {
+        if (! $this->isNew) {
             // Get counts for removed and new groups/channels
             $removedGroupCount = $removedGroups->count();
             $newGroupCount = $newGroups->count();
@@ -135,7 +137,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                     // If the new count will be less than the current count (minus the threshold), invalidate the import
                     if ($newCount < ($currentCount - $this->invalidateImportThreshold)) {
                         $message = "Playlist Sync Invalidated: The channel count would have been {$newCount} after import, which is less than the current count of {$currentCount} minus the threshold of {$this->invalidateImportThreshold}.";
-                        if (!$syncLogsDisabled) {
+                        if (! $syncLogsDisabled) {
                             $sync = PlaylistSyncStatus::create([
                                 'name' => $playlist->name,
                                 'user_id' => $user->id,
@@ -150,7 +152,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                                     'max_hit' => $this->maxHit,
                                     'message' => $message,
                                     'status' => 'canceled',
-                                ]
+                                ],
                             ]);
 
                             /*
@@ -173,7 +175,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                                 ...$playlist->processing ?? [],
                                 'live_processing' => false,
                                 'vod_processing' => false,
-                            ]
+                            ],
                         ]);
 
                         // Cleanup the any new groups/channels
@@ -190,12 +192,13 @@ class ProcessM3uImportComplete implements ShouldQueue
                             ->body($message)
                             ->broadcast($user)
                             ->sendToDatabase($user);
+
                         return;
                     }
                 }
             }
 
-            if (!$syncLogsDisabled) {
+            if (! $syncLogsDisabled) {
                 $sync = PlaylistSyncStatus::create([
                     'name' => $playlist->name,
                     'user_id' => $user->id,
@@ -209,7 +212,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                         'added_channels' => $newChannelCount,
                         'max_hit' => $this->maxHit,
                         'status' => 'success',
-                    ]
+                    ],
                 ]);
                 $this->createSyncLogEntries(
                     $sync,
@@ -252,10 +255,10 @@ class ProcessM3uImportComplete implements ShouldQueue
 
                 // Make sure EPG doesn't already exist
                 $epg = $user->epgs()->where('url', $epgUrl)->first();
-                if (!$epg) {
+                if (! $epg) {
                     // Create EPG to trigger sync
                     $epg = $user->epgs()->create([
-                        'name' => $playlist->name . ' EPG',
+                        'name' => $playlist->name.' EPG',
                         'url' => $epgUrl,
                         'user_id' => $user->id,
                         'user_agent' => $playlist->user_agent,
@@ -291,7 +294,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                 ...$playlist->processing ?? [],
                 'live_processing' => false,
                 'vod_processing' => false,
-            ]
+            ],
         ];
         if ($this->runningLiveImport) {
             $update['progress'] = 100; // Only set if Live import was run
@@ -300,6 +303,11 @@ class ProcessM3uImportComplete implements ShouldQueue
             $update['vod_progress'] = 100; // Only set if VOD import was run
         }
         $playlist->update($update);
+
+        // Mark job progress as completed
+        JobProgress::forTrackable($playlist)->active()->each(function (JobProgress $job) {
+            $job->complete('Playlist sync completed successfully.');
+        });
 
         // Send notification
         if ($this->maxHit) {
@@ -344,7 +352,7 @@ class ProcessM3uImportComplete implements ShouldQueue
         $syncVod = ($playlist->auto_sync_vod_stream_files || $playlist->auto_fetch_vod_metadata)
             && $playlist->channels()->where([
                 ['enabled', true],
-                ['is_vod', true]
+                ['is_vod', true],
             ])->exists();
 
         if ($syncVod) {
@@ -352,11 +360,11 @@ class ProcessM3uImportComplete implements ShouldQueue
             $syncStreamFiles = $playlist->auto_sync_vod_stream_files;
             $syncMetaData = $playlist->auto_fetch_vod_metadata;
             if ($syncStreamFiles && $syncMetaData) {
-                $message = "Syncing VOD stream files and fetching VOD metadata now. Please check back later.";
+                $message = 'Syncing VOD stream files and fetching VOD metadata now. Please check back later.';
             } elseif ($syncStreamFiles) {
-                $message = "Syncing VOD stream files now. Please check back later.";
+                $message = 'Syncing VOD stream files now. Please check back later.';
             } elseif ($syncMetaData) {
-                $message = "Fetching VOD metadata now. Please check back later.";
+                $message = 'Fetching VOD metadata now. Please check back later.';
             }
 
             // Process VOD import
@@ -416,11 +424,7 @@ class ProcessM3uImportComplete implements ShouldQueue
     /**
      * Create the sync log entries for the import.
      *
-     * @param PlaylistSyncStatus $sync
-     * @param $newChannels
-     * @param $removedChannels
-     * @param $newGroups
-     * @param $removedGroups
+     * @param  PlaylistSyncStatus  $sync
      */
     private function createSyncLogEntries(
         $sync,

--- a/app/Jobs/ProcessM3uImportSeriesComplete.php
+++ b/app/Jobs/ProcessM3uImportSeriesComplete.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Enums\Status;
 use App\Events\SyncCompleted;
 use App\Models\Job;
+use App\Models\JobProgress;
 use App\Models\Playlist;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -41,6 +42,21 @@ class ProcessM3uImportSeriesComplete implements ShouldQueue
             'errors' => null,
             'series_progress' => 100,
         ]);
+
+        // Mark job progress as completed for series jobs
+        JobProgress::forTrackable($this->playlist)
+            ->where('job_type', ProcessM3uImportSeries::class)
+            ->active()
+            ->each(fn (JobProgress $job) => $job->complete('Series sync completed successfully.'));
+
+        // Sync stream files for series, if enabled
+        if ($this->playlist->auto_sync_series_stream_files) {
+            dispatch(new SyncSeriesStrmFiles(
+                playlist_id: $this->playlist->id,
+                user_id: $this->playlist->user_id,
+            ));
+        }
+
         $message = "Series sync completed successfully for playlist \"{$this->playlist->name}\".";
         Notification::make()
             ->success()

--- a/app/Jobs/ProcessVodChannelsComplete.php
+++ b/app/Jobs/ProcessVodChannelsComplete.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Enums\Status;
+use App\Models\JobProgress;
 use App\Models\Playlist;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -41,6 +42,12 @@ class ProcessVodChannelsComplete implements ShouldQueue
             'errors' => null,
             'vod_progress' => 100,
         ]);
+
+        // Mark job progress as completed for VOD jobs
+        JobProgress::forTrackable($this->playlist)
+            ->where('job_type', ProcessVodChannels::class)
+            ->active()
+            ->each(fn (JobProgress $job) => $job->complete('VOD sync completed successfully.'));
 
         $message = "VOD sync completed successfully for playlist \"{$this->playlist->name}\".";
 

--- a/app/Models/JobProgress.php
+++ b/app/Models/JobProgress.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class JobProgress extends Model
+{
+    use HasFactory;
+
+    protected $table = 'job_progress';
+
+    /**
+     * The attributes that should be cast to native types.
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'user_id' => 'integer',
+        'total_items' => 'integer',
+        'processed_items' => 'integer',
+        'started_at' => 'datetime',
+        'completed_at' => 'datetime',
+    ];
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'user_id',
+        'job_type',
+        'batch_id',
+        'trackable_type',
+        'trackable_id',
+        'name',
+        'total_items',
+        'processed_items',
+        'status',
+        'message',
+        'started_at',
+        'completed_at',
+    ];
+
+    // Status constants
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_RUNNING = 'running';
+
+    public const STATUS_COMPLETED = 'completed';
+
+    public const STATUS_FAILED = 'failed';
+
+    public const STATUS_CANCELLED = 'cancelled';
+
+    /**
+     * Get the user that owns this job progress.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the trackable model (Playlist, Epg, etc).
+     */
+    public function trackable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Calculate progress percentage.
+     */
+    public function getProgressPercentAttribute(): float
+    {
+        if ($this->total_items === 0) {
+            return $this->status === self::STATUS_COMPLETED ? 100 : 0;
+        }
+
+        return round(($this->processed_items / $this->total_items) * 100, 2);
+    }
+
+    /**
+     * Check if job is active (pending or running).
+     */
+    public function isActive(): bool
+    {
+        return in_array($this->status, [self::STATUS_PENDING, self::STATUS_RUNNING]);
+    }
+
+    /**
+     * Check if job is finished (completed, failed, or cancelled).
+     */
+    public function isFinished(): bool
+    {
+        return in_array($this->status, [self::STATUS_COMPLETED, self::STATUS_FAILED, self::STATUS_CANCELLED]);
+    }
+
+    /**
+     * Scope for active jobs.
+     */
+    public function scopeActive($query)
+    {
+        return $query->whereIn('status', [self::STATUS_PENDING, self::STATUS_RUNNING]);
+    }
+
+    /**
+     * Scope for finished jobs.
+     */
+    public function scopeFinished($query)
+    {
+        return $query->whereIn('status', [self::STATUS_COMPLETED, self::STATUS_FAILED, self::STATUS_CANCELLED]);
+    }
+
+    /**
+     * Scope for a specific trackable model.
+     */
+    public function scopeForTrackable($query, Model $model)
+    {
+        return $query->where('trackable_type', get_class($model))
+            ->where('trackable_id', $model->getKey());
+    }
+
+    /**
+     * Start the job (set status to running).
+     */
+    public function start(): self
+    {
+        $this->update([
+            'status' => self::STATUS_RUNNING,
+            'started_at' => now(),
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Update progress.
+     */
+    public function progress(int $processed, ?string $message = null): self
+    {
+        $data = ['processed_items' => $processed];
+
+        if ($message !== null) {
+            $data['message'] = $message;
+        }
+
+        $this->update($data);
+
+        return $this;
+    }
+
+    /**
+     * Increment progress by a given amount.
+     */
+    public function incrementProgress(int $amount = 1, ?string $message = null): self
+    {
+        $this->increment('processed_items', $amount);
+
+        if ($message !== null) {
+            $this->update(['message' => $message]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Mark job as completed.
+     */
+    public function complete(?string $message = null): self
+    {
+        $this->update([
+            'status' => self::STATUS_COMPLETED,
+            'completed_at' => now(),
+            'message' => $message ?? $this->message,
+            'processed_items' => $this->total_items > 0 ? $this->total_items : $this->processed_items,
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Mark job as failed.
+     */
+    public function fail(?string $message = null): self
+    {
+        $this->update([
+            'status' => self::STATUS_FAILED,
+            'completed_at' => now(),
+            'message' => $message ?? $this->message,
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Mark job as cancelled.
+     */
+    public function cancel(?string $message = null): self
+    {
+        $this->update([
+            'status' => self::STATUS_CANCELLED,
+            'completed_at' => now(),
+            'message' => $message ?? 'Job was cancelled',
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Create a new job progress record.
+     */
+    public static function createForJob(
+        string $jobType,
+        string $name,
+        ?Model $trackable = null,
+        ?int $totalItems = 0,
+        ?string $batchId = null,
+        ?int $userId = null
+    ): self {
+        return self::create([
+            'user_id' => $userId ?? auth()->id(),
+            'job_type' => $jobType,
+            'batch_id' => $batchId,
+            'trackable_type' => $trackable ? get_class($trackable) : null,
+            'trackable_id' => $trackable?->getKey(),
+            'name' => $name,
+            'total_items' => $totalItems,
+            'processed_items' => 0,
+            'status' => self::STATUS_PENDING,
+        ]);
+    }
+
+    /**
+     * Find or create a job progress for a batch.
+     */
+    public static function findOrCreateForBatch(
+        string $batchId,
+        string $jobType,
+        string $name,
+        ?Model $trackable = null,
+        ?int $totalItems = 0,
+        ?int $userId = null
+    ): self {
+        return self::firstOrCreate(
+            ['batch_id' => $batchId],
+            [
+                'user_id' => $userId ?? auth()->id(),
+                'job_type' => $jobType,
+                'trackable_type' => $trackable ? get_class($trackable) : null,
+                'trackable_id' => $trackable?->getKey(),
+                'name' => $name,
+                'total_items' => $totalItems,
+                'processed_items' => 0,
+                'status' => self::STATUS_PENDING,
+            ]
+        );
+    }
+
+    /**
+     * Get count of active jobs for a user.
+     */
+    public static function activeCountForUser(?int $userId = null): int
+    {
+        $query = self::active();
+
+        if ($userId !== null) {
+            $query->where('user_id', $userId);
+        }
+
+        return $query->count();
+    }
+
+    /**
+     * Check if there are active jobs for a specific trackable.
+     */
+    public static function hasActiveJobsFor(Model $model): bool
+    {
+        return self::forTrackable($model)->active()->exists();
+    }
+}

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -49,6 +49,7 @@ class Playlist extends Model
         'include_series_in_m3u' => 'boolean',
         'include_vod_in_m3u' => 'boolean',
         'auto_fetch_series_metadata' => 'boolean',
+        'auto_sync_series_stream_files' => 'boolean',
         'auto_merge_channels_enabled' => 'boolean',
         'auto_merge_deactivate_failover' => 'boolean',
         'auto_merge_config' => 'array',

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers\Filament;
 
-use AchyutN\FilamentLogViewer\FilamentLogViewer;
 use App\Filament\Auth\EditProfile;
 use App\Filament\Auth\Login;
 use App\Filament\Pages\Backups;
@@ -78,7 +77,7 @@ class AdminPanelProvider extends PanelProvider
                     ->recoverable(),
             ])
             ->brandName('m3u editor')
-            ->brandLogo(fn() => view('filament.admin.logo'))
+            ->brandLogo(fn () => view('filament.admin.logo'))
             ->favicon('/favicon.png')
             ->brandLogoHeight('2.5rem')
             ->databaseNotifications()
@@ -124,7 +123,7 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->plugins([
                 FilamentSpatieLaravelBackupPlugin::make()
-                    ->authorize(fn(): bool => in_array(auth()->user()->email, config('dev.admin_emails'), true))
+                    ->authorize(fn (): bool => in_array(auth()->user()->email, config('dev.admin_emails'), true))
                     ->usingPage(Backups::class),
             ])
             ->maxContentWidth($settings['content_width'])
@@ -146,7 +145,7 @@ class AdminPanelProvider extends PanelProvider
             ->viteTheme('resources/css/app.css')
             ->unsavedChangesAlerts()
             ->spa()
-            ->spaUrlExceptions(fn(): array => [
+            ->spaUrlExceptions(fn (): array => [
                 '*/playlist.m3u',
                 '*/epg.xml',
                 'epgs/*/epg.xml',
@@ -168,12 +167,18 @@ class AdminPanelProvider extends PanelProvider
         if ($settings['output_wan_address']) {
             FilamentView::registerRenderHook(
                 PanelsRenderHook::GLOBAL_SEARCH_BEFORE, // Place it before the global search
-                fn(): string => view('components.external-ip-display')->render()
+                fn (): string => view('components.external-ip-display')->render()
             );
         }
 
+        // Register background jobs indicator in the header
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::GLOBAL_SEARCH_BEFORE,
+            fn (): string => view('components.job-indicator')->render()
+        );
+
         // Register our custom app js
-        FilamentView::registerRenderHook('panels::body.end', fn() => Blade::render("@vite('resources/js/app.js')"));
+        FilamentView::registerRenderHook('panels::body.end', fn () => Blade::render("@vite('resources/js/app.js')"));
 
         // Return the configured panel
         return $adminPanel;

--- a/app/Traits/TracksJobProgress.php
+++ b/app/Traits/TracksJobProgress.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\JobProgress;
+use Illuminate\Database\Eloquent\Model;
+
+trait TracksJobProgress
+{
+    /**
+     * The job progress instance for this job.
+     */
+    protected ?JobProgress $jobProgress = null;
+
+    /**
+     * Initialize job progress tracking.
+     */
+    protected function initializeJobProgress(
+        string $name,
+        ?Model $trackable = null,
+        int $totalItems = 0,
+        ?string $batchId = null
+    ): JobProgress {
+        $this->jobProgress = JobProgress::createForJob(
+            jobType: static::class,
+            name: $name,
+            trackable: $trackable,
+            totalItems: $totalItems,
+            batchId: $batchId,
+            userId: $trackable?->user_id ?? auth()->id()
+        );
+
+        return $this->jobProgress;
+    }
+
+    /**
+     * Find or create job progress for a batch operation.
+     */
+    protected function findOrCreateBatchProgress(
+        string $batchId,
+        string $name,
+        ?Model $trackable = null,
+        int $totalItems = 0
+    ): JobProgress {
+        $this->jobProgress = JobProgress::findOrCreateForBatch(
+            batchId: $batchId,
+            jobType: static::class,
+            name: $name,
+            trackable: $trackable,
+            totalItems: $totalItems,
+            userId: $trackable?->user_id ?? auth()->id()
+        );
+
+        return $this->jobProgress;
+    }
+
+    /**
+     * Start the job progress (mark as running).
+     */
+    protected function startJobProgress(): void
+    {
+        $this->jobProgress?->start();
+    }
+
+    /**
+     * Update the total items count.
+     */
+    protected function setTotalItems(int $total): void
+    {
+        $this->jobProgress?->update(['total_items' => $total]);
+    }
+
+    /**
+     * Update progress with a specific count.
+     */
+    protected function updateJobProgress(int $processed, ?string $message = null): void
+    {
+        $this->jobProgress?->progress($processed, $message);
+    }
+
+    /**
+     * Increment progress by a specific amount.
+     */
+    protected function incrementJobProgress(int $amount = 1, ?string $message = null): void
+    {
+        $this->jobProgress?->incrementProgress($amount, $message);
+    }
+
+    /**
+     * Update the status message.
+     */
+    protected function setJobProgressMessage(string $message): void
+    {
+        $this->jobProgress?->update(['message' => $message]);
+    }
+
+    /**
+     * Mark the job as completed.
+     */
+    protected function completeJobProgress(?string $message = null): void
+    {
+        $this->jobProgress?->complete($message);
+    }
+
+    /**
+     * Mark the job as failed.
+     */
+    protected function failJobProgress(?string $message = null): void
+    {
+        $this->jobProgress?->fail($message);
+    }
+
+    /**
+     * Get the current job progress instance.
+     */
+    protected function getJobProgress(): ?JobProgress
+    {
+        return $this->jobProgress;
+    }
+
+    /**
+     * Check if there's an active job for the given model.
+     */
+    protected function hasActiveJobFor(Model $model): bool
+    {
+        return JobProgress::hasActiveJobsFor($model);
+    }
+}

--- a/database/migrations/2025_12_19_000001_create_job_progress_table.php
+++ b/database/migrations/2025_12_19_000001_create_job_progress_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('job_progress', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('job_type');
+            $table->string('batch_id')->nullable()->index();
+            $table->string('trackable_type')->nullable();
+            $table->unsignedBigInteger('trackable_id')->nullable();
+            $table->string('name');
+            $table->unsignedInteger('total_items')->default(0);
+            $table->unsignedInteger('processed_items')->default(0);
+            $table->string('status')->default('pending'); // pending, running, completed, failed, cancelled
+            $table->text('message')->nullable();
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['trackable_type', 'trackable_id']);
+            $table->index(['status', 'created_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('job_progress');
+    }
+};

--- a/database/migrations/2025_12_20_143500_add_sync_series_files_to_playlists.php
+++ b/database/migrations/2025_12_20_143500_add_sync_series_files_to_playlists.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->boolean('auto_sync_series_stream_files')->default(false)
+                ->after('auto_fetch_series_metadata')
+                ->comment('Automatically sync stream files for series on playlist sync');
+        });
+
+        // Migrate existing data: if auto_fetch_series_metadata was enabled, 
+        // assume they also want stream files synced (to maintain existing behavior)
+        DB::table('playlists')
+            ->where('auto_fetch_series_metadata', true)
+            ->update(['auto_sync_series_stream_files' => true]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->dropColumn('auto_sync_series_stream_files');
+        });
+    }
+};

--- a/resources/views/components/job-indicator.blade.php
+++ b/resources/views/components/job-indicator.blade.php
@@ -1,0 +1,41 @@
+<div 
+    x-data="{ 
+        count: 0,
+        init() {
+            // Initial fetch
+            this.fetchCount();
+            // Poll every 5 seconds for updated job count
+            setInterval(() => this.fetchCount(), 5000);
+        },
+        fetchCount() {
+            fetch('{{ route('jobs.active-count') }}')
+                .then(response => response.json())
+                .then(data => {
+                    this.count = data.count;
+                })
+                .catch(() => {});
+        }
+    }"
+    x-show="count > 0"
+    x-transition
+    x-cloak
+    class="flex items-center gap-2"
+>
+    <a 
+        href="{{ \App\Filament\Pages\Jobs::getUrl() }}"
+        class="flex items-center gap-2 px-3 py-1.5 bg-primary-50 dark:bg-primary-900/50 hover:bg-primary-100 dark:hover:bg-primary-900 rounded-lg border border-primary-200 dark:border-primary-700 transition-colors"
+        title="Background jobs running - click to view"
+    >
+        <div class="relative">
+            <x-heroicon-s-queue-list class="h-5 w-5 text-primary-600 dark:text-primary-400" />
+            <span class="absolute -top-1 -right-1 flex h-3 w-3">
+                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-400 opacity-75"></span>
+                <span class="relative inline-flex rounded-full h-3 w-3 bg-primary-500"></span>
+            </span>
+        </div>
+        <span 
+            x-text="count + ' job' + (count === 1 ? '' : 's')"
+            class="text-xs font-medium text-primary-700 dark:text-primary-300"
+        ></span>
+    </a>
+</div>

--- a/resources/views/filament/pages/jobs.blade.php
+++ b/resources/views/filament/pages/jobs.blade.php
@@ -1,0 +1,3 @@
+<x-filament-panels::page>
+    {{ $this->table }}
+</x-filament-panels::page>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,13 @@ Route::post('/admin/refresh-external-ip', function (ExternalIpService $ipService
     return response()->json(['success' => true, 'external_ip' => $ip]);
 })->middleware(['auth']);
 
+// Background jobs active count for header indicator
+Route::get('/jobs/active-count', function () {
+    return response()->json([
+        'count' => \App\Models\JobProgress::active()->count(),
+    ]);
+})->middleware(['auth'])->name('jobs.active-count');
+
 // Handle short URLs with optional path forwarding (e.g. /s/{key}/device.xml)
 Route::get('/s/{shortUrlKey}/{path?}', function (Request $request, string $shortUrlKey, ?string $path = null) {
     $response = app()->call(ShortURLController::class, [
@@ -32,15 +39,15 @@ Route::get('/s/{shortUrlKey}/{path?}', function (Request $request, string $short
     if ($path) {
         $parsed = parse_url($response->getTargetUrl());
 
-        $base = ($parsed['scheme'] ?? '') . '://' . ($parsed['host'] ?? '');
+        $base = ($parsed['scheme'] ?? '').'://'.($parsed['host'] ?? '');
         if (isset($parsed['port'])) {
-            $base .= ':' . $parsed['port'];
+            $base .= ':'.$parsed['port'];
         }
         $base .= $parsed['path'] ?? '';
-        $base = rtrim($base, '/') . '/' . ltrim($path, '/');
+        $base = rtrim($base, '/').'/'.ltrim($path, '/');
 
         if (! empty($parsed['query'])) {
-            $base .= '?' . $parsed['query'];
+            $base .= '?'.$parsed['query'];
         }
 
         return redirect($base, $response->getStatusCode());
@@ -48,7 +55,6 @@ Route::get('/s/{shortUrlKey}/{path?}', function (Request $request, string $short
 
     return $response;
 })->where('path', '.*');
-
 
 /*
  * Logo proxy route - cache and serve remote logos
@@ -60,7 +66,6 @@ Route::get('/logo-proxy/{encodedUrl}', [LogoProxyController::class, 'serveLogo']
 /*
  * Playlist/EPG output routes
  */
-
 
 // Generate M3U playlist from the playlist configuration
 Route::get('/{uuid}/playlist.m3u', PlaylistGenerateController::class)
@@ -87,7 +92,6 @@ Route::get('/{uuid}/epg.xml.gz', [EpgGenerateController::class, 'compressed'])
 Route::get('epgs/{uuid}/epg.xml', EpgFileController::class)
     ->name('epg.file');
 
-
 /*
  * DEBUG routes
  */
@@ -107,7 +111,6 @@ Route::get('/phpinfo', function () {
     }
 });
 
-
 /*
  * Proxy routes (redirects to m3u-proxy API)
  */
@@ -125,7 +128,6 @@ Route::get('/shared/stream/{encodedId}.{format?}', function (string $encodedId) 
 
     return redirect()->route('m3u-proxy.channel', ['id' => $id]);
 })->name('shared.stream.channel');
-
 
 /*
  * API routes
@@ -163,7 +165,6 @@ Route::group(['prefix' => 'epg'], function () {
     Route::get('{uuid}/sync', [\App\Http\Controllers\EpgController::class, 'refreshEpg'])
         ->name('api.epg.sync');
 });
-
 
 /*
  * Xtream API endpoints at root


### PR DESCRIPTION
- Add new Jobs page (Tools > Background Jobs) with progress tracking table
- Add JobProgress model and migration for tracking job state
- Add TracksJobProgress trait for easy job integration
- Add job indicator in header showing active job count with animation
- Add queue warnings on sync action modals when jobs are already running

Jobs now tracked:
- Playlist sync (ProcessM3uImport)
- EPG sync (ProcessEpgImport)
- EPG mapping (MapPlaylistChannelsToEpg)
- Series metadata sync (ProcessM3uImportSeries)
- Series STRM sync (SyncSeriesStrmFiles)
- VOD metadata sync (ProcessVodChannels)
- VOD STRM sync (SyncVodStrmFiles)

Series Processing improvements:
- Split into 3 separate toggles (matching VOD): Fetch metadata, Sync stream files, Include in M3U
- Add auto_sync_series_stream_files field to playlists
- Auto-trigger Series STRM Sync after Series import when enabled

Progress update optimizations:
- VOD STRM sync: Update every 100 items + final update before completion
- Series STRM sync: Update every 10 series + lazy relation loading