### PR TITLE
chore: Clean up dead cache fallback, cache JWT config, remove unused eager load

### DIFF
--- a/app/Http/Controllers/Api/DispatcharrController.php
+++ b/app/Http/Controllers/Api/DispatcharrController.php
@@ -87,7 +87,7 @@ class DispatcharrController extends Controller
             return response()->json(['detail' => 'Token is invalid or expired'], 401);
         }
 
-        unset($payload['type'], $payload['exp']);
+        unset($payload['type'], $payload['exp'], $payload['iat']);
 
         return response()->json([
             'access' => DispatcharrAuthMiddleware::createToken($payload, self::ACCESS_TTL),
@@ -149,7 +149,6 @@ class DispatcharrController extends Controller
         $channelsQuery = $playlist->channels()
             ->where('channels.enabled', true)
             ->where('channels.is_vod', false)
-            ->with(['group'])
             ->orderBy('channels.channel')
             ->limit(min($limit, 10000));
 

--- a/app/Http/Middleware/DispatcharrAuthMiddleware.php
+++ b/app/Http/Middleware/DispatcharrAuthMiddleware.php
@@ -23,6 +23,11 @@ class DispatcharrAuthMiddleware
      */
     private const REGISTERED_CLAIMS = ['iss', 'sub', 'aud', 'exp', 'nbf', 'iat', 'jti'];
 
+    /**
+     * Cached JWT configuration instance.
+     */
+    private static ?Configuration $jwtConfigInstance = null;
+
     public function handle(Request $request, Closure $next): Response
     {
         $bearer = $request->bearerToken();
@@ -153,11 +158,15 @@ class DispatcharrAuthMiddleware
      */
     private static function jwtConfig(): Configuration
     {
+        if (static::$jwtConfigInstance !== null) {
+            return static::$jwtConfigInstance;
+        }
+
         $key = config('app.key');
         $signingKey = str_starts_with($key, 'base64:')
             ? InMemory::base64Encoded(substr($key, 7))
             : InMemory::plainText($key);
 
-        return Configuration::forSymmetricSigner(new Sha256, $signingKey);
+        return static::$jwtConfigInstance = Configuration::forSymmetricSigner(new Sha256, $signingKey);
     }
 }

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -18,7 +18,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
@@ -263,19 +262,12 @@ class Channel extends Model
      */
     public function getStreamStatsAttribute(): array
     {
-        // Prefer persisted stream_stats from database
-        $persisted = $this->attributes['stream_stats'] ?? null;
-        if ($persisted) {
-            $decoded = is_string($persisted) ? json_decode($persisted, true) : $persisted;
+        $raw = $this->attributes['stream_stats'] ?? null;
+        if ($raw) {
+            $decoded = is_string($raw) ? json_decode($raw, true) : $raw;
             if (! empty($decoded)) {
                 return $decoded;
             }
-        }
-
-        // Fall back to cache
-        $stats = Cache::get("channel_stream_stats_{$this->id}");
-        if ($stats !== null) {
-            return $stats;
         }
 
         return [];


### PR DESCRIPTION
This pull request introduces a few optimizations and minor cleanups, primarily focusing on JWT token handling, model attribute access, and query efficiency. The most important changes are summarized below:

**JWT Token Handling Improvements:**

* Added a cached singleton for the JWT configuration in `DispatcharrAuthMiddleware` to avoid redundant instantiations and improve performance. [[1]](diffhunk://#diff-fae8764bf796766148dc6868fb02decae8250bf8f8fb44ce9fd1733d8a5f1e89R26-R30) [[2]](diffhunk://#diff-fae8764bf796766148dc6868fb02decae8250bf8f8fb44ce9fd1733d8a5f1e89R161-R170)
* In the `refresh` method of `DispatcharrController`, the `iat` (issued at) claim is now also removed from the payload before issuing a new token, improving security and compliance with JWT standards.

**Model and Query Optimizations:**

* In the `Channel` model's `getStreamStatsAttribute`, removed the fallback to cached stats and now only returns persisted database values or an empty array, simplifying logic and ensuring consistency.
* Cleaned up imports in `Channel.php` by removing the unused `Cache` facade.
* In the `channels` method of `DispatcharrController`, removed the unnecessary eager loading of the `group` relationship for channels, likely improving query performance.