### PR TITLE
fix: resolve multiple Plex DVR integration issues

### DIFF
--- a/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
+++ b/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
@@ -216,6 +216,13 @@ class MediaServerIntegrationResource extends Resource
                                 ->required()
                                 ->default('emby')
                                 ->live()
+                                ->afterStateUpdated(function (Set $set, ?string $state): void {
+                                    $set('port', match ($state) {
+                                        'plex' => 32400,
+                                        'webdav' => 5005,
+                                        default => 8096,
+                                    });
+                                })
                                 ->disabledOn('edit')
                                 ->native(false),
                         ]),
@@ -234,7 +241,11 @@ class MediaServerIntegrationResource extends Resource
                             TextInput::make('port')
                                 ->label('Port')
                                 ->numeric()
-                                ->default(fn (callable $get) => $get('type') === 'webdav' ? 5005 : 8096)
+                                ->default(fn (callable $get) => match ($get('type')) {
+                                    'plex' => 32400,
+                                    'webdav' => 5005,
+                                    default => 8096,
+                                })
                                 ->helperText(fn (callable $get) => match ($get('type')) {
                                     'webdav' => 'e.g., 5005 for Synology, 80/443 for standard WebDAV',
                                     default => 'e.g., 8096 for Emby/Jellyfin, 32400 for Plex',
@@ -613,28 +624,53 @@ class MediaServerIntegrationResource extends Resource
                                     }
                                 }),
 
-                            Placeholder::make('plex_active_sessions')
-                                ->label('Active Sessions')
+                            Placeholder::make('plex_dvr_sync_status')
+                                ->label('DVR Sync Status')
                                 ->content(function ($record) {
                                     if (! $record || ! $record->isPlex()) {
                                         return '—';
                                     }
                                     try {
                                         $service = PlexManagementService::make($record);
-                                        $result = $service->getActiveSessions();
-                                        if ($result['success']) {
-                                            $count = $result['data']->count();
-                                            if ($count === 0) {
-                                                return 'No active sessions';
-                                            }
-                                            $lines = $result['data']->map(fn ($s) => '<li>'.$s['user'].' — '.$s['title'].' ('.$s['state'].')</li>')->implode('');
-
-                                            return new HtmlString('<ul class="text-sm list-disc list-inside">'.$lines.'</ul>');
+                                        $result = $service->verifyDvrSync();
+                                        if (! $result['success']) {
+                                            return new HtmlString('<span class="text-danger-500">'.e($result['message'] ?? 'Verification failed').'</span>');
                                         }
 
-                                        return '—';
+                                        $data = $result['data'];
+                                        $status = $data['status'];
+
+                                        if ($status === 'not_configured') {
+                                            return new HtmlString('<span class="text-gray-400">'.e($data['summary']).'</span>');
+                                        }
+
+                                        if ($status === 'error') {
+                                            return new HtmlString('<span class="text-danger-500">'.e($data['summary']).'</span>');
+                                        }
+
+                                        $icon = $status === 'ok'
+                                            ? '<svg xmlns="http://www.w3.org/2000/svg" class="inline-block h-5 w-5 text-success-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" /></svg>'
+                                            : '<svg xmlns="http://www.w3.org/2000/svg" class="inline-block h-5 w-5 text-warning-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd" /></svg>';
+
+                                        $colorClass = $status === 'ok' ? 'text-success-500' : 'text-warning-500';
+                                        $html = '<div class="text-sm space-y-1">';
+                                        $html .= '<p class="'.$colorClass.' font-medium">'.$icon.' '.e($data['summary']).'</p>';
+
+                                        if (! empty($data['tuners'])) {
+                                            $totalChannels = $data['total_channels'] ?? 0;
+                                            $totalPlex = $data['total_in_plex'] ?? 0;
+                                            $totalEpg = $data['total_epg_mapped'] ?? 0;
+                                            $html .= '<div class="mt-2 text-xs text-gray-500 dark:text-gray-400">';
+                                            $html .= '<p>Channels: '.$totalPlex.'/'.$totalChannels.' in Plex</p>';
+                                            $html .= '<p>EPG: '.$totalEpg.'/'.$totalChannels.' mapped</p>';
+                                            $html .= '</div>';
+                                        }
+
+                                        $html .= '</div>';
+
+                                        return new HtmlString($html);
                                     } catch (\Exception $e) {
-                                        return '—';
+                                        return new HtmlString('<span class="text-danger-500">Error: '.e($e->getMessage()).'</span>');
                                     }
                                 }),
                         ])->visible(fn (callable $get) => $get('plex_management_enabled')),
@@ -739,7 +775,7 @@ class MediaServerIntegrationResource extends Resource
                                                 })
                                                 ->required(),
                                             Placeholder::make('tvg_id_warning')
-                                                ->content(new HtmlString('<p style="color: #f59e0b; font-weight: 600;">⚠ This playlist\'s TVG ID output is not set to "Channel ID". For HDHR/Plex DVR to match EPG correctly, set the playlist\'s "Preferred TVG ID output" to "Channel ID (recommended for HDHR)".</p>'))
+                                                ->content(new HtmlString('<p style="color: #f59e0b; font-weight: 600;">⚠ This playlist\'s TVG ID output is not set to "Channel Number". For HDHR/Plex DVR to match EPG correctly, set the playlist\'s "Preferred TVG ID output" to "Channel Number".</p>'))
                                                 ->visible(function (Get $get): bool {
                                                     $uuid = $get('playlist_uuid');
                                                     if (! $uuid) {
@@ -749,7 +785,9 @@ class MediaServerIntegrationResource extends Resource
                                                         ?? CustomPlaylist::where('uuid', $uuid)->first()
                                                         ?? MergedPlaylist::where('uuid', $uuid)->first();
 
-                                                    return $playlist && ($playlist->id_channel_by?->value ?? $playlist->id_channel_by ?? 'stream_id') !== 'channel_id';
+                                                    $value = $playlist->id_channel_by?->value ?? $playlist->id_channel_by ?? 'stream_id';
+
+                                                    return $playlist && $value !== 'number';
                                                 }),
                                             TextInput::make('hdhr_base_url')
                                                 ->label('HDHR Base URL')
@@ -878,28 +916,6 @@ class MediaServerIntegrationResource extends Resource
                                         })
                                         ->visible(fn ($record) => $record && $record->isPlex() && ! empty($record->plex_dvr_tuners)),
                                 ])->fullWidth(),
-
-                                Placeholder::make('plex_dvr_channels')
-                                    ->label('DVR Channels')
-                                    ->content(function ($record) {
-                                        if (! $record || ! $record->plex_dvr_id) {
-                                            return 'Register a DVR tuner first';
-                                        }
-                                        try {
-                                            $service = PlexManagementService::make($record);
-                                            $result = $service->getDvrChannels($record->plex_dvr_id);
-                                            if ($result['success']) {
-                                                $count = $result['data']->count();
-
-                                                return "{$count} channels available in Plex DVR";
-                                            }
-
-                                            return 'Could not fetch channels';
-                                        } catch (\Exception $e) {
-                                            return 'Error: '.$e->getMessage();
-                                        }
-                                    })
-                                    ->visible(fn ($record) => $record && $record->plex_dvr_id),
                             ])
                             ->visible(fn (callable $get) => $get('plex_management_enabled')),
 

