### PR TITLE
Fix/stability test english responses

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -1209,10 +1209,10 @@ class ChannelController extends Controller
 
         $live = $stableChecks > 0;
         $stable = $failedChecks === 0;
-        $quality = '❌ Offline';
+        $quality = 'offline';
 
         if ($live) {
-            $quality = $stable ? '✅ Online' : '⚠️ Instabil';
+            $quality = $stable ? 'online' : 'unstable';
         }
 
         return response()->json([

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -1097,7 +1097,7 @@ class ChannelController extends Controller
      *     "url": "https://example.com/stream.m3u8",
      *     "live": true,
      *     "stable": true,
-     *     "quality": "✅ Online",
+     *     "quality": "online",
      *     "connect_time_ms": 245,
      *     "checks_passed": 3,
      *     "checks_failed": 0,


### PR DESCRIPTION
This pull request updates how the channel quality status is represented in API responses. The main change is standardizing the `quality` field to use plain string values instead of emoji-prefixed labels.

API response consistency:

* Changed the `quality` field in the `batchCheckAvailability` and `stabilityTest` methods in `ChannelController.php` to use values `"online"`, `"offline"`, and `"unstable"` instead of emoji-prefixed labels like `"✅ Online"` and `"❌ Offline"`. [[1]](diffhunk://#diff-2f36572d39f0c63cd7726d54fa998c62995a2c6ca9af37156db720ef47f33438L1100-R1100) [[2]](diffhunk://#diff-2f36572d39f0c63cd7726d54fa998c62995a2c6ca9af37156db720ef47f33438L1212-R1215)