### PR TITLE
fix: use relationLoaded to avoid group column/relation conflict in channel API

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -182,12 +182,12 @@ class ChannelController extends Controller
                     ];
                 }
 
-                // Build group info
+                // Build group info (use relationLoaded to avoid conflict with 'group' column)
                 $groupInfo = null;
-                if ($channel->group) {
+                if ($channel->relationLoaded('group') && $channel->getRelation('group')) {
                     $groupInfo = [
-                        'id' => $channel->group->id,
-                        'name' => $channel->group->name,
+                        'id' => $channel->getRelation('group')->id,
+                        'name' => $channel->getRelation('group')->name,
                     ];
                 }
 
@@ -641,12 +641,12 @@ class ChannelController extends Controller
             ];
         }
 
-        // Build group info
+        // Build group info (use relationLoaded to avoid conflict with 'group' column)
         $groupInfo = null;
-        if ($channel->group) {
+        if ($channel->relationLoaded('group') && $channel->getRelation('group')) {
             $groupInfo = [
-                'id' => $channel->group->id,
-                'name' => $channel->group->name,
+                'id' => $channel->getRelation('group')->id,
+                'name' => $channel->getRelation('group')->name,
             ];
         }
 


### PR DESCRIPTION
This pull request updates how group information is accessed in the `ChannelController` to avoid conflicts with a possible `group` column in the database. The changes ensure that Eloquent relationships are checked using `relationLoaded` and accessed via `getRelation` instead of direct property access.

**Improvements to relationship handling:**

* Updated group info construction in the `index` method to use `relationLoaded('group')` and `getRelation('group')` for safer and more explicit relationship access, preventing conflicts with a `group` column.
* Made the same update in the `show` method to consistently use `relationLoaded('group')` and `getRelation('group')` for group information.