### PR TITLE
Fix 500 errors in EpgViewer and getFloatingPlayerAttributes

### DIFF
--- a/app/Livewire/EpgViewer.php
+++ b/app/Livewire/EpgViewer.php
@@ -110,7 +110,7 @@ class EpgViewer extends Component implements HasActions, HasForms
                     // Add URL for Playlist channels
                     if ($this->type !== 'Epg') {
                         $playlist = $updated->playlist;
-                        $proxyEnabled = $playlist->enable_proxy;
+                        $proxyEnabled = $playlist?->enable_proxy ?? false;
                         $url = $updated->url_custom ?? $updated->url;
 
                         // Get the URL based on proxy settings

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -142,7 +142,7 @@ class Channel extends Model
         )->orderBy('channel_failovers.sort');
     }
 
-    public function getFloatingPlayerAttributes(?string $username, ?string $password): array
+    public function getFloatingPlayerAttributes(?string $username = null, ?string $password = null): array
     {
         $settings = app(GeneralSettings::class);
 

--- a/app/Models/Episode.php
+++ b/app/Models/Episode.php
@@ -75,7 +75,7 @@ class Episode extends Model
         return $this->morphMany(StrmFileMapping::class, 'syncable');
     }
 
-    public function getFloatingPlayerAttributes(?string $username, ?string $password): array
+    public function getFloatingPlayerAttributes(?string $username = null, ?string $password = null): array
     {
         $settings = app(GeneralSettings::class);
 


### PR DESCRIPTION
## Summary

- Add null-safe access for playlist relationship in `EpgViewer.php` — prevents crash when a channel's parent playlist is missing
- Add default `null` values for `$username` and `$password` params in `Channel::getFloatingPlayerAttributes()` and `Episode::getFloatingPlayerAttributes()` — most callers (admin panel play buttons) don't pass credentials