### PR TITLE
Rework Stream Monitor playlist and profile badges

### DIFF
--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -6,6 +6,7 @@ use App\Facades\LogoFacade;
 use App\Models\Channel;
 use App\Models\Episode;
 use App\Models\Network;
+use App\Models\Playlist;
 use App\Models\PlaylistAlias;
 use App\Models\PlaylistProfile;
 use App\Models\StreamProfile;
@@ -213,14 +214,19 @@ class M3uProxyStreamMonitor extends Page
                 ->groupBy('stream_id')
                 ->toArray();
 
-            // Pre-fetch alias names for all playlist UUIDs to avoid N+1
+            // Pre-fetch alias and playlist data for all playlist UUIDs to avoid N+1
             $playlistUuids = collect($apiStreams['streams'])
                 ->pluck('metadata.playlist_uuid')
                 ->filter()
                 ->unique()
                 ->values();
             $aliasNamesByUuid = PlaylistAlias::whereIn('uuid', $playlistUuids)
-                ->pluck('name', 'uuid');
+                ->with('playlist:id,name,profiles_enabled')
+                ->get()
+                ->keyBy('uuid');
+            $playlistsByUuid = Playlist::whereIn('uuid', $playlistUuids)
+                ->get(['id', 'uuid', 'name', 'profiles_enabled'])
+                ->keyBy('uuid');
 
             foreach ($apiStreams['streams'] as $stream) {
                 $streamId = $stream['stream_id'];
@@ -297,6 +303,23 @@ class M3uProxyStreamMonitor extends Page
                     }
                 }
 
+                // Resolve playlist name, profiles_enabled, and alias name from metadata
+                $playlistUuid = $stream['metadata']['playlist_uuid'] ?? '';
+                $aliasName = null;
+                $playlistName = null;
+                $profilesEnabled = false;
+
+                $alias = $aliasNamesByUuid[$playlistUuid] ?? null;
+                if ($alias) {
+                    $aliasName = $alias->name;
+                } else {
+                    $playlist = $playlistsByUuid[$playlistUuid] ?? null;
+                    if ($playlist) {
+                        $playlistName = $playlist->name;
+                        $profilesEnabled = (bool) $playlist->profiles_enabled;
+                    }
+                }
+
                 // Look up provider profile name from metadata
                 $providerProfileName = null;
                 $providerProfileId = $stream['metadata']['provider_profile_id'] ?? null;
@@ -304,13 +327,10 @@ class M3uProxyStreamMonitor extends Page
                     $providerProfile = PlaylistProfile::find($providerProfileId);
                     if ($providerProfile) {
                         $providerProfileName = $providerProfile->is_primary
-                            ? 'Primary'
+                            ? 'Primary profile'
                             : ($providerProfile->name ?? "Profile #{$providerProfile->id}");
                     }
                 }
-
-                // Check if this stream belongs to an alias
-                $aliasName = $aliasNamesByUuid[$stream['metadata']['playlist_uuid'] ?? ''] ?? null;
 
                 $streams[] = [
                     'stream_id' => $streamId,
@@ -331,6 +351,8 @@ class M3uProxyStreamMonitor extends Page
                     'segments_served' => $stream['total_segments_served'],
                     'transcoding' => $transcoding,
                     'transcoding_format' => $transcodingFormat,
+                    'playlist_name' => $playlistName,
+                    'profiles_enabled' => $profilesEnabled,
                     'provider_profile' => $providerProfileName,
                     'alias_name' => $aliasName,
                     // Failover details

--- a/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
+++ b/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
@@ -160,19 +160,27 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
                                 </div>
                                 
                                 <div class="flex items-center space-x-2">
-                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200">
-                                        {{ $stream['format'] }}
-                                    </span>
-                                    @if($stream['provider_profile'] ?? false)
-                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-violet-100 dark:bg-violet-900 text-violet-800 dark:text-violet-200">
-                                            Provider Profile: {{ $stream['provider_profile'] }}
-                                        </span>
-                                    @endif
                                     @if($stream['alias_name'] ?? false)
-                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-200">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-violet-100 dark:bg-violet-900 text-violet-800 dark:text-violet-200">
                                             Alias: {{ $stream['alias_name'] }}
                                         </span>
                                     @endif
+                                    @if($stream['playlist_name'] ?? false)
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-violet-100 dark:bg-violet-900 text-violet-800 dark:text-violet-200">
+                                            @if($stream['profiles_enabled'] && ($stream['provider_profile'] ?? false))
+                                                {{ $stream['playlist_name'] }}: {{ $stream['provider_profile'] }}
+                                            @else
+                                                {{ $stream['playlist_name'] }}
+                                            @endif
+                                        </span>
+                                    @elseif($stream['provider_profile'] ?? false)
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-violet-100 dark:bg-violet-900 text-violet-800 dark:text-violet-200">
+                                            {{ $stream['provider_profile'] }}
+                                        </span>
+                                    @endif
+                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200">
+                                        {{ $stream['format'] }}
+                                    </span>
                                     @if($stream['broadcast'] ?? false)
                                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-200 ml-2">
                                             Broadcast


### PR DESCRIPTION
## Summary
- Move alias and playlist badges to first position with violet/purple styling
- Show playlist name with profile info when Provider Profiles is enabled (e.g. "My Playlist: Primary profile"), or just the playlist name when disabled
- When a stream uses a playlist alias, show only the alias badge (not both alias and playlist)
- Change alias badge from amber to violet to match playlist badge styling

## Test plan
- [ ] Start a stream through a playlist with Provider Profiles enabled — verify badge shows `[PlaylistName]: Primary profile` or `[PlaylistName]: [ProfileName]`
- [ ] Start a stream through a playlist with Provider Profiles disabled — verify badge shows just the playlist name
- [ ] Start a stream through a playlist alias — verify only the alias badge shows, not both alias and playlist
- [ ] Verify alias and playlist badges appear before the format badge
- [ ] Verify both badges use violet/purple styling