### PR TITLE
fix: Enforce capacity check on affinity profile selection

### DIFF
--- a/app/Services/ProfileService.php
+++ b/app/Services/ProfileService.php
@@ -147,7 +147,7 @@ class ProfileService
             if ($affinityProfileId !== null) {
                 $affinityProfile = $profiles->firstWhere('id', $affinityProfileId);
 
-                if ($affinityProfile) {
+                if ($affinityProfile && static::hasCapacity($affinityProfile)) {
                     Log::debug('Returning affinity profile for client', [
                         'client_identifier' => $clientIdentifier,
                         'profile_id' => $affinityProfile->id,
@@ -155,6 +155,16 @@ class ProfileService
                     ]);
 
                     return $affinityProfile;
+                }
+
+                if ($affinityProfile) {
+                    Log::info('Affinity profile at capacity, selecting next available', [
+                        'client_identifier' => $clientIdentifier,
+                        'affinity_profile_id' => $affinityProfile->id,
+                        'affinity_profile_name' => $affinityProfile->name,
+                        'active_connections' => static::getConnectionCount($affinityProfile),
+                        'max_connections' => $affinityProfile->effective_max_streams,
+                    ]);
                 }
             }
         }
@@ -406,6 +416,10 @@ class ProfileService
 
     /**
      * Check if a profile has available capacity.
+     *
+     * Uses the proxy API as the source of truth for upstream connection
+     * count (not the Redis counter, which can drift when pooled streams
+     * outlive the client that originally created them).
      */
     public static function hasCapacity(PlaylistProfile $profile): bool
     {
@@ -413,7 +427,17 @@ class ProfileService
             return false;
         }
 
-        $activeConnections = static::getConnectionCount($profile);
+        $proxyCount = M3uProxyService::getActiveStreamsCountByMetadata(
+            'provider_profile_id',
+            (string) $profile->id
+        );
+        $redisCount = static::getConnectionCount($profile);
+
+        // Use the higher of proxy or Redis count. Redis may include a
+        // just-reserved slot that the proxy hasn't registered yet; the
+        // proxy count reflects actual upstream connections including
+        // pooled streams inherited by subscribers.
+        $activeConnections = max($proxyCount, $redisCount);
         $maxConnections = $profile->effective_max_streams;
 
         return $activeConnections < $maxConnections;
@@ -948,12 +972,14 @@ class ProfileService
             return;
         }
 
-        // Build map of profile_id => active stream count
+        // Build map of profile_id => active stream count.
+        // Each stream entry represents one upstream provider connection,
+        // regardless of how many proxy clients are pooling from it.
         $profileStreamCounts = [];
         foreach ($activeStreams as $stream) {
             $profileId = $stream['metadata']['provider_profile_id'] ?? null;
             if ($profileId) {
-                $profileStreamCounts[$profileId] = ($profileStreamCounts[$profileId] ?? 0) + ($stream['client_count'] ?? 1);
+                $profileStreamCounts[$profileId] = ($profileStreamCounts[$profileId] ?? 0) + 1;
             }
         }
 

--- a/tests/Feature/BypassProviderLimitsTest.php
+++ b/tests/Feature/BypassProviderLimitsTest.php
@@ -15,6 +15,7 @@ use App\Models\PlaylistProfile;
 use App\Models\User;
 use App\Services\ProfileService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Redis;
 
