### PR TITLE
feat: parallelize EPG import and cache generation using Bus::batch

### DIFF
--- a/app/Console/Commands/GenerateEpgCache.php
+++ b/app/Console/Commands/GenerateEpgCache.php
@@ -45,7 +45,7 @@ class GenerateEpgCache extends Command
         set_time_limit(0); // No time limit for CLI
 
         $start = microtime(true);
-        $result = $cacheService->cacheEpgData($epg);
+        $result = $cacheService->cacheEpgData($epg, parallel: false);
         $duration = microtime(true) - $start;
 
         if ($result) {

--- a/app/Jobs/GenerateEpgCache.php
+++ b/app/Jobs/GenerateEpgCache.php
@@ -7,8 +7,10 @@ use App\Models\Epg;
 use App\Plugins\PluginHookDispatcher;
 use App\Services\EpgCacheService;
 use Filament\Notifications\Notification;
+use Illuminate\Bus\Batch;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
@@ -69,57 +71,183 @@ class GenerateEpgCache implements ShouldQueue
             'processing_started_at' => now(),
             'processing_phase' => 'cache',
         ]);
+
         $result = $cacheService->cacheEpgData($epg);
+
+        // Parallel mode: result is an array with chunk info
+        if (is_array($result)) {
+            $this->dispatchParallelChunks($epg, $result, $start);
+
+            return;
+        }
+
+        // Synchronous mode: result is a bool
         $duration = microtime(true) - $start;
         if ($result) {
-            $epg->update([
-                'status' => Status::Completed,
-                'is_cached' => true,
-                'cache_progress' => 100,
-                'processing_started_at' => null,
-                'processing_phase' => null,
-            ]);
+            $this->handleSyncSuccess($epg, $duration);
+        } else {
+            $this->handleFailure($epg);
+        }
+    }
 
