### PR TITLE
feat: Add optional series metadata to M3U output

### DIFF
--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2128,12 +2128,23 @@ class PlaylistResource extends Resource implements CopilotResource
                     Toggle::make('include_series_in_m3u')
                         ->label(__('Include series in M3U output'))
                         ->inline(false)
+                        ->live()
                         ->hintIcon(
                             'heroicon-m-question-mark-circle',
                             tooltip: 'Enable this to output your enabled series in the M3U file. It is recommended to enable the "Fetch metadata" option when enabled, otherwise you will need to manually fetch metadata for each series.'
                         )
                         ->default(false)
                         ->helperText(__('When enabled, series will be included in the M3U output. It is recommended to enable the "Fetch metadata" option when enabled.')),
+                    Toggle::make('include_series_metadata_in_m3u')
+                        ->label(__('Include series metadata in M3U output'))
+                        ->inline(false)
+                        ->hintIcon(
+                            'heroicon-m-question-mark-circle',
+                            tooltip: 'Adds season and episode number attributes to the M3U output for series episodes, helping external tools identify content correctly.'
+                        )
+                        ->default(false)
+                        ->visible(fn (Get $get): bool => (bool) $get('include_series_in_m3u'))
+                        ->helperText(__('When enabled, season and episode numbers will be included as attributes in the M3U output for series episodes.')),
                 ])->hidden(fn (Get $get): bool => ! $get('xtream')),
 
             Section::make(__('VOD Processing'))

--- a/app/Http/Controllers/PlaylistGenerateController.php
+++ b/app/Http/Controllers/PlaylistGenerateController.php
@@ -336,6 +336,16 @@ class PlaylistGenerateController extends Controller
                             if ($episodeTmdbId) {
                                 $extInf .= " tmdb-id=\"{$episodeTmdbId}\"";
                             }
+                            if ($playlist->include_series_metadata_in_m3u) {
+                                $seasonNum = $episode->season;
+                                $episodeNum = $episode->episode_num;
+                                if ($seasonNum !== null) {
+                                    $extInf .= " tvg-season=\"{$seasonNum}\"";
+                                }
+                                if ($episodeNum !== null) {
+                                    $extInf .= " tvg-episode=\"{$episodeNum}\"";
+                                }
+                            }
                             $extInf .= " tvg-chno=\"$channelNo\" tvg-id=\"$tvgId\" tvg-name=\"$name\" tvg-logo=\"$icon\" group-title=\"$group\"";
                             echo "$extInf,".$title."\n";
                             echo $url."\n";

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -49,6 +49,7 @@ class Playlist extends Model
         'backup_before_sync' => 'boolean',
         'sync_logs_enabled' => 'boolean',
         'include_series_in_m3u' => 'boolean',
+        'include_series_metadata_in_m3u' => 'boolean',
         'include_vod_in_m3u' => 'boolean',
         'auto_fetch_series_metadata' => 'boolean',
         'auto_sync_series_stream_files' => 'boolean',

--- a/database/migrations/2026_04_11_234551_add_include_series_metadata_to_playlists_table.php
+++ b/database/migrations/2026_04_11_234551_add_include_series_metadata_to_playlists_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->boolean('include_series_metadata_in_m3u')->default(false)->after('include_series_in_m3u');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->dropColumn('include_series_metadata_in_m3u');
+        });
+    }
+};

--- a/tests/Feature/SeriesMetadataOutputTest.php
+++ b/tests/Feature/SeriesMetadataOutputTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Models\Category;
+use App\Models\Episode;
+use App\Models\Playlist;
+use App\Models\Season;
+use App\Models\Series;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    Event::fake();
+    $this->user = User::factory()->create();
+});
+
+it('includes season and episode metadata in M3U output when enabled', function () {
+    $playlist = Playlist::factory()->for($this->user)->create([
+        'include_series_in_m3u' => true,
+        'include_series_metadata_in_m3u' => true,
+        'xtream' => true,
+    ]);
+
+    $category = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+    ]);
+
+    $series = Series::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+        'category_id' => $category->id,
+        'enabled' => true,
+        'name' => 'Test Show',
+    ]);
+
+    $season = Season::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+        'series_id' => $series->id,
+        'category_id' => $category->id,
+        'season_number' => 2,
+    ]);
+
+    Episode::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+        'series_id' => $series->id,
+        'season_id' => $season->id,
+        'season' => 2,
+        'episode_num' => 5,
+        'title' => 'The Great Episode',
+        'enabled' => true,
+    ]);
+
+    $response = $this->get(route('playlist.generate', ['uuid' => $playlist->uuid]));
+
+    $response->assertSuccessful();
+    $content = $response->streamedContent();
+
+    expect($content)->toContain('tvg-season="2"');
+    expect($content)->toContain('tvg-episode="5"');
+    expect($content)->toContain('The Great Episode');
+});
+
+it('omits season and episode metadata when setting is disabled', function () {
+    $playlist = Playlist::factory()->for($this->user)->create([
+        'include_series_in_m3u' => true,
+        'include_series_metadata_in_m3u' => false,
+        'xtream' => true,
+    ]);
+
+    $category = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+    ]);
+
+    $series = Series::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+        'category_id' => $category->id,
+        'enabled' => true,
+        'name' => 'Another Show',
+    ]);
+
+    $season = Season::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+        'series_id' => $series->id,
+        'category_id' => $category->id,
+        'season_number' => 1,
+    ]);
+
+    Episode::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+        'series_id' => $series->id,
+        'season_id' => $season->id,
+        'season' => 1,
+        'episode_num' => 3,
+        'title' => 'Hidden Metadata',
+        'enabled' => true,
+    ]);
+
+    $response = $this->get(route('playlist.generate', ['uuid' => $playlist->uuid]));
+
+    $response->assertSuccessful();
+    $content = $response->streamedContent();
+
+    expect($content)->not->toContain('tvg-season=');
+    expect($content)->not->toContain('tvg-episode=');
+    expect($content)->toContain('Hidden Metadata');
+});


### PR DESCRIPTION
## Summary
- Adds a new `include_series_metadata_in_m3u` toggle to playlists, visible when "Include series in M3U output" is enabled
- When enabled, appends `tvg-season` and `tvg-episode` attributes to series episode EXTINF lines in M3U output
- Helps external tools (e.g. Emby) correctly identify episodes from the M3U file

Closes #399

## Test plan
- [x] Enable "Include series in M3U output" on an Xtream playlist — verify the new metadata toggle appears
- [x] Enable the metadata toggle, save, and fetch the M3U output — verify `tvg-season` and `tvg-episode` attributes appear on episode lines
- [x] Disable the metadata toggle — verify those attributes are absent from the output
- [x] Verify regular channel and VOD output is unaffected