### PR TITLE
fix: allow use of  m3u-proxy streams

### DIFF
--- a/docker/8.4/nginx/xtream.conf
+++ b/docker/8.4/nginx/xtream.conf
@@ -90,6 +90,24 @@ server {
       proxy_set_header X-Real-IP $remote_addr;
     }
 
+    ### M3U-PROXY DEFAULT HLS STREAMS - ANY EXTENSION ###
+    # /m3u-proxy/hls/<hash>/playlist.m3u8
+    location ~ "^/m3u-proxy/hls/[A-Za-z0-9-]+/playlist.m3u8+$" {
+      proxy_pass http://127.0.0.1:${APP_PORT};
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    ### M3U-PROXY DEFAULT MPEG-TS STREAMS - ANY EXTENSION ###
+    # /m3u-proxy/hls/<hash>
+    location ~ "^/m3u-proxy/stream/[A-Za-z0-9-]+$" {
+      proxy_pass http://127.0.0.1:${APP_PORT};
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Real-IP $remote_addr;
+    }
+
     # ========= BLOCK EVERYTHING ELSE =========
 
     location / {


### PR DESCRIPTION
When using XTREAM_ONLY_ENABLED=true, published playlists cannot currently be set to proxied as the current xtream.conf file is not configured to allow this.

There are 2 changes to the file which will allow proxied MPEG-TS and HLS streams to work.