### PR TITLE
fix: Remove APP_URL fallback from HTTPS detection

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -298,13 +298,7 @@ class AppServiceProvider extends ServiceProvider
             return true;
         }
 
-        // Fallback: Check if APP_URL contains https
-        // This ensures backward compatibility when no reverse proxy is used
-        if (Str::contains(config('app.url'), 'https')) {
-            return true;
-        }
-
-        // No HTTPS detected
+        // No HTTPS detected from headers
         return false;
     }
 


### PR DESCRIPTION
The APP_URL-based fallback in detectHttpsFromHeaders() forced HTTPS for all generated URLs whenever APP_URL contained 'https', regardless of the actual request protocol. This broke direct HTTP access (e.g. LAN, Docker) when APP_URL was configured for a reverse proxy with TLS.

HTTPS detection now relies solely on reverse proxy headers (X-Forwarded-Proto, X-Forwarded-Scheme, etc.), which correctly reflects the actual client connection protocol.