### PR TITLE
fix: 500 error when creating a new Playlist Alias

### DIFF
--- a/app/Filament/Resources/PlaylistAliases/PlaylistAliasResource.php
+++ b/app/Filament/Resources/PlaylistAliases/PlaylistAliasResource.php
@@ -413,7 +413,7 @@ class PlaylistAliasResource extends Resource
                                         ->body('Provider timezone not found in playlist status. Make sure the playlist is connected and has synced at least once to retrieve this information.')
                                         ->danger()
                                         ->send();
-                                })->hidden(fn ($record) => $record->playlist_id === null)
+                                })->hidden(fn ($record) => $record?->playlist_id === null)
                         ),
 
                     Grid::make()


### PR DESCRIPTION
## Summary

- **Fixes #827** — Clicking "New Playlist Alias" threw a 500 `ErrorException: Attempt to read property "playlist_id" on null`
- Uses null-safe operator (`$record?->playlist_id`) in the `hidden()` callback on the timezone hint action, since `$record` is `null` during creation