### PR TITLE
fix: correct EPG URL path in Plex tuner registration form\n\nThe auto…

### DIFF
--- a/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
+++ b/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
@@ -792,7 +792,7 @@ class MediaServerIntegrationResource extends Resource implements CopilotResource
                                                         : '';
 
                                                     $set('hdhr_base_url', $baseUrl."/{$uuid}/hdhr{$hdhrAuthPath}");
-                                                    $set('epg_url', $baseUrl."/epg/{$uuid}");
+                                                    $set('epg_url', $baseUrl."/{$uuid}/epg.xml");
                                                 })
                                                 ->required(),
                                             Placeholder::make('tvg_id_warning')


### PR DESCRIPTION
…-filled EPG URL was using /epg/{uuid} which doesn't match\nany route. The correct route is /{uuid}/epg.xml. This caused Plex\nto fail resolving the lineup and report the tuner as unreachable."