### PR TITLE
fix: add missing is_vod and container_extension to M3U+ import

### DIFF
--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -814,6 +814,8 @@ class ProcessM3uImport implements ShouldQueue
                     'catchup_source' => null,
                     'shift' => 0,
                     'tvg_shift' => null,
+                    'is_vod' => false, // default false, matches Xtream API path
+                    'container_extension' => null,
                     'source_id' => null, // source ID for the channel
                     'can_merge' => $this->canMergeEnabled,
                     'epg_map_enabled' => $this->epgMapEnabled,


### PR DESCRIPTION
## Summary

- The M3U+ import path (`processM3uPlus()`) is missing `is_vod` and `container_extension` from its `$channelFields` template
- The Xtream API path (`processXtreamApi()`) already has both fields (lines 536-537)
- Without `is_vod` explicitly set to `false`, the `Playlist::live_channels()` relationship (`->where('is_vod', false)`) may not match M3U+ imported channels, causing them to disappear from the live channel list

## Root cause

When VOD support was added, `is_vod` and `container_extension` were included in the Xtream API `$channelFields` but never added to the M3U+ equivalent. The DB column default (`false`) masks this on fresh INSERTs, but upsert behavior on re-imports can leave the field unset.

## Fix

Two lines added to the M3U+ `$channelFields` array to match the Xtream API path:
```php
'is_vod' => false,
'container_extension' => null,
```

## Test plan

- [ ] Import an M3U+ format playlist and verify channels appear under Live channels
- [ ] Re-sync the same playlist and confirm channels remain visible
- [ ] Verify Xtream API imports still work as before (no change to that path)