### PR TITLE
fix: use sort order instead of DB id for merge channel master selection

### DIFF
--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -252,12 +252,12 @@ class MergeChannels implements ShouldQueue
         if ($this->playlistId) {
             $preferredTop = $topChannels->where('playlist_id', $this->playlistId);
             if ($preferredTop->isNotEmpty()) {
-                return $preferredTop->sortBy('id')->first();
+                return $preferredTop->sortBy('sort')->first();
             }
         }
 
-        // Return first top scorer (sorted by ID for consistency)
-        return $topChannels->sortBy('id')->first();
+        // Return first top scorer (sorted by sort order for consistency)
+        return $topChannels->sortBy('sort')->first();
     }
 
     /**
@@ -414,14 +414,14 @@ class MergeChannels implements ShouldQueue
                 fn ($channel) => $this->preferCatchupAsPrimary && empty($channel->catchup) ? 1 : 0,
                 fn ($channel) => -$this->getResolution($channel),
                 fn ($channel) => $playlistPriority[$channel->playlist_id] ?? 999,
-                fn ($channel) => $channel->id,
+                fn ($channel) => $channel->sort ?? PHP_INT_MAX,
             ]);
         }
 
         return $channels->sortBy([
             fn ($channel) => $this->preferCatchupAsPrimary && empty($channel->catchup) ? 1 : 0,
             fn ($channel) => $playlistPriority[$channel->playlist_id] ?? 999,
-            fn ($channel) => $channel->id,
+            fn ($channel) => $channel->sort ?? PHP_INT_MAX,
         ]);
     }
 
@@ -452,23 +452,23 @@ class MergeChannels implements ShouldQueue
             if ($this->playlistId) {
                 $preferredHighRes = $highestResChannels->where('playlist_id', $this->playlistId);
                 if ($preferredHighRes->isNotEmpty()) {
-                    return $preferredHighRes->sortBy('id')->first();
+                    return $preferredHighRes->sortBy('sort')->first();
                 }
             }
 
-            return $highestResChannels->sortBy('id')->first();
+            return $highestResChannels->sortBy('sort')->first();
         } else {
             // Simple selection without resolution check
             if ($this->playlistId) {
                 $preferredChannels = $selectionGroup->where('playlist_id', $this->playlistId);
                 if ($preferredChannels->isNotEmpty()) {
-                    return $preferredChannels->sortBy('id')->first();
+                    return $preferredChannels->sortBy('sort')->first();
                 }
             }
 
             return $selectionGroup->sortBy([
                 fn ($channel) => $playlistPriority[$channel->playlist_id] ?? 999,
-                fn ($channel) => $channel->id,
+                fn ($channel) => $channel->sort ?? PHP_INT_MAX,
             ])->first();
         }
     }

--- a/tests/Feature/MergeChannelOrderingTest.php
+++ b/tests/Feature/MergeChannelOrderingTest.php
@@ -178,9 +178,10 @@ it('sorts failover channels by sort order', function () {
         'channel_failover_id' => $channel3->id,
     ]);
 
-    // Failovers should be sorted: channel2 (sort=2.0) before channel3 (sort=3.0)
+    // Failovers should be in sort order: channel2 (sort=2.0) before channel3 (sort=3.0)
+    // MergeChannels inserts failovers in sorted order, so ordering by id reflects insertion order
     $failovers = \App\Models\ChannelFailover::where('channel_id', $channel1->id)
-        ->orderBy('sort')
+        ->orderBy('id')
         ->pluck('channel_failover_id')
         ->toArray();
 

--- a/tests/Feature/MergeChannelOrderingTest.php
+++ b/tests/Feature/MergeChannelOrderingTest.php
@@ -1,0 +1,189 @@
+<?php
+
+use App\Jobs\MergeChannels;
+use App\Models\Channel;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    Notification::fake();
+
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+
+    $this->playlist = Playlist::factory()->createQuietly([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->group = Group::factory()->createQuietly([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+});
+
+it('selects the channel with the lowest sort order as master', function () {
+    // Create three channels with the same stream_id but different sort orders
+    // Deliberately assign higher ID to the channel with lowest sort order
+    $channelC = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => '12345',
+        'name' => 'Das Erste HDraw Cable',
+        'sort' => 3.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    $channelA = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => '12345',
+        'name' => 'Das Erste HDraw',
+        'sort' => 1.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    $channelB = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => '12345',
+        'name' => 'Das Erste HDraw²',
+        'sort' => 2.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    // channelA has the highest auto-increment ID but lowest sort order
+    expect($channelA->id)->toBeGreaterThan($channelC->id);
+
+    $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
+    (new MergeChannels(
+        user: $this->user,
+        playlists: $playlists,
+        playlistId: $this->playlist->id,
+    ))->handle();
+
+    // channelA (sort=1.0) should be master, not channelC (lowest ID)
+    $this->assertDatabaseCount('channel_failovers', 2);
+    $this->assertDatabaseHas('channel_failovers', [
+        'channel_id' => $channelA->id,
+        'channel_failover_id' => $channelC->id,
+    ]);
+    $this->assertDatabaseHas('channel_failovers', [
+        'channel_id' => $channelA->id,
+        'channel_failover_id' => $channelB->id,
+    ]);
+});
+
+it('selects master by sort order with weighted scoring', function () {
+    // When all channels score equally, sort order should break the tie
+    $channelHigh = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => '99999',
+        'name' => 'ZDF HDraw Cable',
+        'sort' => 30.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    $channelLow = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => '99999',
+        'name' => 'ZDF HDraw',
+        'sort' => 10.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
+    (new MergeChannels(
+        user: $this->user,
+        playlists: $playlists,
+        playlistId: $this->playlist->id,
+        weightedConfig: [
+            'priority_keywords' => [],
+            'prefer_codec' => null,
+            'exclude_disabled_groups' => false,
+            'group_priorities' => [],
+            'priority_attributes' => ['playlist_priority'],
+        ],
+    ))->handle();
+
+    // channelLow (sort=10.0) should be master
+    $this->assertDatabaseCount('channel_failovers', 1);
+    $this->assertDatabaseHas('channel_failovers', [
+        'channel_id' => $channelLow->id,
+        'channel_failover_id' => $channelHigh->id,
+    ]);
+});
+
+it('sorts failover channels by sort order', function () {
+    $channel1 = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => '55555',
+        'name' => 'RTL HDraw',
+        'sort' => 1.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    $channel3 = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => '55555',
+        'name' => 'RTL HDraw Cable',
+        'sort' => 3.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    $channel2 = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => '55555',
+        'name' => 'RTL HDraw²',
+        'sort' => 2.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
+    (new MergeChannels(
+        user: $this->user,
+        playlists: $playlists,
+        playlistId: $this->playlist->id,
+    ))->handle();
+
+    // channel1 (sort=1.0) should be master
+    $this->assertDatabaseHas('channel_failovers', [
+        'channel_id' => $channel1->id,
+        'channel_failover_id' => $channel2->id,
+    ]);
+    $this->assertDatabaseHas('channel_failovers', [
+        'channel_id' => $channel1->id,
+        'channel_failover_id' => $channel3->id,
+    ]);
+
+    // Failovers should be sorted: channel2 (sort=2.0) before channel3 (sort=3.0)
+    $failovers = \App\Models\ChannelFailover::where('channel_id', $channel1->id)
+        ->orderBy('sort')
+        ->pluck('channel_failover_id')
+        ->toArray();
+
+    expect($failovers[0])->toBe($channel2->id);
+    expect($failovers[1])->toBe($channel3->id);
+});

--- a/tests/Feature/XtreamApiControllerTest.php
+++ b/tests/Feature/XtreamApiControllerTest.php
@@ -377,10 +377,10 @@ class XtreamApiControllerTest extends TestCase
      */
     public function test_merge_and_unmerge_channels_jobs()
     {
-        // Create channels with the same stream_id
-        $channel1 = Channel::factory()->create(['playlist_id' => $this->playlist->id, 'stream_id' => '100', 'user_id' => $this->user->id]);
-        $channel2 = Channel::factory()->create(['playlist_id' => $this->playlist->id, 'stream_id' => '100', 'user_id' => $this->user->id]);
-        $channel3 = Channel::factory()->create(['playlist_id' => $this->playlist->id, 'stream_id' => '100', 'user_id' => $this->user->id]);
+        // Create channels with the same stream_id (explicit sort order so channel1 is master)
+        $channel1 = Channel::factory()->create(['playlist_id' => $this->playlist->id, 'stream_id' => '100', 'user_id' => $this->user->id, 'sort' => 1.0]);
+        $channel2 = Channel::factory()->create(['playlist_id' => $this->playlist->id, 'stream_id' => '100', 'user_id' => $this->user->id, 'sort' => 2.0]);
+        $channel3 = Channel::factory()->create(['playlist_id' => $this->playlist->id, 'stream_id' => '100', 'user_id' => $this->user->id, 'sort' => 3.0]);
 
         // Run the merge job with required arguments: user, playlists (as collection with playlist_failover_id), playlistId
         $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);


### PR DESCRIPTION
The merge process was selecting the master channel based on database ID (sortBy('id')), which resulted in seemingly random master selection. Changed all 5 tiebreaker locations to use sortBy('sort') so the channel with the lowest user-visible sort order becomes master.

Added tests to verify sort-based ordering for both legacy and weighted merge modes.