### PR TITLE
feat: Add bulk EPG shift (tvg-shift) action for live channels

### DIFF
--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -1059,6 +1059,35 @@ class ChannelResource extends Resource implements CopilotResource
                         ->modalIcon('heroicon-o-clock')
                         ->modalDescription(__('Set the timeshift value for the selected channels. Use 0 to disable catch-up.'))
                         ->modalSubmitActionLabel(__('Set timeshift')),
+                    BulkAction::make('set-epg-shift')
+                        ->label(__('Set EPG Shift'))
+                        ->schema([
+                            TextInput::make('tvg_shift')
+                                ->label(__('EPG Shift value'))
+                                ->helperText(__('Shift the EPG time for the selected channels by this many hours. Use values like -2, -1, 0, 1, 2, etc. Use 0 to reset.'))
+                                ->type('number')
+                                ->rules(['required', 'numeric'])
+                                ->default(0)
+                                ->required(),
+                        ])
+                        ->action(function (Collection $records, array $data): void {
+                            $value = (string) $data['tvg_shift'];
+                            foreach ($records->chunk(100) as $chunk) {
+                                Channel::whereIn('id', $chunk->pluck('id'))->update(['tvg_shift' => $value]);
+                            }
+                        })->after(function (array $data) {
+                            Notification::make()
+                                ->success()
+                                ->title(__('EPG Shift updated'))
+                                ->body("EPG Shift set to {$data['tvg_shift']} for the selected channels.")
+                                ->send();
+                        })
+                        ->deselectRecordsAfterCompletion()
+                        ->requiresConfirmation()
+                        ->icon('heroicon-o-clock')
+                        ->modalIcon('heroicon-o-clock')
+                        ->modalDescription(__('Set the EPG time shift (tvg-shift) for the selected channels. This shifts the EPG program schedule by the specified number of hours.'))
+                        ->modalSubmitActionLabel(__('Set EPG Shift')),
                     BulkAction::make('probe-streams')
                         ->label(__('Probe Streams'))
                         ->action(function (Collection $records): void {

--- a/tests/Feature/BulkEpgShiftTest.php
+++ b/tests/Feature/BulkEpgShiftTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Filament\Resources\Channels\ChannelResource;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+use Filament\Actions\BulkAction;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    $this->playlist = Playlist::factory()->for($this->user)->createQuietly();
+});
+
+/**
+ * Return the flat list of BulkAction names from the BulkModalActionGroup schema.
+ */
+function getBulkActionNames(): array
+{
+    $bulkActions = ChannelResource::getTableBulkActions();
+    $group = $bulkActions[0];
+
+    $schemaProp = new ReflectionProperty($group, 'schema');
+    $outerSchema = $schemaProp->getValue($group);
+
+    $grid = $outerSchema[0];
+
+    $childProp = new ReflectionProperty($grid, 'childComponents');
+    $children = $childProp->getValue($grid)['default'] ?? [];
+
+    return collect($children)
+        ->filter(fn ($c) => $c instanceof BulkAction)
+        ->map(fn ($c) => $c->getName())
+        ->values()
+        ->all();
+}
+
+it('registers set-epg-shift bulk action inside the channel BulkModalActionGroup', function () {
+    $names = getBulkActionNames();
+    expect($names)->toContain('set-epg-shift');
+});
+
+it('bulk sets tvg_shift for selected channels', function () {
+    $channels = Channel::factory()
+        ->count(3)
+        ->for($this->playlist)
+        ->create(['tvg_shift' => null]);
+
+    foreach ($channels->chunk(100) as $chunk) {
+        Channel::whereIn('id', $chunk->pluck('id'))->update(['tvg_shift' => '2']);
+    }
+
+    foreach ($channels as $channel) {
+        expect($channel->fresh()->tvg_shift)->toBe('2');
+    }
+});
+
+it('bulk sets negative tvg_shift for selected channels', function () {
+    $channels = Channel::factory()
+        ->count(3)
+        ->for($this->playlist)
+        ->create(['tvg_shift' => '0']);
+
+    foreach ($channels->chunk(100) as $chunk) {
+        Channel::whereIn('id', $chunk->pluck('id'))->update(['tvg_shift' => '-3']);
+    }
+
+    foreach ($channels as $channel) {
+        expect($channel->fresh()->tvg_shift)->toBe('-3');
+    }
+});
+
+it('bulk resets tvg_shift to zero for selected channels', function () {
+    $channels = Channel::factory()
+        ->count(3)
+        ->for($this->playlist)
+        ->create(['tvg_shift' => '5']);
+
+    foreach ($channels->chunk(100) as $chunk) {
+        Channel::whereIn('id', $chunk->pluck('id'))->update(['tvg_shift' => '0']);
+    }
+
+    foreach ($channels as $channel) {
+        expect($channel->fresh()->tvg_shift)->toBe('0');
+    }
+});


### PR DESCRIPTION
## Summary

- Adds a new "Set EPG Shift" bulk action to the channel bulk actions menu, placed alongside the existing "Set Timeshift" action
- Supports positive and negative hour offsets (e.g., -2, -1, 0, 1, 2) for shifting EPG program schedules per-channel
- Chunks updates by 100 for performance on large selections

## Test plan

- [x] Select multiple live channels, open bulk actions, use "Set EPG Shift" with a positive value — all selected channels update
- [x] Repeat with a negative value — negative offsets accepted
- [x] Set to 0 to reset — clears shift for selected channels
- [x] Verify generated M3U playlist reflects the updated tvg-shift values