### PR TITLE
fix: use exit code instead of stderr to detect ffprobe failures

### DIFF
--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -311,25 +311,15 @@ class Channel extends Model
 
             $process = new SymfonyProcess(['ffprobe', '-v', 'quiet', '-print_format', 'json', '-show_streams', $url]);
             $process->setTimeout(15);
-            $output = '';
-            $errors = '';
-            $hasErrors = false;
-            $process->run(
-                function ($type, $buffer) use (&$output, &$hasErrors, &$errors) {
-                    if ($type === SymfonyProcess::OUT) {
-                        $output .= $buffer;
-                    }
-                    if ($type === SymfonyProcess::ERR) {
-                        $hasErrors = true;
-                        $errors .= $buffer;
-                    }
-                }
-            );
-            if ($hasErrors) {
-                Log::error("Error running ffprobe for channel \"{$this->title}\": {$errors}");
+            $process->run();
+
+            if ($process->getExitCode() !== 0) {
+                Log::error("Error running ffprobe for channel \"{$this->title}\": {$process->getErrorOutput()}");
 
                 return [];
             }
+
+            $output = $process->getOutput();
             $json = json_decode($output, true);
             if (isset($json['streams']) && is_array($json['streams'])) {
                 $streamStats = [];

--- a/tests/Unit/NetworkPersistedSeekTest.php
+++ b/tests/Unit/NetworkPersistedSeekTest.php
@@ -5,6 +5,8 @@ use App\Models\NetworkProgramme;
 use Illuminate\Support\Carbon;
 
 it('calculates persisted broadcast seek correctly', function () {
+    Carbon::setTestNow(Carbon::now());
+
     $network = Network::factory()->create();
 
     $programme = NetworkProgramme::factory()->create([
@@ -26,4 +28,6 @@ it('calculates persisted broadcast seek correctly', function () {
     // Expect initial 120 + 30 elapsed = 150 seconds
     expect($seek)->toBeInt();
     expect($seek)->toBe(150);
+
+    Carbon::setTestNow();
 });


### PR DESCRIPTION
HLS streams produce informational stderr output (segment downloads, protocol negotiation) even with -v quiet, but return exit code 0 with valid JSON on stdout. The old logic treated any stderr output as a fatal error, causing all HLS probes to fail. Now only a non-zero exit code is treated as failure.