### PR TITLE
fix: Handle missing/corrupted EPG source files in download

### DIFF
--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -702,14 +702,20 @@ class EpgGenerateController extends Controller
         // Get the content
         $filePath = null;
         if ($epg->url && str_starts_with($epg->url, 'http')) {
-            $filePath = Storage::disk('local')->path($epg->file_path);
+            $localPath = Storage::disk('local')->path($epg->file_path);
+            if (! file_exists($localPath)) {
+                Log::warning("EPG source file not found on disk for EPG \"{$epg->name}\": {$localPath}");
+
+                return;
+            }
+            $filePath = $localPath;
         } elseif ($epg->uploads && Storage::disk('local')->exists($epg->uploads)) {
             $filePath = Storage::disk('local')->path($epg->uploads);
         } elseif ($epg->url) {
             $filePath = $epg->url;
         }
 
-        if (! $filePath || ! file_exists($filePath)) {
+        if (! $filePath) {
             // Send notification
             $error = 'Invalid EPG file. Unable to read or download an associated EPG file. Please check the URL or uploaded file and try again.';
             Notification::make()

--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -18,6 +18,7 @@ use DOMDocument;
 use Exception;
 use Filament\Notifications\Notification;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use XMLReader;
@@ -379,7 +380,11 @@ class EpgGenerateController extends Controller
                 }
             } catch (Exception $e) {
                 // If cache fails, fallback to original XML reading
-                $this->processEpgWithXmlReader($epg, $channels, $playlist);
+                try {
+                    $this->processEpgWithXmlReader($epg, $channels, $playlist);
+                } catch (Exception $e) {
+                    Log::warning("EPG fallback XMLReader also failed for EPG {$epg->name}: {$e->getMessage()}");
+                }
             }
         }
 
@@ -704,7 +709,7 @@ class EpgGenerateController extends Controller
             $filePath = $epg->url;
         }
 
-        if (! $filePath) {
+        if (! $filePath || ! file_exists($filePath)) {
             // Send notification
             $error = 'Invalid EPG file. Unable to read or download an associated EPG file. Please check the URL or uploaded file and try again.';
             Notification::make()
@@ -723,7 +728,11 @@ class EpgGenerateController extends Controller
 
         // Set up the reader
         $programReader = new XMLReader;
-        $programReader->open('compress.zlib://'.$filePath);
+        if (! @$programReader->open('compress.zlib://'.$filePath)) {
+            Log::warning("Failed to open EPG file for XMLReader: {$filePath}");
+
+            return;
+        }
 
         // Loop through the XML data
         while (@$programReader->read()) {

--- a/tests/Feature/EpgGenerateControllerTest.php
+++ b/tests/Feature/EpgGenerateControllerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Epg;
+use App\Models\EpgChannel;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Clean up any leftover playlist EPG cache files from previous runs
+    Storage::disk('local')->deleteDirectory('playlist-epg-files');
+});
+
+test('epg download does not crash when epg source file is missing', function () {
+    $user = User::factory()->create();
+
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => false,
+    ]);
+
+    // Create an EPG with a URL but no cached data and no file on disk
+    $epg = Epg::factory()->create([
+        'user_id' => $user->id,
+        'url' => 'http://example.com/epg.xml',
+        'is_cached' => false,
+    ]);
+
+    $epgChannel = EpgChannel::factory()->create([
+        'epg_id' => $epg->id,
+        'channel_id' => 'test-channel-1',
+        'user_id' => $user->id,
+    ]);
+
+    Channel::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $user->id,
+        'enabled' => true,
+        'is_vod' => false,
+        'epg_channel_id' => $epgChannel->id,
+        'channel' => 1,
+    ]);
+
+    // The EPG source file does not exist — should return valid XML without crashing
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertStatus(200);
+    $response->assertHeader('Content-Type', 'application/gzip');
+
+    $content = gzdecode($response->getContent());
+    expect($content)->toContain('<?xml version="1.0"');
+    expect($content)->toContain('</tv>');
+});
+
+test('epg download does not crash when epg source file is corrupted', function () {
+    $user = User::factory()->create();
+
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => false,
+    ]);
+
+    $epg = Epg::factory()->create([
+        'user_id' => $user->id,
+        'url' => 'http://example.com/epg.xml',
+        'is_cached' => false,
+    ]);
+
+    // Write a corrupted file at the expected path
+    Storage::disk('local')->put($epg->file_path, 'not-valid-xml-or-gzip-data');
+
+    $epgChannel = EpgChannel::factory()->create([
+        'epg_id' => $epg->id,
+        'channel_id' => 'test-channel-1',
+        'user_id' => $user->id,
+    ]);
+
+    Channel::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $user->id,
+        'enabled' => true,
+        'is_vod' => false,
+        'epg_channel_id' => $epgChannel->id,
+        'channel' => 1,
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertStatus(200);
+    $response->assertHeader('Content-Type', 'application/gzip');
+
+    $content = gzdecode($response->getContent());
+    expect($content)->toContain('<?xml version="1.0"');
+    expect($content)->toContain('</tv>');
+
+    // Cleanup
+    Storage::disk('local')->delete($epg->file_path);
+});


### PR DESCRIPTION
## Summary

- Builds on 54d466e which keeps the EPG cache valid when the source XML is missing — this PR handles the complementary case where the XMLReader fallback **is** reached and the source file is missing or corrupted
- When `is_cached` is `false` (EPG was never successfully cached), the fallback to `processEpgWithXmlReader()` would crash the streaming response if the source file didn't exist on disk, producing a truncated/corrupted XML download
- Now the method checks file existence before opening, handles `XMLReader::open()` failures gracefully, and wraps the catch-block fallback in its own try/catch — skipping the EPG's programmes instead of crashing the entire response

Attempts to fix #1012

## Test plan

- [ ] EPG download with a missing source file returns valid XML (channel tags, no programmes) instead of crashing
- [ ] EPG download with a corrupted source file returns valid XML instead of crashing
- [ ] Normal EPG download (source file exists, cache valid) still works as before
- [ ] Normal EPG download (cache expired, source file exists) regenerates correctly via XMLReader fallback
- [ ] Multiple EPGs on one playlist — if one EPG's source is missing, others still produce programmes