### PR TITLE
fix: dropdown menus hidden behind sticky topbar

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -42,7 +42,9 @@
 }
 
 .fi-dropdown-panel {
-    z-index: 20; /* Ensure dropdowns appear above other elements */
+    z-index: 40; /* Ensure dropdowns appear above the topbar (z-30) */
+    max-height: 50vh;
+    overflow-y: auto;
 }
 
 /* Force inclusion of commonly used Alpine.js classes for Tailwind v4 */
@@ -75,7 +77,3 @@
     transition: all 0.2s;
 }
 
-/* .fi-dropdown-panel {
-    max-height: calc(100vh - 64px);
-    overflow-y: auto;
-} */


### PR DESCRIPTION
## Summary
- Increased `.fi-dropdown-panel` z-index from 20 to 40 so dropdown menus render above the sticky topbar (z-30)
- Added `max-height: 50vh` with `overflow-y: auto` so dropdowns become scrollable before overflowing the viewport
- Removed the previously commented-out duplicate `.fi-dropdown-panel` rule

Fixes #892