### PR TITLE
fix: use hardcoded 'master' for GIT_BRANCH in release workflow

### DIFF
--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -90,7 +90,7 @@ jobs:
           tags: ${{ steps.meta-amd64.outputs.tags }}
           labels: ${{ steps.meta-amd64.outputs.labels }}
           build-args: |
-            GIT_BRANCH=${{ github.ref_name }}
+            GIT_BRANCH=master
             GIT_COMMIT=${{ github.sha }}
             GIT_TAG=${{ github.ref_type == 'tag' && github.ref_name || '' }}
             M3U_PROXY_REPO=https://github.com/${{ github.repository_owner }}/m3u-proxy.git
@@ -139,7 +139,7 @@ jobs:
           tags: ${{ steps.meta-arm64.outputs.tags }}
           labels: ${{ steps.meta-arm64.outputs.labels }}
           build-args: |
-            GIT_BRANCH=${{ github.ref_name }}
+            GIT_BRANCH=master
             GIT_COMMIT=${{ github.sha }}
             GIT_TAG=${{ github.ref_type == 'tag' && github.ref_name || '' }}
             M3U_PROXY_REPO=https://github.com/${{ github.repository_owner }}/m3u-proxy.git


### PR DESCRIPTION
The release workflow is triggered by a tag/release event, which means github.ref_name resolves to the tag name (e.g. '0.8.39') instead of the branch name. This caused .git-info to contain GIT_BRANCH=0.8.39, which made the update checker construct an invalid GitHub raw URL (refs/heads/0.8.39 does not exist), resulting in a 404 and an empty 'Latest version' field.

The dev and experimental workflows are unaffected because they trigger on branch pushes where github.ref_name correctly resolves to 'dev' or 'experimental'.

Hardcode GIT_BRANCH=master for both amd64 and arm64 build steps in the release workflow since releases are always built from the master branch.