### PR TITLE
Fix drop_enabled_from_alias migration for prefixed index names

### DIFF
--- a/database/migrations/2026_03_18_083841_drop_enabled_from_alias.php
+++ b/database/migrations/2026_03_18_083841_drop_enabled_from_alias.php
@@ -12,7 +12,14 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('playlist_aliases', function (Blueprint $table) {
-            $table->dropIndex(['playlist_id', 'enabled']);
+            // Find and drop the composite index by its columns, regardless of
+            // naming convention (handles prefixed names from database imports)
+            foreach (Schema::getIndexes('playlist_aliases') as $index) {
+                if ($index['columns'] === ['playlist_id', 'enabled']) {
+                    $table->dropIndex($index['name']);
+                    break;
+                }
+            }
             $table->dropColumn('enabled');
             $table->index(['playlist_id']);
         });


### PR DESCRIPTION
## Summary

- Fixes the `drop_enabled_from_alias` migration failing on databases with prefixed index names (e.g. from DB imports/copies)
- Uses `Schema::getIndexes()` to look up the actual index name by its columns before dropping, instead of relying on Laravel's conventional naming

Closes #864