### PR TITLE
feat: Plugin update checker with GitHub release notifications

### DIFF
--- a/app/Console/Commands/CheckPluginUpdates.php
+++ b/app/Console/Commands/CheckPluginUpdates.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Plugin;
+use App\Plugins\PluginUpdateChecker;
+use Illuminate\Console\Command;
+
+class CheckPluginUpdates extends Command
+{
+    protected $signature = 'plugins:check-updates
+        {--plugin= : Check a specific plugin ID only}
+        {--force : Ignore the update check cooldown}';
+
+    protected $description = 'Check GitHub repositories for new plugin releases.';
+
+    public function handle(PluginUpdateChecker $checker): int
+    {
+        if (! config('plugins.update_check.enabled', true)) {
+            $this->info('Plugin update checking is disabled.');
+
+            return self::SUCCESS;
+        }
+
+        $pluginId = $this->option('plugin');
+
+        if ($pluginId) {
+            $plugin = Plugin::query()->where('plugin_id', $pluginId)->first();
+            if (! $plugin) {
+                $this->error("Plugin [{$pluginId}] not found.");
+
+                return self::FAILURE;
+            }
+
+            if (! $plugin->repository) {
+                $this->warn("Plugin [{$pluginId}] has no repository configured.");
+
+                return self::SUCCESS;
+            }
+
+            $result = $checker->check($plugin);
+            $this->displayResults([$result]);
+
+            return self::SUCCESS;
+        }
+
+        $results = $checker->checkAll();
+
+        if (empty($results)) {
+            $this->info('No plugins with configured repositories found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->displayResults(array_values($results));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<int, array{plugin_id: string, current: ?string, latest: ?string, update_available: bool, error: ?string}>  $results
+     */
+    private function displayResults(array $results): void
+    {
+        $rows = [];
+        $updatesAvailable = 0;
+
+        foreach ($results as $result) {
+            $status = match (true) {
+                $result['error'] !== null => '<fg=red>Error</>',
+                $result['update_available'] => '<fg=green>Update available</>',
+                default => 'Up to date',
+            };
+
+            if ($result['update_available']) {
+                $updatesAvailable++;
+            }
+
+            $rows[] = [
+                $result['plugin_id'],
+                $result['current'] ?? '-',
+                $result['latest'] ?? '-',
+                strip_tags($status),
+                $result['error'] ?? '',
+            ];
+        }
+
+        $this->table(
+            ['Plugin', 'Current', 'Latest', 'Status', 'Error'],
+            $rows,
+        );
+
+        if ($updatesAvailable > 0) {
+            $this->info("{$updatesAvailable} plugin(s) have updates available.");
+        } else {
+            $this->info('All plugins are up to date.');
+        }
+    }
+}

--- a/app/Filament/Pages/PluginsDashboard.php
+++ b/app/Filament/Pages/PluginsDashboard.php
@@ -9,7 +9,9 @@ use App\Models\Plugin;
 use App\Models\PluginInstallReview;
 use App\Models\PluginRun;
 use App\Plugins\PluginManager;
+use App\Plugins\PluginUpdateChecker;
 use Filament\Actions\Action;
+use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -74,6 +76,31 @@ class PluginsDashboard extends Page
 
         return [
             PluginInstallActions::discover(),
+            Action::make('check_all_updates')
+                ->label(__('Check for Updates'))
+                ->icon('heroicon-o-arrow-path')
+                ->color('info')
+                ->requiresConfirmation()
+                ->modalHeading(__('Check Plugin Updates'))
+                ->modalDescription(__('This will query GitHub for the latest release of every plugin that has a repository configured. Continue?'))
+                ->action(function (): void {
+                    $checker = app(PluginUpdateChecker::class);
+                    $results = $checker->checkAll();
+
+                    $updatesFound = collect($results)->filter(fn (array $r): bool => $r['update_available'] ?? false)->count();
+                    $errors = collect($results)->filter(fn (array $r): bool => isset($r['error']))->count();
+
+                    $message = trans_choice(':count update available.|:count updates available.', $updatesFound, ['count' => $updatesFound]);
+                    if ($errors > 0) {
+                        $message .= ' '.trans_choice(':count plugin had errors.', $errors, ['count' => $errors]);
+                    }
+
+                    Notification::make()
+                        ->title(__('Plugin Update Check Complete'))
+                        ->body($message)
+                        ->success()
+                        ->send();
+                }),
             ...PluginInstallActions::staging(),
         ];
     }
@@ -91,6 +118,12 @@ class PluginsDashboard extends Page
             'canManagePlugins' => $this->canManagePlugins(),
             'extensionsUrl' => PluginResource::getUrl(),
             'pluginInstallsUrl' => $this->canManagePlugins() ? PluginInstallReviewResource::getUrl() : null,
+            'updatesAvailableCount' => Plugin::query()
+                ->where('installation_status', 'installed')
+                ->whereNotNull('latest_version')
+                ->get()
+                ->filter(fn (Plugin $p): bool => $p->hasUpdateAvailable())
+                ->count(),
         ];
     }
 
@@ -139,6 +172,18 @@ class PluginsDashboard extends Page
                 'description' => __('Plugins that are blocked, modified, invalid, or not fully installed.'),
                 'icon' => 'heroicon-s-exclamation-triangle',
                 'color' => 'red',
