### PR TITLE
fix: preserve status filter when switching playlist tabs

### DIFF
--- a/app/Filament/Resources/Channels/Pages/ListChannels.php
+++ b/app/Filament/Resources/Channels/Pages/ListChannels.php
@@ -450,7 +450,7 @@ class ListChannels extends ListRecords
     public function updatedActiveTab(): void
     {
         parent::updatedActiveTab();
-        $this->statusFilter = 'all';
+        $this->resetPage();
     }
 
     public function updatedStatusFilter(): void

--- a/app/Filament/Resources/Series/Pages/ListSeries.php
+++ b/app/Filament/Resources/Series/Pages/ListSeries.php
@@ -459,7 +459,7 @@ class ListSeries extends ListRecords
     public function updatedActiveTab(): void
     {
         parent::updatedActiveTab();
-        $this->statusFilter = 'all';
+        $this->resetPage();
     }
 
     public function updatedStatusFilter(): void

--- a/app/Filament/Resources/Vods/Pages/ListVod.php
+++ b/app/Filament/Resources/Vods/Pages/ListVod.php
@@ -536,7 +536,7 @@ class ListVod extends ListRecords
     public function updatedActiveTab(): void
     {
         parent::updatedActiveTab();
-        $this->statusFilter = 'all';
+        $this->resetPage();
     }
 
     public function updatedStatusFilter(): void


### PR DESCRIPTION
## Summary

- Switching playlist tabs (top row) no longer resets the status filter tabs (bottom row) back to "All Channels"
- Applies to Channels, Series, and VODs list pages
- The `updatedActiveTab()` hook was explicitly resetting `statusFilter` to `'all'` — replaced with `resetPage()` to only reset pagination

## Test plan

- [x] Go to Channels page, select "Enabled" on the bottom status tabs, then switch playlists on the top tabs — status filter should remain on "Enabled"
- [x] Repeat for Series and VODs pages
- [x] Verify pagination resets correctly when switching playlists