### PR TITLE
fix: preserve group sort_order and enabled state across syncs

### DIFF
--- a/app/Filament/Resources/Groups/GroupResource.php
+++ b/app/Filament/Resources/Groups/GroupResource.php
@@ -323,7 +323,8 @@ class GroupResource extends Resource
                         ->modalDescription('Disable group channels now?')
                         ->modalSubmitActionLabel('Yes, disable now'),
                     DeleteAction::make()
-                        ->hidden(fn ($record) => ! $record->custom),
+                        ->hidden(fn ($record) => ! $record->custom)
+                        ->using(fn ($record) => $record->forceDelete()),
                 ])->button()->hiddenLabel()->size('sm'),
                 EditAction::make()
                     ->button()->hiddenLabel()->size('sm'),

--- a/app/Filament/Resources/Groups/Pages/EditGroup.php
+++ b/app/Filament/Resources/Groups/Pages/EditGroup.php
@@ -192,7 +192,8 @@ class EditGroup extends EditRecord
                     ->modalSubmitActionLabel('Yes, disable now'),
 
                 DeleteAction::make()
-                    ->hidden(fn ($record) => ! $record->custom),
+                    ->hidden(fn ($record) => ! $record->custom)
+                    ->using(fn ($record) => $record->forceDelete()),
             ])->button()->label('Actions'),
         ];
     }

--- a/app/Filament/Resources/VodGroups/Pages/EditVodGroup.php
+++ b/app/Filament/Resources/VodGroups/Pages/EditVodGroup.php
@@ -231,7 +231,8 @@ class EditVodGroup extends EditRecord
                     ->modalSubmitActionLabel('Yes, disable now'),
 
                 DeleteAction::make()
-                    ->hidden(fn ($record) => ! $record->custom),
+                    ->hidden(fn ($record) => ! $record->custom)
+                    ->using(fn ($record) => $record->forceDelete()),
             ])->button()->label('Actions'),
         ];
     }

--- a/app/Filament/Resources/VodGroups/VodGroupResource.php
+++ b/app/Filament/Resources/VodGroups/VodGroupResource.php
@@ -355,7 +355,8 @@ class VodGroupResource extends Resource
                         ->modalSubmitActionLabel('Yes, disable now'),
 
                     DeleteAction::make()
-                        ->hidden(fn ($record) => ! $record->custom),
+                        ->hidden(fn ($record) => ! $record->custom)
+                        ->using(fn ($record) => $record->forceDelete()),
                 ])->button()->hiddenLabel()->size('sm'),
                 EditAction::make()
                     ->button()->hiddenLabel()->size('sm'),

--- a/app/Http/Controllers/GroupController.php
+++ b/app/Http/Controllers/GroupController.php
@@ -462,7 +462,7 @@ class GroupController extends Controller
                 $orphanedChannels = $channelCount;
             }
 
