### PR TITLE
feat: Change preferred icon source on EPG map

### DIFF
--- a/app/Filament/Resources/EpgMaps/EpgMapResource.php
+++ b/app/Filament/Resources/EpgMaps/EpgMapResource.php
@@ -298,6 +298,13 @@ class EpgMapResource extends Resource
                         ->default(false)
                         ->helperText('When enabled, exact matches on channel name/display name will be prioritized over channel_id matches. Enable this if your EPG has duplicate channel_ids for different quality versions (e.g., DasErsteHD for "Das Erste HDraw", "Das Erste HDraw²", etc.). Disable if your EPG uses unique channel_ids.'),
 
+                    Toggle::make('settings.set_epg_icon')
+                        ->label('Set preferred icon to EPG')
+                        ->columnSpanFull()
+                        ->inline(true)
+                        ->default(false)
+                        ->helperText('When enabled, matched channels will have their preferred icon set to "EPG" instead of "Channel". This uses the EPG channel icon as the preferred logo source.'),
+
                     Fieldset::make('Matching Thresholds')
                         ->schema([
                             Forms\Components\TextInput::make('settings.similarity_threshold')

--- a/app/Jobs/MapEpgToChannels.php
+++ b/app/Jobs/MapEpgToChannels.php
@@ -59,7 +59,8 @@ class MapEpgToChannels implements ShouldQueue
 
             // Upsert the channels
             Channel::upsert($bulk, uniqueBy: ['source_id', 'playlist_id'], update: [
-                'epg_channel_id', // this is the only field we want to update...
+                'epg_channel_id',
+                'logo_type',
             ]);
         }
     }

--- a/app/Jobs/MapPlaylistChannelsToEpgChunk.php
+++ b/app/Jobs/MapPlaylistChannelsToEpgChunk.php
@@ -68,6 +68,7 @@ class MapPlaylistChannelsToEpgChunk implements ShouldQueue
         $patterns = $this->settings['exclude_prefixes'] ?? [];
         $useRegex = $this->settings['use_regex'] ?? false;
         $skipMissing = $this->settings['skip_missing'] ?? false;
+        $setEpgIcon = $this->settings['set_epg_icon'] ?? false;
         $mappedChannels = [];
 
         foreach ($channels->cursor() as $channel) {
@@ -233,6 +234,10 @@ class MapPlaylistChannelsToEpgChunk implements ShouldQueue
 
             // If EPG channel found, link it to the Playlist channel
             if ($epgChannel) {
+                if ($setEpgIcon) {
+                    $channel->logo_type = 'epg';
+                }
+
                 $mappedChannels[] = [
                     'title' => $this->sanitizeUtf8($channel->title),
                     'name' => $this->sanitizeUtf8($channel->name),
@@ -241,6 +246,7 @@ class MapPlaylistChannelsToEpgChunk implements ShouldQueue
                     'playlist_id' => $channel->playlist_id,
                     'source_id' => $channel->source_id,
                     'epg_channel_id' => $epgChannel->id,
+                    'logo_type' => $channel->logo_type,
                 ];
             }
         }


### PR DESCRIPTION
New toggle in the advanced settings of the EPG map modal, allowing if preferred the option to set the icon source of channels to be from the EPG. 