### PR TITLE
fix: use ProxyFacade for Plex DVR URL generation and store hdhr_base_url per tuner

### DIFF
--- a/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
+++ b/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\MediaServerIntegrations;
 
 use App\Facades\PlaylistFacade;
+use App\Facades\ProxyFacade;
 use App\Filament\Concerns\HasCopilotSupport;
 use App\Filament\Resources\MediaServerIntegrations\Pages\CreateMediaServerIntegration;
 use App\Filament\Resources\MediaServerIntegrations\Pages\EditMediaServerIntegration;
@@ -778,9 +779,22 @@ class MediaServerIntegrationResource extends Resource implements CopilotResource
                                                         return;
                                                     }
 
-                                                    $urls = PlaylistFacade::getUrls($playlist);
-                                                    $set('hdhr_base_url', $urls['hdhr'] ?? '');
-                                                    $set('epg_url', $urls['epg'] ?? '');
+                                                    // Build HDHR and EPG URLs using ProxyFacade which respects
+                                                    // the url_override setting and is request-aware via url('')
+                                                    $baseUrl = ProxyFacade::getBaseUrl();
+                                                    $uuid = $playlist->uuid;
+
+                                                    $playlistAuth = null;
+                                                    if (method_exists($playlist, 'playlistAuths')) {
+                                                        $playlistAuth = $playlist->playlistAuths()->where('enabled', true)->first();
+                                                    }
+                                                    $hdhrAuthPath = '';
+                                                    if ($playlistAuth) {
+                                                        $hdhrAuthPath = '/'.rawurlencode($playlistAuth->username).'/'.rawurlencode($playlistAuth->password);
+                                                    }
+
+                                                    $set('hdhr_base_url', $baseUrl."/{$uuid}/hdhr{$hdhrAuthPath}");
+                                                    $set('epg_url', $baseUrl."/epg/{$uuid}");
                                                 })
                                                 ->required(),
                                             Placeholder::make('tvg_id_warning')
@@ -798,11 +812,11 @@ class MediaServerIntegrationResource extends Resource implements CopilotResource
                                                 }),
                                             TextInput::make('hdhr_base_url')
                                                 ->label(__('HDHR Base URL'))
-                                                ->helperText(__('This URL must be reachable from your Plex server. Use your machine\\\'s LAN IP, not localhost.'))
+                                                ->helperText(__('This URL must be reachable from your Plex server. Uses the Proxy URL Override or APP_URL. Adjust if Plex reaches m3u-editor via a different address (e.g. Docker internal IP).'))
                                                 ->required(),
                                             TextInput::make('epg_url')
                                                 ->label(__('EPG URL'))
-                                                ->helperText(__('XMLTV EPG guide URL. Must also be reachable from Plex.'))
+                                                ->helperText(__('XMLTV EPG guide URL. Must also be reachable from Plex. Adjust if needed.'))
                                                 ->required(),
                                             TextInput::make('dvr_country')
                                                 ->label(__('Country Code'))

