### PR TITLE
fix: Use nullish coalescing for numeric ID fields in floating player

### DIFF
--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -86,7 +86,7 @@ function multiStreamManager() {
 
             const player = {
                 id: playerId,
-                channelId: channelData.id || null,
+                channelId: channelData.id ?? null,
                 channelType: channelData.type || 'channel', // default to 'channel' if type not provided
                 title: channelData.title || channelData.name || 'Unknown Channel',
                 display_title: channelData.display_title || channelData.title || channelData.name || 'Unknown Channel',
@@ -94,10 +94,10 @@ function multiStreamManager() {
                 url: channelData.url || '',
                 format: channelData.format || 'ts',
                 content_type: channelData.content_type || '',
-                stream_id: channelData.stream_id || null,
-                playlist_id: channelData.playlist_id || null,
-                series_id: channelData.series_id || null,
-                season_number: channelData.season_number || null,
+                stream_id: channelData.stream_id ?? null,
+                playlist_id: channelData.playlist_id ?? null,
+                series_id: channelData.series_id ?? null,
+                season_number: channelData.season_number ?? null,
                 zIndex: ++this.zIndexCounter,
                 position: this.getRandomPosition(),
                 size: { width: 480, height: 270 }, // 16:9 aspect ratio


### PR DESCRIPTION
## Summary
- Changes `||` to `??` for five numeric ID fields (`channelId`, `stream_id`, `playlist_id`, `series_id`, `season_number`) in the multi-stream manager
- Prevents a value of `0` being coerced to `null`, which could break watch progress tracking and proxy stream stop notifications
- String fields (title, url, format, etc.) are left with `||` since empty strings should still trigger their fallbacks

## Test plan
- [x] Open a floating player from a channel table — opens and plays normally
- [x] Open a floating player from VOD/series — watch progress resume prompt works
- [x] Close a floating player — proxy stream stop notification fires correctly