### PR TITLE
feat: Add Picture-in-Picture support to players

### DIFF
--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -102,6 +102,7 @@ function multiStreamManager() {
                 position: this.getRandomPosition(),
                 size: { width: 480, height: 270 }, // 16:9 aspect ratio
                 isMinimized: false,
+                isPiP: false,
                 streamPlayer: null
             };
 
@@ -132,11 +133,14 @@ function multiStreamManager() {
             if (playerIndex !== -1) {
                 const player = this.players[playerIndex];
 
+                // Exit PiP if this player is in PiP mode
+                const videoElement = document.getElementById(player.id + '-video');
+                if (document.pictureInPictureElement === videoElement) {
+                    document.exitPictureInPicture().catch(() => {});
+                }
+
                 // Notify server to stop the proxy stream (best-effort via sendBeacon)
                 this.notifyServerStreamStop(player);
-
-                // Cleanup stream player via video element
-                const videoElement = document.getElementById(player.id + '-video');
                 if (videoElement && videoElement._streamPlayer) {
                     videoElement._streamPlayer.cleanup();
                 }
@@ -229,6 +233,26 @@ function multiStreamManager() {
             const player = this.players.find(p => p.id === playerId);
             if (player) {
                 player.isMinimized = !player.isMinimized;
+            }
+        },
+
+        togglePiP(playerId) {
+            const videoElement = document.getElementById(playerId + '-video');
+            if (!videoElement) return;
+
+            const player = this.players.find(p => p.id === playerId);
+
+            if (document.pictureInPictureElement === videoElement) {
+                document.exitPictureInPicture().catch(() => {});
+            } else if (document.pictureInPictureEnabled) {
+                videoElement.requestPictureInPicture().then(() => {
+                    if (player) player.isPiP = true;
+                }).catch(() => {});
+
+                // Listen for PiP exit (user closes PiP window or we call exitPiP)
+                videoElement.addEventListener('leavepictureinpicture', () => {
+                    if (player) player.isPiP = false;
+                }, { once: true });
             }
         },
 
@@ -343,8 +367,8 @@ function multiStreamManager() {
                 position: 'fixed',
                 left: player.position.x + 'px',
                 top: player.position.y + 'px',
-                width: player.size.width + 'px',
-                height: (player.size.height + 40) + 'px', // Add height for title bar
+                width: player.isPiP ? '280px' : player.size.width + 'px',
+                height: player.isPiP ? 'auto' : (player.size.height + 40) + 'px', // Add height for title bar
                 zIndex: player.zIndex
             };
         },

--- a/resources/views/components/floating-stream-players.blade.php
+++ b/resources/views/components/floating-stream-players.blade.php
@@ -70,8 +70,21 @@
                         <x-heroicon-o-arrow-top-right-on-square class="w-3 h-3" />
                     </button>
 
+                    <!-- Picture-in-Picture Button -->
+                    <button
+                        x-show="document.pictureInPictureEnabled"
+                        @click.stop="togglePiP(player.id)"
+                        class="p-1 text-gray-400 hover:text-purple-600 dark:hover:text-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 rounded transition-colors focus:outline-none"
+                        title="Picture-in-Picture"
+                    >
+                        <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="2" y="3" width="20" height="14" rx="2" />
+                            <rect x="12" y="9" width="8" height="6" rx="1" fill="currentColor" />
+                        </svg>
+                    </button>
+
                     <!-- Minimize Button -->
-                    <button 
+                    <button
                         @click.stop="toggleMinimize(player.id)"
                         class="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors focus:outline-none"
                         title="Minimize"
@@ -90,9 +103,21 @@
                 </div>
             </div>
 
+            <!-- PiP Indicator (shown when video is in Picture-in-Picture) -->
+            <div
+                x-show="player.isPiP && !player.isMinimized"
+                class="flex items-center justify-center gap-2 bg-gray-900 px-4 py-3 text-xs text-gray-400"
+            >
+                <svg class="w-4 h-4 text-purple-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="2" y="3" width="20" height="14" rx="2" />
+                    <rect x="12" y="9" width="8" height="6" rx="1" fill="currentColor" />
+                </svg>
+                <span>Playing in Picture-in-Picture</span>
+            </div>
+
             <!-- Video Player Area -->
-            <div 
-                x-show="!player.isMinimized"
+            <div
+                x-show="!player.isMinimized && !player.isPiP"
                 class="relative bg-black group"
                 :style="getVideoStyle(player)"
             >

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -73,11 +73,19 @@
                 </div>
             </div>
 
-            <div class="absolute top-2 left-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            <div class="absolute top-2 left-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex gap-1">
                 <button type="button" onclick="toggleStreamDetails('popout-player')"
                     class="rounded bg-black/75 hover:bg-black/90 px-2 py-1 text-xs text-white transition-colors"
                     title="Toggle Stream Details">
                     <x-heroicon-o-information-circle class="w-4 h-4" />
+                </button>
+                <button type="button" id="popout-pip-btn" onclick="togglePopoutPiP()"
+                    class="rounded bg-black/75 hover:bg-black/90 px-2 py-1 text-xs text-white transition-colors"
+                    title="Picture-in-Picture" style="display: none;">
+                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="2" y="3" width="20" height="14" rx="2" />
+                        <rect x="12" y="9" width="8" height="6" rx="1" fill="currentColor" />
+                    </svg>
                 </button>
             </div>
 
@@ -117,6 +125,20 @@
 
             const player = window.streamPlayer();
             player.initPlayer(streamUrl, streamFormat, 'popout-player');
+
+            // Show PiP button if supported
+            if (document.pictureInPictureEnabled) {
+                const pipBtn = document.getElementById('popout-pip-btn');
+                if (pipBtn) pipBtn.style.display = '';
+            }
+
+            window.togglePopoutPiP = function() {
+                if (document.pictureInPictureElement === videoElement) {
+                    document.exitPictureInPicture().catch(() => {});
+                } else if (document.pictureInPictureEnabled) {
+                    videoElement.requestPictureInPicture().catch(() => {});
+                }
+            };
 
             window.addEventListener('beforeunload', () => {
                 if (typeof player.cleanup === 'function') {


### PR DESCRIPTION
## Summary
- Adds PiP toggle button to floating player header (between pop-out and minimize) and pop-out player overlay controls
- Uses the standard browser PiP API, button only shown when browser supports it
- Floating player collapses to a compact "Playing in Picture-in-Picture" bar while PiP is active, restores when PiP exits
- Closing a floating player that's in PiP mode exits PiP first

## Test plan
- [x] Click PiP button on floating player — video enters PiP, player collapses to bar
- [x] Close PiP window — floating player restores to full size
- [x] Click PiP button again while in PiP — exits PiP
- [x] Close floating player while in PiP — PiP exits cleanly
- [x] Click PiP button on pop-out player — video enters PiP
- [x] Button hidden in browsers without PiP support (e.g. Firefox)