### PR TITLE
fix: Remove duplicate unload cleanup on floating players

### DIFF
--- a/resources/views/components/floating-stream-players.blade.php
+++ b/resources/views/components/floating-stream-players.blade.php
@@ -117,16 +117,6 @@
                             playerInstance.initPlayer($el.dataset.streamUrl, $el.dataset.streamFormat, $el.id);
                         }
                     "
-                    x-on:beforeunload.window="
-                        if (playerInstance && typeof playerInstance.cleanup === 'function') {
-                            playerInstance.cleanup();
-                        }
-                    "
-                    x-on:pagehide.window="
-                        if (playerInstance && typeof playerInstance.cleanup === 'function') {
-                            playerInstance.cleanup();
-                        }
-                    "
                 >
                     <p class="text-white p-4">Your browser does not support video playback.</p>
                 </video>


### PR DESCRIPTION
## Summary
- Removes per-video `beforeunload` and `pagehide` listeners from floating player elements
- The multi-stream manager already handles cleanup for all players via `cleanupAllStreams()` on these events, so each player's `cleanup()` was running twice on page unload

## Test plan
- [x] Open floating player, navigate away, confirm stream is cleaned up (proxy stream stops)
- [x] Open multiple floating players, navigate away, confirm all streams clean up
- [x] Play VOD/episode in floating player, navigate away, return and confirm resume works