### PR TITLE
feat: positional index for M3U source_id and regex-based failover matching

### DIFF
--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -1290,6 +1290,16 @@ class ChannelResource extends Resource implements CopilotResource
                         ->placeholder(fn (Get $get) => $get('stream_id'))
                         ->helperText(fn (Get $get) => $get('is_custom') ? '' : 'Leave empty to use default value.')
                         ->rules(['min:1', 'max:255']),
+                    TextInput::make('merge_regex')
+                        ->label(__('Merge Regex'))
+                        ->hintIcon(
+                            'heroicon-m-question-mark-circle',
+                            tooltip: 'A regex pattern to match streams from other playlists for failover merging. Matched against the channel title and name. Example: /^CCTV[-]?1$/i'
+                        )
+                        ->columnSpan(1)
+                        ->placeholder('/^CCTV[-]?1$/i')
+                        ->helperText(__('Regex pattern for cross-playlist failover matching.'))
+                        ->rules(['max:500']),
                     TextInput::make('station_id')
                         ->label(__('Station ID'))
                         ->hint(__('tvc-guide-stationid'))

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -1771,6 +1771,18 @@ class PlaylistResource extends Resource implements CopilotResource
                         ->helperText(__('When enabled, groups will be included based on regex pattern match instead of prefix.'))
                         ->hidden(fn (Get $get): bool => ! $get('import_prefs.preprocess') || ! $get('status')),
 
+                    Toggle::make('import_prefs.use_positional_index')
+                        ->label(__('Use positional index for channel identity'))
+                        ->columnSpan(2)
+                        ->inline(true)
+                        ->default(false)
+                        ->hintIcon(
+                            'heroicon-m-question-mark-circle',
+                            tooltip: 'Enable this when your M3U playlist contains multiple entries with the same channel name, group, and tvg-id but different stream URLs (e.g. failover/backup streams). Without this, only one entry per unique name/group combination is imported.'
+                        )
+                        ->helperText(__('When enabled, each line in the M3U file is treated as a unique channel, allowing duplicate entries with different URLs to be imported separately for failover merging.'))
+                        ->hidden(fn (Get $get): bool => $get('xtream')),
+
                     Fieldset::make(__('Live channel processing'))
                         ->schema([
                             ModalTableSelect::make('import_prefs.selected_groups')

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -174,7 +174,99 @@ class MergeChannels implements ShouldQueue
             }
         }
 
+        // Process regex-based merge matching (second pass)
+        $regexResults = $this->processRegexMerges($playlistIds, $playlistPriority);
+        $processed += $regexResults['processed'];
+        $deactivatedCount += $regexResults['deactivated'];
+
         $this->sendCompletionNotification($processed, $deactivatedCount);
