### PR TITLE
feat: Show provider profile name on Stream Monitor page

### DIFF
--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -6,6 +6,7 @@ use App\Facades\LogoFacade;
 use App\Models\Channel;
 use App\Models\Episode;
 use App\Models\Network;
+use App\Models\PlaylistProfile;
 use App\Models\StreamProfile;
 use App\Services\M3uProxyService;
 use Carbon\Carbon;
@@ -286,6 +287,18 @@ class M3uProxyStreamMonitor extends Page
                     }
                 }
 
+                // Look up provider profile name from metadata
+                $providerProfileName = null;
+                $providerProfileId = $stream['metadata']['provider_profile_id'] ?? null;
+                if ($providerProfileId) {
+                    $providerProfile = PlaylistProfile::find($providerProfileId);
+                    if ($providerProfile) {
+                        $providerProfileName = $providerProfile->is_primary
+                            ? 'Primary'
+                            : ($providerProfile->name ?? "Profile #{$providerProfile->id}");
+                    }
+                }
+
                 $streams[] = [
                     'stream_id' => $streamId,
                     'source_url' => $this->truncateUrl($stream['original_url']),
@@ -305,6 +318,7 @@ class M3uProxyStreamMonitor extends Page
                     'segments_served' => $stream['total_segments_served'],
                     'transcoding' => $transcoding,
                     'transcoding_format' => $transcodingFormat,
+                    'provider_profile' => $providerProfileName,
                     // Failover details
                     'failover_urls' => $stream['failover_urls'] ?? [],
                     'failover_resolver_url' => $stream['failover_resolver_url'] ?? null,

--- a/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
+++ b/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
@@ -163,6 +163,11 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
                                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200">
                                         {{ $stream['format'] }}
                                     </span>
+                                    @if($stream['provider_profile'] ?? false)
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-violet-100 dark:bg-violet-900 text-violet-800 dark:text-violet-200">
+                                            Provider Profile: {{ $stream['provider_profile'] }}
+                                        </span>
+                                    @endif
                                     @if($stream['broadcast'] ?? false)
                                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-200 ml-2">
                                             Broadcast


### PR DESCRIPTION
Displays which provider profile each stream is using as a badge next to the stream format. Shows "Provider Profile: Primary" for the primary account or "Provider Profile: [Name]" for additional profiles.