### PR TITLE
fix: re-use playlist URL helpers within Plex logic.

### DIFF
--- a/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
+++ b/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\MediaServerIntegrations;
 
+use App\Facades\PlaylistFacade;
 use App\Filament\Concerns\HasCopilotSupport;
 use App\Filament\Resources\MediaServerIntegrations\Pages\CreateMediaServerIntegration;
 use App\Filament\Resources\MediaServerIntegrations\Pages\EditMediaServerIntegration;
@@ -99,23 +100,6 @@ class MediaServerIntegrationResource extends Resource implements CopilotResource
     }
 
     /**
-     * Build the external base URL for HDHR/EPG endpoints.
-     * Handles APP_URL values with or without a scheme.
-     */
-    protected static function buildHdhrBaseUrl(): string
-    {
-        $appUrl = rtrim(config('app.url'), '/');
-        if (! parse_url($appUrl, PHP_URL_SCHEME)) {
-            $appUrl = 'http://'.$appUrl;
-        }
-        $scheme = parse_url($appUrl, PHP_URL_SCHEME) ?: 'http';
-        $host = parse_url($appUrl, PHP_URL_HOST) ?: 'localhost';
-        $port = parse_url($appUrl, PHP_URL_PORT) ?: config('app.port', 36400);
-
-        return "{$scheme}://{$host}:{$port}";
-    }
-
-    /**
      * Resolve a playlist UUID to a human-readable name.
      */
     protected static function resolvePlaylistName(string $uuid): string
@@ -124,9 +108,7 @@ class MediaServerIntegrationResource extends Resource implements CopilotResource
             return '—';
         }
 
-        $playlist = Playlist::where('uuid', $uuid)->first()
-            ?? CustomPlaylist::where('uuid', $uuid)->first()
-            ?? MergedPlaylist::where('uuid', $uuid)->first();
+        $playlist = PlaylistFacade::resolvePlaylistByUuid($uuid);
 
         return $playlist ? $playlist->name : $uuid;
     }
@@ -790,9 +772,15 @@ class MediaServerIntegrationResource extends Resource implements CopilotResource
                                                     if (! $state) {
                                                         return;
                                                     }
-                                                    $baseUrl = self::buildHdhrBaseUrl();
-                                                    $set('hdhr_base_url', "{$baseUrl}/{$state}/hdhr");
-                                                    $set('epg_url', "{$baseUrl}/{$state}/epg.xml");
+
+                                                    $playlist = PlaylistFacade::resolvePlaylistByUuid($state);
+                                                    if (! $playlist) {
+                                                        return;
+                                                    }
+
+                                                    $urls = PlaylistFacade::getUrls($playlist);
+                                                    $set('hdhr_base_url', $urls['hdhr'] ?? '');
+                                                    $set('epg_url', $urls['epg'] ?? '');
                                                 })
                                                 ->required(),
                                             Placeholder::make('tvg_id_warning')
@@ -802,11 +790,9 @@ class MediaServerIntegrationResource extends Resource implements CopilotResource
                                                     if (! $uuid) {
                                                         return false;
                                                     }
-                                                    $playlist = Playlist::where('uuid', $uuid)->first()
-                                                        ?? CustomPlaylist::where('uuid', $uuid)->first()
-                                                        ?? MergedPlaylist::where('uuid', $uuid)->first();
+                                                    $playlist = PlaylistFacade::resolvePlaylistByUuid($uuid);
 
-                                                    $value = $playlist->id_channel_by?->value ?? $playlist->id_channel_by ?? 'stream_id';
+                                                    $value = $playlist?->id_channel_by?->value ?? $playlist?->id_channel_by ?? 'stream_id';
 
                                                     return $playlist && $value !== 'number';
                                                 }),

