### PR TITLE
fix: Consolidate player cleanup lifecycle and fix orphaned proxy clients

### DIFF
--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -302,10 +302,10 @@ function multiStreamManager() {
                 return;
             }
 
-            // Notify the proxy to de-register this floating player client so
-            // it doesn't linger as an orphan and block stream cleanup later.
-            // The pop-out window opens its own connection with a new client_id.
-            this.closeStream(player.id, { notifyServer: true });
+            // Close the floating player locally without notifying the proxy —
+            // the pop-out window inherits the same client_id so the proxy sees
+            // an uninterrupted connection with no gap at 0 clients.
+            this.closeStream(player.id, { notifyServer: false });
 
             const params = new URLSearchParams({
                 title: player.title ?? '',
@@ -318,6 +318,7 @@ function multiStreamManager() {
                 playlist_id: player.playlist_id ?? '',
                 series_id: player.series_id ?? '',
                 season_number: player.season_number ?? '',
+                client_id: player.id,
             });
 
             window.open(popoutRoute + '?' + params.toString(), '_blank', 'noopener');

--- a/resources/js/vendor/multi-stream-manager.js
+++ b/resources/js/vendor/multi-stream-manager.js
@@ -6,6 +6,7 @@ function multiStreamManager() {
         zIndexCounter: 1000,
         _initialized: false,
         _abortController: null,
+        _finalized: false,
         _lastClickPos: { x: 0, y: 0 },
         dragState: {
             isDragging: false,
@@ -29,6 +30,8 @@ function multiStreamManager() {
             if (this._initialized) {
                 return;
             }
+
+            this._finalized = false;
 
             // Read max players from container data attribute
             const container = document.querySelector('[data-max-players]');
@@ -125,8 +128,7 @@ function multiStreamManager() {
                 position: this.getRandomPosition(),
                 size: { width: 480, height: 270 }, // 16:9 aspect ratio
                 isMinimized: false,
-                isPiP: false,
-                streamPlayer: null
+                isPiP: false
             };
 
             this.players.push(player);
@@ -141,18 +143,6 @@ function multiStreamManager() {
                 x: Math.max(padding, Math.random() * maxX),
                 y: Math.max(padding, Math.random() * maxY)
             };
-        },
-
-        initializePlayer(player) {
-            const videoElement = document.getElementById(player.id + '-video');
-            if (videoElement && window.streamPlayer) {
-                player.streamPlayer = window.streamPlayer();
-                // Append a unique client_id so the proxy can distinguish each browser
-                // tab / player instance even when they share the same IP + User-Agent.
-                const sep = player.url.includes('?') ? '&' : '?';
-                const url = player.url + sep + 'client_id=' + encodeURIComponent(player.id);
-                player.streamPlayer.initPlayer(url, player.format, player.id + '-video');
-            }
         },
 
         closeStream(playerId, { notifyServer = true } = {}) {
@@ -170,13 +160,8 @@ function multiStreamManager() {
                 if (notifyServer) {
                     this.notifyServerStreamStop(player);
                 }
-                if (videoElement && videoElement._streamPlayer) {
+                if (videoElement?._streamPlayer) {
                     videoElement._streamPlayer.cleanup();
-                }
-
-                // Also cleanup via stored reference
-                if (player.streamPlayer && typeof player.streamPlayer.cleanup === 'function') {
-                    player.streamPlayer.cleanup();
                 }
 
                 // Remove from array
@@ -185,25 +170,19 @@ function multiStreamManager() {
         },
 
         cleanupAllStreams() {
+            if (this._finalized) return;
+            this._finalized = true;
+
             this.players.forEach(player => {
                 // Notify server to stop the proxy stream (best-effort via sendBeacon)
                 this.notifyServerStreamStop(player);
-                // Cleanup via video element
+                // Cleanup local media via video element
                 const videoElement = document.getElementById(player.id + '-video');
-                if (videoElement && videoElement._streamPlayer) {
+                if (videoElement?._streamPlayer) {
                     try {
                         videoElement._streamPlayer.cleanup();
                     } catch (e) {
-                        console.warn('Error cleaning up video element:', e);
-                    }
-                }
-
-                // Also cleanup via stored reference
-                if (player.streamPlayer && typeof player.streamPlayer.cleanup === 'function') {
-                    try {
-                        player.streamPlayer.cleanup();
-                    } catch (e) {
-                        console.warn('Error cleaning up player reference:', e);
+                        console.warn('Error cleaning up stream:', e);
                     }
                 }
             });
@@ -323,9 +302,10 @@ function multiStreamManager() {
                 return;
             }
 
-            // Close the floating player locally without telling the proxy to stop —
-            // the pop-out window will pick up the same stream.
-            this.closeStream(player.id, { notifyServer: false });
+            // Notify the proxy to de-register this floating player client so
+            // it doesn't linger as an orphan and block stream cleanup later.
+            // The pop-out window opens its own connection with a new client_id.
+            this.closeStream(player.id, { notifyServer: true });
 
             const params = new URLSearchParams({
                 title: player.title ?? '',

--- a/resources/js/vendor/stream-viewer.js
+++ b/resources/js/vendor/stream-viewer.js
@@ -19,6 +19,7 @@ function streamPlayer() {
         selectedAudioTrack: null,
         fragmentErrorCount: 0,
         _videoHandlers: {},
+        _cleaned: false,
 
         // ── Watch Progress ────────────────────────────────────────────────
         progressConfig: null,   // { contentType, streamId, playlistId, seriesId, seasonNumber }
@@ -191,6 +192,7 @@ function streamPlayer() {
 
             // Clean up any existing players before binding the new video element
             this.cleanup();
+            this._cleaned = false;
 
             // Store reference to video element for cleanup
             this.player = video;
@@ -767,6 +769,9 @@ function streamPlayer() {
         },
 
         cleanup() {
+            if (this._cleaned) return;
+            this._cleaned = true;
+
             // Save final progress and stop timer
             this._saveProgress(true);
             this._stopProgressTimer();

--- a/resources/views/components/floating-stream-players.blade.php
+++ b/resources/views/components/floating-stream-players.blade.php
@@ -28,10 +28,6 @@
         if (typeof cleanupAllStreams === 'function') {
             cleanupAllStreams();
         }
-    " x-on:livewire:navigating.window="
-        if (typeof cleanupAllStreams === 'function') {
-            cleanupAllStreams();
-        }
     " class="fixed inset-0 pointer-events-none z-[9999]">
     <!-- Multiple Floating Players -->
     <template x-for="player in players" :key="player.id">

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -73,7 +73,8 @@
                 </div>
             </div>
 
-            <div class="absolute top-2 left-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex gap-1">
+            <div
+                class="absolute top-2 left-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex gap-1">
                 <button type="button" onclick="toggleStreamDetails('popout-player')"
                     class="rounded bg-black/75 hover:bg-black/90 px-2 py-1 text-xs text-white transition-colors"
                     title="Toggle Stream Details">
@@ -82,7 +83,8 @@
                 <button type="button" id="popout-pip-btn" onclick="togglePopoutPiP()"
                     class="rounded bg-black/75 hover:bg-black/90 px-2 py-1 text-xs text-white transition-colors"
                     title="Picture-in-Picture" style="display: none;">
-                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round">
                         <rect x="2" y="3" width="20" height="14" rx="2" />
                         <rect x="12" y="9" width="8" height="6" rx="1" fill="currentColor" />
                     </svg>
@@ -123,9 +125,11 @@
             const streamUrl = videoElement.dataset.url ?? '';
             const streamFormat = videoElement.dataset.format ?? 'ts';
 
-            // Generate a unique client_id for this popout window so the proxy
-            // distinguishes it from other tabs / players watching the same stream.
-            const popoutClientId = 'popout-' + Math.random().toString(36).substring(2, 11);
+            // Inherit the client_id from the floating player if this popout was
+            // opened via "open in new tab", so the proxy sees an uninterrupted
+            // connection. Fall back to a fresh id for direct popout loads.
+            const urlParams = new URLSearchParams(window.location.search);
+            const popoutClientId = urlParams.get('client_id') ?? 'popout-' + Math.random().toString(36).substr(2, 9);
             const clientIdSep = streamUrl.includes('?') ? '&' : '?';
             const streamUrlWithClientId = streamUrl + clientIdSep + 'client_id=' + encodeURIComponent(popoutClientId);
 
@@ -138,11 +142,11 @@
                 if (pipBtn) pipBtn.style.display = '';
             }
 
-            window.togglePopoutPiP = function() {
+            window.togglePopoutPiP = function () {
                 if (document.pictureInPictureElement === videoElement) {
-                    document.exitPictureInPicture().catch(() => {});
+                    document.exitPictureInPicture().catch(() => { });
                 } else if (document.pictureInPictureEnabled) {
-                    videoElement.requestPictureInPicture().catch(() => {});
+                    videoElement.requestPictureInPicture().catch(() => { });
                 }
             };
 

--- a/resources/views/player/popout.blade.php
+++ b/resources/views/player/popout.blade.php
@@ -146,24 +146,29 @@
                 }
             };
 
-            window.addEventListener('beforeunload', () => {
-                if (typeof player.cleanup === 'function') {
-                    player.cleanup();
-                }
-            });
+            // Unified cleanup for page unload (beforeunload + pagehide for
+            // mobile Safari). Runs once to avoid duplicate proxy stop
+            // requests and double media teardown.
+            const streamType = (videoElement.dataset.contentType === 'episode') ? 'episode' : 'channel';
+            let popoutFinalized = false;
+            function finalizePopoutSession() {
+                if (popoutFinalized) return;
+                popoutFinalized = true;
 
-            window.addEventListener('pagehide', () => {
-                // Notify proxy to stop the stream before the page unloads
-                const contentType = videoElement.dataset.contentType || '';
-                const streamId = videoElement.dataset.streamId || '';
-                const type = contentType === 'episode' ? 'episode' : 'channel';
                 if (window.notifyProxyStreamStop) {
-                    window.notifyProxyStreamStop(streamId, type, popoutClientId);
+                    window.notifyProxyStreamStop(
+                        videoElement.dataset.streamId || '',
+                        streamType,
+                        popoutClientId,
+                    );
                 }
                 if (typeof player.cleanup === 'function') {
                     player.cleanup();
                 }
-            });
+            }
+
+            window.addEventListener('beforeunload', finalizePopoutSession);
+            window.addEventListener('pagehide', finalizePopoutSession);
 
             document.addEventListener('visibilitychange', () => {
                 const isLive = videoElement.dataset.contentType === 'live';


### PR DESCRIPTION
## Summary

- Adds idempotency guards to `cleanup()` and `cleanupAllStreams()` so duplicate triggers (alpine:destroyed, beforeunload, pagehide, livewire:navigating) only run once per session
- Removes duplicate livewire:navigating handler from blade template (already registered in JS init)
- Removes dead `initializePlayer()` method and unused `player.streamPlayer` property
- Unifies popout `beforeunload`/`pagehide` into single `finalizePopoutSession()`, fixing a bug where `beforeunload` was missing the server stop notification
- Fixes `openInNewTab` to properly de-register the floating player client on the proxy, preventing orphaned clients from blocking stream deletion when the popout tab is closed

## Test plan

- [x] Open a floating player, close it via the X button — proxy stream stops
- [x] Open multiple floating players, navigate to another page — all streams stop, no console errors
- [x] Open a floating player, click "open in new tab", play in popout, close the popout tab — proxy stream stops (previously left orphaned client)
- [x] Open a floating player, close the browser tab — proxy stream stops
- [x] Open a floating player, watch VOD partially, close, reopen — resume prompt appears