### PR TITLE
Show full stream URLs when browser is wide enough

### DIFF
--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -314,7 +314,7 @@ class M3uProxyStreamMonitor extends Page
 
                 $streams[] = [
                     'stream_id' => $streamId,
-                    'source_url' => $this->truncateUrl($stream['original_url']),
+                    'source_url' => $stream['original_url'],
                     'current_url' => $stream['current_url'],
                     'format' => strtoupper($stream['stream_type']),
                     'status' => $stream['is_active'] && $stream['client_count'] > 0 ? 'active' : 'idle',

--- a/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
+++ b/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
@@ -150,12 +150,12 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
                                             </div>
                                         </div>
                                     @endif
-                                    <div>
+                                    <div class="min-w-0">
                                         <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
                                             Stream {{ substr($stream['stream_id'], -8) }}
                                         </h3>
                                         <p class="text-sm text-gray-500 dark:text-gray-400 font-mono">{{ $stream['model']['title'] ?? 'N/A' }}</p>
-                                        <p class="text-sm text-gray-500 dark:text-gray-400 font-mono">{{ $stream['source_url'] }}</p>
+                                        <p class="text-sm text-gray-500 dark:text-gray-400 font-mono truncate">{{ $stream['source_url'] }}</p>
                                     </div>
                                 </div>
                                 
@@ -362,11 +362,11 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
                                                             Stream is using a failover source
                                                         </p>
                                                         <p class="text-xs text-orange-600 dark:text-orange-300 mt-1">
-                                                            Original URL: <span class="font-mono">{{ Str::limit($stream['source_url'], 60) }}</span>
+                                                            Original URL: <span class="font-mono break-all">{{ $stream['source_url'] }}</span>
                                                         </p>
                                                         @if($stream['current_url'] && $stream['current_url'] !== $stream['source_url'])
                                                             <p class="text-xs text-orange-600 dark:text-orange-300">
-                                                                Current URL: <span class="font-mono">{{ Str::limit($stream['current_url'], 60) }}</span>
+                                                                Current URL: <span class="font-mono break-all">{{ $stream['current_url'] }}</span>
                                                             </p>
                                                         @endif
                                                     </div>
@@ -387,7 +387,7 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
                                                                     {{ $index + 1 }}
                                                                 </span>
                                                                 <span class="{{ $stream['current_failover_index'] === $index + 1 ? 'text-orange-600 dark:text-orange-400 font-medium' : '' }}">
-                                                                    {{ Str::limit($url, 70) }}
+                                                                    {{ $url }}
                                                                 </span>
                                                                 @if($stream['current_failover_index'] === $index + 1)
                                                                     <span class="ml-2 text-orange-500">(active)</span>


### PR DESCRIPTION
## Summary
- Remove server-side URL truncation (`truncateUrl()`) and `Str::limit()` calls from Stream Monitor
- Use CSS `truncate` and `break-all` so URLs display fully when space permits and gracefully truncate/wrap when the window is narrow
- Applies to main source URL, failover original/current URLs, and failover URL list

## Test plan
- [ ] View Stream Monitor with a wide browser window — URLs should show in full
- [ ] Narrow the browser window — main source URL should truncate with ellipsis
- [ ] Check failover URLs wrap naturally on narrower screens