+    }
+
+    /**
+     * Process regex-based merge matching after standard stream ID merging.
+     * Channels with a merge_regex pattern will match against all mergeable channels.
+     *
+     * @return array{processed: int, deactivated: int}
+     */
+    protected function processRegexMerges(array $playlistIds, array $playlistPriority): array
+    {
+        $processed = 0;
+        $deactivatedCount = 0;
+
+        // Find all channels with merge_regex set
+        $regexChannels = Channel::where([
+            ['user_id', $this->user->id],
+            ['can_merge', true],
+        ])->whereIn('playlist_id', $playlistIds)
+            ->whereNotNull('merge_regex')
+            ->where('merge_regex', '!=', '')
+            ->when($this->groupId, fn ($query) => $query->where('group_id', $this->groupId))
+            ->get();
+
+        if ($regexChannels->isEmpty()) {
+            return ['processed' => 0, 'deactivated' => 0];
+        }
+
+        // Get all candidate channels for matching
+        $candidates = Channel::where([
+            ['user_id', $this->user->id],
+            ['can_merge', true],
+        ])->whereIn('playlist_id', $playlistIds)
+            ->get();
+
+        foreach ($regexChannels as $master) {
+            $pattern = $master->merge_regex;
+
+            // Validate the regex pattern
+            if (@preg_match($pattern, '') === false) {
+                continue; // Skip invalid patterns
+            }
+
+            // Find matching channels
+            $matches = $candidates->filter(function ($candidate) use ($master, $pattern) {
+                if ($candidate->id === $master->id) {
+                    return false;
+                }
+
+                $title = $candidate->title_custom ?: $candidate->title;
+                $name = $candidate->name_custom ?: $candidate->name;
+
+                return preg_match($pattern, $title) === 1 || preg_match($pattern, $name) === 1;
+            });
+
+            if ($matches->isEmpty()) {
+                continue;
+            }
+
+            // Sort matches using the same scoring system
+            $matches = $this->sortChannelsByScore($matches, $playlistPriority);
+
+            // Get existing max sort order for this master's failovers
+            $maxSort = ChannelFailover::where('channel_id', $master->id)->max('sort') ?? 0;
+            $sortOrder = $maxSort + 1;
+
+            foreach ($matches as $failover) {
+                ChannelFailover::updateOrCreate(
+                    [
+                        'channel_id' => $master->id,
+                        'channel_failover_id' => $failover->id,
+                    ],
+                    [
+                        'user_id' => $this->user->id,
+                        'sort' => $sortOrder++,
+                    ]
+                );
+
+                if ($this->deactivateFailoverChannels && $failover->enabled) {
+                    $failover->update(['enabled' => false]);
+                    $deactivatedCount++;
+                }
+
+                $processed++;
+            }
+        }
+
+        return ['processed' => $processed, 'deactivated' => $deactivatedCount];
     }
 
     /**

--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -98,6 +98,9 @@ class ProcessM3uImport implements ShouldQueue
 
     public bool $probeEnabled = true;
 
+    // Use positional index for source_id (allows duplicate entries with same metadata)
+    public bool $usePositionalIndex = false;
+
     // VOD merging enabled by default
     public bool $canMergeVodEnabled = true;
 
@@ -152,6 +155,9 @@ class ProcessM3uImport implements ShouldQueue
             $vodCanMergeEnabled = $playlist->import_prefs['vod_channel_default_merge_enabled'] ?? null;
             $this->canMergeVodEnabled = $vodCanMergeEnabled !== null ? $vodCanMergeEnabled : true;
         }
+
+        // Use positional index for source_id (allows duplicate entries with same metadata)
+        $this->usePositionalIndex = $playlist->import_prefs['use_positional_index'] ?? false;
 
         // Get the enabled groups and categories for this playlist
         $this->enabledGroups = $playlist->groups()->where('enabled', true)->get('name')->pluck('name');
@@ -865,11 +871,13 @@ class ProcessM3uImport implements ShouldQueue
 
                 // Extract the channels and groups from the m3u
                 $excludeFileTypes = $playlist->import_prefs['ignored_file_types'] ?? [];
+                $usePositionalIndex = $this->usePositionalIndex;
                 $collection = LazyCollection::make(function () use (
                     $filePath,
                     $channelFields,
                     $excludeFileTypes,
                     $autoSort,
+                    $usePositionalIndex,
                 ) {
                     // Keep track of channel number
                     $channelNo = 0;
@@ -990,7 +998,11 @@ class ProcessM3uImport implements ShouldQueue
                                 }
 
                                 // Set the source ID based on our composite index
-                                $channel['source_id'] = md5($channel['title'].$channel['name'].$chGroup);
+                                $sourceKey = $channel['title'].$channel['name'].$chGroup;
+                                if ($usePositionalIndex) {
+                                    $sourceKey .= ':'.$channelNo;
+                                }
+                                $channel['source_id'] = md5($sourceKey);
 
                                 // Update group name to the singular name and return the channel
                                 $channel['group'] = $chGroup;
@@ -1029,7 +1041,11 @@ class ProcessM3uImport implements ShouldQueue
                             }
 
                             // Set the source ID based on our composite index
-                            $channel['source_id'] = md5($channel['title'].$channel['name'].$channel['group']);
+                            $sourceKey = $channel['title'].$channel['name'].$channel['group'];
+                            if ($usePositionalIndex) {
+                                $sourceKey .= ':'.$channelNo;
+                            }
+                            $channel['source_id'] = md5($sourceKey);
 
                             // Set channel number, if auto sort is enabled
                             if ($autoSort) {

--- a/database/migrations/2026_04_07_160725_add_merge_regex_to_channels_table.php
+++ b/database/migrations/2026_04_07_160725_add_merge_regex_to_channels_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->string('merge_regex')->nullable()->after('stream_id_custom');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropColumn('merge_regex');
+        });
+    }
+};

--- a/tests/Feature/RegexMergeTest.php
+++ b/tests/Feature/RegexMergeTest.php
@@ -1,0 +1,169 @@
+<?php
+
+use App\Jobs\MergeChannels;
+use App\Models\Channel;
+use App\Models\ChannelFailover;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    Notification::fake();
+
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+
+    $this->playlist = Playlist::factory()->createQuietly([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->group = Group::factory()->createQuietly([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+});
+
+it('merges channels matching a regex pattern as failovers', function () {
+    // Master channel with a regex pattern
+    $master = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => 'CCTV1',
+        'title' => 'CCTV-1',
+        'name' => 'CCTV1',
+        'can_merge' => true,
+        'merge_regex' => '/^CCTV[-]?1$/i',
+    ]);
+
+    // Channels that should match the regex
+    $match1 = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => 'different-id-1',
+        'title' => 'CCTV1',
+        'name' => 'cctv1',
+        'can_merge' => true,
+    ]);
+
+    $match2 = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => 'different-id-2',
+        'title' => 'CCTV-1',
+        'name' => 'cctv-1',
+        'can_merge' => true,
+    ]);
+
+    // Channel that should NOT match (CCTV10)
+    $noMatch = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => 'different-id-3',
+        'title' => 'CCTV10',
+        'name' => 'CCTV10',
+        'can_merge' => true,
+    ]);
+
+    $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
+
+    MergeChannels::dispatchSync(
+        $this->user,
+        $playlists,
+        $this->playlist->id,
+        forceCompleteRemerge: true,
+    );
+
+    // Assert regex-matched channels are failovers of the master
+    expect(ChannelFailover::where('channel_id', $master->id)->count())->toBe(2);
+    $this->assertDatabaseHas('channel_failovers', [
+        'channel_id' => $master->id,
+        'channel_failover_id' => $match1->id,
+    ]);
+    $this->assertDatabaseHas('channel_failovers', [
+        'channel_id' => $master->id,
+        'channel_failover_id' => $match2->id,
+    ]);
+
+    // CCTV10 should NOT be a failover of the master
+    $this->assertDatabaseMissing('channel_failovers', [
+        'channel_id' => $master->id,
+        'channel_failover_id' => $noMatch->id,
+    ]);
+});
+
+it('skips channels with invalid regex patterns', function () {
+    $master = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => 'TEST1',
+        'title' => 'Test Channel',
+        'name' => 'Test',
+        'can_merge' => true,
+        'merge_regex' => '/[invalid', // Invalid regex
+    ]);
+
+    $candidate = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => 'TEST2',
+        'title' => 'Test Channel 2',
+        'name' => 'Test2',
+        'can_merge' => true,
+    ]);
+
+    $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
+
+    MergeChannels::dispatchSync(
+        $this->user,
+        $playlists,
+        $this->playlist->id,
+        forceCompleteRemerge: true,
+    );
+
+    // No failovers should be created from the invalid regex
+    expect(ChannelFailover::where('channel_id', $master->id)->count())->toBe(0);
+});
+
+it('matches regex against channel name when title does not match', function () {
+    $master = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => 'BBC1',
+        'title' => 'BBC One',
+        'name' => 'BBC1',
+        'can_merge' => true,
+        'merge_regex' => '/^BBC\s*One$/i',
+    ]);
+
+    $matchByName = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->group->id,
+        'stream_id' => 'bbc-other',
+        'title' => 'Something Else',
+        'name' => 'BBC One',
+        'can_merge' => true,
+    ]);
+
+    $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
+
+    MergeChannels::dispatchSync(
+        $this->user,
+        $playlists,
+        $this->playlist->id,
+        forceCompleteRemerge: true,
+    );
+
+    $this->assertDatabaseHas('channel_failovers', [
+        'channel_id' => $master->id,
+        'channel_failover_id' => $matchByName->id,
+    ]);
+});

--- a/tests/Unit/PositionalIndexSourceIdTest.php
+++ b/tests/Unit/PositionalIndexSourceIdTest.php
@@ -1,0 +1,35 @@
+<?php
+
+it('generates unique source_ids with positional index enabled', function () {
+    // Simulate the source_id computation logic from ProcessM3uImport
+    $title = 'CCTV-1';
+    $name = 'CCTV1';
+    $group = 'CCTV';
+
+    // Without positional index: all entries get the same source_id
+    $sourceKeyBase = $title.$name.$group;
+    $hash1 = md5($sourceKeyBase);
+    $hash2 = md5($sourceKeyBase);
+    expect($hash1)->toBe($hash2);
+
+    // With positional index: each entry gets a unique source_id
+    $hashPos1 = md5($sourceKeyBase.':1');
+    $hashPos2 = md5($sourceKeyBase.':2');
+    $hashPos3 = md5($sourceKeyBase.':3');
+
+    expect($hashPos1)->not->toBe($hashPos2);
+    expect($hashPos2)->not->toBe($hashPos3);
+    expect($hashPos1)->not->toBe($hashPos3);
+});
+
+it('generates stable source_ids for the same position', function () {
+    $title = 'CCTV-1';
+    $name = 'CCTV1';
+    $group = 'CCTV';
+    $channelNo = 42;
+
+    $hash1 = md5($title.$name.$group.':'.$channelNo);
+    $hash2 = md5($title.$name.$group.':'.$channelNo);
+
+    expect($hash1)->toBe($hash2);
+});

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,25 @@ foreach (glob(__DIR__.'/../bootstrap/cache/routes-v*.php') as $routeCache) {
     unlink($routeCache);
 }
 
-// 2. Fix broken database symlinks that point to Docker container paths.
+// 2. Fix broken storage/logs symlink that points to Docker container path.
+//    In Docker, this is a valid symlink to /var/www/config/logs.
+//    Locally, the target doesn't exist and Monolog will fail.
+$logsPath = __DIR__.'/../storage/logs';
+if (is_link($logsPath) && ! file_exists($logsPath)) {
+    unlink($logsPath);
+    mkdir($logsPath, 0755, true);
+}
+
+// 2b. Fix broken .env symlink that points to Docker container path.
+//     Without a valid .env, Laravel can't load env vars and phpunit.xml
+//     env overrides may not work. The .env.testing file is used instead.
+$envPath = __DIR__.'/../.env';
+if (is_link($envPath) && ! file_exists($envPath)) {
+    unlink($envPath);
+    copy(__DIR__.'/../.env.testing', $envPath);
+}
+
+// 3. Fix broken database symlinks that point to Docker container paths.
 //    In Docker, these are valid symlinks to /var/www/config/database/*.sqlite.
 //    Locally, the targets don't exist and SQLite will fail.
 foreach (['jobs.sqlite', 'database.sqlite'] as $dbFile) {


### PR DESCRIPTION
- Add 'use_positional_index' import pref for M3U playlists that includes the line number in the source_id hash, allowing duplicate entries with different URLs to be imported as separate channels for failover merging
- Add 'merge_regex' column to channels table for per-channel regex-based stream matching across playlists (e.g. /^CCTV[-]?1$/i)
- Integrate regex merge as second pass in MergeChannels job after standard stream_id grouping
- Add UI toggle in Playlist Processing settings and regex field in Channel edit form
- Fix broken Docker symlinks in test bootstrap (.env, storage/logs)
- Add tests for both features