### PR TITLE
fix: add default sort order to Channels, VODs, and Series tables

### DIFF
--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -147,6 +147,7 @@ class ChannelResource extends Resource
             ->deferLoading()
             ->paginated([10, 25, 50, 100])
             ->defaultPaginationPageOption(25)
+            ->defaultSort('sort')
             ->columns(self::getTableColumns(showGroup: ! $relationId, showPlaylist: ! $relationId))
             ->filters(self::getTableFilters(showPlaylist: ! $relationId))
             ->recordActions(self::getTableActions(), position: RecordActionsPosition::BeforeCells)

--- a/app/Filament/Resources/Series/SeriesResource.php
+++ b/app/Filament/Resources/Series/SeriesResource.php
@@ -111,6 +111,7 @@ class SeriesResource extends Resource
             })
             ->paginated([10, 25, 50, 100])
             ->defaultPaginationPageOption(25)
+            ->defaultSort('sort')
             ->columns(self::getTableColumns(showCategory: ! $relationId, showPlaylist: ! $relationId))
             ->filters(self::getTableFilters(showPlaylist: ! $relationId))
             ->recordActions(self::getTableActions(), position: RecordActionsPosition::BeforeCells)

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -155,6 +155,7 @@ class VodResource extends Resource
             ->deferLoading()
             ->paginated([10, 25, 50, 100])
             ->defaultPaginationPageOption(25)
+            ->defaultSort('sort')
             ->columns(self::getTableColumns(showGroup: ! $relationId, showPlaylist: ! $relationId))
             ->filters(self::getTableFilters(showPlaylist: ! $relationId))
             ->recordActions(self::getTableActions(), position: RecordActionsPosition::BeforeCells)


### PR DESCRIPTION
## Summary

- Channels, VODs, and Series tables were missing a `defaultSort`, causing rows to appear in arbitrary database order on fresh sessions
- Added `->defaultSort('sort')` so tables default to Sort Order column
- User-chosen sorts are still honoured via the existing `persistSortInSession()`

## Test plan

- [x] Visit /channels on a fresh session (or clear session) — table should be sorted by Sort Order
- [x] Manually sort by a different column, navigate away and back — user sort should persist
- [x] Repeat for VODs and Series pages