### PR TITLE
feat: Add option to reactivate disabled channels during unmerge

### DIFF
--- a/app/Filament/Resources/Channels/Pages/ListChannels.php
+++ b/app/Filament/Resources/Channels/Pages/ListChannels.php
@@ -167,13 +167,18 @@ class ListChannels extends ListRecords
                             ->live()
                             ->searchable()
                             ->helperText('Playlist to unmerge channels from (or leave empty to unmerge all).'),
+                        Toggle::make('reactivate_channels')
+                            ->label('Reactivate disabled channels')
+                            ->helperText('Enable channels that were previously disabled during merge.')
+                            ->default(false),
                     ])
                     ->label('Unmerge Same ID')
-                    ->action(function ($data): void {
+                    ->action(function (array $data): void {
                         app('Illuminate\Contracts\Bus\Dispatcher')
                             ->dispatch(new UnmergeChannels(
                                 user: auth()->user(),
-                                playlistId: $data['playlist_id'] ?? null
+                                playlistId: $data['playlist_id'] ?? null,
+                                reactivateChannels: $data['reactivate_channels'] ?? false,
                             ));
                     })->after(function () {
                         Notification::make()

--- a/app/Filament/Resources/Groups/GroupResource.php
+++ b/app/Filament/Resources/Groups/GroupResource.php
@@ -410,11 +410,18 @@ class GroupResource extends Resource
 
                     Action::make('unmerge')
                         ->label('Unmerge Same ID')
-                        ->action(function (Group $record, $data): void {
+                        ->schema([
+                            Toggle::make('reactivate_channels')
+                                ->label('Reactivate disabled channels')
+                                ->helperText('Enable channels that were previously disabled during merge.')
+                                ->default(false),
+                        ])
+                        ->action(function (Group $record, array $data): void {
                             app('Illuminate\Contracts\Bus\Dispatcher')
                                 ->dispatch(new UnmergeChannels(
                                     user: auth()->user(),
                                     groupId: $record->id,
+                                    reactivateChannels: $data['reactivate_channels'] ?? false,
                                 ));
                         })->after(function () {
                             Notification::make()

--- a/app/Filament/Resources/Groups/Pages/ViewGroup.php
+++ b/app/Filament/Resources/Groups/Pages/ViewGroup.php
@@ -288,11 +288,18 @@ class ViewGroup extends ViewRecord
 
                 Action::make('unmerge')
                     ->label('Unmerge Same ID')
-                    ->action(function (Group $record, $data): void {
+                    ->schema([
+                        Toggle::make('reactivate_channels')
+                            ->label('Reactivate disabled channels')
+                            ->helperText('Enable channels that were previously disabled during merge.')
+                            ->default(false),
+                    ])
+                    ->action(function (Group $record, array $data): void {
                         app('Illuminate\Contracts\Bus\Dispatcher')
                             ->dispatch(new UnmergeChannels(
                                 user: auth()->user(),
                                 groupId: $record->id,
+                                reactivateChannels: $data['reactivate_channels'] ?? false,
                             ));
                     })->after(function () {
                         Notification::make()

--- a/app/Filament/Resources/Vods/Pages/ListVod.php
+++ b/app/Filament/Resources/Vods/Pages/ListVod.php
@@ -168,13 +168,18 @@ class ListVod extends ListRecords
                             ->live()
                             ->searchable()
                             ->helperText('Playlist to unmerge channels from (or leave empty to unmerge all).'),
+                        Toggle::make('reactivate_channels')
+                            ->label('Reactivate disabled channels')
+                            ->helperText('Enable channels that were previously disabled during merge.')
+                            ->default(false),
                     ])
                     ->label('Unmerge Same ID')
-                    ->action(function ($data): void {
+                    ->action(function (array $data): void {
                         app('Illuminate\Contracts\Bus\Dispatcher')
                             ->dispatch(new UnmergeChannels(
                                 user: auth()->user(),
-                                playlistId: $data['playlist_id'] ?? null
+                                playlistId: $data['playlist_id'] ?? null,
+                                reactivateChannels: $data['reactivate_channels'] ?? false,
                             ));
                     })->after(function () {
                         Notification::make()


### PR DESCRIPTION
- Add reactivateChannels parameter to UnmergeChannels job
- Add reactivateFailoverChannels() method to re-enable channels disabled during merge
- Update notification to show count of reactivated channels
- Add 'Reactivate disabled channels' toggle to unmerge actions in:
  - Groups (ViewGroup and GroupResource)
  - Channels (ListChannels)
  - VODs (ListVod)