-            $group->delete();
+            $group->forceDelete();
         });
 
         return response()->json([

--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -1150,7 +1150,7 @@ class ProcessM3uImport implements ShouldQueue
                 $grouped->each(function ($channels, $groupName) use ($userId, $playlistId, $batchNo, $preProcessingLive, &$groupOrder, &$liveGroups) {
                     // Add group and associated channels
                     if (! $preProcessingLive) {
-                        $group = Group::where([
+                        $group = Group::withTrashed()->where([
                             'name_internal' => $groupName ?? '',
                             'playlist_id' => $playlistId,
                             'user_id' => $userId,
@@ -1172,6 +1172,9 @@ class ProcessM3uImport implements ShouldQueue
                             }
                             $group = Group::create($data);
                         } else {
+                            if ($group->trashed()) {
+                                $group->restore();
+                            }
                             $data = [
                                 'import_batch_no' => $batchNo,
                                 'new' => false,
@@ -1210,7 +1213,7 @@ class ProcessM3uImport implements ShouldQueue
                 $grouped->each(function ($channels, $groupName) use ($userId, $playlistId, $batchNo, $preProcessingVod, &$groupOrder, &$vodGroups) {
                     // Add group and associated channels
                     if (! $preProcessingVod) {
-                        $group = Group::where([
+                        $group = Group::withTrashed()->where([
                             'name_internal' => $groupName ?? '',
                             'playlist_id' => $playlistId,
                             'user_id' => $userId,
@@ -1232,6 +1235,9 @@ class ProcessM3uImport implements ShouldQueue
                             }
                             $group = Group::create($data);
                         } else {
+                            if ($group->trashed()) {
+                                $group->restore();
+                            }
                             $data = [
                                 'import_batch_no' => $batchNo,
                                 'new' => false,
@@ -1573,7 +1579,7 @@ class ProcessM3uImport implements ShouldQueue
             $grouped->each(function ($channels, $groupName) use ($userId, $playlistId, $batchNo, $preProcessing, &$groupOrder) {
                 // Add group and associated channels
                 if (! $preProcessing) {
-                    $group = Group::where([
+                    $group = Group::withTrashed()->where([
                         'name_internal' => $groupName ?? '',
                         'playlist_id' => $playlistId,
                         'user_id' => $userId,
@@ -1595,6 +1601,9 @@ class ProcessM3uImport implements ShouldQueue
                         }
                         $group = Group::create($data);
                     } else {
+                        if ($group->trashed()) {
+                            $group->restore();
+                        }
                         $data = [
                             'import_batch_no' => $batchNo,
                             'new' => false,

--- a/app/Jobs/ProcessM3uImportComplete.php
+++ b/app/Jobs/ProcessM3uImportComplete.php
@@ -178,7 +178,7 @@ class ProcessM3uImportComplete implements ShouldQueue
                         ]);
 
                         // Cleanup the any new groups/channels
-                        $newGroups->delete();
+                        $newGroups->forceDelete();
                         $newChannels->delete();
 
                         // Clear out the jobs
@@ -232,6 +232,12 @@ class ProcessM3uImportComplete implements ShouldQueue
             ->where('is_custom', false)
             ->whereNull('group_id')
             ->delete();
+
+        // Clean up groups that have been soft-deleted for over 30 days
+        Group::onlyTrashed()
+            ->where('playlist_id', $playlist->id)
+            ->where('deleted_at', '<', now()->subDays(30))
+            ->forceDelete();
 
         // Clear out the jobs
         Job::where('batch_no', $this->batchNo)->delete();

--- a/app/Jobs/SyncMediaServer.php
+++ b/app/Jobs/SyncMediaServer.php
@@ -466,7 +466,8 @@ class SyncMediaServer implements ShouldBeUnique, ShouldQueue
      */
     protected function ensureGroup(Playlist $playlist, string $genreName): Group
     {
-        $group = Group::where('playlist_id', $playlist->id)
+        $group = Group::withTrashed()
+            ->where('playlist_id', $playlist->id)
             ->where('name', $genreName)
             ->first();
 
@@ -481,6 +482,9 @@ class SyncMediaServer implements ShouldBeUnique, ShouldQueue
             ]);
             $this->stats['groups_created']++;
         } else {
+            if ($group->trashed()) {
+                $group->restore();
+            }
             $group->update(['import_batch_no' => $this->batchNo]);
         }
 

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -6,10 +6,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Group extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     /**
      * The attributes that should be cast to native types.

--- a/database/migrations/2025_12_09_100000_add_soft_deletes_to_groups_table.php
+++ b/database/migrations/2025_12_09_100000_add_soft_deletes_to_groups_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->softDeletes();
+            $table->index('deleted_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/tests/Feature/GroupSoftDeleteTest.php
+++ b/tests/Feature/GroupSoftDeleteTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+});
+
+it('preserves sort_order when a group is soft-deleted and restored', function () {
+    $group = Group::factory()->create([
+        'name' => 'Sports',
+        'name_internal' => 'Sports',
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'sort_order' => 5,
+        'enabled' => true,
+        'custom' => false,
+        'type' => 'live',
+        'import_batch_no' => 'batch-1',
+    ]);
+
+    // Soft-delete the group (simulates sync removing it)
+    $group->delete();
+
+    expect($group->trashed())->toBeTrue();
+    expect(Group::where('id', $group->id)->exists())->toBeFalse();
+    expect(Group::withTrashed()->where('id', $group->id)->exists())->toBeTrue();
+
+    // Simulate the group reappearing in a future sync — find with withTrashed and restore
+    $restored = Group::withTrashed()->where([
+        'name_internal' => 'Sports',
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'custom' => false,
+        'type' => 'live',
+    ])->first();
+
+    expect($restored)->not->toBeNull();
+
+    $restored->restore();
+    $restored->update(['import_batch_no' => 'batch-2']);
+
+    // Verify sort_order and enabled state are preserved
+    expect((float) $restored->sort_order)->toBe(5.0);
+    expect((bool) $restored->enabled)->toBeTrue();
+    expect($restored->trashed())->toBeFalse();
+});
+
+it('does not find soft-deleted groups in normal queries', function () {
+    $group = Group::factory()->create([
+        'name' => 'Movies',
+        'name_internal' => 'Movies',
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'custom' => false,
+        'type' => 'vod',
+        'import_batch_no' => 'batch-1',
+    ]);
+
+    $group->delete();
+
+    // Normal query should not find the group
+    expect(Group::where('playlist_id', $this->playlist->id)->count())->toBe(0);
+
+    // withTrashed should find it
+    expect(Group::withTrashed()->where('playlist_id', $this->playlist->id)->count())->toBe(1);
+});
+
+it('permanently deletes groups with forceDelete', function () {
+    $group = Group::factory()->create([
+        'name' => 'Custom Group',
+        'name_internal' => 'Custom Group',
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'custom' => true,
+        'type' => 'live',
+        'import_batch_no' => 'batch-1',
+    ]);
+
+    $group->forceDelete();
+
+    expect(Group::withTrashed()->where('id', $group->id)->exists())->toBeFalse();
+});
+
+it('cleans up old soft-deleted groups', function () {
+    // Create a group soft-deleted 31 days ago
+    $oldGroup = Group::factory()->create([
+        'name' => 'Old Group',
+        'name_internal' => 'Old Group',
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'custom' => false,
+        'type' => 'live',
+        'import_batch_no' => 'batch-1',
+    ]);
+    $oldGroup->delete();
+    $oldGroup->update(['deleted_at' => now()->subDays(31)]);
+
+    // Create a group soft-deleted 5 days ago
+    $recentGroup = Group::factory()->create([
+        'name' => 'Recent Group',
+        'name_internal' => 'Recent Group',
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'custom' => false,
+        'type' => 'live',
+        'import_batch_no' => 'batch-1',
+    ]);
+    $recentGroup->delete();
+    $recentGroup->update(['deleted_at' => now()->subDays(5)]);
+
+    // Clean up groups soft-deleted >30 days ago
+    Group::onlyTrashed()
+        ->where('playlist_id', $this->playlist->id)
+        ->where('deleted_at', '<', now()->subDays(30))
+        ->forceDelete();
+
+    // Old group should be permanently gone
+    expect(Group::withTrashed()->where('id', $oldGroup->id)->exists())->toBeFalse();
+
+    // Recent group should still be soft-deleted
+    expect(Group::withTrashed()->where('id', $recentGroup->id)->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Adds `SoftDeletes` to the Group model so groups removed during sync are soft-deleted instead of hard-deleted
- When a group with the same name reappears in a future sync, it is restored with its `sort_order`, `enabled` state, and all other attributes preserved
- Manual deletions (custom groups via UI/API) use `forceDelete()` for permanent removal
- Soft-deleted groups older than 30 days are automatically cleaned up during sync completion

## Changes
- **Group model**: Added `SoftDeletes` trait
- **ProcessM3uImport**: Group lookups use `withTrashed()` to find and restore soft-deleted groups (3 sites: live Xtream, VOD Xtream, M3U)
- **ProcessM3uImportComplete**: Invalidated import cleanup uses `forceDelete()`; added 30-day purge of old soft-deleted groups
- **SyncMediaServer**: `ensureGroup()` uses `withTrashed()` to restore soft-deleted groups
- **Filament Resources + GroupController**: Delete actions use `forceDelete()` for custom groups
- **Migration**: Adds `deleted_at` column with index to groups table

Closes #891

## Test plan
- [x] Added `GroupSoftDeleteTest` with 4 tests covering soft-delete, restore with preserved attributes, forceDelete, and 30-day cleanup
- [ ] Manual test: sync a playlist, manually reorder groups, re-sync with a group missing, re-sync with the group returned — verify order preserved