### PR TITLE
fix: Ensure specific jobs are ran concurrently instead of async

### DIFF
--- a/app/Listeners/SyncListener.php
+++ b/app/Listeners/SyncListener.php
@@ -12,8 +12,7 @@ use App\Jobs\RunPlaylistSortAlpha;
 use App\Jobs\RunPostProcess;
 use App\Models\Epg;
 use App\Models\Playlist;
-use Filament\Notifications\Notification;
-use Throwable;
+use Illuminate\Support\Facades\Bus;
 
 class SyncListener
 {
@@ -26,50 +25,21 @@ class SyncListener
             $playlist = $event->model;
             $lastSync = $playlist->syncStatuses()->first();
 
-            // Handle auto-merge channels if enabled
-            if ($playlist->auto_merge_channels_enabled && $playlist->status === Status::Completed) {
-                $this->handleAutoMergeChannels($playlist);
-            }
-
-            // Handle saved find & replace rules
-            if ($playlist->status === Status::Completed && collect($playlist->find_replace_rules ?? [])->contains(fn ($r) => $r['enabled'] ?? false)) {
-                dispatch(new RunPlaylistFindReplaceRules($playlist));
-            }
-
-            // Handle sort alpha rules
-            if ($playlist->status === Status::Completed && collect($playlist->sort_alpha_config ?? [])->contains(fn ($r) => $r['enabled'] ?? false)) {
-                dispatch(new RunPlaylistSortAlpha($playlist));
-            }
-
-            // Handle post-processes
-            $playlist->postProcesses()->where([
-                ['event', 'synced'],
-                ['enabled', true],
-            ])->get()->each(function ($postProcess) use ($playlist, $lastSync) {
-                dispatch(new RunPostProcess(
-                    $postProcess,
-                    $playlist,
-                    $lastSync
-                ));
-            });
-
-            // Dispatch recurring channel scrubbers after playlist sync
+            // Only run the following on completed syncs
             if ($playlist->status === Status::Completed) {
-                $playlist->channelScrubbers()->where('recurring', true)->get()->each(function ($scrubber) {
-                    dispatch(new ProcessChannelScrubber($scrubber->id));
-                });
+                // Handle saved find & replace rules and sort alpha if enabled
+                $this->dispatchNameProcessingPipeline($playlist);
+
+                // Handle channel merge & scrubbers if enabled
+                $this->dispatchChannelScanJobs($playlist);
             }
+
+            // Handle Playlist post-processes
+            $this->dispatchPostProcessJobs($event->model, $lastSync);
         }
         if ($event->model instanceof Epg) {
-            $event->model->postProcesses()->where([
-                ['event', 'synced'],
-                ['enabled', true],
-            ])->get()->each(function ($postProcess) use ($event) {
-                dispatch(new RunPostProcess(
-                    $postProcess,
-                    $event->model
-                ));
-            });
+            // Handle EPG post-processes
+            $this->dispatchPostProcessJobs($event->model);
 
             // Generate EPG cache if sync was successful
             if ($event->model->status === Status::Completed) {
@@ -79,68 +49,119 @@ class SyncListener
     }
 
     /**
+     * Group 1: Find & Replace → Sort Alpha.
+     *
+     * Sort alpha depends on channel names, which Find & Replace may change,
+     * so these must run in sequence when both are enabled.
+     */
+    private function dispatchNameProcessingPipeline(Playlist $playlist): void
+    {
+        $hasFindReplace = collect($playlist->find_replace_rules ?? [])
+            ->contains(fn ($r) => $r['enabled'] ?? false);
+        $hasSortAlpha = collect($playlist->sort_alpha_config ?? [])
+            ->contains(fn ($r) => $r['enabled'] ?? false);
+
+        if ($hasFindReplace && $hasSortAlpha) {
+            Bus::chain([
+                new RunPlaylistFindReplaceRules($playlist),
+                new RunPlaylistSortAlpha($playlist),
+            ])->dispatch();
+        } elseif ($hasFindReplace) {
+            dispatch(new RunPlaylistFindReplaceRules($playlist));
+        } elseif ($hasSortAlpha) {
+            dispatch(new RunPlaylistSortAlpha($playlist));
+        }
+    }
+
+    /**
+     * Group 2. Merge Channels → Channel Scrubber.
+     *
+     * Merge uses `stream_id` and doesn't rely on name/titles, so can be run in parallel with name processing jobs.
+     * However, channel scrubber jobs should be dispatched after the merge channels job completes,
+     * to ensure they run against the updated channel list and avoid potential conflicts with the merge process.
+     */
+    private function dispatchChannelScanJobs(Playlist $playlist): void
+    {
+        $mergeJob = ($playlist->auto_merge_channels_enabled ?? false)
+            ? $this->getMergeJob($playlist)
+            : null;
+
+        $scrubberJobs = $playlist->channelScrubbers()
+            ->where('recurring', true)->get()
+            ->map(fn ($scrubber) => new ProcessChannelScrubber($scrubber->id))
+            ->toArray();
+
+        if ($mergeJob) {
+            Bus::chain([$mergeJob, ...$scrubberJobs])->dispatch();
+        } elseif (! empty($scrubberJobs)) {
+            Bus::chain($scrubberJobs)->dispatch();
+        }
+    }
+
+    /**
+     * Dispatch post-processes for a model after sync.
+     */
+    private function dispatchPostProcessJobs(Playlist|Epg $model, $lastSync = null): void
+    {
+        $model->postProcesses()->where([
+            ['event', 'synced'],
+            ['enabled', true],
+        ])->get()->each(function ($postProcess) use ($model, $lastSync) {
+            dispatch(new RunPostProcess(
+                $postProcess,
+                $model,
+                $lastSync
+            ));
+        });
+    }
+
+    /**
      * Handle auto-merge channels after playlist sync.
      */
-    private function handleAutoMergeChannels(Playlist $playlist): void
+    private function getMergeJob(Playlist $playlist): ?MergeChannels
     {
-        try {
-            // Get auto-merge configuration
-            $config = $playlist->auto_merge_config ?? [];
-            $useResolution = $config['check_resolution'] ?? false;
-            $forceCompleteRemerge = $config['force_complete_remerge'] ?? false;
-            $preferCatchupAsPrimary = $config['prefer_catchup_as_primary'] ?? false;
-            $newChannelsOnly = $config['new_channels_only'] ?? true; // Default to true for new channels only
-            $preferredPlaylistId = $config['preferred_playlist_id'] ?? null;
-            $failoverPlaylists = $config['failover_playlists'] ?? [];
-            $deactivateFailover = $playlist->auto_merge_deactivate_failover;
+        // Get auto-merge configuration
+        $config = $playlist->auto_merge_config ?? [];
+        $useResolution = $config['check_resolution'] ?? false;
+        $forceCompleteRemerge = $config['force_complete_remerge'] ?? false;
+        $preferCatchupAsPrimary = $config['prefer_catchup_as_primary'] ?? false;
+        $newChannelsOnly = $config['new_channels_only'] ?? true; // Default to true for new channels only
+        $preferredPlaylistId = $config['preferred_playlist_id'] ?? null;
+        $failoverPlaylists = $config['failover_playlists'] ?? [];
+        $deactivateFailover = (bool) ($playlist->auto_merge_deactivate_failover ?? false);
 
-            // Build the playlists collection for merging
-            // Start with the current playlist
-            $playlists = collect([['playlist_failover_id' => $playlist->id]]);
+        // Build the playlists collection for merging
+        // Start with the current playlist
+        $playlists = collect([['playlist_failover_id' => $playlist->id]]);
 
-            // Add any additional failover playlists from config
-            if (! empty($failoverPlaylists)) {
-                foreach ($failoverPlaylists as $failover) {
-                    $failoverId = is_array($failover) ? ($failover['playlist_failover_id'] ?? null) : $failover;
-                    if ($failoverId && $failoverId != $playlist->id) {
-                        $playlists->push(['playlist_failover_id' => $failoverId]);
-                    }
+        // Add any additional failover playlists from config
+        if (! empty($failoverPlaylists)) {
+            foreach ($failoverPlaylists as $failover) {
+                $failoverId = is_array($failover) ? ($failover['playlist_failover_id'] ?? null) : $failover;
+                if ($failoverId && $failoverId != $playlist->id) {
+                    $playlists->push(['playlist_failover_id' => $failoverId]);
                 }
             }
-
-            // Determine the preferred playlist ID (use configured one or fallback to current playlist)
-            $effectivePlaylistId = $preferredPlaylistId ? (int) $preferredPlaylistId : $playlist->id;
-
-            // Build weighted config if any weighted priority options are set
-            $weightedConfig = $this->buildWeightedConfig($config);
-
-            // Dispatch the merge job
-            dispatch(new MergeChannels(
-                user: $playlist->user,
-                playlists: $playlists,
-                playlistId: $effectivePlaylistId,
-                checkResolution: $useResolution,
-                deactivateFailoverChannels: $deactivateFailover,
-                forceCompleteRemerge: $forceCompleteRemerge,
-                preferCatchupAsPrimary: $preferCatchupAsPrimary,
-                weightedConfig: $weightedConfig,
-                newChannelsOnly: $newChannelsOnly,
-            ));
-        } catch (Throwable $e) {
-            // Log error and send notification
-            logger()->error('Auto-merge failed for playlist: '.$playlist->name, [
-                'playlist_id' => $playlist->id,
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
-            ]);
-
-            Notification::make()
-                ->title('Auto-merge failed')
-                ->body("Failed to auto-merge channels for playlist \"{$playlist->name}\": {$e->getMessage()}")
-                ->danger()
-                ->broadcast($playlist->user)
-                ->sendToDatabase($playlist->user);
         }
+
+        // Determine the preferred playlist ID (use configured one or fallback to current playlist)
+        $effectivePlaylistId = $preferredPlaylistId ? (int) $preferredPlaylistId : $playlist->id;
+
+        // Build weighted config if any weighted priority options are set
+        $weightedConfig = $this->buildWeightedConfig($config);
+
+        // Dispatch the merge job
+        return new MergeChannels(
+            user: $playlist->user,
+            playlists: $playlists,
+            playlistId: $effectivePlaylistId,
+            checkResolution: $useResolution,
+            deactivateFailoverChannels: $deactivateFailover,
+            forceCompleteRemerge: $forceCompleteRemerge,
+            preferCatchupAsPrimary: $preferCatchupAsPrimary,
+            weightedConfig: $weightedConfig,
+            newChannelsOnly: $newChannelsOnly,
+        );
     }
 
     /**

--- a/tests/Feature/SyncListenerTest.php
+++ b/tests/Feature/SyncListenerTest.php
@@ -1,0 +1,331 @@
+<?php
+
+/**
+ * Tests for SyncListener job dispatch ordering.
+ *
+ * Verifies:
+ *  - Group 1 (Name Processing): RunPlaylistFindReplaceRules runs before RunPlaylistSortAlpha
+ *    when both are enabled, replacing + sorting in the correct sequence.
+ *  - Group 2 (Channel Scan): MergeChannels runs before ProcessChannelScrubber(s) when
+ *    both are enabled, ensuring scrubbers operate on the fully-merged channel list.
+ *  - Jobs in each group are skipped correctly when disabled/absent.
+ *  - Non-Completed playlist status prevents Group 1 and Group 2 from running.
+ *  - EPG post-processing (status reset + GenerateEpgCache dispatch) only fires on success.
+ */
+
+use App\Enums\Status;
+use App\Events\SyncCompleted;
+use App\Jobs\GenerateEpgCache;
+use App\Jobs\MergeChannels;
+use App\Jobs\ProcessChannelScrubber;
+use App\Jobs\RunPlaylistFindReplaceRules;
+use App\Jobs\RunPlaylistSortAlpha;
+use App\Models\ChannelScrubber;
+use App\Models\Epg;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    Bus::fake();
+    Notification::fake();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'status' => Status::Completed,
+        'find_replace_rules' => null,
+        'sort_alpha_config' => null,
+        'auto_merge_channels_enabled' => false,
+    ]);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Group 1: Name Processing Pipeline (find-replace → sort-alpha)
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('chains find-replace before sort-alpha when both have enabled rules', function () {
+    $this->playlist->update([
+        'find_replace_rules' => [['enabled' => true, 'find_replace' => '^US- ', 'replace_with' => '']],
+        'sort_alpha_config' => [['enabled' => true, 'target' => 'live_groups', 'group' => ['all'], 'column' => 'title', 'sort' => 'ASC']],
+    ]);
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertChained([
+        RunPlaylistFindReplaceRules::class,
+        RunPlaylistSortAlpha::class,
+    ]);
+});
+
+it('dispatches only find-replace when sort-alpha has no enabled rules', function () {
+    $this->playlist->update([
+        'find_replace_rules' => [['enabled' => true, 'find_replace' => '^US- ', 'replace_with' => '']],
+        'sort_alpha_config' => [['enabled' => false, 'target' => 'live_groups', 'group' => ['all'], 'column' => 'title', 'sort' => 'ASC']],
+    ]);
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertDispatched(RunPlaylistFindReplaceRules::class);
+    Bus::assertNotDispatched(RunPlaylistSortAlpha::class);
+});
+
+it('dispatches only sort-alpha when find-replace has no enabled rules', function () {
+    $this->playlist->update([
+        'find_replace_rules' => [['enabled' => false, 'find_replace' => '^US- ', 'replace_with' => '']],
+        'sort_alpha_config' => [['enabled' => true, 'target' => 'live_groups', 'group' => ['all'], 'column' => 'title', 'sort' => 'ASC']],
+    ]);
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertDispatched(RunPlaylistSortAlpha::class);
+    Bus::assertNotDispatched(RunPlaylistFindReplaceRules::class);
+});
+
+it('dispatches neither name processing job when both configs are null', function () {
+    // find_replace_rules and sort_alpha_config are already null in beforeEach
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertNotDispatched(RunPlaylistFindReplaceRules::class);
+    Bus::assertNotDispatched(RunPlaylistSortAlpha::class);
+});
+
+it('dispatches neither name processing job when both configs contain only disabled rules', function () {
+    $this->playlist->update([
+        'find_replace_rules' => [['enabled' => false, 'find_replace' => '^US- ', 'replace_with' => '']],
+        'sort_alpha_config' => [['enabled' => false, 'target' => 'live_groups', 'group' => ['all'], 'column' => 'title', 'sort' => 'ASC']],
+    ]);
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertNotDispatched(RunPlaylistFindReplaceRules::class);
+    Bus::assertNotDispatched(RunPlaylistSortAlpha::class);
+});
+
+it('dispatches find-replace independently (not chained) when sort-alpha is absent', function () {
+    $this->playlist->update([
+        'find_replace_rules' => [['enabled' => true, 'find_replace' => '^US- ', 'replace_with' => '']],
+        'sort_alpha_config' => null,
+    ]);
+
+    event(new SyncCompleted($this->playlist));
+
+    // A single-job dispatch, not a chain
+    Bus::assertDispatched(RunPlaylistFindReplaceRules::class);
+    Bus::assertNotDispatched(RunPlaylistSortAlpha::class);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Group 2: Channel Scan Jobs (merge → scrubbers)
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('chains merge job alone when auto-merge is enabled and no recurring scrubbers exist', function () {
+    $this->playlist->update(['auto_merge_channels_enabled' => true]);
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertChained([MergeChannels::class]);
+    Bus::assertNotDispatched(ProcessChannelScrubber::class);
+});
+
+it('chains merge job before scrubber when both are enabled', function () {
+    $this->playlist->update(['auto_merge_channels_enabled' => true]);
+
+    ChannelScrubber::withoutEvents(fn () => ChannelScrubber::create([
+        'name' => 'Recurring Scrubber',
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'recurring' => true,
+        'status' => 'pending',
+        'check_method' => 'http',
+    ]));
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertChained([MergeChannels::class, ProcessChannelScrubber::class]);
+});
+
+it('chains merge job before multiple scrubbers when both are enabled', function () {
+    $this->playlist->update(['auto_merge_channels_enabled' => true]);
+
+    foreach (['Scrubber A', 'Scrubber B'] as $name) {
+        ChannelScrubber::withoutEvents(fn () => ChannelScrubber::create([
+            'name' => $name,
+            'user_id' => $this->user->id,
+            'playlist_id' => $this->playlist->id,
+            'recurring' => true,
+            'status' => 'pending',
+            'check_method' => 'http',
+        ]));
+    }
+
+    event(new SyncCompleted($this->playlist));
+
+    // Chain should be: MergeChannels → ProcessChannelScrubber × 2
+    Bus::assertChained([MergeChannels::class, ProcessChannelScrubber::class, ProcessChannelScrubber::class]);
+});
+
+it('batches recurring scrubbers when auto-merge is disabled', function () {
+    ChannelScrubber::withoutEvents(fn () => ChannelScrubber::create([
+        'name' => 'Recurring Scrubber',
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'recurring' => true,
+        'status' => 'pending',
+        'check_method' => 'http',
+    ]));
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertChained([ProcessChannelScrubber::class]);
+    Bus::assertNotDispatched(MergeChannels::class);
+});
+
+it('batches all recurring scrubbers together when auto-merge is disabled', function () {
+    foreach (['Scrubber X', 'Scrubber Y'] as $name) {
+        ChannelScrubber::withoutEvents(fn () => ChannelScrubber::create([
+            'name' => $name,
+            'user_id' => $this->user->id,
+            'playlist_id' => $this->playlist->id,
+            'recurring' => true,
+            'status' => 'pending',
+            'check_method' => 'http',
+        ]));
+    }
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertChained([ProcessChannelScrubber::class, ProcessChannelScrubber::class]);
+    Bus::assertNotDispatched(MergeChannels::class);
+});
+
+it('does not dispatch merge or scrubbers when both are disabled', function () {
+    // auto_merge_channels_enabled is false in beforeEach, and no scrubbers exist
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertNotDispatched(MergeChannels::class);
+    Bus::assertNotDispatched(ProcessChannelScrubber::class);
+});
+
+it('ignores non-recurring scrubbers', function () {
+    ChannelScrubber::withoutEvents(fn () => ChannelScrubber::create([
+        'name' => 'Non-recurring Scrubber',
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'recurring' => false,
+        'status' => 'pending',
+        'check_method' => 'http',
+    ]));
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertNotDispatched(MergeChannels::class);
+    Bus::assertNotDispatched(ProcessChannelScrubber::class);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Playlist status guard
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('skips all pipeline and scan jobs when playlist sync did not complete', function () {
+    $this->playlist->update([
+        'status' => Status::Failed,
+        'find_replace_rules' => [['enabled' => true, 'find_replace' => '^US- ', 'replace_with' => '']],
+        'sort_alpha_config' => [['enabled' => true, 'target' => 'live_groups', 'group' => ['all'], 'column' => 'title', 'sort' => 'ASC']],
+        'auto_merge_channels_enabled' => true,
+    ]);
+
+    ChannelScrubber::withoutEvents(fn () => ChannelScrubber::create([
+        'name' => 'Recurring Scrubber',
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'recurring' => true,
+        'status' => 'pending',
+        'check_method' => 'http',
+    ]));
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertNotDispatched(RunPlaylistFindReplaceRules::class);
+    Bus::assertNotDispatched(RunPlaylistSortAlpha::class);
+    Bus::assertNotDispatched(MergeChannels::class);
+    Bus::assertNotDispatched(ProcessChannelScrubber::class);
+});
+
+it('skips pipeline and scan jobs when playlist is still processing', function () {
+    $this->playlist->update([
+        'status' => Status::Processing,
+        'find_replace_rules' => [['enabled' => true, 'find_replace' => '^US- ', 'replace_with' => '']],
+        'auto_merge_channels_enabled' => true,
+    ]);
+
+    event(new SyncCompleted($this->playlist));
+
+    Bus::assertNotDispatched(RunPlaylistFindReplaceRules::class);
+    Bus::assertNotDispatched(MergeChannels::class);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// EPG: post-processing
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('dispatches GenerateEpgCache after a successful EPG sync', function () {
+    $uuid = (string) Str::orderedUuid();
+    $epg = Epg::factory()->for($this->user)->createQuietly([
+        'uuid' => $uuid,
+        'status' => Status::Completed,
+        'is_cached' => true,
+        'cache_meta' => ['entries' => 100],
+    ]);
+
+    event(new SyncCompleted($epg));
+
+    Bus::assertDispatched(
+        GenerateEpgCache::class,
+        fn ($job) => $job->uuid === $uuid && $job->notify === true
+    );
+});
+
+it('does not dispatch GenerateEpgCache when EPG sync failed', function () {
+    $epg = Epg::factory()->for($this->user)->createQuietly([
+        'uuid' => (string) Str::orderedUuid(),
+        'status' => Status::Failed,
+    ]);
+
+    event(new SyncCompleted($epg));
+
+    Bus::assertNotDispatched(GenerateEpgCache::class);
+});
+
+it('does not dispatch GenerateEpgCache when EPG sync is still processing', function () {
+    $epg = Epg::factory()->for($this->user)->createQuietly([
+        'uuid' => (string) Str::orderedUuid(),
+        'status' => Status::Processing,
+    ]);
+
+    event(new SyncCompleted($epg));
+
+    Bus::assertNotDispatched(GenerateEpgCache::class);
+});
+
+it('resets EPG cache state to prevent stale reads before dispatching GenerateEpgCache', function () {
+    $epg = Epg::factory()->for($this->user)->createQuietly([
+        'uuid' => (string) Str::orderedUuid(),
+        'status' => Status::Completed,
+        'is_cached' => true,
+        'cache_meta' => ['entries' => 100],
+        'processing_started_at' => now(),
+        'processing_phase' => 'channels',
+    ]);
+
+    event(new SyncCompleted($epg));
+
+    $epg->refresh();
+
+    expect($epg->status)->toBe(Status::Processing)
+        ->and($epg->is_cached)->toBeFalse()
+        ->and($epg->cache_meta)->toBeNull()
+        ->and($epg->processing_started_at)->toBeNull()
+        ->and($epg->processing_phase)->toBeNull();
+});


### PR DESCRIPTION
`RunPlaylistSortAlpha` should run AFTER `RunPlaylistFindReplaceRules` since the find/replace may change the name and thus the order.

`ProcessChannelScrubber` should be run AFTER `MergeChannels`.