### PR TITLE
Fix tv_archive flag on custom channels with non-zero shift

### DIFF
--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -674,7 +674,7 @@ class XtreamApiController extends Controller
                         'added' => (string) $channel->created_at->timestamp,
                         'category_id' => $channelCategoryId,
                         'category_ids' => [(int) $channelCategoryId],
-                        'tv_archive' => (! $disableCatchup && $channel->catchup) ? 1 : 0,
+                        'tv_archive' => (! $disableCatchup && ($channel->catchup || $channel->shift)) ? 1 : 0,
                         'tv_archive_duration' => $disableCatchup ? 0 : ($channel->shift ?? 0),
                         'custom_sid' => $channel->stream_id_custom ?? '',
                         'thumbnail' => $thumbnail,

--- a/tests/Feature/XtreamApiControllerTest.php
+++ b/tests/Feature/XtreamApiControllerTest.php
@@ -709,4 +709,50 @@ class XtreamApiControllerTest extends TestCase
         $response->assertOk();
         $response->assertJsonCount(1);
     }
+
+    public function test_get_live_streams_tv_archive_enabled_when_shift_set()
+    {
+        $group = Group::factory()->for($this->user)->create();
+
+        // Channel with shift > 0 but no catchup value (custom channel scenario)
+        $channelWithShift = Channel::factory()->for($this->playlist)->for($group)->create([
+            'enabled' => true,
+            'title_custom' => 'Channel With Shift',
+            'shift' => 12,
+            'catchup' => null,
+        ]);
+
+        // Channel with catchup set (provider-imported scenario)
+        $channelWithCatchup = Channel::factory()->for($this->playlist)->for($group)->create([
+            'enabled' => true,
+            'title_custom' => 'Channel With Catchup',
+            'shift' => 24,
+            'catchup' => 'default',
+        ]);
+
+        // Channel with no shift and no catchup
+        $channelWithoutArchive = Channel::factory()->for($this->playlist)->for($group)->create([
+            'enabled' => true,
+            'title_custom' => 'Channel Without Archive',
+            'shift' => 0,
+            'catchup' => null,
+        ]);
+
+        $response = $this->getJson($this->getXtreamApiUrl('get_live_streams'));
+        $response->assertStatus(200);
+
+        $jsonResponse = $response->json();
+
+        $shiftData = collect($jsonResponse)->firstWhere('stream_id', $channelWithShift->id);
+        $this->assertEquals(1, $shiftData['tv_archive'], 'tv_archive should be 1 when shift > 0');
+        $this->assertEquals(12, $shiftData['tv_archive_duration']);
+
+        $catchupData = collect($jsonResponse)->firstWhere('stream_id', $channelWithCatchup->id);
+        $this->assertEquals(1, $catchupData['tv_archive'], 'tv_archive should be 1 when catchup is set');
+        $this->assertEquals(24, $catchupData['tv_archive_duration']);
+
+        $noArchiveData = collect($jsonResponse)->firstWhere('stream_id', $channelWithoutArchive->id);
+        $this->assertEquals(0, $noArchiveData['tv_archive'], 'tv_archive should be 0 when no shift and no catchup');
+        $this->assertEquals(0, $noArchiveData['tv_archive_duration']);
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes `tv_archive` always returning `0` for custom channels in the xtream `get_live_streams` response
- The condition now also considers `$channel->shift` so that entering a non-zero Time Shift value correctly sets `tv_archive=1`
- Adds test coverage for shift-only, catchup+shift, and no-archive scenarios

Closes #996

## Test plan

- [ ] Create a custom channel with a non-zero Time Shift value
- [ ] Hit the `get_live_streams` xtream endpoint and verify `tv_archive` is `1`
- [ ] Verify channels with no shift and no catchup still return `tv_archive=0`
- [ ] Verify the `disable_catchup` playlist-level flag still overrides to `0`