### PR TITLE
fix: Exclude disabled and VOD groups from EPG viewer category tabs

### DIFF
--- a/app/Http/Controllers/Api/EpgApiController.php
+++ b/app/Http/Controllers/Api/EpgApiController.php
@@ -771,17 +771,20 @@ class EpgApiController extends Controller
         }
 
         $vod = (bool) $request->get('vod', false);
+        $includeVod = $vod && $playlist->include_vod_in_m3u;
 
         $channelQuery = $playlist->channels();
         $g = $channelQuery->getQuery()->getGrammar();
         $coalesce = 'COALESCE('.$g->wrap('channels.group').', '.$g->wrap('channels.group_internal').')';
 
         $groups = $channelQuery
+            ->leftJoin('groups', 'channels.group_id', '=', 'groups.id')
             ->selectRaw("{$coalesce} as effective_group")
-            ->when(! $vod, function ($q) {
+            ->when(! $includeVod, function ($q) {
                 $q->where('channels.is_vod', false);
             })
             ->where('channels.enabled', true)
+            ->where(fn ($q) => $q->where('groups.enabled', true)->orWhereNull('channels.group_id'))
             ->whereRaw("{$coalesce} IS NOT NULL")
             ->whereRaw("{$coalesce} != ''")
             ->groupByRaw($coalesce)

--- a/tests/Feature/EpgGroupsTest.php
+++ b/tests/Feature/EpgGroupsTest.php
@@ -17,8 +17,8 @@ beforeEach(function () {
 });
 
 it('returns distinct sorted groups for a playlist', function () {
-    $sportsGroup = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id]);
-    $newsGroup = Group::factory()->create(['name' => 'News', 'user_id' => $this->user->id]);
+    $sportsGroup = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id, 'enabled' => true]);
+    $newsGroup = Group::factory()->create(['name' => 'News', 'user_id' => $this->user->id, 'enabled' => true]);
 
     Channel::factory()->create([
         'playlist_id' => $this->playlist->id,
@@ -56,7 +56,7 @@ it('returns distinct sorted groups for a playlist', function () {
 });
 
 it('excludes disabled channels from groups response', function () {
-    $group = Group::factory()->create(['name' => 'Hidden', 'user_id' => $this->user->id]);
+    $group = Group::factory()->create(['name' => 'Hidden', 'user_id' => $this->user->id, 'enabled' => true]);
 
     Channel::factory()->create([
         'playlist_id' => $this->playlist->id,
@@ -73,10 +73,92 @@ it('excludes disabled channels from groups response', function () {
         ->assertJson(['groups' => []]);
 });
 
+it('excludes disabled groups from groups response', function () {
+    $group = Group::factory()->create(['name' => 'Disabled Group', 'user_id' => $this->user->id, 'enabled' => false]);
+
+    Channel::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'group_id' => $group->id,
+        'group' => 'Disabled Group',
+        'enabled' => true,
+        'is_vod' => false,
+    ]);
+
+    $response = $this->getJson("/api/epg/playlist/{$this->playlist->uuid}/groups");
+
+    $response->assertOk()
+        ->assertJson(['groups' => []]);
+});
+
+it('excludes vod groups when playlist does not include vod in m3u', function () {
+    $liveGroup = Group::factory()->create(['name' => 'Live Sports', 'user_id' => $this->user->id, 'enabled' => true]);
+    $vodGroup = Group::factory()->create(['name' => 'VOD Movies', 'user_id' => $this->user->id, 'enabled' => true]);
+
+    Channel::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'group_id' => $liveGroup->id,
+        'group' => 'Live Sports',
+        'enabled' => true,
+        'is_vod' => false,
+    ]);
+
+    Channel::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'group_id' => $vodGroup->id,
+        'group' => 'VOD Movies',
+        'enabled' => true,
+        'is_vod' => true,
+    ]);
+
+    // Playlist has include_vod_in_m3u = false, so even with vod=1 param,
+    // VOD groups should be excluded to stay consistent with the data endpoint
+    $this->playlist->update(['include_vod_in_m3u' => false]);
+
+    $response = $this->getJson("/api/epg/playlist/{$this->playlist->uuid}/groups?vod=1");
+
+    $response->assertOk()
+        ->assertJson(['groups' => ['Live Sports']])
+        ->assertJsonMissing(['groups' => ['VOD Movies']]);
+});
+
+it('includes vod groups when playlist includes vod in m3u', function () {
+    $liveGroup = Group::factory()->create(['name' => 'Live Sports', 'user_id' => $this->user->id, 'enabled' => true]);
+    $vodGroup = Group::factory()->create(['name' => 'VOD Movies', 'user_id' => $this->user->id, 'enabled' => true]);
+
+    Channel::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'group_id' => $liveGroup->id,
+        'group' => 'Live Sports',
+        'enabled' => true,
+        'is_vod' => false,
+    ]);
+
+    Channel::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'group_id' => $vodGroup->id,
+        'group' => 'VOD Movies',
+        'enabled' => true,
+        'is_vod' => true,
+    ]);
+
+    $this->playlist->update(['include_vod_in_m3u' => true]);
+
+    $response = $this->getJson("/api/epg/playlist/{$this->playlist->uuid}/groups?vod=1");
+
+    $response->assertOk()
+        ->assertJson(['groups' => ['Live Sports', 'VOD Movies']]);
+});
+
 it('falls back to group_internal when group is null', function () {
     Channel::factory()->create([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
+        'group_id' => null,
         'group' => null,
         'group_internal' => 'Entertainment',
         'enabled' => true,
@@ -95,8 +177,8 @@ it('returns 404 for unknown playlist uuid', function () {
 });
 
 it('filters channels by group when group param is provided', function () {
-    $sportsGroup = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id]);
-    $newsGroup = Group::factory()->create(['name' => 'News', 'user_id' => $this->user->id]);
+    $sportsGroup = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id, 'enabled' => true]);
+    $newsGroup = Group::factory()->create(['name' => 'News', 'user_id' => $this->user->id, 'enabled' => true]);
 
     $sportsChannel = Channel::factory()->create([
         'playlist_id' => $this->playlist->id,
@@ -130,8 +212,8 @@ it('filters channels by group when group param is provided', function () {
 });
 
 it('returns all channels when no group param is provided', function () {
-    $sportsGroup = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id]);
-    $newsGroup = Group::factory()->create(['name' => 'News', 'user_id' => $this->user->id]);
+    $sportsGroup = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id, 'enabled' => true]);
+    $newsGroup = Group::factory()->create(['name' => 'News', 'user_id' => $this->user->id, 'enabled' => true]);
 
     Channel::factory()->create([
         'playlist_id' => $this->playlist->id,
@@ -162,7 +244,7 @@ it('returns all channels when no group param is provided', function () {
 });
 
 it('group filter is case-insensitive', function () {
-    $group = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id]);
+    $group = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id, 'enabled' => true]);
 
     $channel = Channel::factory()->create([
         'playlist_id' => $this->playlist->id,


### PR DESCRIPTION
## Summary
- EPG viewer category tabs now respect the playlist's `include_vod_in_m3u` setting, so VOD groups only appear when the playlist is configured to include VOD content
- Also filters out disabled groups (via `groups.enabled`) from the category tabs
- Previously, clicking VOD group tabs showed nothing because the data endpoint excluded VOD channels while the groups endpoint still listed them

## Test plan
- [x] Existing EPG groups tests updated and passing
- [x] New tests added for VOD group exclusion and disabled group filtering