### PR TITLE
fix: hide Plex Management tab for non-Plex integrations

### DIFF
--- a/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
+++ b/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
@@ -142,9 +142,15 @@ class MediaServerIntegrationResource extends Resource
                 default => null,
             };
 
-            $tabs[] = Tab::make($section)
+            $tab = Tab::make($section)
                 ->icon($icon)
                 ->schema($fields);
+
+            if ($section === 'Plex Management') {
+                $tab->visible(fn (Get $get): bool => $get('type') === 'plex');
+            }
+
+            $tabs[] = $tab;
         }
 
         return [


### PR DESCRIPTION
@sparkison never bothered to check :wink: 