### PR TITLE
feat: Add inline custom group creation when adding items to custom playlists

### DIFF
--- a/app/Filament/Resources/Groups/GroupResource.php
+++ b/app/Filament/Resources/Groups/GroupResource.php
@@ -170,12 +170,27 @@ class GroupResource extends Resource
                                 ->afterStateUpdated(function (Set $set, $state) {
                                     if ($state) {
                                         $set('category', null);
+                                        $set('new_group', null);
+                                        $set('create_new_group', false);
                                     }
                                 })
                                 ->searchable(),
+                            Toggle::make('create_new_group')
+                                ->label('Create new group')
+                                ->helperText('Enable to create a new group instead of selecting an existing one.')
+                                ->live()
+                                ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->afterStateUpdated(function (Set $set, $state) {
+                                    if ($state) {
+                                        $set('category', null);
+                                    } else {
+                                        $set('new_group', null);
+                                    }
+                                }),
                             Select::make('category')
                                 ->label('Custom Group')
                                 ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->hidden(fn (Get $get) => $get('create_new_group'))
                                 ->helperText(fn (Get $get) => ! $get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
                                 ->options(function ($get) {
                                     $customList = CustomPlaylist::find($get('playlist'));
@@ -185,13 +200,40 @@ class GroupResource extends Resource
                                         ->toArray() : [];
                                 })
                                 ->searchable(),
+                            TextInput::make('new_group')
+                                ->label('New Group Name')
+                                ->helperText('Enter a name for the new group to create.')
+                                ->hidden(fn (Get $get) => ! $get('create_new_group'))
+                                ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->required(fn (Get $get) => $get('create_new_group'))
+                                ->maxLength(255),
                         ])
                         ->action(function ($record, array $data): void {
                             $playlist = CustomPlaylist::findOrFail($data['playlist']);
                             $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
-                            if ($data['category']) {
-                                $tags = $playlist->groupTags()->get();
+
+                            // Determine which tag to use (existing or new)
+                            $tag = null;
+                            if ($data['create_new_group'] && $data['new_group']) {
+                                // Create new group tag
+                                $existingTag = \Spatie\Tags\Tag::where('type', $playlist->uuid)
+                                    ->where('name->en', $data['new_group'])
+                                    ->first();
+                                if ($existingTag) {
+                                    $tag = $existingTag;
+                                } else {
+                                    $tag = \Spatie\Tags\Tag::create([
+                                        'name' => ['en' => $data['new_group']],
+                                        'type' => $playlist->uuid,
+                                    ]);
+                                    $playlist->attachTag($tag);
+                                }
+                            } elseif ($data['category']) {
                                 $tag = $playlist->groupTags()->where('name->en', $data['category'])->first();
+                            }
+
+                            if ($tag) {
+                                $tags = $playlist->groupTags()->get();
                                 foreach ($record->channels()->cursor() as $channel) {
                                     // Need to detach any existing tags from this playlist first
                                     $channel->detachTags($tags);
@@ -486,12 +528,27 @@ class GroupResource extends Resource
                                 ->afterStateUpdated(function (Set $set, $state) {
                                     if ($state) {
                                         $set('category', null);
+                                        $set('new_group', null);
+                                        $set('create_new_group', false);
                                     }
                                 })
                                 ->searchable(),
+                            Toggle::make('create_new_group')
+                                ->label('Create new group')
+                                ->helperText('Enable to create a new group instead of selecting an existing one.')
+                                ->live()
+                                ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->afterStateUpdated(function (Set $set, $state) {
+                                    if ($state) {
+                                        $set('category', null);
+                                    } else {
+                                        $set('new_group', null);
+                                    }
+                                }),
                             Select::make('category')
                                 ->label('Custom Group')
                                 ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->hidden(fn (Get $get) => $get('create_new_group'))
                                 ->helperText(fn (Get $get) => ! $get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
                                 ->options(function ($get) {
                                     $customList = CustomPlaylist::find($get('playlist'));
@@ -501,17 +558,44 @@ class GroupResource extends Resource
                                         ->toArray() : [];
                                 })
                                 ->searchable(),
+                            TextInput::make('new_group')
+                                ->label('New Group Name')
+                                ->helperText('Enter a name for the new group to create.')
+                                ->hidden(fn (Get $get) => ! $get('create_new_group'))
+                                ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->required(fn (Get $get) => $get('create_new_group'))
+                                ->maxLength(255),
                         ])
                         ->action(function (Collection $records, array $data): void {
                             $playlist = CustomPlaylist::findOrFail($data['playlist']);
+
+                            // Determine which tag to use (existing or new)
+                            $tag = null;
+                            if ($data['create_new_group'] && $data['new_group']) {
+                                // Create new group tag
+                                $existingTag = \Spatie\Tags\Tag::where('type', $playlist->uuid)
+                                    ->where('name->en', $data['new_group'])
+                                    ->first();
+                                if ($existingTag) {
+                                    $tag = $existingTag;
+                                } else {
+                                    $tag = \Spatie\Tags\Tag::create([
+                                        'name' => ['en' => $data['new_group']],
+                                        'type' => $playlist->uuid,
+                                    ]);
+                                    $playlist->attachTag($tag);
+                                }
+                            } elseif ($data['category']) {
+                                $tag = $playlist->groupTags()->where('name->en', $data['category'])->first();
+                            }
+
                             $tags = $playlist->groupTags()->get();
-                            $tag = $data['category'] ? $playlist->groupTags()->where('name->en', $data['category'])->first() : null;
                             foreach ($records as $record) {
                                 // Sync the channels to the custom playlist
                                 // This will add the channels to the playlist without detaching existing ones
                                 // Prevents duplicates in the playlist
                                 $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
-                                if ($data['category']) {
+                                if ($tag) {
                                     foreach ($record->channels()->cursor() as $channel) {
                                         // Need to detach any existing tags from this playlist first
                                         $channel->detachTags($tags);

--- a/app/Filament/Resources/Groups/Pages/ViewGroup.php
+++ b/app/Filament/Resources/Groups/Pages/ViewGroup.php
@@ -43,12 +43,27 @@ class ViewGroup extends ViewRecord
                             ->afterStateUpdated(function (Set $set, $state) {
                                 if ($state) {
                                     $set('category', null);
+                                    $set('new_group', null);
+                                    $set('create_new_group', false);
                                 }
                             })
                             ->searchable(),
+                        Toggle::make('create_new_group')
+                            ->label('Create new group')
+                            ->helperText('Enable to create a new group instead of selecting an existing one.')
+                            ->live()
+                            ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->afterStateUpdated(function (Set $set, $state) {
+                                if ($state) {
+                                    $set('category', null);
+                                } else {
+                                    $set('new_group', null);
+                                }
+                            }),
                         Select::make('category')
                             ->label('Custom Group')
                             ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->hidden(fn (Get $get) => $get('create_new_group'))
                             ->helperText(fn (Get $get) => ! $get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the channels to.')
                             ->options(function ($get) {
                                 $customList = CustomPlaylist::find($get('playlist'));
@@ -58,13 +73,40 @@ class ViewGroup extends ViewRecord
                                     ->toArray() : [];
                             })
                             ->searchable(),
+                        TextInput::make('new_group')
+                            ->label('New Group Name')
+                            ->helperText('Enter a name for the new group to create.')
+                            ->hidden(fn (Get $get) => ! $get('create_new_group'))
+                            ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->required(fn (Get $get) => $get('create_new_group'))
+                            ->maxLength(255),
                     ])
                     ->action(function ($record, array $data): void {
                         $playlist = CustomPlaylist::findOrFail($data['playlist']);
                         $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
-                        if ($data['category']) {
-                            $tags = $playlist->groupTags()->get();
+
+                        // Determine which tag to use (existing or new)
+                        $tag = null;
+                        if ($data['create_new_group'] && $data['new_group']) {
+                            // Create new group tag
+                            $existingTag = \Spatie\Tags\Tag::where('type', $playlist->uuid)
+                                ->where('name->en', $data['new_group'])
+                                ->first();
+                            if ($existingTag) {
+                                $tag = $existingTag;
+                            } else {
+                                $tag = \Spatie\Tags\Tag::create([
+                                    'name' => ['en' => $data['new_group']],
+                                    'type' => $playlist->uuid,
+                                ]);
+                                $playlist->attachTag($tag);
+                            }
+                        } elseif ($data['category']) {
                             $tag = $playlist->groupTags()->where('name->en', $data['category'])->first();
+                        }
+
+                        if ($tag) {
+                            $tags = $playlist->groupTags()->get();
                             foreach ($record->channels()->cursor() as $channel) {
                                 // Need to detach any existing tags from this playlist first
                                 $channel->detachTags($tags);

--- a/app/Filament/Resources/Series/SeriesResource.php
+++ b/app/Filament/Resources/Series/SeriesResource.php
@@ -487,12 +487,27 @@ class SeriesResource extends Resource
                             ->afterStateUpdated(function (Set $set, $state) {
                                 if ($state) {
                                     $set('category', null);
+                                    $set('new_category', null);
+                                    $set('create_new_category', false);
                                 }
                             })
                             ->searchable(),
+                        Toggle::make('create_new_category')
+                            ->label('Create new category')
+                            ->helperText('Enable to create a new category instead of selecting an existing one.')
+                            ->live()
+                            ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->afterStateUpdated(function (Set $set, $state) {
+                                if ($state) {
+                                    $set('category', null);
+                                } else {
+                                    $set('new_category', null);
+                                }
+                            }),
                         Select::make('category')
                             ->label('Custom Category')
                             ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->hidden(fn (Get $get) => $get('create_new_category'))
                             ->helperText(fn (Get $get) => ! $get('playlist') ? 'Select a custom playlist first.' : 'Select the category you would like to assign to the selected series to.')
                             ->options(function ($get) {
                                 $customList = CustomPlaylist::find($get('playlist'));
@@ -502,13 +517,41 @@ class SeriesResource extends Resource
                                     ->toArray() : [];
                             })
                             ->searchable(),
+                        TextInput::make('new_category')
+                            ->label('New Category Name')
+                            ->helperText('Enter a name for the new category to create.')
+                            ->hidden(fn (Get $get) => ! $get('create_new_category'))
+                            ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->required(fn (Get $get) => $get('create_new_category'))
+                            ->maxLength(255),
                     ])
                     ->action(function (Collection $records, array $data): void {
                         $playlist = CustomPlaylist::findOrFail($data['playlist']);
                         $playlist->series()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $tags = $playlist->categoryTags()->get();
+
+                        // Determine which tag to use (existing or new)
+                        $tag = null;
+                        if ($data['create_new_category'] && $data['new_category']) {
+                            // Create new category tag
+                            $tagType = $playlist->uuid.'-category';
+                            $existingTag = \Spatie\Tags\Tag::where('type', $tagType)
+                                ->where('name->en', $data['new_category'])
+                                ->first();
+                            if ($existingTag) {
+                                $tag = $existingTag;
+                            } else {
+                                $tag = \Spatie\Tags\Tag::create([
+                                    'name' => ['en' => $data['new_category']],
+                                    'type' => $tagType,
+                                ]);
+                                $playlist->attachTag($tag);
+                            }
+                        } elseif ($data['category']) {
                             $tag = $playlist->categoryTags()->where('name->en', $data['category'])->first();
+                        }
+
+                        if ($tag) {
+                            $tags = $playlist->categoryTags()->get();
                             foreach ($records as $record) {
                                 // Need to detach any existing tags from this playlist first
                                 $record->detachTags($tags);

--- a/app/Filament/Resources/VodGroups/Pages/ViewVodGroup.php
+++ b/app/Filament/Resources/VodGroups/Pages/ViewVodGroup.php
@@ -11,6 +11,7 @@ use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Utilities\Get;
@@ -36,12 +37,27 @@ class ViewVodGroup extends ViewRecord
                             ->afterStateUpdated(function (Set $set, $state) {
                                 if ($state) {
                                     $set('category', null);
+                                    $set('new_group', null);
+                                    $set('create_new_group', false);
                                 }
                             })
                             ->searchable(),
+                        Toggle::make('create_new_group')
+                            ->label('Create new group')
+                            ->helperText('Enable to create a new group instead of selecting an existing one.')
+                            ->live()
+                            ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->afterStateUpdated(function (Set $set, $state) {
+                                if ($state) {
+                                    $set('category', null);
+                                } else {
+                                    $set('new_group', null);
+                                }
+                            }),
                         Select::make('category')
                             ->label('Custom Group')
                             ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->hidden(fn (Get $get) => $get('create_new_group'))
                             ->helperText(fn (Get $get) => ! $get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the channels to.')
                             ->options(function ($get) {
                                 $customList = CustomPlaylist::find($get('playlist'));
@@ -51,13 +67,40 @@ class ViewVodGroup extends ViewRecord
                                     ->toArray() : [];
                             })
                             ->searchable(),
+                        TextInput::make('new_group')
+                            ->label('New Group Name')
+                            ->helperText('Enter a name for the new group to create.')
+                            ->hidden(fn (Get $get) => ! $get('create_new_group'))
+                            ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->required(fn (Get $get) => $get('create_new_group'))
+                            ->maxLength(255),
                     ])
                     ->action(function ($record, array $data): void {
                         $playlist = CustomPlaylist::findOrFail($data['playlist']);
                         $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
-                        if ($data['category']) {
-                            $tags = $playlist->groupTags()->get();
+
+                        // Determine which tag to use (existing or new)
+                        $tag = null;
+                        if ($data['create_new_group'] && $data['new_group']) {
+                            // Create new group tag
+                            $existingTag = \Spatie\Tags\Tag::where('type', $playlist->uuid)
+                                ->where('name->en', $data['new_group'])
+                                ->first();
+                            if ($existingTag) {
+                                $tag = $existingTag;
+                            } else {
+                                $tag = \Spatie\Tags\Tag::create([
+                                    'name' => ['en' => $data['new_group']],
+                                    'type' => $playlist->uuid,
+                                ]);
+                                $playlist->attachTag($tag);
+                            }
+                        } elseif ($data['category']) {
                             $tag = $playlist->groupTags()->where('name->en', $data['category'])->first();
+                        }
+
+                        if ($tag) {
+                            $tags = $playlist->groupTags()->get();
                             foreach ($record->channels()->cursor() as $channel) {
                                 // Need to detach any existing tags from this playlist first
                                 $channel->detachTags($tags);

--- a/app/Filament/Resources/VodGroups/VodGroupResource.php
+++ b/app/Filament/Resources/VodGroups/VodGroupResource.php
@@ -19,6 +19,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
@@ -164,12 +165,27 @@ class VodGroupResource extends Resource
                                 ->afterStateUpdated(function (Set $set, $state) {
                                     if ($state) {
                                         $set('category', null);
+                                        $set('new_group', null);
+                                        $set('create_new_group', false);
                                     }
                                 })
                                 ->searchable(),
+                            Toggle::make('create_new_group')
+                                ->label('Create new group')
+                                ->helperText('Enable to create a new group instead of selecting an existing one.')
+                                ->live()
+                                ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->afterStateUpdated(function (Set $set, $state) {
+                                    if ($state) {
+                                        $set('category', null);
+                                    } else {
+                                        $set('new_group', null);
+                                    }
+                                }),
                             Select::make('category')
                                 ->label('Custom Group')
                                 ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->hidden(fn (Get $get) => $get('create_new_group'))
                                 ->helperText(fn (Get $get) => ! $get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
                                 ->options(function ($get) {
                                     $customList = CustomPlaylist::find($get('playlist'));
@@ -179,13 +195,40 @@ class VodGroupResource extends Resource
                                         ->toArray() : [];
                                 })
                                 ->searchable(),
+                            TextInput::make('new_group')
+                                ->label('New Group Name')
+                                ->helperText('Enter a name for the new group to create.')
+                                ->hidden(fn (Get $get) => ! $get('create_new_group'))
+                                ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->required(fn (Get $get) => $get('create_new_group'))
+                                ->maxLength(255),
                         ])
                         ->action(function ($record, array $data): void {
                             $playlist = CustomPlaylist::findOrFail($data['playlist']);
                             $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
-                            if ($data['category']) {
-                                $tags = $playlist->groupTags()->get();
+
+                            // Determine which tag to use (existing or new)
+                            $tag = null;
+                            if ($data['create_new_group'] && $data['new_group']) {
+                                // Create new group tag
+                                $existingTag = \Spatie\Tags\Tag::where('type', $playlist->uuid)
+                                    ->where('name->en', $data['new_group'])
+                                    ->first();
+                                if ($existingTag) {
+                                    $tag = $existingTag;
+                                } else {
+                                    $tag = \Spatie\Tags\Tag::create([
+                                        'name' => ['en' => $data['new_group']],
+                                        'type' => $playlist->uuid,
+                                    ]);
+                                    $playlist->attachTag($tag);
+                                }
+                            } elseif ($data['category']) {
                                 $tag = $playlist->groupTags()->where('name->en', $data['category'])->first();
+                            }
+
+                            if ($tag) {
+                                $tags = $playlist->groupTags()->get();
                                 foreach ($record->channels()->cursor() as $channel) {
                                     // Need to detach any existing tags from this playlist first
                                     $channel->detachTags($tags);
@@ -358,12 +401,27 @@ class VodGroupResource extends Resource
                                 ->afterStateUpdated(function (Set $set, $state) {
                                     if ($state) {
                                         $set('category', null);
+                                        $set('new_group', null);
+                                        $set('create_new_group', false);
                                     }
                                 })
                                 ->searchable(),
+                            Toggle::make('create_new_group')
+                                ->label('Create new group')
+                                ->helperText('Enable to create a new group instead of selecting an existing one.')
+                                ->live()
+                                ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->afterStateUpdated(function (Set $set, $state) {
+                                    if ($state) {
+                                        $set('category', null);
+                                    } else {
+                                        $set('new_group', null);
+                                    }
+                                }),
                             Select::make('category')
                                 ->label('Custom Group')
                                 ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->hidden(fn (Get $get) => $get('create_new_group'))
                                 ->helperText(fn (Get $get) => ! $get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
                                 ->options(function ($get) {
                                     $customList = CustomPlaylist::find($get('playlist'));
@@ -373,17 +431,44 @@ class VodGroupResource extends Resource
                                         ->toArray() : [];
                                 })
                                 ->searchable(),
+                            TextInput::make('new_group')
+                                ->label('New Group Name')
+                                ->helperText('Enter a name for the new group to create.')
+                                ->hidden(fn (Get $get) => ! $get('create_new_group'))
+                                ->disabled(fn (Get $get) => ! $get('playlist'))
+                                ->required(fn (Get $get) => $get('create_new_group'))
+                                ->maxLength(255),
                         ])
                         ->action(function (Collection $records, array $data): void {
                             $playlist = CustomPlaylist::findOrFail($data['playlist']);
+
+                            // Determine which tag to use (existing or new)
+                            $tag = null;
+                            if ($data['create_new_group'] && $data['new_group']) {
+                                // Create new group tag
+                                $existingTag = \Spatie\Tags\Tag::where('type', $playlist->uuid)
+                                    ->where('name->en', $data['new_group'])
+                                    ->first();
+                                if ($existingTag) {
+                                    $tag = $existingTag;
+                                } else {
+                                    $tag = \Spatie\Tags\Tag::create([
+                                        'name' => ['en' => $data['new_group']],
+                                        'type' => $playlist->uuid,
+                                    ]);
+                                    $playlist->attachTag($tag);
+                                }
+                            } elseif ($data['category']) {
+                                $tag = $playlist->groupTags()->where('name->en', $data['category'])->first();
+                            }
+
                             $tags = $playlist->groupTags()->get();
-                            $tag = $data['category'] ? $playlist->groupTags()->where('name->en', $data['category'])->first() : null;
                             foreach ($records as $record) {
                                 // Sync the channels to the custom playlist
                                 // This will add the channels to the playlist without detaching existing ones
                                 // Prevents duplicates in the playlist
                                 $playlist->channels()->syncWithoutDetaching($record->channels()->pluck('id'));
-                                if ($data['category']) {
+                                if ($tag) {
                                     foreach ($record->channels()->cursor() as $channel) {
                                         // Need to detach any existing tags from this playlist first
                                         $channel->detachTags($tags);

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -694,12 +694,27 @@ class VodResource extends Resource
                             ->afterStateUpdated(function (Set $set, $state) {
                                 if ($state) {
                                     $set('category', null);
+                                    $set('new_group', null);
+                                    $set('create_new_group', false);
                                 }
                             })
                             ->searchable(),
+                        Toggle::make('create_new_group')
+                            ->label('Create new group')
+                            ->helperText('Enable to create a new group instead of selecting an existing one.')
+                            ->live()
+                            ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->afterStateUpdated(function (Set $set, $state) {
+                                if ($state) {
+                                    $set('category', null);
+                                } else {
+                                    $set('new_group', null);
+                                }
+                            }),
                         Select::make('category')
                             ->label('Custom Group')
                             ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->hidden(fn (Get $get) => $get('create_new_group'))
                             ->helperText(fn (Get $get) => ! $get('playlist') ? 'Select a custom playlist first.' : 'Select the group you would like to assign to the selected channel(s) to.')
                             ->options(function ($get) {
                                 $customList = CustomPlaylist::find($get('playlist'));
@@ -709,13 +724,40 @@ class VodResource extends Resource
                                     ->toArray() : [];
                             })
                             ->searchable(),
+                        TextInput::make('new_group')
+                            ->label('New Group Name')
+                            ->helperText('Enter a name for the new group to create.')
+                            ->hidden(fn (Get $get) => ! $get('create_new_group'))
+                            ->disabled(fn (Get $get) => ! $get('playlist'))
+                            ->required(fn (Get $get) => $get('create_new_group'))
+                            ->maxLength(255),
                     ])
                     ->action(function (Collection $records, array $data): void {
                         $playlist = CustomPlaylist::findOrFail($data['playlist']);
                         $playlist->channels()->syncWithoutDetaching($records->pluck('id'));
-                        if ($data['category']) {
-                            $tags = $playlist->groupTags()->get();
+
+                        // Determine which tag to use (existing or new)
+                        $tag = null;
+                        if ($data['create_new_group'] && $data['new_group']) {
+                            // Create new group tag
+                            $existingTag = \Spatie\Tags\Tag::where('type', $playlist->uuid)
+                                ->where('name->en', $data['new_group'])
+                                ->first();
+                            if ($existingTag) {
+                                $tag = $existingTag;
+                            } else {
+                                $tag = \Spatie\Tags\Tag::create([
+                                    'name' => ['en' => $data['new_group']],
+                                    'type' => $playlist->uuid,
+                                ]);
+                                $playlist->attachTag($tag);
+                            }
+                        } elseif ($data['category']) {
                             $tag = $playlist->groupTags()->where('name->en', $data['category'])->first();
+                        }
+
+                        if ($tag) {
+                            $tags = $playlist->groupTags()->get();
                             foreach ($records as $record) {
                                 // Need to detach any existing tags from this playlist first
                                 $record->detachTags($tags);


### PR DESCRIPTION
- Add toggle and text input to create new groups directly in 'Add to Custom Playlist' dialogs
- Implemented in ChannelResource, GroupResource, VodResource, VodGroupResource, CategoryResource, SeriesResource
- Also added to ViewGroup, ViewVodGroup, and ViewCategory header actions
- Groups are created as Spatie Tags with the custom playlist UUID as type
- Categories use UUID-category suffix for proper separation