### PR TITLE
fix: Null-safe EPG access when editing channel

### DIFF
--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -1307,7 +1307,7 @@ class ChannelResource extends Resource
                         ->label('EPG Channel')
                         ->helperText('Select an associated EPG channel for this channel.')
                         ->relationship('epgChannel', 'name')
-                        ->getOptionLabelFromRecordUsing(fn ($record) => "$record->name [{$record->epg->name}]")
+                        ->getOptionLabelFromRecordUsing(fn ($record) => "$record->name [{$record->epg?->name}]")
                         ->getSearchResultsUsing(function (string $search) {
                             $searchLower = strtolower($search);
                             $channels = auth()->user()->epgChannels()


### PR DESCRIPTION
## Summary
- Fixes #887 — editing a channel crashes with "Attempt to read property 'name' on null" when the EPG channel's parent EPG record is missing
- Adds null-safe operator (`?->`) to `getOptionLabelFromRecordUsing` callback in `ChannelResource.php:1310`, consistent with the existing guard on line 1328

## Test plan
- [ ] Edit a channel whose EPG channel has a deleted/missing parent EPG — should no longer error
- [ ] Edit a channel with a valid EPG channel — label should still display correctly