--- a/app/Services/PlexManagementService.php
+++ b/app/Services/PlexManagementService.php
@@ -84,6 +84,9 @@ class PlexManagementService
     /**
      * Get active sessions (currently streaming).
      *
+     * Checks both /status/sessions (regular + Live TV playback) and
+     * /transcode/sessions (active transcodes) for completeness.
+     *
      * @return array{success: bool, data?: Collection, message?: string}
      */
     public function getActiveSessions(): array
@@ -95,18 +98,49 @@ class PlexManagementService
                 return ['success' => false, 'message' => 'Failed to fetch sessions: '.$response->status()];
             }
 
-            $sessions = collect($response->json('MediaContainer.Metadata', []))
+            $container = $response->json('MediaContainer', []);
+
+            // Plex may nest sessions under 'Metadata', 'Video', or 'Track'
+            // depending on what is being played (movies, live tv, music).
+            $metadata = $container['Metadata']
+                ?? $container['Video']
+                ?? $container['Track']
+                ?? [];
+
+            $reportedSize = (int) ($container['size'] ?? 0);
+
+            if ($reportedSize > 0 && empty($metadata)) {
+                Log::warning('PlexManagementService: Plex reports sessions but no Metadata/Video/Track key found', [
+                    'integration_id' => $this->integration->id,
+                    'reported_size' => $reportedSize,
+                    'container_keys' => array_keys($container),
+                ]);
+            }
+
+            $sessions = collect($metadata)
                 ->map(fn (array $session) => [
                     'id' => $session['sessionKey'] ?? null,
-                    'title' => $session['title'] ?? 'Unknown',
+                    'title' => $session['title'] ?? $session['grandparentTitle'] ?? 'Unknown',
                     'type' => $session['type'] ?? 'unknown',
                     'user' => $session['User']['title'] ?? 'Unknown',
                     'player' => $session['Player']['title'] ?? 'Unknown',
-                    'state' => $session['Player']['state'] ?? 'unknown',
+                    'state' => $session['Player']['state'] ?? $session['Session']['location'] ?? 'unknown',
                     'progress' => $session['viewOffset'] ?? 0,
                     'duration' => $session['duration'] ?? 0,
                     'transcode' => ! empty($session['TranscodeSession']),
+                    'live' => ! empty($session['live']),
                 ]);