@@ -29,6 +30,15 @@ beforeEach(function () {
     config(['proxy.m3u_proxy_host' => 'http://localhost:8765']);
     config(['proxy.m3u_proxy_token' => 'test-token']);
     config(['cache.default' => 'array']);
+
+    // Default: proxy reports 0 active streams (hasCapacity uses proxy API)
+    Http::fake([
+        '*/streams/by-metadata*' => Http::response([
+            'matching_streams' => [],
+            'total_matching' => 0,
+            'total_clients' => 0,
+        ]),
+    ]);
 });
 
 /**

--- a/tests/Feature/ClientProfileAffinityTest.php
+++ b/tests/Feature/ClientProfileAffinityTest.php
@@ -13,6 +13,7 @@ use App\Models\PlaylistProfile;
 use App\Models\User;
 use App\Services\ProfileService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Redis;
 
@@ -27,6 +28,15 @@ beforeEach(function () {
     config(['proxy.m3u_proxy_host' => 'http://localhost:8765']);
     config(['proxy.m3u_proxy_token' => 'test-token']);
     config(['cache.default' => 'array']);
+
+    // Default: proxy reports 0 active streams per profile (hasCapacity uses proxy API)
+    Http::fake([
+        '*/streams/by-metadata*' => Http::response([
+            'matching_streams' => [],
+            'total_matching' => 0,
+            'total_clients' => 0,
+        ]),
+    ]);
 });
 
 /**
@@ -130,11 +140,12 @@ test('selectProfile reuses affinity profile when it has capacity', function () {
         ->and($selected->id)->toBe($secondProfile->id);
 });
 
-// ── Affinity to at-capacity profile → still uses affinity (capacity ignored) ─
+// ── Affinity to at-capacity profile → falls back to next available ────────
 
-test('selectProfile uses affinity profile even when it is at capacity', function () {
+test('selectProfile falls back when affinity profile is at capacity', function () {
     $playlist = createAffinityPlaylist($this->user, profileCount: 2, maxStreams: 2);
     $profiles = $playlist->enabledProfiles()->get();
+    $firstProfile = $profiles->first();
     $secondProfile = $profiles->skip(1)->first();
 
     // Store affinity pointing to the SECOND profile
@@ -150,12 +161,40 @@ test('selectProfile uses affinity profile even when it is at capacity', function
         ->once()
         ->andReturn(true);
 
-    // Affinity profile is at capacity — but affinity always wins when enable_provider_affinity is true
+    // Affinity profile is at capacity (proxy reports 2 streams, max is 2)
+    Http::fake([
+        '*/streams/by-metadata*' => function ($request) use ($secondProfile) {
+            $profileId = $request['value'] ?? '';
+            if ((string) $profileId === (string) $secondProfile->id) {
+                return Http::response([
+                    'matching_streams' => [],
+                    'total_matching' => 2,
+                    'total_clients' => 2,
+                ]);
+            }
+
+            return Http::response([
+                'matching_streams' => [],
+                'total_matching' => 0,
+                'total_clients' => 0,
+            ]);
+        },
+    ]);
+
+    // Redis counts for capacity checks in the fallback loop
+    Redis::shouldReceive('get')
+        ->with("playlist_profile:{$secondProfile->id}:connections")
+        ->andReturn(2);
+
+    Redis::shouldReceive('get')
+        ->with("playlist_profile:{$firstProfile->id}:connections")
+        ->andReturn(0);
+
     $selected = ProfileService::selectProfile($playlist, clientIdentifier: '10.0.0.1:bob');
 
-    // Capacity is not checked for the affinity profile — it is always returned
+    // Affinity profile is at capacity, so falls back to priority-based selection
     expect($selected)->not->toBeNull()
-        ->and($selected->id)->toBe($secondProfile->id);
+        ->and($selected->id)->toBe($firstProfile->id);
 });
 
 // ── forceSelect does not affect affinity behaviour ────────────────────────

--- a/tests/Feature/ProfileAuditFixesTest.php
+++ b/tests/Feature/ProfileAuditFixesTest.php
@@ -168,6 +168,15 @@ test('selectAndReserveProfile returns profile and reservation ID on success', fu
         ->withProviderInfo(0, 5)
         ->create();
 
+    // hasCapacity queries proxy API for upstream connection count
+    Http::fake([
+        '*/streams/by-metadata*' => Http::response([
+            'matching_streams' => [],
+            'total_matching' => 0,
+            'total_clients' => 0,
+        ]),
+    ]);
+
     // selectProfile reads connection count => 0 (has capacity)
     // hasCapacity also reads count => 0
     // incrementConnections reads count after pipeline
@@ -206,6 +215,15 @@ test('selectAndReserveProfile returns null tuple when no capacity', function () 
         ->withMaxStreams(1)
         ->withProviderInfo(0, 1)
         ->create();
+
+    // hasCapacity queries proxy API — profile at capacity
+    Http::fake([
+        '*/streams/by-metadata*' => Http::response([
+            'matching_streams' => [],
+            'total_matching' => 1,
+            'total_clients' => 1,
+        ]),
+    ]);
 
     // Connection count is at max (1)
     Redis::shouldReceive('get')
@@ -551,6 +569,7 @@ test('reconcileAndSelectProfile returns array with profile and reservation on su
     Http::fake([
         '*/streams/by-metadata*' => Http::response([
             'matching_streams' => [],
+            'total_matching' => 0,
             'total_clients' => 0,
         ]),
     ]);
@@ -627,6 +646,7 @@ test('reconcileAndSelectProfile returns null tuple when truly at capacity after 
                     ],
                 ],
             ],
+            'total_matching' => 1,
             'total_clients' => 1,
         ]),
     ]);
