### PR TITLE
fix: Handle null backdrop paths in Xtream API series/VOD responses

### DIFF
--- a/app/Http/Controllers/LogoProxyController.php
+++ b/app/Http/Controllers/LogoProxyController.php
@@ -70,7 +70,7 @@ class LogoProxyController extends Controller
     /**
      * Generate a proxy URL for a given logo URL
      */
-    public static function generateProxyUrl(string $originalUrl, $internal = false): string
+    public static function generateProxyUrl(?string $originalUrl, $internal = false): string
     {
         // Get the config values (takes priority over settings values)
         $proxyUrlOverride = config('proxy.url_override');

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -927,6 +927,7 @@ class XtreamApiController extends Controller
                     if (is_string($backdropPaths)) {
                         $backdropPaths = json_decode($backdropPaths, true) ?? [];
                     }
+                    $backdropPaths = array_filter($backdropPaths);
                     if ($playlist->enable_logo_proxy) {
                         $cover = LogoProxyController::generateProxyUrl($cover);
                         $backdropPaths = array_map(fn ($path) => LogoProxyController::generateProxyUrl($path), $backdropPaths);
@@ -994,6 +995,7 @@ class XtreamApiController extends Controller
             if (is_string($backdropPaths)) {
                 $backdropPaths = json_decode($backdropPaths, true) ?? [];
             }
+            $backdropPaths = array_filter($backdropPaths);
             if ($playlist->enable_logo_proxy) {
                 $cover = LogoProxyController::generateProxyUrl($cover);
                 $backdropPaths = array_map(fn ($path) => LogoProxyController::generateProxyUrl($path), $backdropPaths);
@@ -1443,6 +1445,7 @@ class XtreamApiController extends Controller
             if (is_string($backdropPaths)) {
                 $backdropPaths = json_decode($backdropPaths, true) ?? [];
             }
+            $backdropPaths = array_filter($backdropPaths);
             if ($playlist->enable_logo_proxy) {
                 $cover = LogoProxyController::generateProxyUrl($cover);
                 $movieImage = LogoProxyController::generateProxyUrl($movieImage);

--- a/tests/Feature/XtreamApiControllerTest.php
+++ b/tests/Feature/XtreamApiControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Enums\ChannelLogoType;
 use App\Jobs\MergeChannels;
 use App\Jobs\UnmergeChannels;
+use App\Models\Category;
 use App\Models\Channel;
 use App\Models\Group;
 use App\Models\Playlist;
@@ -685,5 +686,27 @@ class XtreamApiControllerTest extends TestCase
 
         $response->assertStatus(403)
             ->assertJson(['error' => 'Unauthorized or stream not found']);
+    }
+
+    public function test_get_series_with_logo_proxy_handles_null_backdrop_paths(): void
+    {
+        $this->playlist->update(['enable_logo_proxy' => true]);
+
+        $category = Category::factory()->for($this->user)->create();
+
+        Series::factory()->create([
+            'user_id' => $this->user->id,
+            'playlist_id' => $this->playlist->id,
+            'category_id' => $category->id,
+            'enabled' => true,
+            'backdrop_path' => json_encode([null, 'https://example.com/img.jpg', null]),
+            'cover' => 'https://example.com/cover.jpg',
+            'metadata' => json_encode(['tmdb' => '', 'last_modified' => null]),
+        ]);
+
+        $response = $this->getJson($this->getXtreamApiUrl('get_series'));
+
+        $response->assertOk();
+        $response->assertJsonCount(1);
     }
 }


### PR DESCRIPTION
Fixes #999

## Summary

- Accept nullable `$originalUrl` in `LogoProxyController::generateProxyUrl()` so null values reach the existing empty/invalid URL check (returns placeholder) instead of throwing a TypeError
- Filter null entries from `backdrop_path` arrays with `array_filter()` before processing in `get_series`, `get_series_info`, and `get_vod_info` actions
- Add test covering `get_series` with logo proxy enabled and null backdrop path entries

## Root cause

Series metadata from Xtream providers can contain null elements in the `backdrop_path` JSON array. When logo proxy is enabled, `array_map` passes these nulls to `generateProxyUrl(string $originalUrl)`, which throws a TypeError before the method's own empty-check logic can handle it.