--- a/app/Services/PlexManagementService.php
+++ b/app/Services/PlexManagementService.php
@@ -412,11 +412,14 @@ class PlexManagementService
     {
         $playlist = PlaylistFacade::resolvePlaylistByUuid($playlistUuid);
 
-        if (! $playlist) {
-            return null;
+        if ($playlist) {
+            return PlaylistFacade::getUrls($playlist);
         }
 
-        return PlaylistFacade::getUrls($playlist);
+        return [
+            'hdhr' => route('playlist.hdhr.overview', ['uuid' => $playlistUuid]),
+            'epg' => route('epg.generate', ['uuid' => $playlistUuid]),
+        ];
     }
 
     /**

--- a/app/Services/PlexManagementService.php
+++ b/app/Services/PlexManagementService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Facades\PlaylistFacade;
 use App\Models\MediaServerIntegration;
 use Exception;
 use Illuminate\Http\Client\PendingRequest;
@@ -403,6 +404,52 @@ class PlexManagementService
     }
 
     /**
+     * Resolve the canonical playlist URLs used across the application.
+     *
+     * @return array{hdhr?: string, epg?: string}|null
+     */
+    protected function resolvePlaylistUrls(string $playlistUuid): ?array
+    {
+        $playlist = PlaylistFacade::resolvePlaylistByUuid($playlistUuid);
+
+        if (! $playlist) {
+            return null;
+        }
+
+        return PlaylistFacade::getUrls($playlist);
+    }
+
+    /**
+     * Fetch discover.json from the same HDHR base URL we register in Plex.
+     *
+     * @return array{success: bool, data?: array, message?: string}
+     */
+    protected function fetchDiscoverPayload(string $hdhrBaseUrl): array
+    {
+        try {
+            $discoverUrl = rtrim($hdhrBaseUrl, '/').'/discover.json';
+            $response = Http::timeout(10)->get($discoverUrl);
+
+            if ($response->successful()) {
+                return [
+                    'success' => true,
+                    'data' => $response->json() ?? [],
+                ];
+            }
+
+            return [
+                'success' => false,
+                'message' => "Could not reach HDHR discover.json (HTTP {$response->status()}) at {$discoverUrl}.",
+            ];
+        } catch (Exception $e) {
+            return [
+                'success' => false,
+                'message' => 'Could not reach HDHR discover.json: '.$e->getMessage(),
+            ];
+        }
+    }
+
+    /**
      * Register an m3u-editor playlist's HDHR endpoint as a DVR tuner in Plex.
      *
      * Follows the correct Plex DVR API flow (as implemented by Headendarr):
@@ -421,21 +468,16 @@ class PlexManagementService
     {
         try {
             // Step 1: Fetch discover.json to get device info (DeviceID, DeviceAuth, etc.)
-            // The hdhrBaseUrl is the external URL for Plex. We build a local URL
-            // to fetch discover.json from ourselves since we host the HDHR endpoint.
-            $parsedHdhr = parse_url($hdhrBaseUrl);
-            $hdhrPath = $parsedHdhr['path'] ?? '';
-            $appPort = config('app.port', 36400);
-            $localDiscoverUrl = "http://localhost:{$appPort}".rtrim($hdhrPath, '/').'/discover.json';
-
-            $discoverResponse = Http::timeout(10)->get($localDiscoverUrl);
-            if (! $discoverResponse->successful()) {
+            // Use the exact HDHR URL that will be registered in Plex so this
+            // follows the same public URL path used elsewhere in the app.
+            $discoverResult = $this->fetchDiscoverPayload($hdhrBaseUrl);
+            if (! $discoverResult['success']) {
                 return [
                     'success' => false,
-                    'message' => "Could not reach HDHR discover.json (HTTP {$discoverResponse->status()}). Ensure the HDHR endpoint is available.",
+                    'message' => $discoverResult['message'],
                 ];
             }
-            $discoverPayload = $discoverResponse->json() ?? [];
+            $discoverPayload = $discoverResult['data'] ?? [];
 
             // Step 2: Create the device in Plex
             $created = $this->tryCreateDevice($hdhrBaseUrl, $discoverPayload);
@@ -1189,9 +1231,13 @@ class PlexManagementService
     public function syncDvrChannelsForTuner(string $deviceKey, string $playlistUuid): array
     {
         try {
+            $urls = $this->resolvePlaylistUrls($playlistUuid);
+            if (! $urls || empty($urls['hdhr'])) {
+                return ['success' => false, 'message' => 'Could not resolve playlist HDHR URL.'];
+            }
+
             // Fetch current HDHR lineup from our own endpoint
-            $appPort = config('app.port', 36400);
-            $lineupUrl = "http://localhost:{$appPort}/{$playlistUuid}/hdhr/lineup.json";
+            $lineupUrl = rtrim($urls['hdhr'], '/').'/lineup.json';
             $lineupResponse = Http::timeout(15)->get($lineupUrl);
 
             if (! $lineupResponse->successful()) {
@@ -1208,7 +1254,10 @@ class PlexManagementService
 
             if (! $lineupId) {
                 // Fallback: rebuild from our known URL
-                $epgUrl = $this->buildExternalUrl($playlistUuid, 'epg.xml');
+                $epgUrl = $urls['epg'] ?? null;
+                if (! $epgUrl) {
+                    return ['success' => false, 'message' => 'Could not resolve playlist EPG URL.'];
+                }
                 $lineupId = $this->buildLineupId($epgUrl);
                 Log::warning('PlexManagementService: Could not get lineup ID from DVR, using fallback', [
                     'integration_id' => $this->integration->id,
@@ -1386,23 +1435,6 @@ class PlexManagementService
 
             return ['success' => false, 'message' => $e->getMessage()];
         }
-    }
-
-    /**
-     * Build an external URL for HDHR/EPG endpoints.
-     * Uses app.url with scheme handling.
-     */
-    protected function buildExternalUrl(string $playlistUuid, string $suffix): string
-    {
-        $appUrl = rtrim(config('app.url'), '/');
-        if (! parse_url($appUrl, PHP_URL_SCHEME)) {
-            $appUrl = 'http://'.$appUrl;
-        }
-        $scheme = parse_url($appUrl, PHP_URL_SCHEME) ?: 'http';
-        $host = parse_url($appUrl, PHP_URL_HOST) ?: 'localhost';
-        $port = parse_url($appUrl, PHP_URL_PORT) ?: config('app.port', 36400);
-
-        return "{$scheme}://{$host}:{$port}/{$playlistUuid}/{$suffix}";
     }
 
     /**
@@ -1673,7 +1705,6 @@ class PlexManagementService
         }
 
         $lineupId = $this->getDvrLineupId();
-        $appPort = config('app.port', 36400);
 
         // Fetch Plex DVR channels (from Device[].ChannelMapping[])
         $plexChannelsResult = $this->getDvrChannels($dvrId);
@@ -1719,8 +1750,23 @@ class PlexManagementService
                 continue;
             }
 
+            $urls = $this->resolvePlaylistUrls($playlistUuid);
+            if (! $urls || empty($urls['hdhr'])) {
+                $allInSync = false;
+                $tunerReports[] = [
+                    'playlist' => $playlistUuid,
+                    'channels_hdhr' => 0,
+                    'channels_plex' => 0,
+                    'epg_mapped' => 0,
+                    'epg_missing' => 0,
+                    'in_sync' => false,
+                ];
+
+                continue;
+            }
+
             // Fetch HDHR lineup for this tuner
-            $lineupUrl = "http://localhost:{$appPort}/{$playlistUuid}/hdhr/lineup.json";
+            $lineupUrl = rtrim($urls['hdhr'], '/').'/lineup.json';
             $hdhrChannelCount = 0;
             $hdhrNumbers = [];
             try {

--- a/tests/Feature/PlexManagementServiceTest.php
+++ b/tests/Feature/PlexManagementServiceTest.php
@@ -262,6 +262,38 @@ it('can get DVR configurations', function () {
     expect($result['data']->first()['device_count'])->toBe(1);
 });
 
+it('prefers the provided hdhr url when fetching discover json', function () {
+    $requestedUrls = [];
+
+    Http::fake(function ($request) use (&$requestedUrls) {
+        $requestedUrls[] = $request->url();
+
+        return match ($request->url()) {
+            'https://iptv.chorkley.uk/test-playlist-uuid/hdhr/discover.json' => Http::response([
+                'DeviceID' => 'hdhr-device-123',
+                'DeviceAuth' => 'auth-abc',
+            ]),
+            default => Http::response(null, 500),
+        };
+    });
+
+    $service = new class($this->integration) extends PlexManagementService
+    {
+        public function fetchDiscoverPayloadForTest(string $hdhrBaseUrl): array
+        {
+            return $this->fetchDiscoverPayload($hdhrBaseUrl);
+        }
+    };
+
+    $result = $service->fetchDiscoverPayloadForTest('https://iptv.chorkley.uk/test-playlist-uuid/hdhr');
+
+    expect($result['success'])->toBeTrue();
+    expect($result['data']['DeviceID'])->toBe('hdhr-device-123');
+    expect($requestedUrls)->toContain('https://iptv.chorkley.uk/test-playlist-uuid/hdhr/discover.json');
+    expect($requestedUrls)->not->toContain('http://localhost:443/test-playlist-uuid/hdhr/discover.json');
+    expect($requestedUrls)->not->toContain('http://127.0.0.1:443/test-playlist-uuid/hdhr/discover.json');
+});
+
 it('can register a DVR device', function () {
     $devicesCallCount = 0;
     $dvrsCallCount = 0;
@@ -269,7 +301,7 @@ it('can register a DVR device', function () {
     Http::fake(function ($request) use (&$devicesCallCount, &$dvrsCallCount) {
         $url = $request->url();
 
-        // Step 1: discover.json fetched via local app URL
+        // Step 1: discover.json fetched via the configured HDHR URL
         if (str_contains($url, '/hdhr/discover.json')) {
             return Http::response([
                 'DeviceID' => 'hdhr-device-123',


### PR DESCRIPTION
Plex URL building path for discover.json / lineup.json assumed webserver running in the m3u-editor container.

This fix ensures the existing url helpers are used within the plex functionality, allowing Caddy / external webserver usage.