### PR TITLE
fix: Sync public disk URL with resolved base URL

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -118,6 +118,11 @@ class AppServiceProvider extends ServiceProvider
             $this->configureDynamicHttpsDetection();
         }
 
+        // Sync the public disk URL with the resolved base URL so that
+        // Storage::disk('public')->url() includes the correct scheme,
+        // host, and port — regardless of what APP_URL is set to.
+        config(['filesystems.disks.public.url' => url('/storage')]);
+
         // Setup the middleware
         $this->setupMiddleware();
 


### PR DESCRIPTION
## Summary
- Fixes placeholder image uploads showing perpetual loading spinners after saving in Settings > Assets
- `Storage::disk('public')->url()` was using the static `APP_URL` from config, which often omits the port (e.g. `http://localhost` instead of `http://localhost:36400`), causing Filament FileUpload previews to fetch from the wrong origin and 404
- Sets the public disk URL dynamically in `AppServiceProvider::boot()` using `url('/storage')`, which runs after the existing URL configuration (console port appending, reverse proxy HTTPS detection) and always reflects the actual access URL

Closes #872

## Test plan
- [x] Upload a placeholder image in Settings > Assets, click Save Changes — image should display correctly
- [x] Refresh the page — image should still display (no spinner/loading)
- [x] Open in new tab / download buttons should work
- [x] Logo override picker on channel edit should still populate full URLs
- [ ] Test behind a reverse proxy (HTTPS) — storage URLs should use correct scheme and host