+            ],
+            [
+                'label' => __('Updates Available'),
+                'value' => Plugin::query()
+                    ->where('installation_status', 'installed')
+                    ->whereNotNull('latest_version')
+                    ->get()
+                    ->filter(fn (Plugin $p): bool => $p->hasUpdateAvailable())
+                    ->count(),
+                'description' => __('Installed plugins with a newer version available on GitHub.'),
+                'icon' => 'heroicon-s-arrow-up-circle',
+                'color' => 'info',
             ],
         ];
     }

--- a/app/Filament/Resources/Plugins/Pages/EditPlugin.php
+++ b/app/Filament/Resources/Plugins/Pages/EditPlugin.php
@@ -2,14 +2,17 @@
 
 namespace App\Filament\Resources\Plugins\Pages;
 
+use App\Filament\Resources\PluginInstallReviews\PluginInstallReviewResource;
 use App\Filament\Resources\Plugins\PluginResource;
 use App\Jobs\ExecutePluginInvocation;
 use App\Models\Plugin;
 use App\Plugins\PluginManager;
 use App\Plugins\PluginSchemaMapper;
+use App\Plugins\PluginUpdateChecker;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
@@ -199,6 +202,96 @@ class EditPlugin extends EditRecord
 
             // Lifecycle management group
             ActionGroup::make([
+                Action::make('check_for_updates')
+                    ->label(__('Check for Updates'))
+                    ->icon('heroicon-o-arrow-path')
+                    ->color('info')
+                    ->visible(fn () => $canManagePlugins && filled($this->record->repository))
+                    ->action(function () use ($record): void {
+                        $result = app(PluginUpdateChecker::class)->check($record);
+
+                        if ($result['error']) {
+                            Notification::make()
+                                ->warning()
+                                ->title(__('Update check failed'))
+                                ->body($result['error'])
+                                ->send();
+                        } elseif ($result['update_available']) {
+                            Notification::make()
+                                ->info()
+                                ->title(__('Update available'))
+                                ->body(__('Version :version is available (current: :current).', [
+                                    'version' => $result['latest'],
+                                    'current' => $result['current'],
+                                ]))
+                                ->send();
+                        } else {
+                            Notification::make()
+                                ->success()
+                                ->title(__('Up to date'))
+                                ->body(__('This plugin is already on the latest version.'))
+                                ->send();
+                        }
+
+                        $this->refreshFormData(['latest_version', 'last_update_check_at']);
+                    }),
+                Action::make('stage_update')
+                    ->label(fn () => __('Update to :version', ['version' => $this->record->latest_version]))
+                    ->icon('heroicon-o-arrow-up-circle')
+                    ->color('success')
+                    ->visible(fn () => $canManagePlugins && $this->record->hasUpdateAvailable() && filled($this->record->latest_release_url))
+                    ->requiresConfirmation()
+                    ->modalHeading(__('Stage plugin update'))
+                    ->modalDescription(fn () => filled($this->record->latest_release_sha256)
+                        ? __('This will download the latest release and stage it for review. The checksum will be verified automatically.')
+                        : __('No checksum was found for this release. Please provide the SHA-256 hash to verify the download.'))
+                    ->schema(fn () => filled($this->record->latest_release_sha256)
+                        ? []
+                        : [
+                            TextInput::make('sha256')
+                                ->label(__('SHA-256 Checksum'))
+                                ->placeholder('e.g. a1b2c3d4...')
+                                ->required()
+                                ->length(64)
+                                ->helperText(__('Copy the file hash from the GitHub release page.')),
+                        ])
+                    ->action(function (array $data) use ($record): void {
+                        try {
+                            $sha256 = $data['sha256'] ?? $record->latest_release_sha256;
+                            if (! $sha256) {
+                                Notification::make()
+                                    ->danger()
+                                    ->title(__('Missing checksum'))
+                                    ->body(__('A SHA-256 checksum is required to stage this update.'))
+                                    ->send();
+
+                                return;
+                            }
+
+                            $review = app(PluginManager::class)->stageGithubReleaseReview(
+                                $record->latest_release_url,
+                                $sha256,
+                                auth()->id(),
+                            );
+
+                            Notification::make()
+                                ->success()
+                                ->title(__('Update staged for review'))
+                                ->body(__('Review #:id is ready - check Plugin Installs to scan and approve it.', ['id' => $review->id]))
+                                ->actions([
+                                    \Filament\Notifications\Actions\Action::make('view_review')
+                                        ->label(__('View Review'))
+                                        ->url(PluginInstallReviewResource::getUrl('edit', ['record' => $review->id])),
+                                ])
+                                ->send();
+                        } catch (\RuntimeException $exception) {
+                            Notification::make()
+                                ->danger()
+                                ->title(__('Update staging failed'))
+                                ->body($exception->getMessage())
+                                ->send();
+                        }
+                    }),
                 Action::make('stage_review')
                     ->label(__('Submit for Review'))
                     ->icon('heroicon-o-archive-box')

--- a/app/Filament/Resources/Plugins/PluginResource.php
+++ b/app/Filament/Resources/Plugins/PluginResource.php
@@ -201,7 +201,10 @@ class PluginResource extends Resource implements CopilotResource
                     ->searchable()
                     ->sortable(),
                 TextColumn::make('version')
-                    ->sortable(),
+                    ->sortable()
+                    ->description(fn (Plugin $record) => $record->hasUpdateAvailable() ? "Update: {$record->latest_version}" : null)
+                    ->color(fn (Plugin $record) => $record->hasUpdateAvailable() ? 'warning' : null)
+                    ->icon(fn (Plugin $record) => $record->hasUpdateAvailable() ? 'heroicon-m-arrow-up-circle' : null),
                 TextColumn::make('validation_status')
                     ->badge()
                     ->color(fn (string $state) => match ($state) {

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -24,8 +24,11 @@ class Plugin extends Model
         'data_ownership' => 'array',
         'trusted_hashes' => 'array',
         'validation_errors' => 'array',
+        'latest_release_metadata' => 'array',
+        'update_check_enabled' => 'boolean',
         'available' => 'boolean',
         'enabled' => 'boolean',
+        'last_update_check_at' => 'datetime',
         'trusted_at' => 'datetime',
         'blocked_at' => 'datetime',
         'integrity_verified_at' => 'datetime',
@@ -107,5 +110,23 @@ class Plugin extends Model
         return $this->runs()
             ->where('status', 'running')
             ->exists();
+    }
+
+    public function hasUpdateAvailable(): bool
+    {
+        if (! $this->version || ! $this->latest_version) {
+            return false;
+        }
+
+        return version_compare(
+            ltrim($this->version, 'v'),
+            ltrim($this->latest_version, 'v'),
+            '<',
+        );
+    }
+
+    public function isFromGithub(): bool
+    {
+        return $this->source_type === 'github_release' || filled($this->repository);
     }
 }

--- a/app/Plugins/PluginManager.php
+++ b/app/Plugins/PluginManager.php
@@ -67,6 +67,7 @@ class PluginManager
                 'schema_definition' => $manifest?->schema ?? Arr::get($result->manifestData, 'schema', []),
                 'settings_schema' => $manifest?->settings ?? Arr::get($result->manifestData, 'settings', []),
                 'data_ownership' => $manifest?->dataOwnership ?? Arr::get($result->manifestData, 'data_ownership', []),
+                'repository' => $manifest?->repository ?? $record->repository,
                 'path' => $pluginPath,
                 'source_type' => $this->determineSourceType($pluginPath, $record),
                 'available' => true,
@@ -132,6 +133,7 @@ class PluginManager
             'schema_definition' => $result->manifest?->schema ?? $plugin->schema_definition,
             'settings_schema' => $result->manifest?->settings ?? $plugin->settings_schema,
             'data_ownership' => $result->manifest?->dataOwnership ?? $plugin->data_ownership,
+            'repository' => $result->manifest?->repository ?? $plugin->repository,
             'validation_status' => $result->valid ? 'valid' : 'invalid',
             'validation_errors' => $result->errors,
             'manifest_hash' => $result->hashes['manifest_hash'] ?? null,
@@ -518,6 +520,7 @@ class PluginManager
             'source_type' => $review->source_type,
             'installation_status' => 'installed',
             'available' => true,
+            'repository' => $plugin->repository ?? $this->repositoryFromReview($review),
         ]);
         $plugin = $this->validate($plugin->fresh());
 
