### PR TITLE
feat: Pop-in from pop-out player back to floating player

### DIFF
--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -68,14 +68,27 @@ function multiStreamManager() {
             // Reposition players when viewport shrinks
             window.addEventListener('resize', () => this.constrainAllToViewport(), { signal });
 
-            // Listen for pop-in requests from pop-out windows
+            // Listen for pop-in requests from pop-out windows (two-phase handshake)
             this._popinChannel = new BroadcastChannel('m3u-editor-popin');
+            this._popinTabId = Date.now() + '-' + Math.random().toString(36).substr(2, 9);
+            this._popinPending = null;
             this._popinChannel.onmessage = (event) => {
                 if (event.data?.type === 'popin-ping') {
                     this._popinChannel.postMessage({ type: 'popin-pong' });
                 } else if (event.data?.type === 'popin-request') {
-                    this.openStream(event.data.channel);
-                    this._popinChannel.postMessage({ type: 'popin-ack' });
+                    // Phase 1: store data and offer to handle it
+                    this._popinPending = event.data.channel;
+                    this._popinChannel.postMessage({ type: 'popin-offer', tabId: this._popinTabId });
+                } else if (event.data?.type === 'popin-accept' && event.data.tabId === this._popinTabId) {
+                    // Phase 2: we were chosen — open the stream
+                    if (this._popinPending) {
+                        this.openStream(this._popinPending);
+                        this._popinPending = null;
+                        this._popinChannel.postMessage({ type: 'popin-ack' });
+                    }
+                } else if (event.data?.type === 'popin-accept' && event.data.tabId !== this._popinTabId) {
+                    // A different tab was chosen — discard
+                    this._popinPending = null;
                 }
             };
 

--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -68,10 +68,9 @@ function multiStreamManager() {
             // Reposition players when viewport shrinks
             window.addEventListener('resize', () => this.constrainAllToViewport(), { signal });
 
-            // Listen for pop-in requests from pop-out windows (two-phase handshake)
+            // Listen for pop-in requests from pop-out windows
             this._popinChannel = new BroadcastChannel('m3u-editor-popin');
             this._popinTabId = Date.now() + '-' + Math.random().toString(36).substr(2, 9);
-            this._popinPending = null;
             this._popinChannel.onmessage = (event) => {
                 const targetTab = event.data?.targetTab;
                 const isForMe = !targetTab || targetTab === this._popinTabId;

--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -73,22 +73,14 @@ function multiStreamManager() {
             this._popinTabId = Date.now() + '-' + Math.random().toString(36).substr(2, 9);
             this._popinPending = null;
             this._popinChannel.onmessage = (event) => {
-                if (event.data?.type === 'popin-ping') {
+                const targetTab = event.data?.targetTab;
+                const isForMe = !targetTab || targetTab === this._popinTabId;
+
+                if (event.data?.type === 'popin-ping' && isForMe) {
                     this._popinChannel.postMessage({ type: 'popin-pong' });
-                } else if (event.data?.type === 'popin-request') {
-                    // Phase 1: store data and offer to handle it
-                    this._popinPending = event.data.channel;
-                    this._popinChannel.postMessage({ type: 'popin-offer', tabId: this._popinTabId });
-                } else if (event.data?.type === 'popin-accept' && event.data.tabId === this._popinTabId) {
-                    // Phase 2: we were chosen — open the stream
-                    if (this._popinPending) {
-                        this.openStream(this._popinPending);
-                        this._popinPending = null;
-                        this._popinChannel.postMessage({ type: 'popin-ack' });
-                    }
-                } else if (event.data?.type === 'popin-accept' && event.data.tabId !== this._popinTabId) {
-                    // A different tab was chosen — discard
-                    this._popinPending = null;
+                } else if (event.data?.type === 'popin-request' && isForMe) {
+                    this.openStream(event.data.channel);
+                    this._popinChannel.postMessage({ type: 'popin-ack' });
                 }
             };
 
@@ -310,6 +302,7 @@ function multiStreamManager() {
                 playlist_id: player.playlist_id ?? '',
                 series_id: player.series_id ?? '',
                 season_number: player.season_number ?? '',
+                source_tab: this._popinTabId ?? '',
             });
 
             window.open(popoutRoute + '?' + params.toString(), '_blank', 'noopener');

--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -71,7 +71,9 @@ function multiStreamManager() {
             // Listen for pop-in requests from pop-out windows
             this._popinChannel = new BroadcastChannel('m3u-editor-popin');
             this._popinChannel.onmessage = (event) => {
-                if (event.data?.type === 'popin-request') {
+                if (event.data?.type === 'popin-ping') {
+                    this._popinChannel.postMessage({ type: 'popin-pong' });
+                } else if (event.data?.type === 'popin-request') {
                     this.openStream(event.data.channel);
                     this._popinChannel.postMessage({ type: 'popin-ack' });
                 }

--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -68,6 +68,15 @@ function multiStreamManager() {
             // Reposition players when viewport shrinks
             window.addEventListener('resize', () => this.constrainAllToViewport(), { signal });
 
+            // Listen for pop-in requests from pop-out windows
+            this._popinChannel = new BroadcastChannel('m3u-editor-popin');
+            this._popinChannel.onmessage = (event) => {
+                if (event.data?.type === 'popin-request') {
+                    this.openStream(event.data.channel);
+                    this._popinChannel.postMessage({ type: 'popin-ack' });
+                }
+            };
+
             // Global mouse events for drag and resize
             document.addEventListener('mousemove', (e) => this.handleMouseMove(e), { signal });
             document.addEventListener('mouseup', () => this.handleMouseUp(), { signal });
@@ -100,6 +109,7 @@ function multiStreamManager() {
                 playlist_id: channelData.playlist_id ?? null,
                 series_id: channelData.series_id ?? null,
                 season_number: channelData.season_number ?? null,
+                resume_time: channelData.resume_time ?? null,
                 zIndex: ++this.zIndexCounter,
                 position: this.getRandomPosition(),
                 size: { width: 480, height: 270 }, // 16:9 aspect ratio
@@ -183,6 +193,10 @@ function multiStreamManager() {
                 }
             });
             this.players = [];
+
+            // Close the pop-in broadcast channel
+            this._popinChannel?.close();
+            this._popinChannel = null;
 
             // Remove all event listeners registered by this instance
             this._abortController?.abort();

--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -166,7 +166,7 @@ function multiStreamManager() {
                     document.exitPictureInPicture().catch(() => {});
                 }
 
-                // Notify server to stop the proxy stream (skip for transfers to pop-out)
+                // Notify server to stop the proxy stream (skip for transfers to pop-out/pop-in)
                 if (notifyServer) {
                     this.notifyServerStreamStop(player);
                 }

--- a/resources/views/components/floating-stream-players.blade.php
+++ b/resources/views/components/floating-stream-players.blade.php
@@ -140,6 +140,9 @@
                         if (window.streamPlayer && $el.dataset.streamUrl && $el.dataset.streamUrl !== '') {
                             playerInstance = window.streamPlayer();
                             playerInstance.initPlayer($el.dataset.streamUrl, $el.dataset.streamFormat, $el.id);
+                            if (player.resume_time > 0) {
+                                $el.addEventListener('loadedmetadata', () => { $el.currentTime = player.resume_time; }, { once: true });
+                            }
                         }
                     "
                 >

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -223,25 +223,30 @@
 
                 popinChannel.postMessage({ type: 'popin-request', channel: data });
 
-                // Wait for acknowledgement then close
+                // Two-phase: wait for an offer, accept the first, then wait for ack
                 popinBtn.disabled = true;
                 popinBtn.textContent = 'Connecting...';
-                let acked = false;
+                let accepted = false;
+                let done = false;
 
-                const ackHandler = (event) => {
-                    if (event.data?.type === 'popin-ack') {
-                        acked = true;
-                        popinChannel.removeEventListener('message', ackHandler);
+                const handler = (event) => {
+                    if (event.data?.type === 'popin-offer' && !accepted) {
+                        // Accept the first tab that offers
+                        accepted = true;
+                        popinChannel.postMessage({ type: 'popin-accept', tabId: event.data.tabId });
+                    } else if (event.data?.type === 'popin-ack') {
+                        done = true;
+                        popinChannel.removeEventListener('message', handler);
                         popinChannel.close();
                         window.close();
                     }
                 };
-                popinChannel.addEventListener('message', ackHandler);
+                popinChannel.addEventListener('message', handler);
 
-                // Timeout fallback — shouldn't happen since heartbeat confirmed tab is alive
+                // Timeout fallback
                 setTimeout(() => {
-                    if (!acked) {
-                        popinChannel.removeEventListener('message', ackHandler);
+                    if (!done) {
+                        popinChannel.removeEventListener('message', handler);
                         setPopinAvailable(false);
                     }
                 }, 1500);

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -25,11 +25,11 @@
             <button type="button" id="popin-btn" onclick="popInToMainWindow()"
                 class="flex items-center gap-1.5 rounded bg-white/10 px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:bg-white/20 hover:text-white"
                 title="Send back to floating player in main window">
-                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <svg class="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <rect x="2" y="3" width="20" height="14" rx="2" />
                     <path d="M12 10l-4 4m0 0h3m-3 0v-3" />
                 </svg>
-                Pop In
+                <span>Pop In</span>
             </button>
         </header>
 

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -147,8 +147,10 @@
             };
 
             // Heartbeat: detect whether a main app tab is open
+            // Read the source tab ID from the URL (set by openInNewTab)
             const popinBtn = document.getElementById('popin-btn');
             const popinChannel = new BroadcastChannel('m3u-editor-popin');
+            const sourceTabId = new URLSearchParams(window.location.search).get('source_tab') || '';
             let mainTabAlive = false;
 
             function setPopinAvailable(available) {
@@ -166,8 +168,7 @@
             }
 
             function pingMainTab() {
-                popinChannel.postMessage({ type: 'popin-ping' });
-                // If no pong within 500ms, mark unavailable
+                popinChannel.postMessage({ type: 'popin-ping', targetTab: sourceTabId });
                 let gotPong = false;
                 const handler = (event) => {
                     if (event.data?.type === 'popin-pong') {
@@ -183,21 +184,25 @@
             }
 
             // Initial ping and periodic re-check
-            setPopinAvailable(false);
-            pingMainTab();
-            const heartbeatInterval = setInterval(pingMainTab, 3000);
+            if (sourceTabId) {
+                setPopinAvailable(false);
+                pingMainTab();
+            } else {
+                // No source tab (opened directly, not from a floating player) — hide button
+                popinBtn.style.display = 'none';
+            }
+            const heartbeatInterval = sourceTabId ? setInterval(pingMainTab, 3000) : null;
 
             // Clean up on page unload
             window.addEventListener('pagehide', () => {
-                clearInterval(heartbeatInterval);
+                if (heartbeatInterval) clearInterval(heartbeatInterval);
                 popinChannel.close();
             }, { once: true });
 
-            // Pop-in: send stream back to main window's floating player
+            // Pop-in: send stream back to the source tab's floating player
             window.popInToMainWindow = function() {
                 if (!mainTabAlive) return;
 
-                // Build channel data matching the openStream() shape
                 const data = {
                     id: videoElement.dataset.streamId || null,
                     type: (videoElement.dataset.contentType === 'episode') ? 'episode' : 'channel',
@@ -213,39 +218,29 @@
                     season_number: videoElement.dataset.seasonNumber || null,
                 };
 
-                // Include current playback position for VOD/episodes
                 if (videoElement.currentTime > 0 && isFinite(videoElement.duration)) {
                     data.resume_time = videoElement.currentTime;
                 }
 
-                // Stop heartbeat — we're about to close
                 clearInterval(heartbeatInterval);
 
-                popinChannel.postMessage({ type: 'popin-request', channel: data });
+                popinChannel.postMessage({ type: 'popin-request', targetTab: sourceTabId, channel: data });
 
-                // Two-phase: wait for an offer, accept the first, then wait for ack
                 popinBtn.disabled = true;
                 popinBtn.textContent = 'Connecting...';
-                let accepted = false;
                 let done = false;
 
                 const handler = (event) => {
-                    if (event.data?.type === 'popin-offer' && !accepted) {
-                        // Accept the first tab that offers
-                        accepted = true;
-                        popinChannel.postMessage({ type: 'popin-accept', tabId: event.data.tabId });
-                    } else if (event.data?.type === 'popin-ack') {
+                    if (event.data?.type === 'popin-ack') {
                         done = true;
                         popinChannel.removeEventListener('message', handler);
                         popinChannel.close();
-                        // Skip proxy stop — the floating player is picking up the stream
                         window._isPopinTransfer = true;
                         window.close();
                     }
                 };
                 popinChannel.addEventListener('message', handler);
 
-                // Timeout fallback
                 setTimeout(() => {
                     if (!done) {
                         popinChannel.removeEventListener('message', handler);

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -146,8 +146,7 @@
                 }
             };
 
-            // Heartbeat: detect whether a main app tab is open
-            // Read the source tab ID from the URL (set by openInNewTab)
+            // Heartbeat: detect whether the source app tab is still open
             const popinBtn = document.getElementById('popin-btn');
             const popinChannel = new BroadcastChannel('m3u-editor-popin');
             const sourceTabId = new URLSearchParams(window.location.search).get('source_tab') || '';

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -25,10 +25,7 @@
             <button type="button" id="popin-btn" onclick="popInToMainWindow()"
                 class="flex items-center gap-1.5 rounded bg-white/10 px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:bg-white/20 hover:text-white"
                 title="Send back to floating player in main window">
-                <svg class="h-4 w-4 shrink-0" viewBox="0 0 24 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="2" y="2" width="20" height="14" rx="2" />
-                    <path d="M12 9l-4 4m0 0h3m-3 0v-3" />
-                </svg>
+                <x-heroicon-o-arrow-uturn-left class="h-4 w-4 shrink-0" />
                 <span>Pop In</span>
             </button>
         </header>

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -238,6 +238,8 @@
                         done = true;
                         popinChannel.removeEventListener('message', handler);
                         popinChannel.close();
+                        // Skip proxy stop — the floating player is picking up the stream
+                        window._isPopinTransfer = true;
                         window.close();
                     }
                 };
@@ -259,12 +261,14 @@
             });
 
             window.addEventListener('pagehide', () => {
-                // Notify proxy to stop the stream before the page unloads
-                const contentType = videoElement.dataset.contentType || '';
-                const streamId = videoElement.dataset.streamId || '';
-                const type = contentType === 'episode' ? 'episode' : 'channel';
-                if (window.notifyProxyStreamStop) {
-                    window.notifyProxyStreamStop(streamId, type);
+                // Skip proxy stop if this is a pop-in transfer (floating player takes over)
+                if (!window._isPopinTransfer) {
+                    const contentType = videoElement.dataset.contentType || '';
+                    const streamId = videoElement.dataset.streamId || '';
+                    const type = contentType === 'episode' ? 'episode' : 'channel';
+                    if (window.notifyProxyStreamStop) {
+                        window.notifyProxyStreamStop(streamId, type);
+                    }
                 }
                 if (typeof player.cleanup === 'function') {
                     player.cleanup();

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -22,6 +22,15 @@
                     <p class="text-xs text-white/70">{{ strtoupper($streamFormat) }} Stream</p>
                 </div>
             </div>
+            <button type="button" id="popin-btn" onclick="popInToMainWindow()"
+                class="flex items-center gap-1.5 rounded bg-white/10 px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:bg-white/20 hover:text-white"
+                title="Send back to floating player in main window">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="2" y="3" width="20" height="14" rx="2" />
+                    <path d="M12 10l-4 4m0 0h3m-3 0v-3" />
+                </svg>
+                Pop In
+            </button>
         </header>
 
         <section class="relative flex-1 overflow-hidden group">
@@ -138,6 +147,83 @@
                 } else if (document.pictureInPictureEnabled) {
                     videoElement.requestPictureInPicture().catch(() => {});
                 }
+            };
+
+            // Pop-in: send stream back to main window's floating player
+            window.popInToMainWindow = function() {
+                const btn = document.getElementById('popin-btn');
+                const channel = new BroadcastChannel('m3u-editor-popin');
+
+                // Build channel data matching the openStream() shape
+                const data = {
+                    id: videoElement.dataset.streamId || null,
+                    type: (videoElement.dataset.contentType === 'episode') ? 'episode' : 'channel',
+                    title: @json($channelTitle),
+                    display_title: @json($channelTitle),
+                    logo: @json($channelLogo ?? ''),
+                    url: videoElement.dataset.url || '',
+                    format: videoElement.dataset.format || 'ts',
+                    content_type: videoElement.dataset.contentType || '',
+                    stream_id: videoElement.dataset.streamId || null,
+                    playlist_id: videoElement.dataset.playlistId || null,
+                    series_id: videoElement.dataset.seriesId || null,
+                    season_number: videoElement.dataset.seasonNumber || null,
+                };
+
+                // Include current playback position for VOD/episodes
+                if (videoElement.currentTime > 0 && isFinite(videoElement.duration)) {
+                    data.resume_time = videoElement.currentTime;
+                }
+
+                channel.postMessage({ type: 'popin-request', channel: data });
+
+                // Wait for acknowledgement from main tab
+                btn.disabled = true;
+                btn.textContent = 'Connecting...';
+                let acked = false;
+
+                channel.onmessage = (event) => {
+                    if (event.data?.type === 'popin-ack') {
+                        acked = true;
+                        channel.close();
+                        window.close();
+                    }
+                };
+
+                // Timeout: no main tab listening
+                setTimeout(() => {
+                    if (!acked) {
+                        channel.close();
+                        btn.disabled = false;
+                        btn.innerHTML = `
+                            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <rect x="2" y="3" width="20" height="14" rx="2" />
+                                <path d="M12 10l-4 4m0 0h3m-3 0v-3" />
+                            </svg>
+                            Pop In
+                        `;
+
+                        // Show a brief error tooltip
+                        const tip = document.createElement('div');
+                        tip.textContent = 'No open app tab found';
+                        Object.assign(tip.style, {
+                            position: 'fixed',
+                            top: (btn.getBoundingClientRect().bottom + 6) + 'px',
+                            right: '12px',
+                            background: 'rgba(220, 38, 38, 0.9)',
+                            color: '#fff',
+                            padding: '4px 10px',
+                            borderRadius: '4px',
+                            fontSize: '12px',
+                            zIndex: '99999',
+                            pointerEvents: 'none',
+                            transition: 'opacity 0.3s',
+                        });
+                        document.body.appendChild(tip);
+                        setTimeout(() => { tip.style.opacity = '0'; }, 2000);
+                        setTimeout(() => { tip.remove(); }, 2300);
+                    }
+                }, 1500);
             };
 
             window.addEventListener('beforeunload', () => {

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -149,10 +149,56 @@
                 }
             };
 
+            // Heartbeat: detect whether a main app tab is open
+            const popinBtn = document.getElementById('popin-btn');
+            const popinChannel = new BroadcastChannel('m3u-editor-popin');
+            let mainTabAlive = false;
+
+            function setPopinAvailable(available) {
+                mainTabAlive = available;
+                popinBtn.disabled = !available;
+                if (available) {
+                    popinBtn.classList.remove('opacity-40', 'cursor-not-allowed');
+                    popinBtn.classList.add('hover:bg-white/20', 'hover:text-white');
+                    popinBtn.title = 'Send back to floating player in main window';
+                } else {
+                    popinBtn.classList.add('opacity-40', 'cursor-not-allowed');
+                    popinBtn.classList.remove('hover:bg-white/20', 'hover:text-white');
+                    popinBtn.title = 'No open app tab found';
+                }
+            }
+
+            function pingMainTab() {
+                popinChannel.postMessage({ type: 'popin-ping' });
+                // If no pong within 500ms, mark unavailable
+                let gotPong = false;
+                const handler = (event) => {
+                    if (event.data?.type === 'popin-pong') {
+                        gotPong = true;
+                        setPopinAvailable(true);
+                    }
+                };
+                popinChannel.addEventListener('message', handler);
+                setTimeout(() => {
+                    popinChannel.removeEventListener('message', handler);
+                    if (!gotPong) setPopinAvailable(false);
+                }, 500);
+            }
+
+            // Initial ping and periodic re-check
+            setPopinAvailable(false);
+            pingMainTab();
+            const heartbeatInterval = setInterval(pingMainTab, 3000);
+
+            // Clean up on page unload
+            window.addEventListener('pagehide', () => {
+                clearInterval(heartbeatInterval);
+                popinChannel.close();
+            }, { once: true });
+
             // Pop-in: send stream back to main window's floating player
             window.popInToMainWindow = function() {
-                const btn = document.getElementById('popin-btn');
-                const channel = new BroadcastChannel('m3u-editor-popin');
+                if (!mainTabAlive) return;
 
                 // Build channel data matching the openStream() shape
                 const data = {
@@ -175,53 +221,31 @@
                     data.resume_time = videoElement.currentTime;
                 }
 
-                channel.postMessage({ type: 'popin-request', channel: data });
+                // Stop heartbeat — we're about to close
+                clearInterval(heartbeatInterval);
 
-                // Wait for acknowledgement from main tab
-                btn.disabled = true;
-                btn.textContent = 'Connecting...';
+                popinChannel.postMessage({ type: 'popin-request', channel: data });
+
+                // Wait for acknowledgement then close
+                popinBtn.disabled = true;
+                popinBtn.textContent = 'Connecting...';
                 let acked = false;
 
-                channel.onmessage = (event) => {
+                const ackHandler = (event) => {
                     if (event.data?.type === 'popin-ack') {
                         acked = true;
-                        channel.close();
+                        popinChannel.removeEventListener('message', ackHandler);
+                        popinChannel.close();
                         window.close();
                     }
                 };
+                popinChannel.addEventListener('message', ackHandler);
 
-                // Timeout: no main tab listening
+                // Timeout fallback — shouldn't happen since heartbeat confirmed tab is alive
                 setTimeout(() => {
                     if (!acked) {
-                        channel.close();
-                        btn.disabled = false;
-                        btn.innerHTML = `
-                            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <rect x="2" y="3" width="20" height="14" rx="2" />
-                                <path d="M12 10l-4 4m0 0h3m-3 0v-3" />
-                            </svg>
-                            Pop In
-                        `;
-
-                        // Show a brief error tooltip
-                        const tip = document.createElement('div');
-                        tip.textContent = 'No open app tab found';
-                        Object.assign(tip.style, {
-                            position: 'fixed',
-                            top: (btn.getBoundingClientRect().bottom + 6) + 'px',
-                            right: '12px',
-                            background: 'rgba(220, 38, 38, 0.9)',
-                            color: '#fff',
-                            padding: '4px 10px',
-                            borderRadius: '4px',
-                            fontSize: '12px',
-                            zIndex: '99999',
-                            pointerEvents: 'none',
-                            transition: 'opacity 0.3s',
-                        });
-                        document.body.appendChild(tip);
-                        setTimeout(() => { tip.style.opacity = '0'; }, 2000);
-                        setTimeout(() => { tip.remove(); }, 2300);
+                        popinChannel.removeEventListener('message', ackHandler);
+                        setPopinAvailable(false);
                     }
                 }, 1500);
             };

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -25,9 +25,9 @@
             <button type="button" id="popin-btn" onclick="popInToMainWindow()"
                 class="flex items-center gap-1.5 rounded bg-white/10 px-3 py-1.5 text-xs font-medium text-white/80 transition-colors hover:bg-white/20 hover:text-white"
                 title="Send back to floating player in main window">
-                <svg class="h-4 w-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <rect x="2" y="3" width="20" height="14" rx="2" />
-                    <path d="M12 10l-4 4m0 0h3m-3 0v-3" />
+                <svg class="h-4 w-4 shrink-0" viewBox="0 0 24 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="2" y="2" width="20" height="14" rx="2" />
+                    <path d="M12 9l-4 4m0 0h3m-3 0v-3" />
                 </svg>
                 <span>Pop In</span>
             </button>


### PR DESCRIPTION
## Summary
- Adds a "Pop In" button to the pop-out player header that sends the stream back to the source tab as a floating player
- Uses BroadcastChannel with source tab targeting so the stream returns to the exact tab it came from
- Heartbeat ping/pong greys out the button with cursor-not-allowed if the source tab has been closed
- VOD/episodes carry their current playback position so the floating player resumes from the same point
- Skips proxy stop notification on pop-in transfer so the stream stays alive during handoff
- Button is hidden entirely if the pop-out was opened directly (not from a floating player)

## Test plan
- [x] Open floating player, pop out, click "Pop In" — stream returns to the same tab as a floating player
- [x] With multiple m3u-editor tabs open, pop-in only goes to the source tab
- [x] Close the source tab — pop-in button greys out within a few seconds
- [x] VOD: pop-in resumes from the same playback position
- [x] Live: pop-in works without interruption
- [x] Proxy logs show no stream stop/restart during the transfer
- [x] Open a pop-out directly via URL — no pop-in button shown