### PR TITLE
fix(deps): add picomatch override to mitigate ReDoS (CVE-2026-33671)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "m3u-editor",
+    "name": "m3u-dev",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
         "hls.js": "^1.6.7",
         "mpegts.js": "^1.8.0",
         "video.js": "^8.23.3"
+    },
+    "overrides": {
+        "picomatch": ">=2.3.2"
     }
 }


### PR DESCRIPTION
Add npm overrides to enforce picomatch >=2.3.2, preventing resolution of vulnerable versions (<2.3.2, 3.0.0-3.0.1, 4.0.0-4.0.3).

See: https://github.com/advisories/GHSA-c2c7-rcm5-vvqj