--- a/app/Services/PlexManagementService.php
+++ b/app/Services/PlexManagementService.php
@@ -420,6 +420,30 @@ class PlexManagementService
     }
 
     /**
+     * Get the stored HDHR base URL from a tuner entry.
+     *
+     * Looks up the tuner by device key and playlist UUID in the integration's
+     * plex_dvr_tuners JSON column and returns the stored hdhr_base_url if present.
+     * Returns null for legacy tuners that don't have a stored URL.
+     */
+    protected function getStoredHdhrBaseUrl(string $deviceKey, string $playlistUuid): ?string
+    {
+        $tuners = $this->integration->plex_dvr_tuners ?? [];
+
+        foreach ($tuners as $tuner) {
+            if (
+                ($tuner['device_key'] ?? '') === $deviceKey
+                && ($tuner['playlist_uuid'] ?? '') === $playlistUuid
+                && ! empty($tuner['hdhr_base_url'])
+            ) {
+                return $tuner['hdhr_base_url'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Fetch discover.json from the same HDHR base URL we register in Plex.
      *
      * @return array{success: bool, data?: array, message?: string}
@@ -611,6 +635,7 @@ class PlexManagementService
                     $tuners[] = [
                         'device_key' => $deviceKey,
                         'playlist_uuid' => $playlistUuid,
+                        'hdhr_base_url' => $hdhrBaseUrl,
                     ];
                 }
                 $this->integration->update([
@@ -1231,13 +1256,22 @@ class PlexManagementService
     public function syncDvrChannelsForTuner(string $deviceKey, string $playlistUuid): array
     {
         try {
-            $urls = $this->resolvePlaylistUrls($playlistUuid);
-            if (! $urls || empty($urls['hdhr'])) {
+            // Prefer the stored HDHR base URL from the tuner entry (set during DVR registration)
+            // so we use the same network path that was verified to work. Fall back to resolving
+            // from PlaylistFacade for legacy tuners that don't have a stored URL.
+            $hdhrBaseUrl = $this->getStoredHdhrBaseUrl($deviceKey, $playlistUuid);
+
+            if (! $hdhrBaseUrl) {
+                $urls = $this->resolvePlaylistUrls($playlistUuid);
+                $hdhrBaseUrl = $urls['hdhr'] ?? null;
+            }
+
+            if (! $hdhrBaseUrl) {
                 return ['success' => false, 'message' => 'Could not resolve playlist HDHR URL.'];
             }
 
             // Fetch current HDHR lineup from our own endpoint
-            $lineupUrl = rtrim($urls['hdhr'], '/').'/lineup.json';
+            $lineupUrl = rtrim($hdhrBaseUrl, '/').'/lineup.json';
             $lineupResponse = Http::timeout(15)->get($lineupUrl);
 
             if (! $lineupResponse->successful()) {
@@ -1254,6 +1288,7 @@ class PlexManagementService
 
             if (! $lineupId) {
                 // Fallback: rebuild from our known URL
+                $urls = $this->resolvePlaylistUrls($playlistUuid);
                 $epgUrl = $urls['epg'] ?? null;
                 if (! $epgUrl) {
                     return ['success' => false, 'message' => 'Could not resolve playlist EPG URL.'];
@@ -1750,8 +1785,15 @@ class PlexManagementService
                 continue;
             }
 
-            $urls = $this->resolvePlaylistUrls($playlistUuid);
-            if (! $urls || empty($urls['hdhr'])) {
+            // Prefer stored HDHR base URL from tuner entry, fall back to resolving from playlist
+            $hdhrBaseUrl = ! empty($tuner['hdhr_base_url']) ? $tuner['hdhr_base_url'] : null;
+
+            if (! $hdhrBaseUrl) {
+                $urls = $this->resolvePlaylistUrls($playlistUuid);
+                $hdhrBaseUrl = $urls['hdhr'] ?? null;
+            }
+
+            if (! $hdhrBaseUrl) {
                 $allInSync = false;
                 $tunerReports[] = [
                     'playlist' => $playlistUuid,
@@ -1766,7 +1808,7 @@ class PlexManagementService
             }
 
             // Fetch HDHR lineup for this tuner
-            $lineupUrl = rtrim($urls['hdhr'], '/').'/lineup.json';
+            $lineupUrl = rtrim($hdhrBaseUrl, '/').'/lineup.json';
             $hdhrChannelCount = 0;
             $hdhrNumbers = [];
             try {

--- a/app/Services/PlexManagementService.php
+++ b/app/Services/PlexManagementService.php
@@ -1256,14 +1256,20 @@ class PlexManagementService
     public function syncDvrChannelsForTuner(string $deviceKey, string $playlistUuid): array
     {
         try {
+            // Memoize resolvePlaylistUrls so it is called at most once, whether we need it for
+            // the HDHR URL fallback, the EPG URL fallback, or both.
+            $resolvedUrls = null;
+            $resolveUrls = function () use (&$resolvedUrls, $playlistUuid): ?array {
+                return $resolvedUrls ??= $this->resolvePlaylistUrls($playlistUuid);
+            };
+
             // Prefer the stored HDHR base URL from the tuner entry (set during DVR registration)
             // so we use the same network path that was verified to work. Fall back to resolving
             // from PlaylistFacade for legacy tuners that don't have a stored URL.
             $hdhrBaseUrl = $this->getStoredHdhrBaseUrl($deviceKey, $playlistUuid);
 
             if (! $hdhrBaseUrl) {
-                $urls = $this->resolvePlaylistUrls($playlistUuid);
-                $hdhrBaseUrl = $urls['hdhr'] ?? null;
+                $hdhrBaseUrl = $resolveUrls()['hdhr'] ?? null;
             }
 
             if (! $hdhrBaseUrl) {
@@ -1288,8 +1294,7 @@ class PlexManagementService
 
             if (! $lineupId) {
                 // Fallback: rebuild from our known URL
-                $urls = $this->resolvePlaylistUrls($playlistUuid);
-                $epgUrl = $urls['epg'] ?? null;
+                $epgUrl = $resolveUrls()['epg'] ?? null;
                 if (! $epgUrl) {
                     return ['success' => false, 'message' => 'Could not resolve playlist EPG URL.'];
                 }
@@ -1786,7 +1791,9 @@ class PlexManagementService
             }
 
             // Prefer stored HDHR base URL from tuner entry, fall back to resolving from playlist
-            $hdhrBaseUrl = ! empty($tuner['hdhr_base_url']) ? $tuner['hdhr_base_url'] : null;
+            $hdhrBaseUrl = $deviceKey !== null
+                ? $this->getStoredHdhrBaseUrl($deviceKey, $playlistUuid)
+                : null;
 
             if (! $hdhrBaseUrl) {
                 $urls = $this->resolvePlaylistUrls($playlistUuid);

--- a/tests/Feature/PlexManagementServiceTest.php
+++ b/tests/Feature/PlexManagementServiceTest.php
@@ -1252,6 +1252,70 @@ it('verifies DVR sync detects stale DVR', function () {
     expect($this->integration->plex_dvr_id)->toBeNull();
 });
 
+it('verifyDvrSync uses stored hdhr_base_url from tuner entry', function () {
+    $storedUrl = 'http://172.18.0.5:36400/test-uuid/hdhr';
+
+    $this->integration->update([
+        'plex_dvr_id' => '42',
+        'plex_dvr_tuners' => [
+            [
+                'device_key' => 'device-1',
+                'playlist_uuid' => 'test-uuid',
+                'hdhr_base_url' => $storedUrl,
+            ],
+        ],
+    ]);
+
+    $lineupFetched = false;
+
+    Http::fake(function ($request) use ($storedUrl, &$lineupFetched) {
+        $url = $request->url();
+
+        // DVR detail (getDvrChannels)
+        if (preg_match('#/livetv/dvrs/42$#', parse_url($url, PHP_URL_PATH) ?? '')) {
+            return Http::response(['MediaContainer' => ['Dvr' => [
+                ['key' => '42', 'Lineup' => [
+                    ['id' => 'lineup://tv.plex.providers.epg.xmltv/test', 'title' => 'XMLTV Guide'],
+                ], 'Device' => [['key' => 'device-1', 'ChannelMapping' => [
+                    ['channelKey' => '1', 'deviceIdentifier' => '1', 'enabled' => '1', 'lineupIdentifier' => '1'],
+                ]]]],
+            ]]]);
+        }
+
+        // DVR list (verifyDvrExists + getDvrLineupId)
+        if (str_contains($url, '/livetv/dvrs') && ! str_contains($url, 'lineupchannels')) {
+            return Http::response(['MediaContainer' => ['Dvr' => [
+                ['key' => '42', 'Lineup' => [
+                    ['id' => 'lineup://tv.plex.providers.epg.xmltv/test', 'title' => 'XMLTV Guide'],
+                ], 'Device' => [['key' => 'device-1']]],
+            ]]]);
+        }
+
+        if (str_contains($url, '/livetv/epg/lineupchannels')) {
+            return Http::response(['MediaContainer' => ['Lineup' => [
+                ['Channel' => [['channelVcn' => '1', 'identifier' => 'ch-1', 'key' => '1']]],
+            ]]]);
+        }
+
+        // HDHR lineup — must be fetched from the stored Docker-internal URL, not a resolved route
+        if ($url === $storedUrl.'/lineup.json') {
+            $lineupFetched = true;
+
+            return Http::response([
+                ['GuideNumber' => '1', 'GuideName' => 'Channel 1', 'URL' => 'http://test/1'],
+            ]);
+        }
+
+        return Http::response([], 200);
+    });
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->verifyDvrSync();
+
+    expect($lineupFetched)->toBeTrue('Expected lineup to be fetched from stored hdhr_base_url');
+    expect($result['success'])->toBeTrue();
+});
+
 it('stores hdhr_base_url in tuner entry when adding DVR device', function () {
     $hdhrBaseUrl = 'http://172.18.0.5:36400/test-uuid/hdhr';
 

--- a/tests/Feature/PlexManagementServiceTest.php
+++ b/tests/Feature/PlexManagementServiceTest.php
@@ -1251,3 +1251,167 @@ it('verifies DVR sync detects stale DVR', function () {
     $this->integration->refresh();
     expect($this->integration->plex_dvr_id)->toBeNull();
 });
+
+it('stores hdhr_base_url in tuner entry when adding DVR device', function () {
+    $hdhrBaseUrl = 'http://172.18.0.5:36400/test-uuid/hdhr';
+
+    Http::fake(function ($request) use ($hdhrBaseUrl) {
+        $url = $request->url();
+
+        // discover.json
+        if (str_contains($url, '/discover.json')) {
+            return Http::response([
+                'DeviceID' => 'test1234',
+                'FriendlyName' => 'Test HDHomeRun',
+                'DeviceAuth' => 'auth-token',
+                'BaseURL' => $hdhrBaseUrl,
+                'LineupURL' => $hdhrBaseUrl.'/lineup.json',
+                'TunerCount' => 2,
+            ]);
+        }
+
+        // Plex device creation - return success
+        if (str_contains($url, '/media/grabbers/devices')) {
+            return Http::response(['MediaContainer' => [
+                'Device' => [[
+                    'key' => 'device-abc',
+                    'uuid' => 'device-uuid-abc',
+                    'uri' => $hdhrBaseUrl,
+                    'parentID' => null,
+                ]],
+            ]]);
+        }
+
+        // DVR listing
+        if (str_contains($url, '/livetv/dvrs')) {
+            if ($request->method() === 'POST') {
+                return Http::response(['MediaContainer' => ['Dvr' => [['key' => 'dvr-42']]]]);
+            }
+
+            return Http::response(['MediaContainer' => ['Dvr' => [[
+                'key' => 'dvr-42',
+                'Device' => [['key' => 'device-abc', 'uuid' => 'device-uuid-abc']],
+            ]]]]);
+        }
+
+        // EPG refresh, lineup channels, channel map — return success stubs
+        if (str_contains($url, '/lineup.json')) {
+            return Http::response([['GuideNumber' => '1', 'GuideName' => 'Test', 'URL' => 'http://test/stream']]);
+        }
+
+        if (str_contains($url, '/lineupchannels')) {
+            return Http::response(['MediaContainer' => ['Directory' => []]]);
+        }
+
+        return Http::response([], 200);
+    });
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->addDvrDevice($hdhrBaseUrl, 'http://172.18.0.5:36400/epg/test-uuid', 'us', 'en', 'test-uuid');
+
+    expect($result['success'])->toBeTrue();
+
+    $this->integration->refresh();
+    $tuners = $this->integration->plex_dvr_tuners;
+
+    expect($tuners)->toBeArray();
+    expect($tuners)->toHaveCount(1);
+    expect($tuners[0])->toHaveKey('hdhr_base_url');
+    expect($tuners[0]['hdhr_base_url'])->toBe($hdhrBaseUrl);
+    expect($tuners[0]['playlist_uuid'])->toBe('test-uuid');
+});
+
+it('syncDvrChannelsForTuner uses stored hdhr_base_url from tuner entry', function () {
+    $storedUrl = 'http://172.18.0.5:36400/test-uuid/hdhr';
+
+    $this->integration->update([
+        'plex_dvr_id' => 'dvr-42',
+        'plex_dvr_tuners' => [
+            [
+                'device_key' => 'device-abc',
+                'playlist_uuid' => 'test-uuid',
+                'hdhr_base_url' => $storedUrl,
+            ],
+        ],
+    ]);
+
+    $lineupFetched = false;
+
+    Http::fake(function ($request) use ($storedUrl, &$lineupFetched) {
+        $url = $request->url();
+
+        // The stored URL should be used for lineup fetch
+        if ($url === $storedUrl.'/lineup.json') {
+            $lineupFetched = true;
+
+            return Http::response([
+                ['GuideNumber' => '1', 'GuideName' => 'Channel 1', 'URL' => 'http://test/1.ts'],
+            ]);
+        }
+
+        // DVR info
+        if (str_contains($url, '/livetv/dvrs')) {
+            return Http::response(['MediaContainer' => ['Dvr' => [[
+                'key' => 'dvr-42',
+                'Lineup' => [['id' => 'lineup://test']],
+                'Device' => [['key' => 'device-abc']],
+            ]]]]);
+        }
+
+        // Lineup channels, device scan, channel map
+        if (str_contains($url, '/lineupchannels')) {
+            return Http::response(['MediaContainer' => ['Directory' => []]]);
+        }
+
+        return Http::response([], 200);
+    });
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->syncDvrChannelsForTuner('device-abc', 'test-uuid');
+
+    expect($lineupFetched)->toBeTrue('Expected lineup to be fetched from stored hdhr_base_url');
+});
+
+it('syncDvrChannelsForTuner falls back to PlaylistFacade for legacy tuners without hdhr_base_url', function () {
+    $this->integration->update([
+        'plex_dvr_id' => 'dvr-42',
+        'plex_dvr_tuners' => [
+            [
+                'device_key' => 'device-abc',
+                'playlist_uuid' => 'test-uuid',
+                // No hdhr_base_url — legacy tuner
+            ],
+        ],
+    ]);
+
+    Http::fake(function ($request) {
+        $url = $request->url();
+
+        // Should fall back to PlaylistFacade-resolved URL (which uses route())
+        if (str_contains($url, '/lineup.json')) {
+            return Http::response([
+                ['GuideNumber' => '1', 'GuideName' => 'Channel 1', 'URL' => 'http://test/1.ts'],
+            ]);
+        }
+
+        if (str_contains($url, '/livetv/dvrs')) {
+            return Http::response(['MediaContainer' => ['Dvr' => [[
+                'key' => 'dvr-42',
+                'Lineup' => [['id' => 'lineup://test']],
+                'Device' => [['key' => 'device-abc']],
+            ]]]]);
+        }
+
+        if (str_contains($url, '/lineupchannels')) {
+            return Http::response(['MediaContainer' => ['Directory' => []]]);
+        }
+
+        return Http::response([], 200);
+    });
+
+    $service = PlexManagementService::make($this->integration);
+    $result = $service->syncDvrChannelsForTuner('device-abc', 'test-uuid');
+
+    // Should not fail — fallback should work
+    expect($result)->toHaveKey('success');
+});


### PR DESCRIPTION
- Store hdhr_base_url in plex_dvr_tuners JSON per tuner entry so sync uses the same network path that was verified during DVR registration
- Auto-fill HDHR/EPG URLs in DVR setup modal using ProxyFacade::getBaseUrl() which respects url_override and is request-aware via url('')
- syncDvrChannelsForTuner() and verifyDvrChannels() prefer stored URL, fall back to resolvePlaylistUrls() for legacy tuners
- Remove getAvailableBaseUrls() IP detection — not needed since ProxyFacade already handles override/request-aware resolution
- Add 3 tests covering stored URL usage and backward compatibility