### PR TITLE
fix: Constrain floating players to viewport bounds

### DIFF
--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -66,6 +66,9 @@ function multiStreamManager() {
                 }
             }, { signal });
 
+            // Reposition players when viewport shrinks
+            window.addEventListener('resize', () => this.constrainAllToViewport(), { signal });
+
             // Global mouse events for drag and resize
             document.addEventListener('mousemove', (e) => this.handleMouseMove(e), { signal });
             document.addEventListener('mouseup', () => this.handleMouseUp(), { signal });
@@ -294,6 +297,25 @@ function multiStreamManager() {
             };
         },
 
+        constrainAllToViewport() {
+            const vw = window.innerWidth;
+            const vh = window.innerHeight;
+
+            this.players.forEach(player => {
+                // Shrink player if it's wider/taller than viewport
+                const maxWidth = Math.max(320, vw - 20);
+                const aspectRatio = 16 / 9;
+                if (player.size.width > maxWidth) {
+                    player.size.width = maxWidth;
+                    player.size.height = maxWidth / aspectRatio;
+                }
+
+                // Clamp position so at least the title bar stays visible
+                player.position.x = Math.max(0, Math.min(vw - player.size.width, player.position.x));
+                player.position.y = Math.max(0, Math.min(vh - 50, player.position.y));
+            });
+        },
+
         handleMouseMove(event) {
             if (this.dragState.isDragging) {
                 const player = this.players.find(p => p.id === this.dragState.playerId);
@@ -318,17 +340,20 @@ function multiStreamManager() {
                     const deltaX = event.clientX - this.resizeState.startX;
                     const deltaY = event.clientY - this.resizeState.startY;
 
-                    const newWidth = Math.max(320, this.resizeState.startWidth + deltaX);
-                    const newHeight = Math.max(180, this.resizeState.startHeight + deltaY);
+                    const maxWidth = window.innerWidth - player.position.x;
+                    const maxHeight = window.innerHeight - player.position.y - 40; // 40 for title bar
+
+                    const newWidth = Math.min(Math.max(320, this.resizeState.startWidth + deltaX), maxWidth);
+                    const newHeight = Math.min(Math.max(180, this.resizeState.startHeight + deltaY), maxHeight);
 
                     // Maintain 16:9 aspect ratio
                     const aspectRatio = 16 / 9;
                     if (Math.abs(deltaX) > Math.abs(deltaY)) {
                         player.size.width = newWidth;
-                        player.size.height = newWidth / aspectRatio;
+                        player.size.height = Math.min(newWidth / aspectRatio, maxHeight);
                     } else {
                         player.size.height = newHeight;
-                        player.size.width = newHeight * aspectRatio;
+                        player.size.width = Math.min(newHeight * aspectRatio, maxWidth);
                     }
                 }
             }

--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -112,8 +112,8 @@ function multiStreamManager() {
         },
 
         getRandomPosition() {
-            const maxX = window.innerWidth - 500; // Account for player width
-            const maxY = window.innerHeight - 300; // Account for player height
+            const maxX = document.documentElement.clientWidth - 500; // Account for player width
+            const maxY = document.documentElement.clientHeight - 300; // Account for player height
             const padding = 50;
 
             return {
@@ -298,8 +298,8 @@ function multiStreamManager() {
         },
 
         constrainAllToViewport() {
-            const vw = window.innerWidth;
-            const vh = window.innerHeight;
+            const vw = document.documentElement.clientWidth;
+            const vh = document.documentElement.clientHeight;
 
             this.players.forEach(player => {
                 // Shrink player if it's wider/taller than viewport
@@ -324,11 +324,11 @@ function multiStreamManager() {
                     const deltaY = event.clientY - this.dragState.startY;
 
                     player.position.x = Math.max(0, Math.min(
-                        window.innerWidth - player.size.width,
+                        document.documentElement.clientWidth - player.size.width,
                         this.dragState.startLeft + deltaX
                     ));
                     player.position.y = Math.max(0, Math.min(
-                        window.innerHeight - 50, // Keep title bar visible
+                        document.documentElement.clientHeight - 50, // Keep title bar visible
                         this.dragState.startTop + deltaY
                     ));
                 }
@@ -340,8 +340,8 @@ function multiStreamManager() {
                     const deltaX = event.clientX - this.resizeState.startX;
                     const deltaY = event.clientY - this.resizeState.startY;
 
-                    const maxWidth = window.innerWidth - player.position.x;
-                    const maxHeight = window.innerHeight - player.position.y - 40; // 40 for title bar
+                    const maxWidth = document.documentElement.clientWidth - player.position.x;
+                    const maxHeight = document.documentElement.clientHeight - player.position.y - 40; // 40 for title bar
 
                     const newWidth = Math.min(Math.max(320, this.resizeState.startWidth + deltaX), maxWidth);
                     const newHeight = Math.min(Math.max(180, this.resizeState.startHeight + deltaY), maxHeight);


### PR DESCRIPTION
## Summary
- Adds a `window.resize` listener that clamps all floating players back into the viewport when the browser window shrinks
- Caps resize so players can't be dragged or resized beyond the viewport edge
- Uses `document.documentElement.clientWidth/clientHeight` instead of `window.innerWidth/innerHeight` to exclude the scrollbar from bounds calculations

## Test plan
- [x] Open a floating player, drag to right edge — stops before the scrollbar
- [x] Open a floating player, resize towards bottom-right — caps at viewport edge
- [x] Open a floating player, shrink the browser window — player slides back into view
- [x] Open multiple floating players, shrink window dramatically — all clamp back in
- [x] Drag and resize within normal bounds — feels the same as before
- [x] Open a new floating player — initial position lands in a sensible spot