### PR TITLE
fix: Add rate limiting to watch progress endpoints

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -35,8 +35,10 @@ Route::get('/auth/oidc/redirect', [OidcController::class, 'redirect'])->name('au
 Route::get('/auth/oidc/callback', [OidcController::class, 'callback'])->name('auth.oidc.callback');
 
 // In-app watch progress tracking (admin panel + guest panel)
-Route::get('/api/watch-progress', [WatchProgressController::class, 'fetch'])->name('watch-progress.fetch');
-Route::post('/api/watch-progress', [WatchProgressController::class, 'update'])->name('watch-progress.update');
+Route::middleware(['throttle:60,1'])->group(function () {
+    Route::get('/api/watch-progress', [WatchProgressController::class, 'fetch'])->name('watch-progress.fetch');
+    Route::post('/api/watch-progress', [WatchProgressController::class, 'update'])->name('watch-progress.update');
+});
 
 // External IP refresh route for admin panel
 Route::post('/admin/refresh-external-ip', function (ExternalIpService $ipService) {

--- a/tests/Feature/WatchProgressRateLimitingTest.php
+++ b/tests/Feature/WatchProgressRateLimitingTest.php
@@ -1,0 +1,15 @@
+<?php
+
+it('applies throttle middleware to the watch progress fetch route', function () {
+    $route = app('router')->getRoutes()->getByName('watch-progress.fetch');
+
+    expect($route)->not->toBeNull();
+    expect($route->middleware())->toContain('throttle:60,1');
+});
+
+it('applies throttle middleware to the watch progress update route', function () {
+    $route = app('router')->getRoutes()->getByName('watch-progress.update');
+
+    expect($route)->not->toBeNull();
+    expect($route->middleware())->toContain('throttle:60,1');
+});


### PR DESCRIPTION
## Summary
- Wraps the watch progress GET/POST routes in `throttle:60,1` middleware
- Matches the same rate limiting already applied to the EPG API routes
- Controller already handles auth internally, so this just adds the missing abuse protection

## Test plan
- [x] Play a VOD/episode — watch progress saves and resumes correctly
- [x] Play a live channel — tune-in is recorded
- [x] Automated tests verify middleware is applied to both routes