### PR TITLE
fix: Stream viewer correctness (fragmentErrorCount + error handling)

### DIFF
--- a/resources/js/vendor/stream-viewer.js
+++ b/resources/js/vendor/stream-viewer.js
@@ -17,6 +17,7 @@ function streamPlayer() {
         },
         availableAudioTracks: [],
         selectedAudioTrack: null,
+        fragmentErrorCount: 0,
 
         // ── Watch Progress ────────────────────────────────────────────────
         progressConfig: null,   // { contentType, streamId, playlistId, seriesId, seasonNumber }
@@ -347,7 +348,6 @@ function streamPlayer() {
                         // For segment loading errors, let's show the specific error
                         if (data.details && data.details.includes('FRAG_LOAD_ERROR')) {
                             // If we've had multiple fragment errors, fall back
-                            if (!this.fragmentErrorCount) this.fragmentErrorCount = 0;
                             this.fragmentErrorCount++;
 
                             if (this.fragmentErrorCount >= 3) {

--- a/resources/js/vendor/stream-viewer.js
+++ b/resources/js/vendor/stream-viewer.js
@@ -562,15 +562,12 @@ function streamPlayer() {
             });
 
             video.addEventListener('error', (e) => {
-                if (video.error.code === video.error.MEDIA_ELEMENT_ERROR) {
-                    return; // Ignore MEDIA_ELEMENT_ERROR which can happen on cleanup
+                if (!video.error || video.error.code === video.error.MEDIA_ERR_ABORTED) {
+                    return; // Ignore abort errors which can happen during cleanup
                 }
                 let errorMessage = 'Playback failed';
                 if (video.error) {
                     switch (video.error.code) {
-                        case video.error.MEDIA_ERR_ABORTED:
-                            errorMessage = 'Playback aborted';
-                            break;
                         case video.error.MEDIA_ERR_NETWORK:
                             errorMessage = 'Network error';
                             break;


### PR DESCRIPTION
## Summary
- Declares `fragmentErrorCount` in the `streamPlayer()` object literal so it's properly initialized instead of relying on dynamic property creation
- Removes the redundant `if (!this.fragmentErrorCount) this.fragmentErrorCount = 0` guard since the property is now always initialized
- Replaces the dead `MEDIA_ELEMENT_ERROR` check (not a real MediaError property) with a proper `MEDIA_ERR_ABORTED` guard that correctly suppresses errors fired during player cleanup
- Adds a null check on `video.error` to handle race conditions during cleanup

## Test plan
- [x] Open a stream, close the player — closes cleanly with no error overlay flash
- [x] Open a stream with a bad URL — error overlay shows with the correct message
- [x] Open an HLS stream, let it fail 3+ fragment loads — falls back to native player correctly