@@ -670,6 +690,7 @@ test('reconcileFromProxy corrects stale count on disabled profile', function () 
     Http::fake([
         '*/streams/by-metadata*' => Http::response([
             'matching_streams' => [],
+            'total_matching' => 0,
             'total_clients' => 0,
         ]),
     ]);
@@ -727,6 +748,7 @@ test('reconcileFromProxy corrects both enabled and disabled profiles', function 
                     ],
                 ],
             ],
+            'total_matching' => 1,
             'total_clients' => 1,
         ]),
     ]);

--- a/tests/Feature/ProfileConnectionRaceConditionTest.php
+++ b/tests/Feature/ProfileConnectionRaceConditionTest.php
@@ -75,6 +75,7 @@ test('cleanupStaleStreams removes Redis entries for streams no longer active in 
                     ],
                 ],
             ],
+            'total_matching' => 1,
             'total_clients' => 1,
         ]),
     ]);
@@ -179,6 +180,7 @@ test('reconcileAndSelectProfile returns profile and reservation after correcting
     Http::fake([
         '*/streams/by-metadata*' => Http::response([
             'matching_streams' => [],
+            'total_matching' => 0,
             'total_clients' => 0,
         ]),
     ]);
@@ -240,6 +242,7 @@ test('reconcileAndSelectProfile returns null when truly at capacity', function (
                     ],
                 ],
             ],
+            'total_matching' => 1,
             'total_clients' => 1,
         ]),
     ]);
@@ -401,6 +404,7 @@ test('reconcileFromProxy corrects Redis counts to match actual proxy state', fun
                     ],
                 ],
             ],
+            'total_matching' => 1,
             'total_clients' => 1,
         ]),
     ]);


### PR DESCRIPTION
## Summary

Fixes #837 — client-provider affinity now respects provider capacity limits instead of blindly returning the affinity profile.

### Changes

**`app/Services/ProfileService.php`**

- **Add capacity check to affinity path** — `selectProfile()` now calls `hasCapacity()` before returning the affinity profile. If the affinity profile is at capacity, it logs a message and falls through to normal priority-based selection, routing the client to a different provider.

- **Proxy-aware capacity check** — `hasCapacity()` now queries the proxy API for the actual upstream connection count (`getActiveStreamsCountByMetadata`) and takes `max(proxyCount, redisCount)`. The Redis counter can drift when pooled streams outlive their original client (subscriber inherits the upstream connection after the primary disconnects, but the Redis counter was already decremented). The proxy count reflects real upstream connections.

- **Fix reconcileFromProxy() stream counting** — Each stream entry represents one upstream provider connection, regardless of how many proxy clients are pooling from it. Changed from `+= client_count` to `+= 1`.

**Tests**

- Updated `ClientProfileAffinityTest` — the "affinity at capacity" test now asserts the correct behavior (falls back to next available profile instead of returning the at-capacity affinity profile)
- Added `Http::fake` to `BypassProviderLimitsTest`, `ProfileAuditFixesTest`, and `ProfileConnectionRaceConditionTest` since `hasCapacity()` now makes a proxy API call

### Testing

- ✅ Affinity profile returned when it has capacity (existing behavior preserved)
- ✅ Affinity profile skipped when at capacity → falls back to priority-based selection
- ✅ Capacity check sees real upstream connections via proxy API (not just Redis counter)
- ✅ All existing tests updated and passing