### PR TITLE
fix: sync PostgreSQL session timezone with app timezone

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -822,8 +822,7 @@ class AppServiceProvider extends ServiceProvider
         // TZ environment variable always takes priority
         $envTimezone = config('dev.timezone');
         if (! empty($envTimezone)) {
-            config(['app.timezone' => $envTimezone]);
-            date_default_timezone_set($envTimezone);
+            $this->setApplicationTimezone($envTimezone);
 
             return;
         }
@@ -833,11 +832,26 @@ class AppServiceProvider extends ServiceProvider
             $timezone = $settings->app_timezone;
 
             if (! empty($timezone) && in_array($timezone, \DateTimeZone::listIdentifiers(), true)) {
-                config(['app.timezone' => $timezone]);
-                date_default_timezone_set($timezone);
+                $this->setApplicationTimezone($timezone);
             }
         } catch (Throwable) {
             // Settings may not be available during fresh installs / migrations
+        }
+    }
+
+    /**
+     * Apply a timezone consistently across the application and database.
+     */
+    private function setApplicationTimezone(string $timezone): void
+    {
+        config(['app.timezone' => $timezone]);
+        date_default_timezone_set($timezone);
+
+        // Sync the database session timezone so that timestamps stored via
+        // PostgreSQL's timestamptz columns use the correct offset.
+        $connection = config('database.default');
+        if (config("database.connections.{$connection}.driver") === 'pgsql') {
+            config(["database.connections.{$connection}.timezone" => $timezone]);
         }
     }
 

--- a/config/database.php
+++ b/config/database.php
@@ -122,6 +122,7 @@ return [
             'prefix_indexes' => true,
             'search_path' => 'public',
             'sslmode' => 'prefer',
+            'timezone' => env('DB_TIMEZONE', env('TZ', 'UTC')),
         ],
 
         'pg_test' => [


### PR DESCRIPTION
## Summary
- Added `timezone` config to the pgsql connection (`DB_TIMEZONE` env, falling back to `TZ`)
- Extracted `setApplicationTimezone()` in AppServiceProvider to sync app timezone, PHP default timezone, and pgsql session timezone in one place
- Fixes midnight syncs running at 01:00 BST and notifications showing "59 minutes from now" after UK clock change

## Context
Postgres sessions defaulted to UTC while the app timezone was `Europe/London`. During BST (UTC+1), `timestamptz` columns returned timestamps with `+00` offset, causing cron expressions to evaluate in UTC and notification diffs to be off by ~1 hour.