@@ -607,6 +610,44 @@ class PluginManager
         ]);
 
         return $plugin->fresh();
+    }
+
+    /**
+     * Stage a plugin update from its stored latest release metadata.
+     */
+    public function stageUpdateFromLatestRelease(Plugin $plugin, ?int $userId = null): PluginInstallReview
+    {
+        if (! $plugin->hasUpdateAvailable()) {
+            throw new RuntimeException("Plugin [{$plugin->plugin_id}] does not have an update available.");
+        }
+
+        if (! $plugin->latest_release_url) {
+            throw new RuntimeException("Plugin [{$plugin->plugin_id}] has no release download URL stored.");
+        }
+
+        $sha256 = $plugin->latest_release_sha256;
+        if (! $sha256) {
+            throw new RuntimeException("Plugin [{$plugin->plugin_id}] has no verified SHA-256 checksum for the latest release. Stage the update manually and provide the checksum.");
+        }
+
+        return $this->stageGithubReleaseReview($plugin->latest_release_url, $sha256, $userId);
+    }
+
+    /**
+     * Derive a repository shorthand from a GitHub release install review.
+     */
+    private function repositoryFromReview(PluginInstallReview $review): ?string
+    {
+        if ($review->source_type !== 'github_release') {
+            return null;
+        }
+
+        $metadata = $review->source_metadata;
+        if (! is_array($metadata) || ! isset($metadata['owner'], $metadata['repo'])) {
+            return null;
+        }
+
+        return $metadata['owner'].'/'.$metadata['repo'];
     }
 
     public function executeAction(

--- a/app/Plugins/PluginUpdateChecker.php
+++ b/app/Plugins/PluginUpdateChecker.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace App\Plugins;
+
+use App\Models\Plugin;
+use Exception;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class PluginUpdateChecker
+{
+    /**
+     * Check all eligible plugins for available updates.
+     *
+     * @return array<string, array{plugin_id: string, current: ?string, latest: ?string, update_available: bool, error: ?string}>
+     */
+    public function checkAll(): array
+    {
+        if (! config('plugins.update_check.enabled', true)) {
+            return [];
+        }
+
+        $plugins = Plugin::query()
+            ->whereNotNull('repository')
+            ->where('repository', '!=', '')
+            ->where('update_check_enabled', true)
+            ->where('installation_status', 'installed')
+            ->get();
+
+        $results = [];
+        foreach ($plugins as $plugin) {
+            $results[$plugin->plugin_id] = $this->check($plugin);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Check a single plugin for available updates via the GitHub Releases API.
+     *
+     * @return array{plugin_id: string, current: ?string, latest: ?string, update_available: bool, error: ?string}
+     */
+    public function check(Plugin $plugin): array
+    {
+        $result = [
+            'plugin_id' => $plugin->plugin_id,
+            'current' => $plugin->version,
+            'latest' => null,
+            'update_available' => false,
+            'error' => null,
+        ];
+
+        if (! $plugin->repository) {
+            $result['error'] = 'No repository configured.';
+
+            return $result;
+        }
+
+        try {
+            $release = $this->fetchLatestRelease($plugin->repository);
+
+            if (! $release) {
+                $result['error'] = 'No releases found.';
+                $plugin->update(['last_update_check_at' => now()]);
+
+                return $result;
+            }
+
+            $latestVersion = $this->normalizeVersion($release['tag_name'] ?? '');
+            $result['latest'] = $latestVersion;
+
+            $asset = $this->findPluginAsset($release['assets'] ?? []);
+            $assetUrl = $asset['browser_download_url'] ?? null;
+
+            $sha256 = $this->resolveSha256($release, $asset);
+
+            $plugin->update([
+                'latest_version' => $latestVersion,
+                'latest_release_url' => $assetUrl,
+                'latest_release_sha256' => $sha256,
+                'latest_release_metadata' => [
+                    'tag' => $release['tag_name'] ?? null,
+                    'name' => $release['name'] ?? null,
+                    'published_at' => $release['published_at'] ?? null,
+                    'html_url' => $release['html_url'] ?? null,
+                    'asset_name' => $asset['name'] ?? null,
+                ],
+                'last_update_check_at' => now(),
+            ]);
+
+            $result['update_available'] = $plugin->version
+                && $latestVersion
+                && version_compare(
+                    ltrim($plugin->version, 'v'),
+                    ltrim($latestVersion, 'v'),
+                    '<',
+                );
+
+        } catch (Exception $exception) {
+            $result['error'] = $exception->getMessage();
+            Log::warning("Plugin update check failed for [{$plugin->plugin_id}]: {$exception->getMessage()}");
+
+            $plugin->update(['last_update_check_at' => now()]);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Fetch the latest release from the GitHub Releases API.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function fetchLatestRelease(string $repository): ?array
+    {
+        $request = Http::timeout(15)
+            ->withHeaders([
+                'Accept' => 'application/vnd.github.v3+json',
+                'User-Agent' => 'm3u-editor-plugin-updater',
+            ]);
+
+        $token = config('plugins.update_check.github_token');
+        if ($token) {
+            $request = $request->withToken($token);
+        }
+
+        $response = $request->get("https://api.github.com/repos/{$repository}/releases/latest");
+
+        if ($response->status() === 404) {
+            return null;
+        }
+
+        if (! $response->successful()) {
+            throw new Exception("GitHub API returned status {$response->status()} for [{$repository}].");
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Find the best plugin archive asset from a release's assets list.
+     *
+     * Prefers .zip, then .tar.gz / .tgz.
+     *
+     * @param  array<int, array<string, mixed>>  $assets
+     * @return array<string, mixed>|null
+     */
+    private function findPluginAsset(array $assets): ?array
+    {
+        $zipAsset = null;
+        $tarAsset = null;
+
+        foreach ($assets as $asset) {
+            $name = Str::lower($asset['name'] ?? '');
+
+            if (Str::endsWith($name, '.sha256') || Str::endsWith($name, '.asc') || Str::endsWith($name, '.sig')) {
+                continue;
+            }
+
+            if (Str::endsWith($name, '.zip')) {
+                $zipAsset ??= $asset;
+            } elseif (Str::endsWith($name, '.tar.gz') || Str::endsWith($name, '.tgz')) {
+                $tarAsset ??= $asset;
+            }
+        }
+
+        return $zipAsset ?? $tarAsset;
+    }
+
+    /**
+     * Resolve the SHA-256 checksum for a release asset.
+     *
+     * Strategy:
+     * 1. Look for a companion .sha256 asset file
+     * 2. Parse the release body for a SHA-256 hash
+     * 3. Return null if neither found
+     */
+    private function resolveSha256(array $release, ?array $asset): ?string
+    {
+        if (! $asset) {
+            return null;
+        }
+
+        // Strategy 1: companion .sha256 asset file
+        $companionName = ($asset['name'] ?? '').'.sha256';
+        foreach ($release['assets'] ?? [] as $releaseAsset) {
+            if (Str::lower($releaseAsset['name'] ?? '') === Str::lower($companionName)) {
+                return $this->downloadCompanionSha256($releaseAsset['browser_download_url']);
+            }
+        }
+
+        // Strategy 2: parse the release body
+        $body = $release['body'] ?? '';
+        if ($body) {
+            return $this->parseSha256FromBody($body, $asset['name'] ?? '');
+        }
+
+        return null;
+    }
+
+    /**
+     * Download and parse a companion .sha256 file.
+     */
+    private function downloadCompanionSha256(string $url): ?string
+    {
+        try {
+            $request = Http::timeout(10)
+                ->withHeaders(['User-Agent' => 'm3u-editor-plugin-updater']);
+
+            $token = config('plugins.update_check.github_token');
+            if ($token) {
+                $request = $request->withToken($token);
+            }
+
+            $response = $request->get($url);
+
+            if ($response->successful()) {
+                $content = trim($response->body());
+
+                // Handle "hash  filename" format
+                if (preg_match('/^([a-fA-F0-9]{64})\b/', $content, $matches)) {
+                    return strtolower($matches[1]);
+                }
+            }
+        } catch (Exception $exception) {
+            Log::debug("Failed to download companion SHA-256 file: {$exception->getMessage()}");
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse a SHA-256 hash from the release body text.
+     *
+     * Supports common formats:
+     * - "SHA-256: abc123..."
+     * - "sha256: abc123..."
+     * - "SHA256(`filename`) = abc123..."
+     * - "`abc123...`"
+     * - Markdown table with hash
+     */
+    private function parseSha256FromBody(string $body, string $assetName): ?string
+    {
+        // Look for a hash near the asset name first
+        $escapedName = preg_quote($assetName, '/');
+        if (preg_match("/(?:{$escapedName})[^a-fA-F0-9]*([a-fA-F0-9]{64})/i", $body, $matches)) {
+            return strtolower($matches[1]);
+        }
+
+        // Generic SHA-256 label patterns
+        if (preg_match('/SHA-?256\s*[:=`(]\s*`?([a-fA-F0-9]{64})`?/i', $body, $matches)) {
+            return strtolower($matches[1]);
+        }
+
+        // Standalone 64-char hex surrounded by backticks
+        if (preg_match('/`([a-fA-F0-9]{64})`/', $body, $matches)) {
+            return strtolower($matches[1]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Normalize a version tag by stripping a leading "v" prefix.
+     */
+    private function normalizeVersion(string $version): string
+    {
+        return ltrim(trim($version), 'v');
+    }
+}

--- a/app/Plugins/PluginValidator.php
+++ b/app/Plugins/PluginValidator.php
@@ -44,6 +44,12 @@ class PluginValidator
             $errors[] = 'Plugin api_version does not match host plugin API version.';
         }
 
+        if (isset($manifestData['repository']) && $manifestData['repository'] !== '') {
+            if (! preg_match('#^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$#', (string) $manifest->repository)) {
+                $errors[] = 'Manifest field [repository] must be in \"owner/repo\" format (GitHub URL is normalized during parsing).';
+            }
+        }
+
         $knownCapabilities = array_keys(config('plugins.capabilities', []));
         foreach ($manifest->capabilities as $capability) {
             if (! in_array($capability, $knownCapabilities, true)) {

--- a/app/Plugins/Support/PluginManifest.php
+++ b/app/Plugins/Support/PluginManifest.php
@@ -23,6 +23,7 @@ class PluginManifest
         public readonly array $settings,
         public readonly array $actions,
         public readonly array $dataOwnership,
+        public readonly ?string $repository,
         public readonly string $path,
         public readonly array $raw,
     ) {}
@@ -54,6 +55,7 @@ class PluginManifest
                 $pluginId,
                 $schema,
             ),
+            repository: self::normalizeRepository($manifest['repository'] ?? null),
             path: $path,
             raw: $manifest,
         );
@@ -144,6 +146,32 @@ class PluginManifest
         return array_values(array_unique(array_map(function (string $path): string {
             return trim(str_replace('\\', '/', $path), '/');
         }, self::normalizeStringList($value, $field))));
+    }
+
+    /**
+     * Normalize a repository value to "owner/repo" shorthand.
+     */
+    public static function normalizeRepository(mixed $repository): ?string
+    {
+        if ($repository === null || $repository === '') {
+            return null;
+        }
+
+        if (! is_string($repository)) {
+            throw new RuntimeException('Manifest field [repository] must be a string.');
+        }
+
+        $repository = trim($repository);
+
+        if (preg_match('#^https?://github\.com/([^/]+/[^/]+?)(?:\.git)?/?$#i', $repository, $matches)) {
+            return $matches[1];
+        }
+
+        if (preg_match('#^[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+$#', $repository)) {
+            return $repository;
+        }
+
+        throw new RuntimeException('Manifest field [repository] must be "owner/repo" or a GitHub URL (e.g. https://github.com/owner/repo).');
     }
 
     private static function defaultDataOwnership(string $pluginId, array $schema): array

--- a/config/plugins.php
+++ b/config/plugins.php
@@ -93,6 +93,12 @@ return [
         'allowed_hosts' => ['github.com'],
     ],
 
+    'update_check' => [
+        'enabled' => (bool) env('PLUGIN_UPDATE_CHECK_ENABLED', true),
+        'frequency_minutes' => (int) env('PLUGIN_UPDATE_CHECK_FREQUENCY', 240),
+        'github_token' => env('PLUGIN_GITHUB_TOKEN'),
+    ],
+
     'archive_limits' => [
         'max_archive_bytes' => (int) env('PLUGIN_MAX_ARCHIVE_BYTES', 50 * 1024 * 1024),
         'max_file_count' => (int) env('PLUGIN_MAX_ARCHIVE_FILES', 500),

--- a/database/migrations/2026_04_08_095437_add_update_check_columns_to_extension_plugins_table.php
+++ b/database/migrations/2026_04_08_095437_add_update_check_columns_to_extension_plugins_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('extension_plugins', function (Blueprint $table) {
+            $table->string('repository')->nullable()->after('source_type');
+            $table->string('latest_version')->nullable()->after('version');
+            $table->text('latest_release_url')->nullable()->after('latest_version');
+            $table->string('latest_release_sha256', 64)->nullable()->after('latest_release_url');
+            $table->json('latest_release_metadata')->nullable()->after('latest_release_sha256');
+            $table->boolean('update_check_enabled')->default(true)->after('latest_release_metadata');
+            $table->timestamp('last_update_check_at')->nullable()->after('update_check_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('extension_plugins', function (Blueprint $table) {
+            $table->dropColumn([
+                'repository',
+                'latest_version',
+                'latest_release_url',
+                'latest_release_sha256',
+                'latest_release_metadata',
+                'update_check_enabled',
+                'last_update_check_at',
+            ]);
+        });
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -82,4 +82,12 @@ Schedule::command('plugins:recover-stale-runs --minutes=15')
     ->everyMinute()
     ->withoutOverlapping();
 
+// Check for plugin updates from GitHub repositories
+if (config('plugins.update_check.enabled', true)) {
+    $updateFrequencyHours = max(1, intdiv((int) config('plugins.update_check.frequency_minutes', 240), 60));
+    Schedule::command('plugins:check-updates')
+        ->cron("0 */{$updateFrequencyHours} * * *")
+        ->withoutOverlapping();
+}
+
 // Note: HLS broadcast files are managed by m3u-proxy service

--- a/tests/Feature/PluginUpdateCheckerTest.php
+++ b/tests/Feature/PluginUpdateCheckerTest.php
@@ -1,0 +1,427 @@
+<?php
+
+use App\Models\Plugin;
+use App\Plugins\PluginUpdateChecker;
+use App\Plugins\Support\PluginManifest;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    config()->set('plugins.update_check.enabled', true);
+    config()->set('plugins.update_check.github_token', null);
+});
+
+/**
+ * Create a minimal plugin row with a repository for update check tests.
+ *
+ * @param  array<string, mixed>  $overrides
+ */
+function createPluginForUpdateTests(string $name, array $overrides = []): Plugin
+{
+    $pluginId = Str::slug($name).'-'.Str::lower(Str::random(4));
+
+    return Plugin::query()->create(array_merge([
+        'plugin_id' => $pluginId,
+        'name' => $name,
+        'version' => '1.0.0',
+        'api_version' => '1.0.0',
+        'description' => 'Update checker test fixture.',
+        'entrypoint' => 'Plugin.php',
+        'class_name' => 'AppLocalPlugins\\'.Str::studly($pluginId).'\\Plugin',
+        'capabilities' => [],
+        'hooks' => [],
+        'permissions' => [],
+        'schema_definition' => ['tables' => []],
+        'actions' => [],
+        'settings_schema' => [],
+        'settings' => [],
+        'data_ownership' => ['tables' => [], 'directories' => [], 'files' => []],
+        'source_type' => 'local_directory',
+        'path' => storage_path('app/testing-plugin-sources/'.$pluginId),
+        'available' => true,
+        'enabled' => false,
+        'installation_status' => 'installed',
+        'trust_state' => 'pending_review',
+        'validation_status' => 'valid',
+        'integrity_status' => 'unknown',
+        'repository' => 'test-owner/test-plugin',
+        'update_check_enabled' => true,
+    ], $overrides));
+}
+
+/**
+ * Build a fake GitHub release response payload.
+ *
+ * @param  array<int, array<string, mixed>>  $assets
+ * @return array<string, mixed>
+ */
+function fakeGitHubRelease(string $tagName = 'v2.0.0', array $assets = [], string $body = ''): array
+{
+    return [
+        'tag_name' => $tagName,
+        'name' => "Release {$tagName}",
+        'published_at' => '2026-04-01T12:00:00Z',
+        'html_url' => "https://github.com/test-owner/test-plugin/releases/tag/{$tagName}",
+        'body' => $body,
+        'assets' => $assets,
+    ];
+}
+
+it('detects an update when the latest version is newer', function () {
+    $plugin = createPluginForUpdateTests('Update Available', [
+        'version' => '1.0.0',
+        'repository' => 'test-owner/test-plugin',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/test-plugin/releases/latest' => Http::response(
+            fakeGitHubRelease('v2.0.0'),
+            200,
+        ),
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $result = $checker->check($plugin);
+
+    expect($result['update_available'])->toBeTrue();
+    expect($result['latest'])->toBe('2.0.0');
+    expect($result['error'])->toBeNull();
+
+    $plugin->refresh();
+    expect($plugin->latest_version)->toBe('2.0.0');
+    expect($plugin->last_update_check_at)->not->toBeNull();
+});
+
+it('reports no update when the current version matches the latest', function () {
+    $plugin = createPluginForUpdateTests('Already Current', [
+        'version' => '2.0.0',
+        'repository' => 'test-owner/current-plugin',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/current-plugin/releases/latest' => Http::response(
+            fakeGitHubRelease('v2.0.0'),
+            200,
+        ),
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $result = $checker->check($plugin);
+
+    expect($result['update_available'])->toBeFalse();
+    expect($result['latest'])->toBe('2.0.0');
+    expect($result['error'])->toBeNull();
+});
+
+it('handles plugins without a repository gracefully', function () {
+    $plugin = createPluginForUpdateTests('No Repo', [
+        'repository' => null,
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $result = $checker->check($plugin);
+
+    expect($result['update_available'])->toBeFalse();
+    expect($result['error'])->toBe('No repository configured.');
+});
+
+it('handles a 404 response (no releases) gracefully', function () {
+    $plugin = createPluginForUpdateTests('No Releases', [
+        'repository' => 'test-owner/no-releases',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/no-releases/releases/latest' => Http::response(
+            ['message' => 'Not Found'],
+            404,
+        ),
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $result = $checker->check($plugin);
+
+    expect($result['update_available'])->toBeFalse();
+    expect($result['error'])->toBe('No releases found.');
+});
+
+it('captures errors from failed API requests', function () {
+    $plugin = createPluginForUpdateTests('API Error', [
+        'repository' => 'test-owner/api-error',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/api-error/releases/latest' => Http::response(
+            ['message' => 'rate limit exceeded'],
+            403,
+        ),
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $result = $checker->check($plugin);
+
+    expect($result['update_available'])->toBeFalse();
+    expect($result['error'])->toContain('403');
+});
+
+it('prefers zip assets over tar.gz', function () {
+    $plugin = createPluginForUpdateTests('Zip Preferred', [
+        'version' => '1.0.0',
+        'repository' => 'test-owner/zip-test',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/zip-test/releases/latest' => Http::response(
+            fakeGitHubRelease('v2.0.0', [
+                ['name' => 'plugin.tar.gz', 'browser_download_url' => 'https://example.com/plugin.tar.gz'],
+                ['name' => 'plugin.zip', 'browser_download_url' => 'https://example.com/plugin.zip'],
+            ]),
+            200,
+        ),
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $checker->check($plugin);
+
+    $plugin->refresh();
+    expect($plugin->latest_release_url)->toBe('https://example.com/plugin.zip');
+});
+
+it('skips signature and checksum assets when selecting download', function () {
+    $plugin = createPluginForUpdateTests('Skip Sigs', [
+        'version' => '1.0.0',
+        'repository' => 'test-owner/sig-test',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/sig-test/releases/latest' => Http::response(
+            fakeGitHubRelease('v2.0.0', [
+                ['name' => 'plugin.zip.sha256', 'browser_download_url' => 'https://example.com/plugin.zip.sha256'],
+                ['name' => 'plugin.zip.asc', 'browser_download_url' => 'https://example.com/plugin.zip.asc'],
+                ['name' => 'plugin.zip', 'browser_download_url' => 'https://example.com/plugin.zip'],
+            ]),
+            200,
+        ),
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $checker->check($plugin);
+
+    $plugin->refresh();
+    expect($plugin->latest_release_url)->toBe('https://example.com/plugin.zip');
+});
+
+it('resolves sha256 from companion file', function () {
+    $expectedHash = str_repeat('ab', 32);
+
+    $plugin = createPluginForUpdateTests('SHA Companion', [
+        'version' => '1.0.0',
+        'repository' => 'test-owner/sha-companion',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/sha-companion/releases/latest' => Http::response(
+            fakeGitHubRelease('v2.0.0', [
+                ['name' => 'plugin.zip', 'browser_download_url' => 'https://example.com/plugin.zip'],
+                ['name' => 'plugin.zip.sha256', 'browser_download_url' => 'https://example.com/plugin.zip.sha256'],
+            ]),
+            200,
+        ),
+        'example.com/plugin.zip.sha256' => Http::response("{$expectedHash}  plugin.zip\n", 200),
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $checker->check($plugin);
+
+    $plugin->refresh();
+    expect($plugin->latest_release_sha256)->toBe($expectedHash);
+});
+
+it('resolves sha256 from release body', function () {
+    $expectedHash = str_repeat('cd', 32);
+
+    $plugin = createPluginForUpdateTests('SHA Body', [
+        'version' => '1.0.0',
+        'repository' => 'test-owner/sha-body',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/sha-body/releases/latest' => Http::response(
+            fakeGitHubRelease('v2.0.0', [
+                ['name' => 'plugin.zip', 'browser_download_url' => 'https://example.com/plugin.zip'],
+            ], "## Checksums\n\nSHA-256: {$expectedHash}"),
+            200,
+        ),
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $checker->check($plugin);
+
+    $plugin->refresh();
+    expect($plugin->latest_release_sha256)->toBe($expectedHash);
+});
+
+it('stores release metadata', function () {
+    $plugin = createPluginForUpdateTests('Metadata', [
+        'version' => '1.0.0',
+        'repository' => 'test-owner/metadata-test',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/metadata-test/releases/latest' => Http::response(
+            fakeGitHubRelease('v2.0.0', [
+                ['name' => 'plugin.zip', 'browser_download_url' => 'https://example.com/plugin.zip'],
+            ]),
+            200,
+        ),
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $checker->check($plugin);
+
+    $plugin->refresh();
+    expect($plugin->latest_release_metadata)->toBeArray();
+    expect($plugin->latest_release_metadata['tag'])->toBe('v2.0.0');
+    expect($plugin->latest_release_metadata['html_url'])->toContain('test-owner/test-plugin');
+});
+
+it('checkAll skips plugins without repository or with update checks disabled', function () {
+    createPluginForUpdateTests('Has Repo', [
+        'repository' => 'test-owner/has-repo',
+        'update_check_enabled' => true,
+    ]);
+
+    createPluginForUpdateTests('No Repo', [
+        'repository' => null,
+        'update_check_enabled' => true,
+    ]);
+
+    createPluginForUpdateTests('Disabled Check', [
+        'repository' => 'test-owner/disabled',
+        'update_check_enabled' => false,
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/has-repo/releases/latest' => Http::response(
+            fakeGitHubRelease('v2.0.0'),
+            200,
+        ),
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $results = $checker->checkAll();
+
+    // Only the plugin with repo + enabled should be checked
+    expect($results)->toHaveCount(1);
+    expect(array_values($results)[0]['latest'])->toBe('2.0.0');
+});
+
+it('checkAll returns empty when update checking is disabled globally', function () {
+    config()->set('plugins.update_check.enabled', false);
+
+    createPluginForUpdateTests('Should Skip', [
+        'repository' => 'test-owner/skip',
+    ]);
+
+    $checker = app(PluginUpdateChecker::class);
+    $results = $checker->checkAll();
+
+    expect($results)->toBeEmpty();
+});
+
+it('hasUpdateAvailable returns true when latest is newer', function () {
+    $plugin = createPluginForUpdateTests('Model Check', [
+        'version' => '1.0.0',
+        'latest_version' => '2.0.0',
+    ]);
+
+    expect($plugin->hasUpdateAvailable())->toBeTrue();
+});
+
+it('hasUpdateAvailable returns false when versions match', function () {
+    $plugin = createPluginForUpdateTests('Same Version', [
+        'version' => '2.0.0',
+        'latest_version' => '2.0.0',
+    ]);
+
+    expect($plugin->hasUpdateAvailable())->toBeFalse();
+});
+
+it('hasUpdateAvailable handles v-prefixed versions', function () {
+    $plugin = createPluginForUpdateTests('V Prefix', [
+        'version' => 'v1.0.0',
+        'latest_version' => 'v2.0.0',
+    ]);
+
+    expect($plugin->hasUpdateAvailable())->toBeTrue();
+});
+
+it('hasUpdateAvailable returns false when latest_version is null', function () {
+    $plugin = createPluginForUpdateTests('No Latest', [
+        'version' => '1.0.0',
+        'latest_version' => null,
+    ]);
+
+    expect($plugin->hasUpdateAvailable())->toBeFalse();
+});
+
+// -- Artisan command tests --
+
+it('runs the plugins:check-updates command successfully', function () {
+    createPluginForUpdateTests('Command Test', [
+        'repository' => 'test-owner/command-test',
+        'version' => '1.0.0',
+    ]);
+
+    Http::fake([
+        'api.github.com/repos/test-owner/command-test/releases/latest' => Http::response(
+            fakeGitHubRelease('v2.0.0'),
+            200,
+        ),
+    ]);
+
+    $this->artisan('plugins:check-updates')
+        ->assertSuccessful();
+});
+
+it('the command reports when update checking is disabled', function () {
+    config()->set('plugins.update_check.enabled', false);
+
+    $this->artisan('plugins:check-updates')
+        ->expectsOutputToContain('disabled')
+        ->assertSuccessful();
+});
+
+it('the command handles a missing plugin gracefully', function () {
+    $this->artisan('plugins:check-updates', ['--plugin' => 'nonexistent-plugin-xyz'])
+        ->assertFailed();
+});
+
+// -- Manifest repository validation tests --
+
+it('normalizes github URLs to owner/repo format', function () {
+    $manifest = PluginManifest::fromArray([
+        'id' => 'test-normalize',
+        'name' => 'Test Normalize',
+        'version' => '1.0.0',
+        'description' => 'Test',
+        'entrypoint' => 'Plugin.php',
+        'api_version' => '1.0.0',
+        'repository' => 'https://github.com/owner/repo',
+    ], '/tmp/test-normalize');
+
+    expect($manifest->repository)->toBe('owner/repo');
+});
+
+it('keeps owner/repo format unchanged in manifest', function () {
+    $manifest = PluginManifest::fromArray([
+        'id' => 'test-passthrough',
+        'name' => 'Test Passthrough',
+        'version' => '1.0.0',
+        'description' => 'Test',
+        'entrypoint' => 'Plugin.php',
+        'api_version' => '1.0.0',
+        'repository' => 'owner/repo',
+    ], '/tmp/test-passthrough');
+
+    expect($manifest->repository)->toBe('owner/repo');
+});


### PR DESCRIPTION
- Add PluginUpdateChecker service that queries GitHub Releases API
- Add plugins:check-updates artisan command with --plugin and --force options
- Add scheduled update check (configurable frequency via PLUGIN_UPDATE_CHECK_FREQUENCY)
- Add migration with update-check columns on extension_plugins table
- Add repository field to PluginManifest with URL normalization
- Add repository format validation in PluginValidator
- Add hasUpdateAvailable() and isFromGithub() to Plugin model
- Add stageUpdateFromLatestRelease() to PluginManager
- Add update badge on plugin version column in PluginResource table
- Add check_for_updates and stage_update actions on EditPlugin page
- Add Check for Updates header action and Updates Available card on PluginsDashboard
- Add SHA-256 resolution from companion files and release body parsing
- Add config/plugins.php update_check section (enabled, frequency, github_token)
- Add 21 tests covering API calls, version comparison, SHA-256, command, manifest