### PR TITLE
fix: apply tvg-shift to programme times in exported EPG XML

### DIFF
--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -296,12 +296,8 @@ class EpgGenerateController extends Controller
 
                                 // Apply tvg_shift offset to programme times if set
                                 if ($tvgShift !== 0) {
-                                    $start = $this->formatXmltvDateTime(
-                                        Carbon::parse($programme['start'])->addHours($tvgShift)->toIso8601String()
-                                    );
-                                    $stop = $this->formatXmltvDateTime(
-                                        Carbon::parse($programme['stop'])->addHours($tvgShift)->toIso8601String()
-                                    );
+                                    $start = Carbon::parse($programme['start'])->addHours($tvgShift)->format('YmdHis O');
+                                    $stop = Carbon::parse($programme['stop'])->addHours($tvgShift)->format('YmdHis O');
                                 } else {
                                     $start = $this->formatXmltvDateTime($programme['start']);
                                     $stop = $this->formatXmltvDateTime($programme['stop']);


### PR DESCRIPTION
The tvg_shift channel setting was applied in the in-app EPG viewer but not in the generated EPG XML file, so external players always received unshifted programme times.

Both the cached EPG path and the XMLReader fallback path in EpgGenerateController now carry tvg_shift through the channel mapping and apply the hour offset to start/stop times before output.

This fixes #794  