### PR TITLE
fix: Remove icon from Tools nav group to resolve Filament v4 conflict

### DIFF
--- a/app/Filament/Pages/Backups.php
+++ b/app/Filament/Pages/Backups.php
@@ -16,7 +16,7 @@ use ShuvroRoy\FilamentSpatieLaravelBackup\Pages\Backups as BaseBackups;
 
 class Backups extends BaseBackups
 {
-    protected static string|\BackedEnum|null $navigationIcon = '';
+    protected static string|\BackedEnum|null $navigationIcon = null;
 
     protected static ?string $navigationLabel = 'Backup & Restore';
 

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -108,8 +108,7 @@ class AdminPanelProvider extends PanelProvider
                 NavigationGroup::make('Proxy')
                     ->icon('heroicon-m-arrows-right-left'),
                 NavigationGroup::make('Tools')
-                    ->collapsed()
-                    ->icon('heroicon-m-wrench-screwdriver'),
+                    ->collapsed(),
             ])
             ->navigationItems([
                 NavigationItem::make('API Docs')


### PR DESCRIPTION
## Summary
- Filament v4 disallows both a navigation group and its items having icons simultaneously
- The `Tools` group had an icon set, while the `Backups` page inherited one from its vendor parent class, causing a 500 error (particularly visible with top navigation)
- Removed the group-level icon from `Tools` and properly nulled the `Backups` page icon override

## Test plan
- [x] Verified app loads without 500 error using top navigation
- [ ] Confirm Tools nav group renders correctly in both top and side nav modes
- [ ] Confirm all Tools group items (API Tokens, Assets, Backup & Restore, Post Processing, Debug Logs, Release Logs) are accessible