+
+            // Also merge in active transcode sessions that may not appear in /status/sessions
+            $transcodeSessions = $this->getTranscodeSessions();
+            if ($transcodeSessions->isNotEmpty()) {
+                $existingIds = $sessions->pluck('id')->filter()->all();
+                $transcodeSessions->each(function (array $ts) use ($sessions, $existingIds): void {
+                    if (! in_array($ts['id'], $existingIds, true)) {
+                        $sessions->push($ts);
+                    }
+                });
+            }
 
             return ['success' => true, 'data' => $sessions];
         } catch (Exception $e) {
@@ -116,6 +150,48 @@ class PlexManagementService
             ]);
 
             return ['success' => false, 'message' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * Get active transcode sessions from Plex.
+     *
+     * These may include Live TV streams being transcoded that don't
+     * always appear in /status/sessions.
+     */
+    protected function getTranscodeSessions(): Collection
+    {
+        try {
+            $response = $this->client()->get('/transcode/sessions');
+
+            if (! $response->successful()) {
+                return collect();
+            }
+
+            $container = $response->json('MediaContainer', []);
+            $metadata = $container['Metadata'] ?? $container['TranscodeSession'] ?? [];
+
+            return collect($metadata)
+                ->filter(fn (array $session) => ! empty($session['sessionKey'] ?? $session['key'] ?? null))
+                ->map(fn (array $session) => [
+                    'id' => $session['sessionKey'] ?? $session['key'] ?? null,
+                    'title' => $session['title'] ?? $session['grandparentTitle'] ?? 'Transcoding',
+                    'type' => $session['type'] ?? 'transcode',
+                    'user' => $session['User']['title'] ?? 'Unknown',
+                    'player' => $session['Player']['title'] ?? 'Unknown',
+                    'state' => $session['Player']['state'] ?? 'transcoding',
+                    'progress' => $session['viewOffset'] ?? 0,
+                    'duration' => $session['duration'] ?? 0,
+                    'transcode' => true,
+                    'live' => ! empty($session['live']),
+                ]);
+        } catch (Exception $e) {
+            Log::debug('PlexManagementService: Failed to get transcode sessions', [
+                'integration_id' => $this->integration->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            return collect();
         }
     }
 
@@ -412,6 +488,33 @@ class PlexManagementService
             // Step 4: Check for existing DVR or create a new one
             $dvrKey = $targetDevice['parentID'] ?? null;
 
+            // Also check if we already have a DVR stored locally
+            if (! $dvrKey && $this->integration->plex_dvr_id) {
+                // Verify the stored DVR still exists in Plex
+                if ($this->verifyDvrExists($this->integration->plex_dvr_id)) {
+                    $dvrKey = $this->integration->plex_dvr_id;
+                }
+            }
+
+            // Search all existing DVRs in Plex for one that already has our specific device
+            // (matched by device key or UUID — NOT by URI pattern, to avoid hijacking real HDHR devices)
+            if (! $dvrKey && $deviceKey) {
+                try {
+                    $existingDvrsResponse = $this->client()->get('/livetv/dvrs');
+                    $existingDvrs = $existingDvrsResponse->json('MediaContainer.Dvr', []);
+                    foreach ($existingDvrs as $dvr) {
+                        foreach ($dvr['Device'] ?? [] as $dvrDevice) {
+                            if (($dvrDevice['key'] ?? '') === $deviceKey || ($dvrDevice['uuid'] ?? '') === $deviceUuid) {
+                                $dvrKey = $dvr['key'] ?? null;
+                                break 2;
+                            }
+                        }
+                    }
+                } catch (Exception) {
+                    // Non-critical: proceed with creating a new DVR
+                }
+            }
+
             if (! $dvrKey) {
                 // No existing DVR — create one
                 $lineupId = $this->buildLineupId($epgUrl);
@@ -628,19 +731,19 @@ class PlexManagementService
         try {
             $response = $this->client()->delete("/livetv/dvrs/{$dvrId}");
 
-            if ($response->successful()) {
-                // Clear stored DVR ID if it matches
-                if ((string) $this->integration->plex_dvr_id === $dvrId) {
-                    $this->integration->update([
-                        'plex_dvr_id' => null,
-                        'plex_dvr_tuners' => null,
-                    ]);
-                }
+            // Treat 404 as success — DVR was already deleted in Plex
+            $deleted = $response->successful() || $response->status() === 404;
+
+            if ($deleted && (string) $this->integration->plex_dvr_id === $dvrId) {
+                $this->integration->update([
+                    'plex_dvr_id' => null,
+                    'plex_dvr_tuners' => null,
+                ]);
             }
 
             return [
-                'success' => $response->successful(),
-                'message' => $response->successful() ? 'DVR removed from Plex' : 'Failed: '.$response->status(),
+                'success' => $deleted,
+                'message' => $deleted ? 'DVR removed from Plex' : 'Failed: '.$response->status(),
             ];
         } catch (Exception $e) {
             return ['success' => false, 'message' => $e->getMessage()];
@@ -649,24 +752,58 @@ class PlexManagementService
 
     /**
      * Get channel lineup for a specific DVR.
+     *
+     * Fetches the DVR detail and extracts ChannelMapping entries from each Device.
+     * The /livetv/dvrs/{id}/channels endpoint is unreliable (often returns 404),
+     * so we use the DVR detail endpoint which always includes device channel mappings.
      */
     public function getDvrChannels(string $dvrId): array
     {
         try {
-            $response = $this->client()->get("/livetv/dvrs/{$dvrId}/channels");
+            $response = $this->client()->get("/livetv/dvrs/{$dvrId}");
 
-            if (! $response->successful()) {
-                return ['success' => false, 'message' => 'Failed to fetch channels: '.$response->status()];
+            if ($response->status() === 404) {
+                return ['success' => true, 'data' => collect()];
             }
 
-            $channels = collect($response->json('MediaContainer.Metadata', []))
-                ->map(fn (array $ch) => [
-                    'id' => $ch['ratingKey'] ?? null,
-                    'title' => $ch['title'] ?? 'Unknown',
-                    'number' => $ch['index'] ?? null,
-                    'enabled' => ($ch['enabled'] ?? true) !== false,
-                    'thumb' => $ch['thumb'] ?? null,
-                ]);
+            if (! $response->successful()) {
+                return ['success' => false, 'message' => 'Failed to fetch DVR details: '.$response->status()];
+            }
+
+            $dvr = $response->json('MediaContainer.Dvr.0') ?? $response->json('MediaContainer.Dvr') ?? [];
+
+            // Handle single DVR object (not wrapped in array)
+            if (isset($dvr['key'])) {
+                $dvr = $dvr;
+            } elseif (is_array($dvr) && ! empty($dvr) && isset($dvr[0])) {
+                $dvr = $dvr[0];
+            }
+
+            $devices = $dvr['Device'] ?? [];
+            if (! is_array($devices) || (! empty($devices) && ! array_is_list($devices))) {
+                $devices = [$devices];
+            }
+
+            $channels = collect();
+            foreach ($devices as $device) {
+                $mappings = $device['ChannelMapping'] ?? [];
+                if (! is_array($mappings) || (! empty($mappings) && ! array_is_list($mappings))) {
+                    $mappings = [$mappings];
+                }
+
+                foreach ($mappings as $mapping) {
+                    if (! is_array($mapping)) {
+                        continue;
+                    }
+                    $channels->push([
+                        'id' => $mapping['channelKey'] ?? null,
+                        'number' => $mapping['channelKey'] ?? null,
+                        'device_identifier' => $mapping['deviceIdentifier'] ?? null,
+                        'lineup_identifier' => $mapping['lineupIdentifier'] ?? null,
+                        'enabled' => ! in_array(trim($mapping['enabled'] ?? '1'), ['0', 'false']),
+                    ]);
+                }
+            }
 
             return ['success' => true, 'data' => $channels];
         } catch (Exception $e) {
@@ -897,6 +1034,11 @@ class PlexManagementService
             return ['success' => false, 'message' => 'DVR not fully configured. Register a DVR tuner first.'];
         }
 
+        // Verify the DVR still exists in Plex before syncing
+        if (! $this->verifyDvrExists($dvrId)) {
+            return ['success' => false, 'message' => 'DVR no longer exists in Plex. Local state has been cleaned up. Please re-register the DVR tuner.'];
+        }
+
         $totalMapped = 0;
         $anyChanged = false;
         $errors = [];
@@ -946,6 +1088,80 @@ class PlexManagementService
     }
 
     /**
+     * Verify that the stored DVR still exists in Plex.
+     *
+     * If it doesn't, clean up the stale local state and return false.
+     */
+    protected function verifyDvrExists(string $dvrId): bool
+    {
+        try {
+            $response = $this->client()->get('/livetv/dvrs');
+            if (! $response->successful()) {
+                return true; // Assume it exists if we can't check
+            }
+
+            $dvrs = $response->json('MediaContainer.Dvr', []);
+            foreach ($dvrs as $dvr) {
+                if ((string) ($dvr['key'] ?? '') === $dvrId) {
+                    return true;
+                }
+            }
+
+            // DVR not found — clean up local state
+            Log::warning('PlexManagementService: DVR no longer exists in Plex, cleaning up', [
+                'integration_id' => $this->integration->id,
+                'dvr_id' => $dvrId,
+            ]);
+
+            $this->integration->update([
+                'plex_dvr_id' => null,
+                'plex_dvr_tuners' => null,
+            ]);
+
+            return false;
+        } catch (Exception $e) {
+            return true; // Assume it exists on network errors
+        }
+    }
+
+    /**
+     * Force Plex to re-scan the HDHR lineup device so it discovers
+     * updated channel numbers and guide data.
+     *
+     * @return bool Whether the refresh was successful
+     */
+    protected function refreshLineupDevice(string $deviceKey): bool
+    {
+        try {
+            // Trigger a channel scan on the device — Plex will re-fetch lineup.json
+            $response = $this->client()->withBody('')->post(
+                "/media/grabbers/devices/{$deviceKey}/scan"
+            );
+
+            if ($response->successful()) {
+                return true;
+            }
+
+            // Fallback: try refreshing via the DVR scan endpoint
+            $dvrId = $this->integration->plex_dvr_id;
+            if ($dvrId) {
+                $response = $this->client()->withBody('')->post("/livetv/dvrs/{$dvrId}/scan");
+
+                return $response->successful();
+            }
+
+            return false;
+        } catch (Exception $e) {
+            Log::debug('PlexManagementService: Lineup device refresh failed (non-critical)', [
+                'device_key' => $deviceKey,
+                'error' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    /**
      * Sync the channel map for a single tuner (device + playlist).
      *
      * @return array{success: bool, message: string, mapped_channels?: int, changed?: bool}
@@ -980,6 +1196,15 @@ class PlexManagementService
                 ]);
             }
 
+            // Force Plex to re-scan the HDHR device so it picks up channel number changes.
+            // Without this, Plex's lineup channels endpoint returns stale data and
+            // EPG-to-channel mapping breaks when numbers are reassigned.
+            $this->refreshLineupDevice($deviceKey);
+
+            // Give Plex a moment to process the device scan before fetching lineup channels.
+            // The scan endpoint is async — without this delay, Plex returns stale/empty data.
+            sleep(3);
+
             // Fetch Plex's current knowledge of the lineup channels
             $lineupChannelsResponse = $this->client()->get('/livetv/epg/lineupchannels', [
                 'lineup' => $lineupId,
@@ -1003,7 +1228,9 @@ class PlexManagementService
                 'integration_id' => $this->integration->id,
                 'lineup_id' => $lineupId,
                 'media_container_keys' => array_keys($lineupChannelsPayload),
-                'channel_count' => is_array($lineupChannelsPayload['Channel'] ?? null) ? count($lineupChannelsPayload['Channel']) : 0,
+                'channel_count' => is_array($lineupChannelsPayload['Lineup'] ?? $lineupChannelsPayload['Channel'] ?? null)
+                    ? count($lineupChannelsPayload['Lineup'] ?? $lineupChannelsPayload['Channel'] ?? [])
+                    : 0,
             ]);
             $channelMapPayload = $this->buildChannelMapPayload($hdhrLineup, $lineupChannelsPayload);
 
@@ -1094,7 +1321,14 @@ class PlexManagementService
         try {
             $dvrId = $this->integration->plex_dvr_id;
             if (! $dvrId) {
-                return ['success' => false, 'message' => 'No DVR registered'];
+                // No DVR registered — just clean up local tuner state
+                $tuners = $this->integration->plex_dvr_tuners ?? [];
+                $remainingTuners = array_values(array_filter($tuners, fn (array $t): bool => ($t['device_key'] ?? '') !== $deviceKey));
+                $this->integration->update([
+                    'plex_dvr_tuners' => $remainingTuners ?: null,
+                ]);
+
+                return ['success' => true, 'message' => 'Tuner reference removed (no DVR registered in Plex).'];
             }
 
             $tuners = $this->integration->plex_dvr_tuners ?? [];
@@ -1105,8 +1339,15 @@ class PlexManagementService
                 return $this->removeDvr($dvrId);
             }
 
-            // Remove device from DVR
-            $this->client()->delete("/livetv/dvrs/{$dvrId}/devices/{$deviceKey}");
+            // Remove device from DVR (ignore 404 — device may already be gone)
+            $response = $this->client()->delete("/livetv/dvrs/{$dvrId}/devices/{$deviceKey}");
+            if (! $response->successful() && $response->status() !== 404) {
+                Log::warning('PlexManagementService: Device removal returned unexpected status', [
+                    'integration_id' => $this->integration->id,
+                    'device_key' => $deviceKey,
+                    'status' => $response->status(),
+                ]);
+            }
 
             $this->integration->update([
                 'plex_dvr_tuners' => $remainingTuners,
@@ -1239,28 +1480,81 @@ class PlexManagementService
     }
 
     /**
+     * Extract channel entries from Plex's lineup channels response.
+     *
+     * Plex returns a nested structure: MediaContainer.Lineup[].Channel[]
+     * where Lineup is an array of lineup objects (usually 1), each containing
+     * a Channel array with the actual channel data.
+     *
+     * @return list<array>
+     */
+    protected function extractLineupChannels(array $lineupChannelsPayload): array
+    {
+        $lineups = $lineupChannelsPayload['Lineup'] ?? [];
+
+        // Not an array at all
+        if (! is_array($lineups)) {
+            return [];
+        }
+
+        // If empty, try flat "Channel" key fallback (older Plex versions)
+        if (empty($lineups)) {
+            $flat = $lineupChannelsPayload['Channel'] ?? [];
+
+            return is_array($flat) ? (array_is_list($flat) ? $flat : [$flat]) : [];
+        }
+
+        // Wrap single associative lineup object in a list
+        if (! array_is_list($lineups)) {
+            $lineups = [$lineups];
+        }
+
+        // Collect all Channel entries from each lineup object
+        $allChannels = [];
+        foreach ($lineups as $lineup) {
+            if (! is_array($lineup)) {
+                continue;
+            }
+            $channels = $lineup['Channel'] ?? [];
+            if (! is_array($channels)) {
+                continue;
+            }
+            if (! empty($channels) && ! array_is_list($channels)) {
+                $channels = [$channels];
+            }
+            foreach ($channels as $ch) {
+                if (is_array($ch)) {
+                    $allChannels[] = $ch;
+                }
+            }
+        }
+
+        return $allChannels;
+    }
+
+    /**
      * Build the channel map payload for Plex from HDHR lineup and Plex lineup channels.
      *
      * @return array{payload: array, enabledIds: list<string>, unmatched: list<string>}
      */
     protected function buildChannelMapPayload(array $hdhrLineup, array $lineupChannelsPayload): array
     {
-        // Build a number→identifier map from Plex's lineup channels.
-        // Plex returns channels under "Channel" key with "number" and "lineupIdentifier" fields.
-        // Handle single-channel responses: Plex may return a single object instead of an array.
-        $channels = $lineupChannelsPayload['Channel'] ?? [];
-        if (is_array($channels) && ! empty($channels) && ! array_is_list($channels)) {
-            // Single channel returned as an associative array — wrap it in a list
-            $channels = [$channels];
-        }
+        // Extract channels from Plex's nested lineup response structure
+        $channels = $this->extractLineupChannels($lineupChannelsPayload);
 
         $numberMap = [];
-        foreach ($channels as $channel) {
+        foreach ($channels as $idx => $channel) {
             if (! is_array($channel)) {
                 continue;
             }
-            $number = trim((string) ($channel['number'] ?? $channel['channelNumber'] ?? $channel['channel'] ?? ''));
-            $identifier = trim((string) ($channel['lineupIdentifier'] ?? $channel['id'] ?? $channel['channelIdentifier'] ?? $channel['key'] ?? ''));
+            if ($idx === 0) {
+                Log::debug('PlexManagementService: First Lineup channel keys', [
+                    'keys' => array_keys($channel),
+                ]);
+            }
+            // Plex lineup channels use: identifier (lineup ID), channelVcn (visible channel number)
+            $number = trim((string) ($channel['channelVcn'] ?? $channel['Number'] ?? $channel['number'] ?? ''));
+            $identifier = trim((string) ($channel['identifier'] ?? $channel['lineupIdentifier'] ?? $channel['Id'] ?? $channel['id'] ?? ''));
             if ($number && $identifier) {
                 $numberMap[$number] = $identifier;
             }
@@ -1305,6 +1599,161 @@ class PlexManagementService
             'enabledIds' => $enabledIds,
             'unmatched' => $unmatched,
         ];
+    }
+
+    /**
+     * Verify the DVR sync status: channel count, EPG mapping, and overall health.
+     *
+     * Returns a structured report indicating whether all tuners are in sync
+     * and EPG data is correctly mapped to channels.
+     *
+     * @return array{success: bool, data?: array{status: string, tuners: list<array{playlist: string, channels_hdhr: int, channels_plex: int, epg_mapped: int, epg_missing: int, in_sync: bool}>, summary: string}, message?: string}
+     */
+    public function verifyDvrSync(): array
+    {
+        $dvrId = $this->integration->plex_dvr_id;
+        $tuners = $this->integration->plex_dvr_tuners ?? [];
+
+        if (! $dvrId || empty($tuners)) {
+            return ['success' => true, 'data' => [
+                'status' => 'not_configured',
+                'tuners' => [],
+                'summary' => 'No DVR tuner registered yet.',
+            ]];
+        }
+
+        if (! $this->verifyDvrExists($dvrId)) {
+            return ['success' => true, 'data' => [
+                'status' => 'error',
+                'tuners' => [],
+                'summary' => 'DVR no longer exists in Plex. Please re-register the tuner.',
+            ]];
+        }
+
+        $lineupId = $this->getDvrLineupId();
+        $appPort = config('app.port', 36400);
+
+        // Fetch Plex DVR channels (from Device[].ChannelMapping[])
+        $plexChannelsResult = $this->getDvrChannels($dvrId);
+        $plexChannels = $plexChannelsResult['success'] ? $plexChannelsResult['data'] : collect();
+        $plexChannelNumbers = $plexChannels
+            ->filter(fn (array $ch) => $ch['enabled'])
+            ->pluck('number')
+            ->filter()
+            ->map(fn ($n) => (string) $n)
+            ->values()
+            ->all();
+
+        // Fetch Plex lineup channels (for EPG mapping verification)
+        $lineupChannelNumbers = [];
+        if ($lineupId) {
+            try {
+                $lineupResponse = $this->client()->get('/livetv/epg/lineupchannels', ['lineup' => $lineupId]);
+                if ($lineupResponse->successful()) {
+                    $container = $lineupResponse->json('MediaContainer', []);
+                    $channels = $this->extractLineupChannels($container);
+                    foreach ($channels as $ch) {
+                        if (! is_array($ch)) {
+                            continue;
+                        }
+                        $num = trim((string) ($ch['channelVcn'] ?? $ch['Number'] ?? $ch['number'] ?? ''));
+                        if ($num) {
+                            $lineupChannelNumbers[] = $num;
+                        }
+                    }
+                }
+            } catch (Exception) {
+                // Non-critical
+            }
+        }
+
+        $tunerReports = [];
+        $allInSync = true;
+
+        foreach ($tuners as $tuner) {
+            $playlistUuid = $tuner['playlist_uuid'] ?? null;
+            $deviceKey = $tuner['device_key'] ?? null;
+            if (! $playlistUuid) {
+                continue;
+            }
+
+            // Fetch HDHR lineup for this tuner
+            $lineupUrl = "http://localhost:{$appPort}/{$playlistUuid}/hdhr/lineup.json";
+            $hdhrChannelCount = 0;
+            $hdhrNumbers = [];
+            try {
+                $lineupResponse = Http::timeout(10)->get($lineupUrl);
+                if ($lineupResponse->successful()) {
+                    $lineup = $lineupResponse->json();
+                    if (is_array($lineup)) {
+                        $hdhrChannelCount = count($lineup);
+                        foreach ($lineup as $ch) {
+                            $num = trim((string) ($ch['GuideNumber'] ?? $ch['channel_number'] ?? ''));
+                            if ($num) {
+                                $hdhrNumbers[] = $num;
+                            }
+                        }
+                    }
+                }
+            } catch (Exception) {
+                // Non-critical
+            }
+
+            // Check how many HDHR channels appear in Plex DVR
+            $channelsInPlex = count(array_intersect($hdhrNumbers, $plexChannelNumbers));
+
+            // Check how many channels have EPG lineup entries
+            $epgMapped = count(array_intersect($hdhrNumbers, $lineupChannelNumbers));
+            $epgMissing = count($hdhrNumbers) - $epgMapped;
+
+            $inSync = $channelsInPlex === $hdhrChannelCount && $epgMissing === 0 && $hdhrChannelCount > 0;
+            if (! $inSync) {
+                $allInSync = false;
+            }
+
+            $tunerReports[] = [
+                'playlist_uuid' => $playlistUuid,
+                'device_key' => $deviceKey,
+                'channels_hdhr' => $hdhrChannelCount,
+                'channels_plex' => $channelsInPlex,
+                'epg_mapped' => $epgMapped,
+                'epg_missing' => $epgMissing,
+                'in_sync' => $inSync,
+            ];
+        }
+
+        $totalHdhr = array_sum(array_column($tunerReports, 'channels_hdhr'));
+        $totalPlex = array_sum(array_column($tunerReports, 'channels_plex'));
+        $totalEpgMapped = array_sum(array_column($tunerReports, 'epg_mapped'));
+        $totalEpgMissing = array_sum(array_column($tunerReports, 'epg_missing'));
+
+        if ($totalHdhr === 0) {
+            $summary = 'No channels found in HDHR lineup. Check your playlist configuration.';
+            $status = 'warning';
+        } elseif ($allInSync) {
+            $summary = "All {$totalHdhr} channels synchronized and EPG mapped correctly.";
+            $status = 'ok';
+        } else {
+            $parts = [];
+            if ($totalPlex < $totalHdhr) {
+                $parts[] = ($totalHdhr - $totalPlex).' channel(s) not yet in Plex';
+            }
+            if ($totalEpgMissing > 0) {
+                $parts[] = "{$totalEpgMissing} channel(s) missing EPG mapping";
+            }
+            $summary = implode('; ', $parts).'. Try "Force Sync Channels" to fix.';
+            $status = 'warning';
+        }
+
+        return ['success' => true, 'data' => [
+            'status' => $status,
+            'tuners' => $tunerReports,
+            'total_channels' => $totalHdhr,
+            'total_in_plex' => $totalPlex,
+            'total_epg_mapped' => $totalEpgMapped,
+            'total_epg_missing' => $totalEpgMissing,
+            'summary' => $summary,
+        ]];
     }
 
     /**

--- a/tests/Feature/PlexManagementServiceTest.php
+++ b/tests/Feature/PlexManagementServiceTest.php
@@ -94,6 +94,9 @@ it('can get active sessions', function () {
                 ],
             ],
         ]),
+        'plex.example.com:32400/transcode/sessions' => Http::response([
+            'MediaContainer' => ['size' => 0],
+        ]),
     ]);
 
     $service = PlexManagementService::make($this->integration);
@@ -104,6 +107,123 @@ it('can get active sessions', function () {
     expect($result['data']->first()['title'])->toBe('Test Movie');
     expect($result['data']->first()['user'])->toBe('TestUser');
     expect($result['data']->first()['state'])->toBe('playing');
+    expect($result['data']->first()['live'])->toBeFalse();
+});
+
+it('can get live tv sessions from Video key', function () {
+    Http::fake([
+        'plex.example.com:32400/status/sessions' => Http::response([
+            'MediaContainer' => [
+                'size' => 1,
+                'Video' => [
+                    [
+                        'sessionKey' => '5',
+                        'title' => 'Live News',
+                        'grandparentTitle' => 'News Channel',
+                        'type' => 'clip',
+                        'live' => '1',
+                        'User' => ['title' => 'Admin'],
+                        'Player' => ['title' => 'Plex Web', 'state' => 'playing'],
+                        'viewOffset' => 0,
+                        'duration' => 0,
+                        'TranscodeSession' => ['key' => 'abc'],
+                    ],
+                ],
+            ],
+        ]),
+        'plex.example.com:32400/transcode/sessions' => Http::response([
+            'MediaContainer' => ['size' => 0],
+        ]),
+    ]);
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->getActiveSessions();
+
+    expect($result['success'])->toBeTrue();
+    expect($result['data'])->toHaveCount(1);
+    expect($result['data']->first()['title'])->toBe('Live News');
+    expect($result['data']->first()['live'])->toBeTrue();
+    expect($result['data']->first()['transcode'])->toBeTrue();
+    expect($result['data']->first()['type'])->toBe('clip');
+});
+
+it('merges transcode sessions not in status sessions', function () {
+    Http::fake([
+        'plex.example.com:32400/status/sessions' => Http::response([
+            'MediaContainer' => [
+                'size' => 1,
+                'Metadata' => [
+                    [
+                        'sessionKey' => '1',
+                        'title' => 'Regular Movie',
+                        'type' => 'movie',
+                        'User' => ['title' => 'User1'],
+                        'Player' => ['title' => 'TV', 'state' => 'playing'],
+                    ],
+                ],
+            ],
+        ]),
+        'plex.example.com:32400/transcode/sessions' => Http::response([
+            'MediaContainer' => [
+                'size' => 1,
+                'Metadata' => [
+                    [
+                        'sessionKey' => '2',
+                        'title' => 'Live Channel',
+                        'type' => 'clip',
+                        'live' => '1',
+                        'User' => ['title' => 'User2'],
+                        'Player' => ['title' => 'iPad', 'state' => 'playing'],
+                        'TranscodeSession' => ['key' => 'xyz'],
+                    ],
+                ],
+            ],
+        ]),
+    ]);
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->getActiveSessions();
+
+    expect($result['success'])->toBeTrue();
+    expect($result['data'])->toHaveCount(2);
+    expect($result['data']->pluck('title')->toArray())->toBe(['Regular Movie', 'Live Channel']);
+});
+
+it('does not duplicate sessions already in status and transcode', function () {
+    Http::fake([
+        'plex.example.com:32400/status/sessions' => Http::response([
+            'MediaContainer' => [
+                'Metadata' => [
+                    [
+                        'sessionKey' => '1',
+                        'title' => 'Same Movie',
+                        'type' => 'movie',
+                        'User' => ['title' => 'User1'],
+                        'Player' => ['title' => 'TV', 'state' => 'playing'],
+                    ],
+                ],
+            ],
+        ]),
+        'plex.example.com:32400/transcode/sessions' => Http::response([
+            'MediaContainer' => [
+                'Metadata' => [
+                    [
+                        'sessionKey' => '1',
+                        'title' => 'Same Movie',
+                        'type' => 'movie',
+                        'User' => ['title' => 'User1'],
+                        'Player' => ['title' => 'TV', 'state' => 'playing'],
+                    ],
+                ],
+            ],
+        ]),
+    ]);
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->getActiveSessions();
+
+    expect($result['success'])->toBeTrue();
+    expect($result['data'])->toHaveCount(1);
 });
 
 it('can get DVR configurations', function () {
@@ -228,8 +348,10 @@ it('can register a DVR device', function () {
 
         // lineupchannels for auto-sync
         if (str_contains($url, '/livetv/epg/lineupchannels')) {
-            return Http::response(['MediaContainer' => ['Channel' => [
-                ['number' => '1', 'lineupIdentifier' => 'ch-1'],
+            return Http::response(['MediaContainer' => ['Lineup' => [
+                ['uuid' => 'lineup://test', 'type' => 'lineup', 'Channel' => [
+                    ['identifier' => 'ch-1', 'channelVcn' => '1', 'key' => '1', 'title' => 'Ch 1', 'callSign' => 'Ch 1'],
+                ]],
             ]]]);
         }
 
@@ -389,6 +511,9 @@ it('can get dashboard summary', function () {
         'plex.example.com:32400/status/sessions' => Http::response([
             'MediaContainer' => ['Metadata' => []],
         ]),
+        'plex.example.com:32400/transcode/sessions' => Http::response([
+            'MediaContainer' => ['size' => 0],
+        ]),
         'plex.example.com:32400/livetv/dvrs' => Http::response([
             'MediaContainer' => ['Dvr' => []],
         ]),
@@ -445,9 +570,11 @@ it('can sync DVR channels when in sync', function () {
         }
 
         if (str_contains($url, '/livetv/epg/lineupchannels')) {
-            return Http::response(['MediaContainer' => ['Channel' => [
-                ['number' => '1', 'lineupIdentifier' => 'ch-1'],
-                ['number' => '2', 'lineupIdentifier' => 'ch-2'],
+            return Http::response(['MediaContainer' => ['Lineup' => [
+                ['uuid' => 'lineup://test', 'type' => 'lineup', 'Channel' => [
+                    ['identifier' => 'ch-1', 'channelVcn' => '1', 'key' => '1', 'title' => 'Ch 1', 'callSign' => 'Ch 1'],
+                    ['identifier' => 'ch-2', 'channelVcn' => '2', 'key' => '2', 'title' => 'Ch 2', 'callSign' => 'Ch 2'],
+                ]],
             ]]]);
         }
 
@@ -501,10 +628,12 @@ it('can sync DVR channels when out of sync', function () {
         }
 
         if (str_contains($url, '/livetv/epg/lineupchannels')) {
-            return Http::response(['MediaContainer' => ['Channel' => [
-                ['number' => '1', 'lineupIdentifier' => 'ch-1'],
-                ['number' => '2', 'lineupIdentifier' => 'ch-2'],
-                ['number' => '3', 'lineupIdentifier' => 'ch-3'],
+            return Http::response(['MediaContainer' => ['Lineup' => [
+                ['uuid' => 'lineup://test', 'type' => 'lineup', 'Channel' => [
+                    ['identifier' => 'ch-1', 'channelVcn' => '1', 'key' => '1', 'title' => 'Ch 1', 'callSign' => 'Ch 1'],
+                    ['identifier' => 'ch-2', 'channelVcn' => '2', 'key' => '2', 'title' => 'Ch 2', 'callSign' => 'Ch 2'],
+                    ['identifier' => 'ch-3', 'channelVcn' => '3', 'key' => '3', 'title' => 'Ch 3', 'callSign' => 'Ch 3'],
+                ]],
             ]]]);
         }
 
@@ -602,7 +731,7 @@ it('can run sync plex dvr command', function () {
         }
 
         if (str_contains($url, '/livetv/epg/lineupchannels')) {
-            return Http::response(['MediaContainer' => ['Channel' => []]]);
+            return Http::response(['MediaContainer' => ['Lineup' => []]]);
         }
 
         if (str_contains($url, '/media/grabbers/devices') && ! str_contains($url, '?')) {
@@ -637,8 +766,10 @@ it('resolves lineup ID from Lineup array entries', function () {
 
         if (str_contains($url, '/livetv/epg/lineupchannels')) {
             // Return a channel using the lineup ID from Lineup array
-            return Http::response(['MediaContainer' => ['Channel' => [
-                ['number' => '5', 'lineupIdentifier' => 'ch-5-from-lineup-array'],
+            return Http::response(['MediaContainer' => ['Lineup' => [
+                ['uuid' => 'lineup://test', 'type' => 'lineup', 'Channel' => [
+                    ['identifier' => 'ch-5-from-lineup-array', 'channelVcn' => '5', 'key' => '5', 'title' => 'Ch 5', 'callSign' => 'Ch 5'],
+                ]],
             ]]]);
         }
 
@@ -700,7 +831,7 @@ it('triggers EPG refresh after channel map changes', function () {
         }
 
         if (str_contains($url, '/livetv/epg/lineupchannels')) {
-            return Http::response(['MediaContainer' => ['Channel' => []]]);
+            return Http::response(['MediaContainer' => ['Lineup' => []]]);
         }
 
         if (str_contains($url, '/media/grabbers/devices') && ! str_contains($url, '?')) {
@@ -747,9 +878,11 @@ it('handles single channel response from Plex lineup', function () {
         }
 
         if (str_contains($url, '/livetv/epg/lineupchannels')) {
-            // Single channel returned as object (not array) — Plex does this for single results
-            return Http::response(['MediaContainer' => ['Channel' => [
-                'number' => '10', 'lineupIdentifier' => 'single-ch-10',
+            // Single lineup returned as object (not array) — Plex does this for single results
+            return Http::response(['MediaContainer' => ['Lineup' => [
+                'uuid' => 'lineup://test', 'type' => 'lineup', 'Channel' => [
+                    ['identifier' => 'single-ch-10', 'channelVcn' => '10', 'key' => '10', 'title' => 'Ch 10', 'callSign' => 'Ch 10'],
+                ],
             ]]]);
         }
 
@@ -777,4 +910,311 @@ it('handles single channel response from Plex lineup', function () {
 
     expect($result['success'])->toBeTrue();
     expect($result['mapped_channels'])->toBe(1);
+});
+
+it('clears local state when removing a DVR that was already deleted in Plex', function () {
+    $this->integration->update([
+        'plex_dvr_id' => '42',
+        'plex_dvr_tuners' => [['device_key' => 'device-99', 'playlist_uuid' => 'test-uuid']],
+    ]);
+
+    Http::fake([
+        'plex.example.com:32400/livetv/dvrs/42' => Http::response(null, 404),
+    ]);
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->removeDvr('42');
+
+    expect($result['success'])->toBeTrue();
+    expect($result['message'])->toBe('DVR removed from Plex');
+
+    $this->integration->refresh();
+    expect($this->integration->plex_dvr_id)->toBeNull();
+    expect($this->integration->plex_dvr_tuners)->toBeNull();
+});
+
+it('can remove a tuner when no DVR is registered in Plex', function () {
+    $this->integration->update([
+        'plex_dvr_id' => null,
+        'plex_dvr_tuners' => [
+            ['device_key' => 'device-99', 'playlist_uuid' => 'test-uuid'],
+            ['device_key' => 'device-100', 'playlist_uuid' => 'test-uuid-2'],
+        ],
+    ]);
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->removeTuner('device-99');
+
+    expect($result['success'])->toBeTrue();
+    expect($result['message'])->toContain('no DVR registered');
+
+    $this->integration->refresh();
+    expect($this->integration->plex_dvr_tuners)->toHaveCount(1);
+    expect($this->integration->plex_dvr_tuners[0]['device_key'])->toBe('device-100');
+});
+
+it('returns empty collection when getDvrChannels returns 404', function () {
+    $this->integration->update([
+        'plex_dvr_id' => '42',
+        'plex_dvr_tuners' => [['device_key' => 'device-99', 'playlist_uuid' => 'test-uuid']],
+    ]);
+
+    Http::fake([
+        'plex.example.com:32400/livetv/dvrs/42' => Http::response(null, 404),
+    ]);
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->getDvrChannels('42');
+
+    // 404 means DVR not found, return empty
+    expect($result['success'])->toBeTrue();
+    expect($result['data'])->toHaveCount(0);
+
+    // DVR state should NOT be cleared — getDvrChannels doesn't manage state
+    $this->integration->refresh();
+    expect($this->integration->plex_dvr_id)->toBe('42');
+    expect($this->integration->plex_dvr_tuners)->not->toBeNull();
+});
+
+it('detects stale DVR during sync and cleans up', function () {
+    $this->integration->update([
+        'plex_dvr_id' => '42',
+        'plex_dvr_tuners' => [['device_key' => 'device-99', 'playlist_uuid' => 'test-uuid']],
+    ]);
+
+    Http::fake([
+        'plex.example.com:32400/livetv/dvrs' => Http::response(['MediaContainer' => ['Dvr' => []]]),
+    ]);
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->syncDvrChannels();
+
+    expect($result['success'])->toBeFalse();
+    expect($result['message'])->toContain('no longer exists');
+
+    $this->integration->refresh();
+    expect($this->integration->plex_dvr_id)->toBeNull();
+    expect($this->integration->plex_dvr_tuners)->toBeNull();
+});
+
+it('refreshes lineup device before syncing channels', function () {
+    $this->integration->update([
+        'plex_dvr_id' => '42',
+        'plex_dvr_tuners' => [['device_key' => 'device-99', 'playlist_uuid' => 'test-uuid']],
+    ]);
+
+    $scanCalled = false;
+    Http::fake(function ($request) use (&$scanCalled) {
+        $url = $request->url();
+
+        // Track the device scan call (lineup refresh)
+        if (str_contains($url, '/media/grabbers/devices/device-99/scan')) {
+            $scanCalled = true;
+
+            return Http::response([], 200);
+        }
+
+        if (str_contains($url, '/hdhr/lineup.json')) {
+            return Http::response([
+                ['GuideNumber' => '40', 'GuideName' => 'Kabel Eins', 'URL' => 'http://example.com/40'],
+            ]);
+        }
+
+        if (str_contains($url, '/livetv/epg/lineupchannels')) {
+            return Http::response(['MediaContainer' => ['Lineup' => [
+                ['uuid' => 'lineup://test', 'type' => 'lineup', 'Channel' => [
+                    ['identifier' => 'ch-40', 'channelVcn' => '40', 'key' => '40', 'title' => 'Kabel Eins', 'callSign' => 'Kabel Eins'],
+                ]],
+            ]]]);
+        }
+
+        if (str_contains($url, '/media/grabbers/devices') && ! str_contains($url, '?') && ! str_contains($url, '/scan')) {
+            return Http::response(['MediaContainer' => ['Device' => [
+                ['key' => 'device-99', 'ChannelMapping' => [
+                    ['lineupIdentifier' => 'ch-40', 'enabled' => '1'],
+                ]],
+            ]]]);
+        }
+
+        if (str_contains($url, '/livetv/dvrs') && ! str_contains($url, '?')) {
+            return Http::response(['MediaContainer' => ['Dvr' => [
+                ['key' => '42', 'lineup' => 'lineup://test', 'Lineup' => [
+                    ['id' => 'lineup://tv.plex.providers.epg.xmltv/test', 'title' => 'XMLTV Guide'],
+                ], 'Device' => [['key' => 'device-99']]],
+            ]]]);
+        }
+
+        return Http::response([], 200);
+    });
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->syncDvrChannels();
+
+    expect($result['success'])->toBeTrue();
+    expect($scanCalled)->toBeTrue();
+});
+
+it('verifies DVR sync status when all channels are in sync', function () {
+    $this->integration->update([
+        'plex_dvr_id' => '42',
+        'plex_dvr_tuners' => [
+            ['device_key' => 'device-1', 'playlist_uuid' => 'playlist-abc'],
+        ],
+    ]);
+
+    Http::fake(function ($request) {
+        $url = $request->url();
+
+        // DVR detail (getDvrChannels) — must match before the broader /livetv/dvrs check
+        if (preg_match('#/livetv/dvrs/42$#', parse_url($url, PHP_URL_PATH) ?? '')) {
+            return Http::response(['MediaContainer' => ['Dvr' => [
+                ['key' => '42', 'lineup' => 'lineup://test', 'Lineup' => [
+                    ['id' => 'lineup://tv.plex.providers.epg.xmltv/test', 'title' => 'XMLTV Guide'],
+                ], 'Device' => [['key' => 'device-1', 'ChannelMapping' => [
+                    ['channelKey' => '10', 'deviceIdentifier' => '10', 'enabled' => '1', 'lineupIdentifier' => '10'],
+                    ['channelKey' => '20', 'deviceIdentifier' => '20', 'enabled' => '1', 'lineupIdentifier' => '20'],
+                ]]]],
+            ]]]);
+        }
+
+        // DVR list (verifyDvrExists)
+        if (str_contains($url, '/livetv/dvrs') && ! str_contains($url, 'lineupchannels')) {
+            return Http::response(['MediaContainer' => ['Dvr' => [
+                ['key' => '42', 'lineup' => 'lineup://test', 'Lineup' => [
+                    ['id' => 'lineup://tv.plex.providers.epg.xmltv/test', 'title' => 'XMLTV Guide'],
+                ], 'Device' => [['key' => 'device-1']]],
+            ]]]);
+        }
+
+        // Lineup channels (EPG mapping)
+        if (str_contains($url, '/livetv/epg/lineupchannels')) {
+            return Http::response(['MediaContainer' => ['Lineup' => [
+                ['uuid' => 'lineup://test', 'type' => 'lineup', 'Channel' => [
+                    ['identifier' => 'ch-10', 'channelVcn' => '10', 'key' => '10', 'title' => 'Channel One', 'callSign' => 'Ch One'],
+                    ['identifier' => 'ch-20', 'channelVcn' => '20', 'key' => '20', 'title' => 'Channel Two', 'callSign' => 'Ch Two'],
+                ]],
+            ]]]);
+        }
+
+        // HDHR lineup (local)
+        if (str_contains($url, 'hdhr/lineup.json')) {
+            return Http::response([
+                ['GuideNumber' => '10', 'GuideName' => 'Channel One', 'URL' => 'http://test/1'],
+                ['GuideNumber' => '20', 'GuideName' => 'Channel Two', 'URL' => 'http://test/2'],
+            ]);
+        }
+
+        return Http::response([], 200);
+    });
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->verifyDvrSync();
+
+    expect($result['success'])->toBeTrue();
+    expect($result['data']['status'])->toBe('ok');
+    expect($result['data']['total_channels'])->toBe(2);
+    expect($result['data']['total_in_plex'])->toBe(2);
+    expect($result['data']['total_epg_mapped'])->toBe(2);
+    expect($result['data']['total_epg_missing'])->toBe(0);
+    expect($result['data']['summary'])->toContain('All 2 channels synchronized');
+});
+
+it('verifies DVR sync status when EPG mapping is missing', function () {
+    $this->integration->update([
+        'plex_dvr_id' => '42',
+        'plex_dvr_tuners' => [
+            ['device_key' => 'device-1', 'playlist_uuid' => 'playlist-abc'],
+        ],
+    ]);
+
+    Http::fake(function ($request) {
+        $url = $request->url();
+
+        // DVR detail (getDvrChannels)
+        if (preg_match('#/livetv/dvrs/42$#', parse_url($url, PHP_URL_PATH) ?? '')) {
+            return Http::response(['MediaContainer' => ['Dvr' => [
+                ['key' => '42', 'lineup' => 'lineup://test', 'Lineup' => [
+                    ['id' => 'lineup://tv.plex.providers.epg.xmltv/test', 'title' => 'XMLTV Guide'],
+                ], 'Device' => [['key' => 'device-1', 'ChannelMapping' => [
+                    ['channelKey' => '10', 'deviceIdentifier' => '10', 'enabled' => '1', 'lineupIdentifier' => '10'],
+                    ['channelKey' => '20', 'deviceIdentifier' => '20', 'enabled' => '1', 'lineupIdentifier' => '20'],
+                ]]]],
+            ]]]);
+        }
+
+        // DVR list (verifyDvrExists)
+        if (str_contains($url, '/livetv/dvrs') && ! str_contains($url, 'lineupchannels')) {
+            return Http::response(['MediaContainer' => ['Dvr' => [
+                ['key' => '42', 'lineup' => 'lineup://test', 'Lineup' => [
+                    ['id' => 'lineup://tv.plex.providers.epg.xmltv/test', 'title' => 'XMLTV Guide'],
+                ], 'Device' => [['key' => 'device-1']]],
+            ]]]);
+        }
+
+        // Only one channel has EPG mapping
+        if (str_contains($url, '/livetv/epg/lineupchannels')) {
+            return Http::response(['MediaContainer' => ['Lineup' => [
+                ['uuid' => 'lineup://test', 'type' => 'lineup', 'Channel' => [
+                    ['identifier' => 'ch-10', 'channelVcn' => '10', 'key' => '10', 'title' => 'Channel One', 'callSign' => 'Ch One'],
+                ]],
+            ]]]);
+        }
+
+        if (str_contains($url, 'hdhr/lineup.json')) {
+            return Http::response([
+                ['GuideNumber' => '10', 'GuideName' => 'Channel One', 'URL' => 'http://test/1'],
+                ['GuideNumber' => '20', 'GuideName' => 'Channel Two', 'URL' => 'http://test/2'],
+            ]);
+        }
+
+        return Http::response([], 200);
+    });
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->verifyDvrSync();
+
+    expect($result['success'])->toBeTrue();
+    expect($result['data']['status'])->toBe('warning');
+    expect($result['data']['total_epg_missing'])->toBe(1);
+    expect($result['data']['summary'])->toContain('missing EPG mapping');
+});
+
+it('verifies DVR sync returns not configured when no DVR registered', function () {
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->verifyDvrSync();
+
+    expect($result['success'])->toBeTrue();
+    expect($result['data']['status'])->toBe('not_configured');
+    expect($result['data']['summary'])->toContain('No DVR tuner registered');
+});
+
+it('verifies DVR sync detects stale DVR', function () {
+    $this->integration->update([
+        'plex_dvr_id' => '99',
+        'plex_dvr_tuners' => [
+            ['device_key' => 'device-1', 'playlist_uuid' => 'playlist-abc'],
+        ],
+    ]);
+
+    Http::fake(function ($request) {
+        $url = $request->url();
+
+        // Return empty DVRs — DVR 99 no longer exists
+        if (str_contains($url, '/livetv/dvrs')) {
+            return Http::response(['MediaContainer' => ['Dvr' => []]]);
+        }
+
+        return Http::response([], 200);
+    });
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->verifyDvrSync();
+
+    expect($result['success'])->toBeTrue();
+    expect($result['data']['status'])->toBe('error');
+    expect($result['data']['summary'])->toContain('no longer exists');
+
+    // Verify local state was cleaned up
+    $this->integration->refresh();
+    expect($this->integration->plex_dvr_id)->toBeNull();
 });


### PR DESCRIPTION
- Fix getDvrChannels to use DVR detail endpoint (/livetv/dvrs/{id}) instead of unreliable /livetv/dvrs/{id}/channels 
- Extract channel data from Device[].ChannelMapping[] in DVR response
- Fix Lineup channel parsing: use nested Lineup[].Channel[] structure with correct field names (channelVcn, identifier)
- Prevent getDvrChannels 404 from clearing stored DVR state
- Add extractLineupChannels() helper for reliable lineup parsing
- Replace Active Sessions with DVR Sync Status verification
- Fix TVG ID warning to require 'Channel Number' instead of 'Channel ID'
- Auto-set port when server type changes (Plex=32400, Emby/Jellyfin=8096)
- Prevent duplicate DVR creation by detecting existing DVR by device key
- Reuse locally stored DVR ID if it still exists in Plex
- Update all tests to match real Plex API response structures