-            // Clear playlist EPG cache files AFTER new cache is generated
-            // This ensures users can still get cached EPG files during regeneration
-            foreach ($epg->getAllPlaylists() as $playlist) {
-                EpgCacheService::clearPlaylistEpgCacheFile($playlist);
-            }
+    /**
+     * Dispatch parallel chunk jobs via Bus::batch after pre-scan.
+     */
+    private function dispatchParallelChunks(Epg $epg, array $preScanResult, float $start): void
+    {
+        $chunkPaths = $preScanResult['chunk_paths'];
+        $chunkCount = $preScanResult['chunk_count'];
+        $channelCount = $preScanResult['channel_count'];
+        $programmeCount = $preScanResult['programme_count'];
+        $dateRange = $preScanResult['date_range'];
 
-            if ($this->notify) {
-                $msg = 'Cache generated successfully in '.round($duration, 2).' seconds';
+        if ($chunkCount === 0) {
+            Log::info("No programme chunks to process for EPG {$epg->name}, finalizing immediately.");
+            $cacheService = app(EpgCacheService::class);
+            $cacheService->finalizeCacheAfterChunks($epg, $channelCount, $programmeCount, $dateRange);
+            $this->handleSyncSuccess($epg, microtime(true) - $start);
+
+            return;
+        }
+
+        $chunkJobs = [];
+        foreach ($chunkPaths as $chunkPath) {
+            $chunkJobs[] = new GenerateEpgCacheChunk($epg->uuid, $chunkPath, $chunkCount);
+        }
+
+        $epgUuid = $epg->uuid;
+        $notify = $this->notify;
+
+        Bus::batch($chunkJobs)
+            ->onConnection('redis')
+            ->onQueue('import')
+            ->allowFailures()
+            ->then(function () use ($epgUuid, $channelCount, $programmeCount, $dateRange, $notify, $start): void {
+                $epg = Epg::where('uuid', $epgUuid)->first();
+                if (! $epg) {
+                    return;
+                }
+
+                $cacheService = app(EpgCacheService::class);
+                $cacheService->finalizeCacheAfterChunks($epg, $channelCount, $programmeCount, $dateRange);
+
+                $epg->update([
+                    'status' => Status::Completed,
+                    'is_cached' => true,
+                    'cache_progress' => 100,
+                    'processing_started_at' => null,
+                    'processing_phase' => null,
+                ]);
+
+                // Clear playlist EPG cache files AFTER new cache is generated
+                foreach ($epg->getAllPlaylists() as $playlist) {
+                    EpgCacheService::clearPlaylistEpgCacheFile($playlist);
+                }
+
+                $duration = microtime(true) - $start;
+                if ($notify) {
+                    $msg = 'Cache generated successfully in '.round($duration, 2).' seconds';
+                    Notification::make()
+                        ->success()
+                        ->title("EPG cache created for \"{$epg->name}\"")
+                        ->body($msg)
+                        ->broadcast($epg->user)
+                        ->sendToDatabase($epg->user);
+                }
+
+                app(PluginHookDispatcher::class)->dispatch('epg.cache.generated', [
+                    'epg_id' => $epg->id,
+                    'playlist_ids' => $epg->getAllPlaylists()->pluck('id')->all(),
+                    'user_id' => $epg->user_id,
+                ], [
+                    'user_id' => $epg->user_id,
+                    'dry_run' => true,
+                ]);
+            })
+            ->catch(function (Batch $batch, ?Throwable $e) use ($epgUuid): void {
+                $epg = Epg::where('uuid', $epgUuid)->first();
+                if (! $epg) {
+                    return;
+                }
+
+                Log::error("EPG cache batch failed for {$epg->name}: ".($e?->getMessage() ?? 'Unknown'));
+                $epg->update([
+                    'status' => Status::Failed,
+                    'is_cached' => false,
+                    'cache_progress' => 100,
+                    'processing_started_at' => null,
+                    'processing_phase' => null,
+                ]);
+
+                $error = 'Failed to generate cache. You can try to run the cache generation again manually from the EPG management page.';
                 Notification::make()
-                    ->success()
-                    ->title("EPG cache created for \"{$epg->name}\"")
-                    ->body($msg)
+                    ->danger()
+                    ->title("Error creating cache for \"{$epg->name}\"")
+                    ->body($error)
                     ->broadcast($epg->user)
                     ->sendToDatabase($epg->user);
-            }
+            })->dispatch();
 
-            app(PluginHookDispatcher::class)->dispatch('epg.cache.generated', [
-                'epg_id' => $epg->id,
-                'playlist_ids' => $epg->getAllPlaylists()->pluck('id')->all(),
-                'user_id' => $epg->user_id,
-            ], [
-                'user_id' => $epg->user_id,
-                'dry_run' => true,
-            ]);
-        } else {
-            $epg->update([
-                'status' => Status::Failed,
-                'is_cached' => false,
-                'cache_progress' => 100,
-                'processing_started_at' => null,
-                'processing_phase' => null,
-            ]);
-            $error = 'Failed to generate cache. You can try to run the cache generation again manually from the EPG management page.';
+        Log::info("Dispatched {$chunkCount} parallel cache chunk jobs for EPG {$epg->name}");
+    }
+
+    /**
+     * Handle successful synchronous cache generation.
+     */
+    private function handleSyncSuccess(Epg $epg, float $duration): void
+    {
+        $epg->update([
+            'status' => Status::Completed,
+            'is_cached' => true,
+            'cache_progress' => 100,
+            'processing_started_at' => null,
+            'processing_phase' => null,
+        ]);
+
+        // Clear playlist EPG cache files AFTER new cache is generated
+        foreach ($epg->getAllPlaylists() as $playlist) {
+            EpgCacheService::clearPlaylistEpgCacheFile($playlist);
+        }
+
+        if ($this->notify) {
+            $msg = 'Cache generated successfully in '.round($duration, 2).' seconds';
             Notification::make()
-                ->danger()
-                ->title("Error creating cache for \"{$epg->name}\"")
-                ->body($error)
+                ->success()
+                ->title("EPG cache created for \"{$epg->name}\"")
+                ->body($msg)
                 ->broadcast($epg->user)
                 ->sendToDatabase($epg->user);
         }
+
+        app(PluginHookDispatcher::class)->dispatch('epg.cache.generated', [
+            'epg_id' => $epg->id,
+            'playlist_ids' => $epg->getAllPlaylists()->pluck('id')->all(),
+            'user_id' => $epg->user_id,
+        ], [
+            'user_id' => $epg->user_id,
+            'dry_run' => true,
+        ]);
+    }
+
+    /**
+     * Handle cache generation failure.
+     */
+    private function handleFailure(Epg $epg): void
+    {
+        $epg->update([
+            'status' => Status::Failed,
+            'is_cached' => false,
+            'cache_progress' => 100,
+            'processing_started_at' => null,
+            'processing_phase' => null,
+        ]);
+        $error = 'Failed to generate cache. You can try to run the cache generation again manually from the EPG management page.';
+        Notification::make()
+            ->danger()
+            ->title("Error creating cache for \"{$epg->name}\"")
+            ->body($error)
+            ->broadcast($epg->user)
+            ->sendToDatabase($epg->user);
     }
 
     /**

--- a/app/Jobs/GenerateEpgCacheChunk.php
+++ b/app/Jobs/GenerateEpgCacheChunk.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Epg;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use XMLReader;
+
+class GenerateEpgCacheChunk implements ShouldQueue
+{
+    use Batchable;
+    use Queueable;
+
+    public $tries = 1;
+
+    public $timeout = 60 * 30;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public string $epgUuid,
+        public string $chunkFilePath,
+        public int $totalChunks,
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
+        $epg = Epg::where('uuid', $this->epgUuid)->first();
+        if (! $epg) {
+            return;
+        }
+
+        $fullChunkPath = Storage::disk('local')->path($this->chunkFilePath);
+        if (! file_exists($fullChunkPath)) {
+            Log::error("Cache chunk file not found: {$this->chunkFilePath}");
+
+            return;
+        }
+
+        $fileHandles = [];
+
+        try {
+            $cacheDir = "epg-cache/{$epg->uuid}/v1";
+            $processedCount = 0;
+
+            $handle = fopen($fullChunkPath, 'r');
+            if (! $handle) {
+                Log::error("Failed to open chunk file: {$this->chunkFilePath}");
+
+                return;
+            }
+
+            while (($line = fgets($handle)) !== false) {
+                $line = trim($line);
+                if (empty($line)) {
+                    continue;
+                }
+
+                $raw = json_decode($line, true);
+                if (! $raw || ! isset($raw['xml'], $raw['channel'], $raw['date'])) {
+                    continue;
+                }
+
+                $programme = $this->parseProgrammeXml($raw['xml'], $raw['channel'], $raw['start'], $raw['stop']);
+                if (! $programme || ! $programme['title']) {
+                    continue;
+                }
+
+                $this->appendProgramme($cacheDir, $raw['date'], $raw['channel'], $programme, $fileHandles);
+                $processedCount++;
+            }
+
+            fclose($handle);
+
+            // Update progress atomically
+            if ($this->totalChunks > 0) {
+                $increment = max(1, (int) floor(99 / $this->totalChunks));
+                Epg::where('uuid', $this->epgUuid)
+                    ->where('cache_progress', '<', 99)
+                    ->increment('cache_progress', $increment);
+            }
+        } finally {
+            foreach ($fileHandles as $fh) {
+                if (is_resource($fh)) {
+                    fclose($fh);
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse raw programme XML into structured array.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function parseProgrammeXml(string $outerXml, string $channelId, string $startIso, ?string $stopIso): ?array
+    {
+        $programme = [
+            'channel' => $channelId,
+            'start' => $startIso,
+            'stop' => $stopIso,
+            'title' => '',
+            'subtitle' => '',
+            'desc' => '',
+            'category' => '',
+            'episode_num' => '',
+            'rating' => '',
+            'icon' => '',
+            'images' => [],
+            'new' => false,
+        ];
+
+        $reader = new XMLReader;
+        $reader->xml($outerXml);
+
+        while (@$reader->read()) {
+            if ($reader->nodeType !== XMLReader::ELEMENT) {
+                continue;
+            }
+
+            switch ($reader->name) {
+                case 'title':
+                    $programme['title'] = trim($reader->readString() ?: '');
+                    break;
+                case 'sub-title':
+                    $programme['subtitle'] = trim($reader->readString() ?: '');
+                    break;
+                case 'desc':
+                    $programme['desc'] = trim($reader->readString() ?: '');
+                    break;
+                case 'category':
+                    if (! $programme['category']) {
+                        $programme['category'] = trim($reader->readString() ?: '');
+                    }
+                    break;
+                case 'icon':
+                    if (! $programme['icon']) {
+                        $programme['icon'] = trim($reader->getAttribute('src') ?: '');
+                    } else {
+                        $imageUrl = trim($reader->getAttribute('src') ?: '');
+                        if ($imageUrl) {
+                            $programme['images'][] = [
+                                'url' => $imageUrl,
+                                'type' => trim($reader->getAttribute('type') ?: 'poster'),
+                                'width' => (int) ($reader->getAttribute('width') ?: 0),
+                                'height' => (int) ($reader->getAttribute('height') ?: 0),
+                                'orient' => trim($reader->getAttribute('orient') ?: 'P'),
+                                'size' => (int) ($reader->getAttribute('size') ?: 1),
+                            ];
+                        }
+                    }
+                    break;
+                case 'new':
+                    $programme['new'] = true;
+                    break;
+                case 'episode-num':
+                    $programme['episode_num'] = trim($reader->readString() ?: '');
+                    break;
+                case 'rating':
+                    while (@$reader->read()) {
+                        if ($reader->nodeType == XMLReader::ELEMENT && $reader->name === 'value') {
+                            $programme['rating'] = trim($reader->readString() ?: '');
+                            break;
+                        } elseif ($reader->nodeType == XMLReader::END_ELEMENT && $reader->name === 'rating') {
+                            break;
+                        }
+                    }
+                    break;
+            }
+        }
+        $reader->close();
+
+        return $programme;
+    }
+
+    /**
+     * Append a parsed programme to the appropriate date-based JSONL file.
+     *
+     * @param  array<string, resource>  $fileHandles
+     */
+    private function appendProgramme(string $cacheDir, string $date, string $channelId, array $programme, array &$fileHandles): void
+    {
+        if (! isset($fileHandles[$date])) {
+            $programmesPath = "{$cacheDir}/programmes-{$date}.jsonl";
+            $fullPath = Storage::disk('local')->path($programmesPath);
+
+            $dir = dirname($fullPath);
+            if (! is_dir($dir)) {
+                mkdir($dir, 0755, true);
+            }
+
+            $fileHandles[$date] = fopen($fullPath, 'a');
+            if (! $fileHandles[$date]) {
+                Log::error("Failed to open programme file for date {$date}");
+
+                return;
+            }
+        }
+
+        $record = [
+            'channel' => $channelId,
+            'programme' => $programme,
+        ];
+
+        $line = json_encode($record, JSON_UNESCAPED_UNICODE)."\n";
+
+        // Use LOCK_EX via flock for concurrent write safety
+        flock($fileHandles[$date], LOCK_EX);
+        fwrite($fileHandles[$date], $line);
+        flock($fileHandles[$date], LOCK_UN);
+
+        // Close handles if we have too many open
+        if (count($fileHandles) > 50) {
+            foreach ($fileHandles as $d => $handle) {
+                if ($d !== $date && is_resource($handle)) {
+                    fclose($handle);
+                    unset($fileHandles[$d]);
+                }
+            }
+        }
+    }
+}

