### PR TITLE
fix: change strmPathToNfoPath visibility from protected to public

### DIFF
--- a/app/Models/StrmFileMapping.php
+++ b/app/Models/StrmFileMapping.php
@@ -834,7 +834,7 @@ class StrmFileMapping extends Model
      * - If the path already ends with ".nfo", return it unchanged.
      * - Otherwise append ".nfo" to the path.
      */
-    protected static function strmPathToNfoPath(string $path): string
+    public static function strmPathToNfoPath(string $path): string
     {
         // Directory path -> tvshow.nfo
         if (str_ends_with($path, '/') || is_dir($path)) {


### PR DESCRIPTION
The method was inaccessible when called from within chunkById closures during STRM file cleanup operations, causing 'undefined method' errors.

Making it public resolves the visibility issue while maintaining the same functionality for path conversion.