### PR TITLE
fix: Remove scroll-to-top on table pagination page change

### DIFF
--- a/app/Filament/Resources/Channels/Pages/ListChannels.php
+++ b/app/Filament/Resources/Channels/Pages/ListChannels.php
@@ -51,13 +51,6 @@ class ListChannels extends ListRecords
     #[Url(as: 'status')]
     public ?string $statusFilter = 'all';
 
-    public function setPage($page, $pageName = 'page'): void
-    {
-        parent::setPage($page, $pageName);
-
-        $this->dispatch('scroll-to-top');
-    }
-
     protected function getHeaderActions(): array
     {
         return [

--- a/app/Filament/Resources/Vods/Pages/ListVod.php
+++ b/app/Filament/Resources/Vods/Pages/ListVod.php
@@ -53,13 +53,6 @@ class ListVod extends ListRecords
     #[Url(as: 'status')]
     public ?string $statusFilter = 'all';
 
-    public function setPage($page, $pageName = 'page'): void
-    {
-        parent::setPage($page, $pageName);
-
-        $this->dispatch('scroll-to-top');
-    }
-
     protected function getHeaderActions(): array
     {
         return [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -66,7 +66,6 @@ use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
-use Illuminate\Support\HtmlString;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
@@ -762,12 +761,6 @@ class AppServiceProvider extends ServiceProvider
      */
     private function registerFilamentHooks(): void
     {
-        // Add scroll to top event listener
-        FilamentView::registerRenderHook(
-            PanelsRenderHook::SCRIPTS_AFTER,
-            fn (): string => new HtmlString('<script>document.addEventListener("scroll-to-top", () => window.scrollTo({top: 0, left: 0, behavior: "smooth"}))</script>'),
-        );
-
         // Add footer view
         FilamentView::registerRenderHook(
             PanelsRenderHook::FOOTER,


### PR DESCRIPTION
## Summary
- Removes `setPage()` overrides in `ListChannels` and `ListVod` that dispatched a `scroll-to-top` event on every page change, causing the browser to smooth-scroll to the top
- Removes the now-unused global `scroll-to-top` JS event listener from `AppServiceProvider` and the orphaned `HtmlString` import

## Test plan
- [x] Navigate to Channels list, scroll down, change page — scroll position should be preserved
- [x] Navigate to VOD list, scroll down, change page — scroll position should be preserved
- [x] Confirm other tables (Series, Groups, Playlists, etc.) still paginate normally