### PR TITLE
fix: refresh table after edit action to remove filtered-out records

### DIFF
--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -399,7 +399,8 @@ class ChannelResource extends Resource
                         Grid::make()
                             ->schema(self::getForm(edit: true))
                             ->columns(2),
-                    ]),
+                    ])
+                    ->after(fn ($livewire) => $livewire->dispatch('$refresh')),
                 DeleteAction::make()->hidden(fn (Model $record) => ! $record->is_custom),
             ])->button()->hiddenLabel()->size('sm')->hidden(fn (Model $record) => ! $record->is_custom),
             EditAction::make('edit')
@@ -409,6 +410,7 @@ class ChannelResource extends Resource
                         ->schema(self::getForm(edit: true))
                         ->columns(2),
                 ])
+                ->after(fn ($livewire) => $livewire->dispatch('$refresh'))
                 ->button()
                 ->hiddenLabel()
                 ->disabled(fn (Model $record) => $record->is_custom)

--- a/app/Filament/Resources/Series/SeriesResource.php
+++ b/app/Filament/Resources/Series/SeriesResource.php
@@ -268,7 +268,8 @@ class SeriesResource extends Resource
         return [
             ActionGroup::make([
                 EditAction::make()
-                    ->slideOver(),
+                    ->slideOver()
+                    ->after(fn ($livewire) => $livewire->dispatch('$refresh')),
                 Action::make('move')
                     ->label('Move Series to Category')
                     ->schema([

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -501,7 +501,8 @@ class VodResource extends Resource
                         Grid::make()
                             ->schema(self::getForm(edit: true))
                             ->columns(2),
-                    ]),
+                    ])
+                    ->after(fn ($livewire) => $livewire->dispatch('$refresh')),
                 Action::make('process_vod')
                     ->label('Fetch Metadata')
                     ->icon('heroicon-o-arrow-down-tray')


### PR DESCRIPTION
When an entry is edited and no longer matches the active table filter (e.g., enabled changed from true to false with 'enabled' filter active), the entry should disappear from the table immediately.

Added ->after() hook with $livewire->dispatch('$refresh') to EditActions in:
- ChannelResource (Channels table)
- VodResource (VOD table)
- SeriesResource (Series table)

This ensures the table refreshes after saving, re-applying all active filters.