### PR TITLE
fix: output set channel numbers correctly

### DIFF
--- a/app/Http/Controllers/Api/EpgApiController.php
+++ b/app/Http/Controllers/Api/EpgApiController.php
@@ -327,7 +327,7 @@ class EpgApiController extends Controller
                         $tvgId = $channel->id;
                         break;
                     case PlaylistChannelId::Number:
-                        $tvgId = $channelNumber;
+                        $tvgId = $channelNo;
                         break;
                     case PlaylistChannelId::Name:
                         $tvgId = $channel->name_custom ?? $channel->name;

--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -125,7 +125,7 @@ class EpgGenerateController extends Controller
                     $tvgId = $channel->id;
                     break;
                 case PlaylistChannelId::Number:
-                    $tvgId = $channelNumber;
+                    $tvgId = $channelNo;
                     break;
                 case PlaylistChannelId::Name:
                     $tvgId = $channel->name_custom ?? $channel->name;

--- a/app/Http/Controllers/PlaylistGenerateController.php
+++ b/app/Http/Controllers/PlaylistGenerateController.php
@@ -152,7 +152,7 @@ class PlaylistGenerateController extends Controller
                             $tvgId = $channel->id;
                             break;
                         case PlaylistChannelId::Number:
-                            $tvgId = $channelNumber;
+                            $tvgId = $channelNo;
                             break;
                         case PlaylistChannelId::Name:
                             $tvgId = $channel->name_custom ?? $channel->name;
@@ -520,7 +520,7 @@ class PlaylistGenerateController extends Controller
                         $tvgId = $channel->id;
                         break;
                     case PlaylistChannelId::Number:
-                        $tvgId = $channelNumber;
+                        $tvgId = $channelNo;
                         break;
                     case PlaylistChannelId::Name:
                         $tvgId = $channel->name_custom ?? $channel->name;

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -632,7 +632,7 @@ class XtreamApiController extends Controller
                             $tvgId = $channel->id;
                             break;
                         case PlaylistChannelId::Number:
-                            $tvgId = $channelNumber;
+                            $tvgId = $channelNo;
                             break;
                         case PlaylistChannelId::Name:
                             $tvgId = $channel->name_custom ?? $channel->name;


### PR DESCRIPTION
When preferred output is "Channel Number", the code uses $channelNumber which is the auto-increment counter, not the channels actual number