### PR TITLE
fix: Add touch support for floating player drag and resize

### DIFF
--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -72,6 +72,10 @@ function multiStreamManager() {
             document.addEventListener('mousemove', (e) => this.handleMouseMove(e), { signal });
             document.addEventListener('mouseup', () => this.handleMouseUp(), { signal });
 
+            // Global touch events for drag and resize (mobile/tablet support)
+            document.addEventListener('touchmove', (e) => this.handleTouchMove(e), { signal, passive: false });
+            document.addEventListener('touchend', () => this.handleMouseUp(), { signal });
+
             // Mark as initialized
             this._initialized = true;
         },
@@ -337,6 +341,50 @@ function multiStreamManager() {
                 player.position.x = Math.max(0, Math.min(vw - player.size.width, player.position.x));
                 player.position.y = Math.max(0, Math.min(vh - 50, player.position.y));
             });
+        },
+
+        startDragTouch(playerId, event) {
+            event.preventDefault();
+            this.bringToFront(playerId);
+
+            const player = this.players.find(p => p.id === playerId);
+            if (!player) return;
+
+            const touch = event.touches[0];
+            this.dragState = {
+                isDragging: true,
+                playerId: playerId,
+                startX: touch.clientX,
+                startY: touch.clientY,
+                startLeft: player.position.x,
+                startTop: player.position.y
+            };
+        },
+
+        startResizeTouch(playerId, event) {
+            event.preventDefault();
+            event.stopPropagation();
+            this.bringToFront(playerId);
+
+            const player = this.players.find(p => p.id === playerId);
+            if (!player) return;
+
+            const touch = event.touches[0];
+            this.resizeState = {
+                isResizing: true,
+                playerId: playerId,
+                startX: touch.clientX,
+                startY: touch.clientY,
+                startWidth: player.size.width,
+                startHeight: player.size.height
+            };
+        },
+
+        handleTouchMove(event) {
+            if (!this.dragState.isDragging && !this.resizeState.isResizing) return;
+            event.preventDefault();
+            const touch = event.touches[0];
+            this.handleMouseMove(touch);
         },
 
         handleMouseMove(event) {

--- a/resources/views/components/floating-stream-players.blade.php
+++ b/resources/views/components/floating-stream-players.blade.php
@@ -48,6 +48,7 @@
             <div 
                 class="flex items-center justify-between p-2 bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600 cursor-move select-none hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
                 @mousedown="startDrag(player.id, $event)"
+                @touchstart="startDragTouch(player.id, $event)"
             >
                 <div class="flex items-center space-x-2 flex-1 min-w-0">
                     <img 
@@ -256,6 +257,7 @@
                 <div 
                     class="absolute bottom-0 right-0 w-4 h-4 cursor-se-resize opacity-50 hover:opacity-100 transition-opacity group"
                     @mousedown.stop="startResize(player.id, $event)"
+                    @touchstart.stop="startResizeTouch(player.id, $event)"
                     title="Resize"
                 >
                     <!-- Visual resize indicator with lines -->

--- a/resources/views/components/floating-stream-players.blade.php
+++ b/resources/views/components/floating-stream-players.blade.php
@@ -61,7 +61,7 @@
                     <span class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate" x-text="player.display_title || player.title"></span>
                 </div>
                 
-                <div class="flex items-center space-x-1 flex-shrink-0">
+                <div class="flex items-center space-x-1 flex-shrink-0" @mousedown.stop @touchstart.stop>
                     <!-- Open in New Tab Button -->
                     <button
                         @click.stop="openInNewTab(player, '{{ route('player.popout') }}')"


### PR DESCRIPTION
## Summary
- Adds touch event handling for drag and resize on floating players (mobile/tablet support)
- Registers `touchmove`/`touchend` listeners alongside existing mouse listeners using the same AbortController
- Adds `@touchstart` bindings to the title bar drag handle and resize handle
- Prevents title bar buttons (pop-out, minimize, close) from triggering drag via `@mousedown.stop @touchstart.stop` on the button wrapper

## Test plan
- [x] On touch device or devtools emulation: drag floating player by title bar — moves smoothly
- [x] On touch device: resize floating player via bottom-right handle — resizes maintaining 16:9
- [x] On desktop: drag with mouse still works as before
- [x] On desktop: resize with mouse still works as before
- [x] Title bar buttons (pop-out, minimize, close) do not trigger drag on click or tap