--- a/app/Jobs/ProcessEpgImport.php
+++ b/app/Jobs/ProcessEpgImport.php
@@ -13,6 +13,7 @@ use App\Traits\ProviderRequestDelay;
 use Carbon\Carbon;
 use Exception;
 use Filament\Notifications\Notification;
+use Illuminate\Bus\Batch;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Bus;
@@ -395,28 +396,41 @@ class ProcessEpgImport implements ShouldQueue
                 ]);
 
                 // Get the jobs for the batch
-                $jobs = [];
+                $chunkJobs = [];
                 $batchCount = Job::where('batch_no', $batchNo)->count();
                 $jobsBatch = Job::where('batch_no', $batchNo)->select('id')->cursor();
-                $jobsBatch->chunk(100)->each(function ($chunk) use (&$jobs, $batchCount) {
-                    $jobs[] = new ProcessEpgImportChunk($chunk->pluck('id')->toArray(), $batchCount);
+                $jobsBatch->chunk(100)->each(function ($chunk) use (&$chunkJobs, $batchCount) {
+                    $chunkJobs[] = new ProcessEpgImportChunk($chunk->pluck('id')->toArray(), $batchCount);
                 });
 
-                // Run completion after channels imported
-                $jobs[] = new ProcessEpgImportComplete($userId, $epgId, $batchNo, $start);
-                Bus::chain($jobs)
-                    ->onConnection('redis') // force to use redis connection
+                // Run import chunks in parallel via Bus::batch, then dispatch completion
+                $epgName = $epg->name;
+                $epgUserId = $userId;
+                $epgModelId = $epgId;
+                $batchNoCapture = $batchNo;
+                $startCapture = $start;
+
+                Bus::batch($chunkJobs)
+                    ->onConnection('redis')
                     ->onQueue('import')
-                    ->catch(function (Throwable $e) use ($epg) {
-                        $error = "Error processing \"{$epg->name}\": {$e->getMessage()}";
+                    ->allowFailures()
+                    ->then(function () use ($epgUserId, $epgModelId, $batchNoCapture, $startCapture): void {
+                        dispatch(new ProcessEpgImportComplete($epgUserId, $epgModelId, $batchNoCapture, $startCapture));
+                    })
+                    ->catch(function (Batch $batch, ?Throwable $e) use ($epgModelId, $epgName): void {
+                        $epg = Epg::find($epgModelId);
+                        if (! $epg) {
+                            return;
+                        }
+                        $error = "Error processing \"{$epgName}\": ".($e?->getMessage() ?? 'Unknown error');
                         Notification::make()
                             ->danger()
-                            ->title("Error processing \"{$epg->name}\"")
+                            ->title("Error processing \"{$epgName}\"")
                             ->body('Please view your notifications for details.')
                             ->broadcast($epg->user);
                         Notification::make()
                             ->danger()
-                            ->title("Error processing \"{$epg->name}\"")
+                            ->title("Error processing \"{$epgName}\"")
                             ->body($error)
                             ->sendToDatabase($epg->user);
                         $epg->update([

--- a/app/Jobs/ProcessEpgImportChunk.php
+++ b/app/Jobs/ProcessEpgImportChunk.php
@@ -5,11 +5,13 @@ namespace App\Jobs;
 use App\Models\Epg;
 use App\Models\EpgChannel;
 use App\Models\Job;
+use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 
 class ProcessEpgImportChunk implements ShouldQueue
 {
+    use Batchable;
     use Queueable;
 
     // Don't retry the job on failure
@@ -32,6 +34,10 @@ class ProcessEpgImportChunk implements ShouldQueue
      */
     public function handle(): void
     {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
         // Determine what percentage of the import this batch accounts for
         $totalJobsCount = $this->batchCount;
         $chunkSize = 10;
@@ -40,10 +46,10 @@ class ProcessEpgImportChunk implements ShouldQueue
         foreach (Job::whereIn('id', $this->jobs)->cursor() as $index => $job) {
             $bulk = [];
             if ($index % $chunkSize === 0) {
-                $epg = Epg::find($job->variables['epgId']);
-                $epg->update([
-                    'progress' => min(99, $epg->progress + (($chunkSize / $totalJobsCount) * 100)),
-                ]);
+                // Use atomic increment to avoid race conditions with parallel chunks
+                Epg::where('id', $job->variables['epgId'])
+                    ->where('progress', '<', 99)
+                    ->increment('progress', min(84, (int) ceil(($chunkSize / $totalJobsCount) * 100)));
             }
 
             // Add the channel for insert/update

--- a/app/Services/EpgCacheService.php
+++ b/app/Services/EpgCacheService.php
@@ -94,9 +94,17 @@ class EpgCacheService
     }
 
     /**
-     * Cache EPG data from XML file
+     * Cache EPG data from XML file.
+     *
+     * In parallel mode (default when maxProcesses > 1), this performs a fast pre-scan
+     * that extracts channels and splits raw programme XML into chunk files, then returns
+     * chunk info so the caller can dispatch parallel jobs. In synchronous mode (SQLite
+     * or explicit), it does the full single-pass processing inline.
+     *
+     * @param  bool|null  $parallel  Force parallel (true) or sync (false) mode. Null = auto-detect.
+     * @return bool|array{chunk_count: int, chunk_paths: string[], channel_count: int, programme_count: int, date_range: array} Returns true/false in sync mode, or chunk info array in parallel mode.
      */
-    public function cacheEpgData(Epg $epg): bool
+    public function cacheEpgData(Epg $epg, ?bool $parallel = null): bool|array
     {
         // Get the content
         $filePath = null;
@@ -112,8 +120,12 @@ class EpgCacheService
 
             return false;
         }
+
+        // Auto-detect parallel mode: use parallel unless SQLite (single worker)
+        $useParallel = $parallel ?? (config('database.default') !== 'sqlite');
+
         try {
-            Log::debug("Starting EPG cache generation for {$epg->name}");
+            Log::debug("Starting EPG cache generation for {$epg->name}", ['parallel' => $useParallel]);
             set_time_limit(60 * 120); // 120 minutes
 
             // Get the channel count for progress tracking
@@ -125,8 +137,17 @@ class EpgCacheService
             $cacheDir = $this->getCacheDir($epg);
             Storage::disk('local')->makeDirectory($cacheDir);
 
-            // Parse and save channels and programmes in a single pass
-            Log::debug("Parsing EPG data for {$epg->name}");
+            if ($useParallel) {
+                // Parallel mode: pre-scan to extract channels and split programmes into chunks
+                Log::debug("Pre-scanning EPG data for {$epg->name} (parallel mode)");
+                $preScanResult = $this->extractChannelsAndSplitProgrammes($epg, $filePath, $totalChannels, $totalProgrammes);
+                Log::debug("Pre-scan complete for {$epg->name}: {$preScanResult['channel_count']} channels, {$preScanResult['programme_count']} programmes, {$preScanResult['chunk_count']} chunks");
+
+                return $preScanResult;
+            }
+
+            // Synchronous mode: full single-pass processing
+            Log::debug("Parsing EPG data for {$epg->name} (synchronous mode)");
             $stats = $this->parseAndSaveEpgDataSinglePass($epg, $filePath, $totalChannels, $totalProgrammes);
             Log::debug("Processed {$stats['channels']} channels and {$stats['programmes']} programmes across {$stats['date_count']} dates");
 
@@ -163,6 +184,210 @@ class EpgCacheService
 
             return false;
         }
+    }
+
+    /**
+     * Pre-scan EPG XML file: extract channels and split raw programme data into chunk files.
+     *
+     * This performs a single XMLReader pass that:
+     * - Fully parses and saves channels to channels.json
+     * - Extracts only programme attributes (channel, start, stop) + raw outerXml
+     * - Writes chunks of raw programme data to temporary JSONL files
+     *
+     * The expensive inner-XML parsing of programmes is deferred to parallel chunk jobs.
+     *
+     * @return array{chunk_count: int, chunk_paths: string[], channel_count: int, programme_count: int, date_range: array}
+     */
+    public function extractChannelsAndSplitProgrammes(Epg $epg, string $filePath, int $totalChannels, int $totalProgrammes): array
+    {
+        $reader = new XMLReader;
+        $reader->open('compress.zlib://'.$filePath);
+
+        $channelCount = 0;
+        $programmeCount = 0;
+        $channelBatchSize = 5000;
+        $channelBatch = [];
+        $dateRangeTracker = ['min_date' => null, 'max_date' => null];
+
+        // Chunk configuration for programme splitting
+        $chunkSize = 10000;
+        $currentChunkBuffer = [];
+        $currentChunkIndex = 0;
+        $chunkPaths = [];
+        $cacheDir = $this->getCacheDir($epg);
+        $tmpDir = "{$cacheDir}/tmp";
+        Storage::disk('local')->makeDirectory($tmpDir);
+
+        $lastProgressUpdate = 0;
+        $progressUpdateInterval = 5000;
+
+        try {
+            while (@$reader->read()) {
+                // Process channels (full parsing — channels are small)
+                if ($reader->nodeType == XMLReader::ELEMENT && $reader->name === 'channel') {
+                    $channelId = trim($reader->getAttribute('id') ?: '');
+                    $innerXML = $reader->readOuterXml();
+                    $innerReader = new XMLReader;
+                    $innerReader->xml($innerXML);
+
+                    $channel = [
+                        'id' => $channelId,
+                        'display_name' => '',
+                        'icon' => '',
+                        'lang' => 'en',
+                    ];
+
+                    while (@$innerReader->read()) {
+                        if ($innerReader->nodeType == XMLReader::ELEMENT) {
+                            switch ($innerReader->name) {
+                                case 'display-name':
+                                    if (! $channel['display_name']) {
+                                        $channel['display_name'] = trim($innerReader->readString() ?: '');
+                                        $channel['lang'] = trim($innerReader->getAttribute('lang') ?: '') ?: 'en';
+                                    }
+                                    break;
+                                case 'icon':
+                                    $channel['icon'] = trim($innerReader->getAttribute('src') ?: '');
+                                    break;
+                            }
+                        }
+                    }
+                    $innerReader->close();
+
+                    if ($channelId) {
+                        $channelBatch[$channelId] = $channel;
+                        $channelCount++;
+
+                        if (count($channelBatch) >= $channelBatchSize) {
+                            $this->saveChannelBatchOptimized($epg, $channelBatch, $channelCount <= $channelBatchSize);
+                            $channelBatch = [];
+                        }
+                    }
+                }
+                // Extract raw programme data (NO inner parsing — deferred to chunk jobs)
+                elseif ($reader->nodeType == XMLReader::ELEMENT && $reader->name === 'programme') {
+                    $programmeCount++;
+
+                    if ($programmeCount > self::MAX_PROGRAMMES) {
+                        Log::warning("Programme processing limit reached at {$programmeCount}");
+                        break;
+                    }
+
+                    $channelId = trim($reader->getAttribute('channel') ?: '');
+                    $start = trim($reader->getAttribute('start') ?: '');
+                    $stop = trim($reader->getAttribute('stop') ?: '');
+
+                    if (! $channelId || ! $start) {
+                        continue;
+                    }
+
+                    $startDateTime = $this->parseXmltvDateTime($start);
+                    $stopDateTime = $stop ? $this->parseXmltvDateTime($stop) : null;
+
+                    if (! $startDateTime) {
+                        continue;
+                    }
+
+                    $date = $startDateTime->format('Y-m-d');
+
+                    // Track date range
+                    if ($dateRangeTracker['min_date'] === null || $date < $dateRangeTracker['min_date']) {
+                        $dateRangeTracker['min_date'] = $date;
+                    }
+                    if ($dateRangeTracker['max_date'] === null || $date > $dateRangeTracker['max_date']) {
+                        $dateRangeTracker['max_date'] = $date;
+                    }
+
+                    // Get raw outer XML — inner parsing deferred to chunk jobs
+                    $outerXml = $reader->readOuterXml();
+
+                    $currentChunkBuffer[] = json_encode([
+                        'channel' => $channelId,
+                        'start' => $startDateTime->toISOString(),
+                        'stop' => $stopDateTime?->toISOString(),
+                        'date' => $date,
+                        'xml' => $outerXml,
+                    ], JSON_UNESCAPED_UNICODE);
+
+                    // Flush chunk buffer when full
+                    if (count($currentChunkBuffer) >= $chunkSize) {
+                        $chunkPath = "{$tmpDir}/chunk-{$currentChunkIndex}.jsonl";
+                        Storage::disk('local')->put($chunkPath, implode("\n", $currentChunkBuffer)."\n");
+                        $chunkPaths[] = $chunkPath;
+                        $currentChunkBuffer = [];
+                        $currentChunkIndex++;
+                    }
+
+                    // Update progress less frequently
+                    $totalProcessed = $channelCount + $programmeCount;
+                    if ($totalProcessed - $lastProgressUpdate >= $progressUpdateInterval) {
+                        $estimatedTotal = $totalChannels + $totalProgrammes;
+                        $progress = $estimatedTotal > 0
+                            ? min(30, round(($totalProcessed / $estimatedTotal) * 30))
+                            : 30;
+                        $epg->update(['cache_progress' => $progress]);
+                        $lastProgressUpdate = $totalProcessed;
+                    }
+                }
+            }
+
+            // Save remaining channels
+            if (! empty($channelBatch)) {
+                $this->saveChannelBatchOptimized($epg, $channelBatch, $channelCount <= $channelBatchSize);
+            }
+
+            // Flush remaining programme chunk buffer
+            if (! empty($currentChunkBuffer)) {
+                $chunkPath = "{$tmpDir}/chunk-{$currentChunkIndex}.jsonl";
+                Storage::disk('local')->put($chunkPath, implode("\n", $currentChunkBuffer)."\n");
+                $chunkPaths[] = $chunkPath;
+            }
+        } finally {
+            $reader->close();
+        }
+
+        return [
+            'chunk_count' => count($chunkPaths),
+            'chunk_paths' => $chunkPaths,
+            'channel_count' => $channelCount,
+            'programme_count' => $programmeCount,
+            'date_range' => $dateRangeTracker,
+        ];
+    }
+
+    /**
+     * Save metadata and finalize cache after all parallel chunk jobs complete.
+     */
+    public function finalizeCacheAfterChunks(Epg $epg, int $channelCount, int $programmeCount, array $dateRange): void
+    {
+        $metadata = [
+            'cache_created' => time(),
+            'cache_version' => self::CACHE_VERSION,
+            'epg_uuid' => $epg->uuid,
+            'total_channels' => $channelCount,
+            'total_programmes' => $programmeCount,
+            'programme_date_range' => $dateRange,
+        ];
+
+        Storage::disk('local')->put(
+            $this->getCacheFilePath($epg, self::METADATA_FILE),
+            json_encode($metadata, JSON_PRETTY_PRINT)
+        );
+
+        // Clean up temp chunk files
+        $tmpDir = $this->getCacheDir($epg).'/tmp';
+        Storage::disk('local')->deleteDirectory($tmpDir);
+
+        // Update EPG model
+        $epg->update([
+            'is_cached' => true,
+            'cache_progress' => 100,
+            'cache_meta' => $metadata,
+            'channel_count' => $channelCount,
+            'programme_count' => $programmeCount,
+        ]);
+
+        Log::debug('EPG cache generated successfully (parallel mode)', $metadata);
     }
 
     /**

--- a/tests/Feature/EpgMultithreadedTest.php
+++ b/tests/Feature/EpgMultithreadedTest.php
@@ -1,0 +1,321 @@
+<?php
+
+use App\Enums\Status;
+use App\Jobs\GenerateEpgCache;
+use App\Jobs\GenerateEpgCacheChunk;
+use App\Jobs\ProcessEpgImportChunk;
+use App\Models\Epg;
+use App\Models\User;
+use App\Services\EpgCacheService;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Phase 1: Import chunk parallelization
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('ProcessEpgImportChunk uses the Batchable trait', function () {
+    $traits = class_uses_recursive(ProcessEpgImportChunk::class);
+    expect($traits)->toContain(Batchable::class);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Phase 2: Cache generation parallelization
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('GenerateEpgCacheChunk uses the Batchable trait', function () {
+    $traits = class_uses_recursive(GenerateEpgCacheChunk::class);
+    expect($traits)->toContain(Batchable::class);
+});
+
+it('EpgCacheService pre-scan splits programmes into chunk files', function () {
+    Storage::fake('local');
+
+    $user = User::factory()->create();
+    $epg = Epg::factory()->for($user)->createQuietly([
+        'uuid' => 'test-prescan-uuid',
+        'url' => 'http://example.com/test.xml',
+        'status' => Status::Processing,
+        'is_cached' => false,
+    ]);
+
+    // Create a minimal EPG XML file
+    $xmlContent = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="ch1">
+    <display-name>Channel One</display-name>
+    <icon src="http://example.com/ch1.png"/>
+  </channel>
+  <channel id="ch2">
+    <display-name>Channel Two</display-name>
+  </channel>
+  <programme start="20260414060000 +0000" stop="20260414070000 +0000" channel="ch1">
+    <title>Morning Show</title>
+    <desc>A morning programme</desc>
+  </programme>
+  <programme start="20260414070000 +0000" stop="20260414080000 +0000" channel="ch1">
+    <title>News Hour</title>
+    <category>News</category>
+  </programme>
+  <programme start="20260414080000 +0000" stop="20260414090000 +0000" channel="ch2">
+    <title>Talk Show</title>
+  </programme>
+</tv>
+XML;
+
+    Storage::disk('local')->put($epg->file_path, $xmlContent);
+
+    $service = new EpgCacheService;
+    $result = $service->extractChannelsAndSplitProgrammes(
+        $epg,
+        Storage::disk('local')->path($epg->file_path),
+        2,
+        3
+    );
+
+    expect($result)
+        ->toBeArray()
+        ->toHaveKeys(['chunk_count', 'chunk_paths', 'channel_count', 'programme_count', 'date_range'])
+        ->and($result['channel_count'])->toBe(2)
+        ->and($result['programme_count'])->toBe(3)
+        ->and($result['chunk_count'])->toBeGreaterThanOrEqual(1)
+        ->and($result['chunk_paths'])->toBeArray()
+        ->and($result['date_range']['min_date'])->toBe('2026-04-14')
+        ->and($result['date_range']['max_date'])->toBe('2026-04-14');
+
+    // Verify channels.json was created
+    $channelsPath = "epg-cache/{$epg->uuid}/v1/channels.json";
+    expect(Storage::disk('local')->exists($channelsPath))->toBeTrue();
+
+    $channels = json_decode(Storage::disk('local')->get($channelsPath), true);
+    expect($channels)
+        ->toHaveKey('ch1')
+        ->toHaveKey('ch2');
+    expect($channels['ch1']['display_name'])->toBe('Channel One');
+
+    // Verify chunk files exist
+    foreach ($result['chunk_paths'] as $chunkPath) {
+        expect(Storage::disk('local')->exists($chunkPath))->toBeTrue();
+    }
+
+    // Verify chunk file content is valid JSONL with raw XML
+    $firstChunkContent = Storage::disk('local')->get($result['chunk_paths'][0]);
+    $lines = array_filter(explode("\n", trim($firstChunkContent)));
+    expect(count($lines))->toBeGreaterThanOrEqual(1);
+
+    $firstLine = json_decode($lines[0], true);
+    expect($firstLine)
+        ->toHaveKeys(['channel', 'start', 'stop', 'date', 'xml'])
+        ->and($firstLine['channel'])->toBe('ch1')
+        ->and($firstLine['date'])->toBe('2026-04-14')
+        ->and($firstLine['xml'])->toContain('<programme');
+});
+
+it('GenerateEpgCacheChunk parses raw XML and writes programme JSONL files', function () {
+    Storage::fake('local');
+
+    $user = User::factory()->create();
+    $epg = Epg::factory()->for($user)->createQuietly([
+        'uuid' => 'test-chunk-uuid',
+        'status' => Status::Processing,
+        'cache_progress' => 10,
+    ]);
+
+    // Create a chunk file with raw programme XML
+    $chunkData = [
+        json_encode([
+            'channel' => 'ch1',
+            'start' => '2026-04-14T06:00:00.000000Z',
+            'stop' => '2026-04-14T07:00:00.000000Z',
+            'date' => '2026-04-14',
+            'xml' => '<programme start="20260414060000 +0000" stop="20260414070000 +0000" channel="ch1"><title>Morning Show</title><desc>A morning programme</desc></programme>',
+        ], JSON_UNESCAPED_UNICODE),
+        json_encode([
+            'channel' => 'ch2',
+            'start' => '2026-04-15T08:00:00.000000Z',
+            'stop' => '2026-04-15T09:00:00.000000Z',
+            'date' => '2026-04-15',
+            'xml' => '<programme start="20260415080000 +0000" stop="20260415090000 +0000" channel="ch2"><title>Evening News</title><category>News</category></programme>',
+        ], JSON_UNESCAPED_UNICODE),
+    ];
+
+    $chunkPath = "epg-cache/{$epg->uuid}/v1/tmp/chunk-0.jsonl";
+    Storage::disk('local')->put($chunkPath, implode("\n", $chunkData)."\n");
+
+    // Create the cache directory
+    Storage::disk('local')->makeDirectory("epg-cache/{$epg->uuid}/v1");
+
+    $job = new GenerateEpgCacheChunk($epg->uuid, $chunkPath, 1);
+    $job->handle();
+
+    // Verify programme files were created for both dates
+    $file14 = "epg-cache/{$epg->uuid}/v1/programmes-2026-04-14.jsonl";
+    $file15 = "epg-cache/{$epg->uuid}/v1/programmes-2026-04-15.jsonl";
+
+    expect(Storage::disk('local')->exists($file14))->toBeTrue();
+    expect(Storage::disk('local')->exists($file15))->toBeTrue();
+
+    // Verify content of date 14
+    $content14 = Storage::disk('local')->get($file14);
+    $lines14 = array_filter(explode("\n", trim($content14)));
+    expect(count($lines14))->toBe(1);
+
+    $parsed = json_decode($lines14[0], true);
+    expect($parsed['channel'])->toBe('ch1');
+    expect($parsed['programme']['title'])->toBe('Morning Show');
+    expect($parsed['programme']['desc'])->toBe('A morning programme');
+
+    // Verify content of date 15
+    $content15 = Storage::disk('local')->get($file15);
+    $lines15 = array_filter(explode("\n", trim($content15)));
+    $parsed15 = json_decode($lines15[0], true);
+    expect($parsed15['channel'])->toBe('ch2');
+    expect($parsed15['programme']['title'])->toBe('Evening News');
+    expect($parsed15['programme']['category'])->toBe('News');
+});
+
+it('finalizeCacheAfterChunks writes metadata and cleans up tmp', function () {
+    Storage::fake('local');
+
+    $user = User::factory()->create();
+    $epg = Epg::factory()->for($user)->createQuietly([
+        'uuid' => 'test-finalize-uuid',
+        'status' => Status::Processing,
+        'is_cached' => false,
+    ]);
+
+    // Create cache dir and temp chunk file
+    $cacheDir = "epg-cache/{$epg->uuid}/v1";
+    $tmpDir = "{$cacheDir}/tmp";
+    Storage::disk('local')->makeDirectory($tmpDir);
+    Storage::disk('local')->put("{$tmpDir}/chunk-0.jsonl", 'test data');
+
+    $service = new EpgCacheService;
+    $service->finalizeCacheAfterChunks($epg, 10, 500, [
+        'min_date' => '2026-04-14',
+        'max_date' => '2026-04-20',
+    ]);
+
+    // Verify metadata file was created
+    $metadataPath = "{$cacheDir}/metadata.json";
+    expect(Storage::disk('local')->exists($metadataPath))->toBeTrue();
+
+    $metadata = json_decode(Storage::disk('local')->get($metadataPath), true);
+    expect($metadata['total_channels'])->toBe(10);
+    expect($metadata['total_programmes'])->toBe(500);
+    expect($metadata['programme_date_range']['min_date'])->toBe('2026-04-14');
+
+    // Verify EPG model was updated
+    $epg->refresh();
+    expect($epg->is_cached)->toBeTrue();
+    expect((int) $epg->cache_progress)->toBe(100);
+    expect($epg->channel_count)->toBe(10);
+    expect($epg->programme_count)->toBe(500);
+
+    // Verify tmp directory was cleaned up
+    expect(Storage::disk('local')->exists("{$tmpDir}/chunk-0.jsonl"))->toBeFalse();
+});
+
+it('cacheEpgData returns array in parallel mode for batch dispatch', function () {
+    Storage::fake('local');
+
+    $user = User::factory()->create();
+    $epg = Epg::factory()->for($user)->createQuietly([
+        'uuid' => 'test-parallel-uuid',
+        'url' => 'http://example.com/epg.xml',
+        'status' => Status::Processing,
+        'is_cached' => false,
+    ]);
+
+    $xmlContent = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="ch1"><display-name>Ch One</display-name></channel>
+  <programme start="20260414060000 +0000" stop="20260414070000 +0000" channel="ch1">
+    <title>Show</title>
+  </programme>
+</tv>
+XML;
+
+    Storage::disk('local')->put($epg->file_path, $xmlContent);
+
+    $service = new EpgCacheService;
+    $result = $service->cacheEpgData($epg, parallel: true);
+
+    expect($result)->toBeArray();
+    expect($result)->toHaveKeys(['chunk_count', 'chunk_paths', 'channel_count', 'programme_count']);
+});
+
+it('cacheEpgData returns bool in synchronous mode', function () {
+    Storage::fake('local');
+
+    $user = User::factory()->create();
+    $epg = Epg::factory()->for($user)->createQuietly([
+        'uuid' => 'test-sync-uuid',
+        'url' => 'http://example.com/epg.xml',
+        'status' => Status::Processing,
+        'is_cached' => false,
+    ]);
+
+    $xmlContent = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="ch1"><display-name>Ch One</display-name></channel>
+  <programme start="20260414060000 +0000" stop="20260414070000 +0000" channel="ch1">
+    <title>Show</title>
+  </programme>
+</tv>
+XML;
+
+    Storage::disk('local')->put($epg->file_path, $xmlContent);
+
+    $service = new EpgCacheService;
+    $result = $service->cacheEpgData($epg, parallel: false);
+
+    expect($result)->toBeTrue();
+    $epg->refresh();
+    expect($epg->is_cached)->toBeTrue();
+    expect((int) $epg->cache_progress)->toBe(100);
+});
+
+it('GenerateEpgCache dispatches batch for parallel cache generation', function () {
+    Bus::fake();
+    Storage::fake('local');
+
+    $user = User::factory()->create();
+    $epg = Epg::factory()->for($user)->createQuietly([
+        'uuid' => 'test-batch-dispatch-uuid',
+        'url' => 'http://example.com/epg.xml',
+        'status' => Status::Completed,
+        'is_cached' => false,
+    ]);
+
+    $xmlContent = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="ch1"><display-name>Ch One</display-name></channel>
+  <programme start="20260414060000 +0000" stop="20260414070000 +0000" channel="ch1">
+    <title>Show</title>
+  </programme>
+</tv>
+XML;
+
+    Storage::disk('local')->put($epg->file_path, $xmlContent);
+
+    // Since Bus is faked, the batch will be captured
+    Bus::assertNothingDispatched();
+
+    $job = new GenerateEpgCache($epg->uuid, notify: true);
+    $job->handle(app(EpgCacheService::class));
+
+    // The job should have dispatched a batch of GenerateEpgCacheChunk jobs
+    Bus::assertBatched(function (PendingBatch $batch) {
+        return $batch->jobs->every(fn ($job) => $job instanceof GenerateEpgCacheChunk);
+    });
+});

--- a/tests/Feature/EpgMultithreadedTest.php
+++ b/tests/Feature/EpgMultithreadedTest.php
@@ -12,6 +12,7 @@ use Illuminate\Bus\PendingBatch;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 uses(RefreshDatabase::class);
 
@@ -38,7 +39,7 @@ it('EpgCacheService pre-scan splits programmes into chunk files', function () {
 
     $user = User::factory()->create();
     $epg = Epg::factory()->for($user)->createQuietly([
-        'uuid' => 'test-prescan-uuid',
+        'uuid' => Str::uuid()->toString(),
         'url' => 'http://example.com/test.xml',
         'status' => Status::Processing,
         'is_cached' => false,
@@ -122,7 +123,7 @@ it('GenerateEpgCacheChunk parses raw XML and writes programme JSONL files', func
 
     $user = User::factory()->create();
     $epg = Epg::factory()->for($user)->createQuietly([
-        'uuid' => 'test-chunk-uuid',
+        'uuid' => Str::uuid()->toString(),
         'status' => Status::Processing,
         'cache_progress' => 10,
     ]);
@@ -185,7 +186,7 @@ it('finalizeCacheAfterChunks writes metadata and cleans up tmp', function () {
 
     $user = User::factory()->create();
     $epg = Epg::factory()->for($user)->createQuietly([
-        'uuid' => 'test-finalize-uuid',
+        'uuid' => Str::uuid()->toString(),
         'status' => Status::Processing,
         'is_cached' => false,
     ]);
@@ -227,7 +228,7 @@ it('cacheEpgData returns array in parallel mode for batch dispatch', function ()
 
     $user = User::factory()->create();
     $epg = Epg::factory()->for($user)->createQuietly([
-        'uuid' => 'test-parallel-uuid',
+        'uuid' => Str::uuid()->toString(),
         'url' => 'http://example.com/epg.xml',
         'status' => Status::Processing,
         'is_cached' => false,
@@ -257,7 +258,7 @@ it('cacheEpgData returns bool in synchronous mode', function () {
 
     $user = User::factory()->create();
     $epg = Epg::factory()->for($user)->createQuietly([
-        'uuid' => 'test-sync-uuid',
+        'uuid' => Str::uuid()->toString(),
         'url' => 'http://example.com/epg.xml',
         'status' => Status::Processing,
         'is_cached' => false,
@@ -290,7 +291,7 @@ it('GenerateEpgCache dispatches batch for parallel cache generation', function (
 
     $user = User::factory()->create();
     $epg = Epg::factory()->for($user)->createQuietly([
-        'uuid' => 'test-batch-dispatch-uuid',
+        'uuid' => Str::uuid()->toString(),
         'url' => 'http://example.com/epg.xml',
         'status' => Status::Completed,
         'is_cached' => false,


### PR DESCRIPTION
- Replace Bus::chain() with Bus::batch() in ProcessEpgImport for parallel chunk processing
- Add Batchable trait to ProcessEpgImportChunk with atomic progress updates
- Add new GenerateEpgCacheChunk job for parallel cache chunk processing
- Refactor EpgCacheService with extractChannelsAndSplitProgrammes() pre-scan method
- Refactor GenerateEpgCache as orchestrator dispatching parallel batch or sync fallback
- Auto-detect parallel mode based on database driver (sync for SQLite)
- Add finalizeCacheAfterChunks() to assemble cache after parallel completion
- Use file locking (flock) for concurrent JSONL write safety
- CLI command uses synchronous mode by default
- Add 8 feature tests covering traits, pre-scan, chunk parsing, and batch dispatch