### PR TITLE
perf: Bulk-load StrmFileMappings to eliminate N+1 queries

### DIFF
--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -209,7 +209,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 $cleanName = $cleanSpecialChars
                     ? PlaylistService::makeFilesystemSafe($catName, $replaceChar)
                     : PlaylistService::makeFilesystemSafe($catName);
-                $path .= '/'.$cleanName;
+                $path .= '/' . $cleanName;
             }
 
             // See if the series is enabled, if not, skip, else create the folder
@@ -244,7 +244,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 $cleanName = $cleanSpecialChars
                     ? PlaylistService::makeFilesystemSafe($seriesFolder, $replaceChar)
                     : PlaylistService::makeFilesystemSafe($seriesFolder);
-                $path .= '/'.$cleanName;
+                $path .= '/' . $cleanName;
             }
 
             // Get filename metadata settings
@@ -256,7 +256,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 // Setup episode prefix
                 $season = $ep->season;
                 $num = str_pad($ep->episode_num, 2, '0', STR_PAD_LEFT);
-                $prefx = 'S'.str_pad($season, 2, '0', STR_PAD_LEFT)."E{$num}";
+                $prefx = 'S' . str_pad($season, 2, '0', STR_PAD_LEFT) . "E{$num}";
 
                 // Build the base filename (apply name filtering to episode title)
                 $episodeTitle = $applyNameFilter($ep->title);
@@ -284,22 +284,22 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 // Remove consecutive replacement characters if enabled
                 if ($removeConsecutiveChars && $replaceChar !== 'remove') {
                     $char = $replaceChar === 'space' ? ' ' : ($replaceChar === 'dash' ? '-' : ($replaceChar === 'underscore' ? '_' : '.'));
-                    $fileName = preg_replace('/'.preg_quote($char, '/').'{2,}/', $char, $fileName);
+                    $fileName = preg_replace('/' . preg_quote($char, '/') . '{2,}/', $char, $fileName);
                 }
 
                 $fileName = "{$fileName}.strm";
 
                 // Build the season folder path
                 if (in_array('season', $pathStructure)) {
-                    $seasonPath = $path.'/Season '.str_pad($season, 2, '0', STR_PAD_LEFT);
-                    $filePath = $seasonPath.'/'.$fileName;
+                    $seasonPath = $path . '/Season ' . str_pad($season, 2, '0', STR_PAD_LEFT);
+                    $filePath = $seasonPath . '/' . $fileName;
                 } else {
-                    $filePath = $path.'/'.$fileName;
+                    $filePath = $path . '/' . $fileName;
                 }
 
                 // Generate the url
                 $containerExtension = $ep->container_extension ?? 'mp4';
-                $url = rtrim("/series/{$playlist->user->name}/{$playlist->uuid}/".$ep->id.'.'.$containerExtension, '.');
+                $url = rtrim("/series/{$playlist->user->name}/{$playlist->uuid}/" . $ep->id . '.' . $containerExtension, '.');
                 $url = PlaylistService::getBaseUrl($url);
 
                 // Build path options for tracking changes

--- a/app/Jobs/SyncVodStrmFiles.php
+++ b/app/Jobs/SyncVodStrmFiles.php
@@ -146,7 +146,7 @@ class SyncVodStrmFiles implements ShouldQueue
                     $groupFolder = $cleanSpecialChars
                         ? PlaylistService::makeFilesystemSafe($groupName, $replaceChar)
                         : PlaylistService::makeFilesystemSafe($groupName);
-                    $groupPath = $path.'/'.$groupFolder;
+                    $groupPath = $path . '/' . $groupFolder;
                     if (! is_dir($groupPath)) {
                         mkdir($groupPath, 0777, true);
                     }
@@ -193,7 +193,7 @@ class SyncVodStrmFiles implements ShouldQueue
                     $titleFolder = $cleanSpecialChars
                         ? PlaylistService::makeFilesystemSafe($titleFolder, $replaceChar)
                         : PlaylistService::makeFilesystemSafe($titleFolder);
-                    $titlePath = $path.'/'.$titleFolder;
+                    $titlePath = $path . '/' . $titleFolder;
                     if (! is_dir($titlePath)) {
                         mkdir($titlePath, 0777, true);
                     }
@@ -240,16 +240,16 @@ class SyncVodStrmFiles implements ShouldQueue
                 // Remove consecutive replacement characters if enabled
                 if ($removeConsecutiveChars && $replaceChar !== 'remove') {
                     $char = $replaceChar === 'space' ? ' ' : ($replaceChar === 'dash' ? '-' : ($replaceChar === 'underscore' ? '_' : '.'));
-                    $fileName = preg_replace('/'.preg_quote($char, '/').'{2,}/', $char, $fileName);
+                    $fileName = preg_replace('/' . preg_quote($char, '/') . '{2,}/', $char, $fileName);
                 }
 
                 $fileName = "{$fileName}.strm";
-                $filePath = $path.'/'.$fileName;
+                $filePath = $path . '/' . $fileName;
 
                 // Generate the url
                 $playlist = $this->playlist ?? $channel->getEffectivePlaylist();
                 $extension = $channel->container_extension ?? 'mkv';
-                $url = rtrim("/movie/{$playlist->user->name}/{$playlist->uuid}/".$channel->id.'.'.$extension, '.');
+                $url = rtrim("/movie/{$playlist->user->name}/{$playlist->uuid}/" . $channel->id . '.' . $extension, '.');
                 $url = PlaylistService::getBaseUrl($url);
 
                 // Build path options for tracking changes
@@ -285,7 +285,7 @@ class SyncVodStrmFiles implements ShouldQueue
             }
         } catch (\Exception $e) {
             // Log the exception or handle it as needed
-            Log::error('Error syncing VOD .strm files: '.$e->getMessage());
+            Log::error('Error syncing VOD .strm files: ' . $e->getMessage());
         }
     }
 }

--- a/app/Models/StrmFileMapping.php
+++ b/app/Models/StrmFileMapping.php
@@ -419,7 +419,7 @@ class StrmFileMapping extends Model
             }
 
             // Ensure directory is within sync location (prevent traversal)
-            if (! str_starts_with($realDirectory.'/', $realSyncLocation.'/')) {
+            if (! str_starts_with($realDirectory . '/', $realSyncLocation . '/')) {
                 Log::warning('STRM Sync: Directory cleanup blocked - path outside sync location', [
                     'directory' => $directory,
                     'sync_location' => $syncLocation,
@@ -491,7 +491,7 @@ class StrmFileMapping extends Model
             $path = $mapping->current_path;
 
             // Sanity check: ensure mapping path is within the requested sync location
-            if (! (str_starts_with($path, $root.'/') || $path === $root)) {
+            if (! (str_starts_with($path, $root . '/') || $path === $root)) {
                 Log::warning('STRM Sync: Skipping mapping outside sync location', [
                     'mapping_id' => $mapping->id,
                     'path' => $path,


### PR DESCRIPTION
- Add bulkLoadForSyncables() method to load all mappings in 1 query
- Add syncFileWithCache() method that uses pre-loaded mapping cache
- Refactor SyncSeriesStrmFiles to bulk-load mappings before episode loop
- Refactor SyncVodStrmFiles to bulk-load mappings before channel loop

This dramatically improves Series/VOD STRM sync performance:
- Before: ~1 DB query per episode (N+1 problem)
- After: 1 DB query per series + O(1) lookups from cache