### PR TITLE
Organize bulk actions menus with section headers

### DIFF
--- a/app/Filament/Actions/BulkModalActionGroup.php
+++ b/app/Filament/Actions/BulkModalActionGroup.php
@@ -51,7 +51,9 @@ class BulkModalActionGroup extends BulkAction
 
     public function schema(array|Closure|null $schema): static
     {
-        // Ensure child actions close the parent modal when they complete
+        // Ensure top-level child actions close the parent modal when they complete.
+        // When actions are nested inside layout components (Section, etc.),
+        // callers must call cancelParentActions() on each action themselves.
         if (is_array($schema)) {
             foreach ($schema as $component) {
                 if ($component instanceof BulkAction) {
@@ -60,11 +62,16 @@ class BulkModalActionGroup extends BulkAction
             }
         }
 
-        // Wrap the schema in our grid layout
-        $schema = [
-            Grid::make(columns: $this->gridColumns)
-                ->schema($schema),
-        ];
+        // When schema contains only flat BulkActions, wrap in a grid.
+        // When it contains layout components (Section, etc.), they manage their own layout.
+        $allBulkActions = is_array($schema) && collect($schema)->every(fn ($c) => $c instanceof BulkAction);
+
+        if ($allBulkActions) {
+            $schema = [
+                Grid::make(columns: $this->gridColumns)
+                    ->schema($schema),
+            ];
+        }
 
         return parent::schema($schema);
     }

--- a/app/Filament/Actions/ModalActionGroup.php
+++ b/app/Filament/Actions/ModalActionGroup.php
@@ -50,7 +50,9 @@ class ModalActionGroup extends Action
 
     public function schema(array|Closure|null $schema): static
     {
-        // Ensure child actions close the parent modal when they complete
+        // Ensure top-level child actions close the parent modal when they complete.
+        // When actions are nested inside layout components (Section, etc.),
+        // callers must call cancelParentActions() on each action themselves.
         if (is_array($schema)) {
             foreach ($schema as $component) {
                 if ($component instanceof Action) {
@@ -59,11 +61,16 @@ class ModalActionGroup extends Action
             }
         }
 
-        // Wrap the schema in our grid layout
-        $schema = [
-            Grid::make(columns: $this->gridColumns)
-                ->schema($schema),
-        ];
+        // When schema contains only flat Actions, wrap in a grid.
+        // When it contains layout components (Section, etc.), they manage their own layout.
+        $allActions = is_array($schema) && collect($schema)->every(fn ($c) => $c instanceof Action);
+
+        if ($allActions) {
+            $schema = [
+                Grid::make(columns: $this->gridColumns)
+                    ->schema($schema),
+            ];
+        }
 
         return parent::schema($schema);
     }

--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -495,671 +495,725 @@ class ChannelResource extends Resource implements CopilotResource
             BulkModalActionGroup::make('Bulk channel actions')
                 ->modalHeading(__('Bulk channel actions'))
                 ->gridColumns(2)
-                ->schema([
-                    PlaylistService::getAddToPlaylistBulkAction('add', 'channel')
-                        ->hidden(fn () => ! $addToCustom),
-                    BulkAction::make('move')
-                        ->label(__('Move to Group'))
+                ->schema(self::getBulkActionSchema($addToCustom, $includeRecount)),
+        ];
+    }
+
+    /**
+     * Create a compact section for the bulk actions modal, ensuring each
+     * action closes the parent modal when it completes.
+     */
+    private static function bulkActionSection(string $heading, array $actions): Section
+    {
+        foreach ($actions as $action) {
+            if ($action instanceof BulkAction) {
+                $action->cancelParentActions();
+            }
+        }
+
+        return Section::make(__($heading))
+            ->columns(2)
+            ->columnSpanFull()
+            ->compact()
+            ->schema($actions);
+    }
+
+    /**
+     * Build the sectioned schema for the bulk actions modal.
+     */
+    private static function getBulkActionSchema(bool $addToCustom, bool $includeRecount): array
+    {
+        return [
+            // -- Playlist & Groups --
+            self::bulkActionSection('Playlist & Groups', [
+                PlaylistService::getAddToPlaylistBulkAction('add', 'channel')
+                    ->hidden(fn () => ! $addToCustom),
+                BulkAction::make('move')
+                    ->label(__('Move to Group'))
+                    ->schema([
+                        Select::make('playlist')
+                            ->required()
+                            ->live()
+                            ->afterStateUpdated(function (Set $set) {
+                                $set('group', null);
+                            })
+                            ->label(__('Playlist'))
+                            ->helperText(__('Select a playlist - only channels in the selected playlist will be moved. Any channels selected from another playlist will be ignored.'))
+                            ->options(Playlist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
+                            ->searchable(),
+                        Select::make('group')
+                            ->required()
+                            ->live()
+                            ->label(__('Group'))
+                            ->helperText(fn (Get $get) => $get('playlist') === null ? 'Select a playlist first...' : 'Select the group you would like to move the items to.')
+                            ->options(fn (Get $get) => Group::where([
+                                'type' => 'live',
+                                'user_id' => auth()->id(),
+                                'playlist_id' => $get('playlist'),
+                            ])->get(['name', 'id'])->pluck('name', 'id'))
+                            ->searchable()
+                            ->disabled(fn (Get $get) => $get('playlist') === null),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        $filtered = $records->where('playlist_id', $data['playlist']);
+                        $group = Group::findOrFail($data['group']);
+                        foreach ($filtered as $record) {
+                            $record->update([
+                                'group' => $group->name,
+                                'group_id' => $group->id,
+                            ]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Channels moved to group'))
+                            ->body(__('The selected channels have been moved to the chosen group.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrows-right-left')
+                    ->modalIcon('heroicon-o-arrows-right-left')
+                    ->modalDescription(__('Move the selected channel(s) to the chosen group.'))
+                    ->modalSubmitActionLabel(__('Move now')),
+                ...($includeRecount ? [
+                    BulkAction::make('recount')
+                        ->label(__('Recount Channels'))
+                        ->icon('heroicon-o-hashtag')
                         ->schema([
-                            Select::make('playlist')
-                                ->required()
-                                ->live()
-                                ->afterStateUpdated(function (Set $set) {
-                                    $set('group', null);
-                                })
-                                ->label(__('Playlist'))
-                                ->helperText(__('Select a playlist - only channels in the selected playlist will be moved. Any channels selected from another playlist will be ignored.'))
-                                ->options(Playlist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                                ->searchable(),
-                            Select::make('group')
-                                ->required()
-                                ->live()
-                                ->label(__('Group'))
-                                ->helperText(fn (Get $get) => $get('playlist') === null ? 'Select a playlist first...' : 'Select the group you would like to move the items to.')
-                                ->options(fn (Get $get) => Group::where([
-                                    'type' => 'live',
-                                    'user_id' => auth()->id(),
-                                    'playlist_id' => $get('playlist'),
-                                ])->get(['name', 'id'])->pluck('name', 'id'))
-                                ->searchable()
-                                ->disabled(fn (Get $get) => $get('playlist') === null),
+                            TextInput::make('start')
+                                ->label(__('Start Number'))
+                                ->numeric()
+                                ->default(1)
+                                ->required(),
                         ])
                         ->action(function (Collection $records, array $data): void {
-                            $filtered = $records->where('playlist_id', $data['playlist']);
-                            $group = Group::findOrFail($data['group']);
-                            foreach ($filtered as $record) {
-                                $record->update([
-                                    'group' => $group->name,
-                                    'group_id' => $group->id,
-                                ]);
-                            }
-                        })->after(function () {
+                            $start = (int) $data['start'];
+                            SortFacade::bulkRecountChannels($records, $start);
+                            dispatch(new SyncPlexDvrJob(trigger: 'channel_recount'));
+                        })
+                        ->after(function ($livewire) {
                             Notification::make()
                                 ->success()
-                                ->title(__('Channels moved to group'))
-                                ->body(__('The selected channels have been moved to the chosen group.'))
+                                ->title(__('Channels Recounted'))
+                                ->body(__('The selected channels have been recounted.'))
                                 ->send();
                         })
-                        ->deselectRecordsAfterCompletion()
                         ->requiresConfirmation()
-                        ->icon('heroicon-o-arrows-right-left')
-                        ->modalIcon('heroicon-o-arrows-right-left')
-                        ->modalDescription(__('Move the selected channel(s) to the chosen group.'))
-                        ->modalSubmitActionLabel(__('Move now')),
-                    BulkAction::make('preferred_logo')
-                        ->label(__('Update preferred icon'))
-                        ->schema([
-                            Select::make('logo_type')
-                                ->label(__('Preferred Icon'))
-                                ->helperText(__('Prefer logo from channel or EPG.'))
-                                ->options([
-                                    'channel' => 'Channel',
-                                    'epg' => 'EPG',
-                                ])
-                                ->searchable(),
+                        ->modalIcon('heroicon-o-hashtag')
+                        ->modalDescription(__('Recount the selected channels sequentially? Channel numbers will be assigned based on the current sort order.')),
+                ] : []),
+            ]),
 
-                        ])
-                        ->action(function (Collection $records, array $data): void {
-                            Channel::whereIn('id', $records->pluck('id')->toArray())
-                                ->update([
-                                    'logo_type' => $data['logo_type'],
-                                ]);
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Preferred icon updated'))
-                                ->body(__('The preferred icon has been updated.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-photo')
-                        ->modalIcon('heroicon-o-photo')
-                        ->modalDescription(__('Update the preferred icon for the selected channel(s).'))
-                        ->modalSubmitActionLabel(__('Update now')),
-                    BulkAction::make('set_logo_override_url')
-                        ->label(__('Set logo override URL'))
-                        ->schema([
-                            TextInput::make('logo')
-                                ->label(__('Logo override URL'))
-                                ->url()
-                                ->nullable()
-                                ->helperText(__('Leave empty to remove the custom logo and use provider/EPG logo.'))
-                                ->suffixActions([
-                                    AssetPickerAction::upload('logo'),
-                                    AssetPickerAction::browse('logo'),
-                                ]),
-                        ])
-                        ->action(function (Collection $records, array $data): void {
-                            Channel::whereIn('id', $records->pluck('id')->toArray())
-                                ->update([
-                                    'logo' => empty($data['logo']) ? null : $data['logo'],
-                                ]);
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Logo override updated'))
-                                ->body(__('The logo override URL has been updated for the selected channels.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-link')
-                        ->modalIcon('heroicon-o-link')
-                        ->modalDescription(__('Apply a single logo override URL to all selected channels. Leave empty to remove overrides.'))
-                        ->modalSubmitActionLabel(__('Apply URL')),
-                    BulkAction::make('refresh_logo_cache')
-                        ->label(__('Refresh logo cache (selected)'))
-                        ->action(function (Collection $records): void {
-                            $urls = [];
-
-                            foreach ($records as $record) {
-                                $urls[] = $record->logo;
-                                $urls[] = $record->logo_internal;
-                                $urls[] = $record->epgChannel?->icon_custom;
-                                $urls[] = $record->epgChannel?->icon;
-                            }
-
-                            $cleared = LogoCacheService::clearByUrls($urls);
-
-                            Notification::make()
-                                ->success()
-                                ->title(__('Selected logo cache refreshed'))
-                                ->body("Removed {$cleared} cache file(s) for selected channels.")
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-path')
-                        ->modalIcon('heroicon-o-arrow-path')
-                        ->modalDescription(__('Clear cached logos for selected channels so they are fetched again on the next request.'))
-                        ->modalSubmitActionLabel(__('Refresh selected cache')),
-                    BulkAction::make('failover')
-                        ->label(__('Add as failover'))
-                        ->schema(function (Collection $records) {
-                            $existingFailoverIds = $records->pluck('id')->toArray();
-                            $initialMasterOptions = [];
-                            foreach ($records as $record) {
-                                $displayTitle = $record->title_custom ?: $record->title;
-                                $playlistName = $record->getEffectivePlaylist()->name ?? 'Unknown';
-                                $initialMasterOptions[$record->id] = "{$displayTitle} [{$playlistName}]";
-                            }
-
-                            return [
-                                ToggleButtons::make('master_source')
-                                    ->label(__('Choose master from?'))
-                                    ->options([
-                                        'selected' => 'Selected Channels',
-                                        'searched' => 'Channel Search',
-                                    ])
-                                    ->icons([
-                                        'selected' => 'heroicon-o-check',
-                                        'searched' => 'heroicon-o-magnifying-glass',
-                                    ])
-                                    ->default('selected')
-                                    ->live()
-                                    ->grouped(),
-                                Select::make('selected_master_id')
-                                    ->label(__('Select master channel'))
-                                    ->helperText(__('From the selected channels'))
-                                    ->options($initialMasterOptions)
-                                    ->required()
-                                    ->hidden(fn (Get $get) => $get('master_source') !== 'selected')
-                                    ->searchable(),
-                                Select::make('master_channel_id')
-                                    ->label(__('Search for master channel'))
-                                    ->searchable()
-                                    ->required()
-                                    ->hidden(fn (Get $get) => $get('master_source') !== 'searched')
-                                    ->getSearchResultsUsing(function (string $search) use ($existingFailoverIds) {
-                                        $searchLower = strtolower($search);
-                                        $channels = auth()->user()->channels()
-                                            ->withoutEagerLoads()
-                                            ->with('playlist')
-                                            ->whereNotIn('id', $existingFailoverIds)
-                                            ->where(function ($query) use ($searchLower) {
-                                                $query->whereRaw('LOWER(title) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(title_custom) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(name) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(name_custom) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(stream_id) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(stream_id_custom) LIKE ?', ["%{$searchLower}%"]);
-                                            })
-                                            ->limit(50) // Keep a reasonable limit
-                                            ->get();
-
-                                        // Create options array
-                                        $options = [];
-                                        foreach ($channels as $channel) {
-                                            $displayTitle = $channel->title_custom ?: $channel->title;
-                                            $playlistName = $channel->getEffectivePlaylist()->name ?? 'Unknown';
-                                            $options[$channel->id] = "{$displayTitle} [{$playlistName}]";
-                                        }
-
-                                        return $options;
-                                    })
-                                    ->helperText(__('To use as the master for the selected channel.'))
-                                    ->required(),
-                            ];
-                        })
-                        ->action(function (Collection $records, array $data): void {
-                            // Filter out the master channel from the records to be added as failovers
-                            $masterRecordId = $data['master_source'] === 'selected'
-                                ? $data['selected_master_id']
-                                : $data['master_channel_id'];
-                            $failoverRecords = $records->filter(function ($record) use ($masterRecordId) {
-                                return (int) $record->id !== (int) $masterRecordId;
-                            });
-
-                            foreach ($failoverRecords as $record) {
-                                ChannelFailover::updateOrCreate([
-                                    'channel_id' => $masterRecordId,
-                                    'channel_failover_id' => $record->id,
-                                ]);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Channels as failover'))
-                                ->body(__('The selected channels have been added as failovers.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-path-rounded-square')
-                        ->modalIcon('heroicon-o-arrow-path-rounded-square')
-                        ->modalDescription(__('Add the selected channel(s) to the chosen channel as failover sources.'))
-                        ->modalSubmitActionLabel(__('Add failovers now')),
-                    ...($includeRecount ? [
-                        BulkAction::make('recount')
-                            ->label(__('Recount Channels'))
-                            ->icon('heroicon-o-hashtag')
-                            ->schema([
-                                TextInput::make('start')
-                                    ->label(__('Start Number'))
-                                    ->numeric()
-                                    ->default(1)
-                                    ->required(),
+            // -- Logo --
+            self::bulkActionSection('Logo', [
+                BulkAction::make('preferred_logo')
+                    ->label(__('Update preferred icon'))
+                    ->schema([
+                        Select::make('logo_type')
+                            ->label(__('Preferred Icon'))
+                            ->helperText(__('Prefer logo from channel or EPG.'))
+                            ->options([
+                                'channel' => 'Channel',
+                                'epg' => 'EPG',
                             ])
-                            ->action(function (Collection $records, array $data): void {
-                                $start = (int) $data['start'];
-                                SortFacade::bulkRecountChannels($records, $start);
-                                dispatch(new SyncPlexDvrJob(trigger: 'channel_recount'));
-                            })
-                            ->after(function ($livewire) {
-                                Notification::make()
-                                    ->success()
-                                    ->title(__('Channels Recounted'))
-                                    ->body(__('The selected channels have been recounted.'))
-                                    ->send();
-                            })
-                            ->requiresConfirmation()
-                            ->modalIcon('heroicon-o-hashtag')
-                            ->modalDescription(__('Recount the selected channels sequentially? Channel numbers will be assigned based on the current sort order.')),
-                    ] : []),
-                    BulkAction::make('map')
-                        ->label(__('Map EPG to selected'))
-                        ->schema(EpgMapResource::getForm(showPlaylist: false, showEpg: true))
-                        ->action(function (Collection $records, array $data): void {
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new MapPlaylistChannelsToEpg(
-                                    epg: (int) $data['epg_id'],
-                                    channels: $records->pluck('id')->toArray(),
-                                    force: $data['override'],
-                                    settings: $data['settings'] ?? [],
-                                ));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('EPG to Channel mapping'))
-                                ->body(__('Mapping started, you will be notified when the process is complete.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-link')
-                        ->modalIcon('heroicon-o-link')
-                        ->modalWidth(Width::FourExtraLarge)
-                        ->modalDescription(__('Map the selected EPG to the selected channel(s).'))
-                        ->modalSubmitActionLabel(__('Map now')),
-                    BulkAction::make('unmap')
-                        ->label(__('Undo EPG Map'))
-                        ->action(function (Collection $records): void {
-                            // Clear the EPG mapping
-                            Channel::whereIn('id', $records->pluck('id'))
-                                ->update(['epg_channel_id' => null]);
+                            ->searchable(),
 
-                            // Invalidate cached EPG XML for all playlists containing these channels
-                            // (regular, custom, and merged) so Xtream API clients receive updated
-                            // XMLTV data immediately instead of waiting for the cache TTL to expire
-                            $records->loadMissing(['playlist.mergedPlaylists', 'customPlaylists']);
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        Channel::whereIn('id', $records->pluck('id')->toArray())
+                            ->update([
+                                'logo_type' => $data['logo_type'],
+                            ]);
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Preferred icon updated'))
+                            ->body(__('The preferred icon has been updated.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-photo')
+                    ->modalIcon('heroicon-o-photo')
+                    ->modalDescription(__('Update the preferred icon for the selected channel(s).'))
+                    ->modalSubmitActionLabel(__('Update now')),
+                BulkAction::make('set_logo_override_url')
+                    ->label(__('Set logo override URL'))
+                    ->schema([
+                        TextInput::make('logo')
+                            ->label(__('Logo override URL'))
+                            ->url()
+                            ->nullable()
+                            ->helperText(__('Leave empty to remove the custom logo and use provider/EPG logo.'))
+                            ->suffixActions([
+                                AssetPickerAction::upload('logo'),
+                                AssetPickerAction::browse('logo'),
+                            ]),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        Channel::whereIn('id', $records->pluck('id')->toArray())
+                            ->update([
+                                'logo' => empty($data['logo']) ? null : $data['logo'],
+                            ]);
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Logo override updated'))
+                            ->body(__('The logo override URL has been updated for the selected channels.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-link')
+                    ->modalIcon('heroicon-o-link')
+                    ->modalDescription(__('Apply a single logo override URL to all selected channels. Leave empty to remove overrides.'))
+                    ->modalSubmitActionLabel(__('Apply URL')),
+                BulkAction::make('refresh_logo_cache')
+                    ->label(__('Refresh logo cache (selected)'))
+                    ->action(function (Collection $records): void {
+                        $urls = [];
 
-                            $affectedPlaylists = collect();
-                            foreach ($records as $channel) {
-                                if ($channel->playlist) {
-                                    $affectedPlaylists->push($channel->playlist);
-                                    foreach ($channel->playlist->mergedPlaylists as $merged) {
-                                        $affectedPlaylists->push($merged);
-                                    }
-                                }
-                                foreach ($channel->customPlaylists as $custom) {
-                                    $affectedPlaylists->push($custom);
+                        foreach ($records as $record) {
+                            $urls[] = $record->logo;
+                            $urls[] = $record->logo_internal;
+                            $urls[] = $record->epgChannel?->icon_custom;
+                            $urls[] = $record->epgChannel?->icon;
+                        }
+
+                        $cleared = LogoCacheService::clearByUrls($urls);
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Selected logo cache refreshed'))
+                            ->body("Removed {$cleared} cache file(s) for selected channels.")
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-path')
+                    ->modalIcon('heroicon-o-arrow-path')
+                    ->modalDescription(__('Clear cached logos for selected channels so they are fetched again on the next request.'))
+                    ->modalSubmitActionLabel(__('Refresh selected cache')),
+            ]),
+
+            // -- EPG --
+            self::bulkActionSection('EPG', [
+                BulkAction::make('map')
+                    ->label(__('Map EPG to selected'))
+                    ->schema(EpgMapResource::getForm(showPlaylist: false, showEpg: true))
+                    ->action(function (Collection $records, array $data): void {
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new MapPlaylistChannelsToEpg(
+                                epg: (int) $data['epg_id'],
+                                channels: $records->pluck('id')->toArray(),
+                                force: $data['override'],
+                                settings: $data['settings'] ?? [],
+                            ));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('EPG to Channel mapping'))
+                            ->body(__('Mapping started, you will be notified when the process is complete.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-link')
+                    ->modalIcon('heroicon-o-link')
+                    ->modalWidth(Width::FourExtraLarge)
+                    ->modalDescription(__('Map the selected EPG to the selected channel(s).'))
+                    ->modalSubmitActionLabel(__('Map now')),
+                BulkAction::make('unmap')
+                    ->label(__('Undo EPG Map'))
+                    ->action(function (Collection $records): void {
+                        // Clear the EPG mapping
+                        Channel::whereIn('id', $records->pluck('id'))
+                            ->update(['epg_channel_id' => null]);
+
+                        // Invalidate cached EPG XML for all playlists containing these channels
+                        // (regular, custom, and merged) so Xtream API clients receive updated
+                        // XMLTV data immediately instead of waiting for the cache TTL to expire
+                        $records->loadMissing(['playlist.mergedPlaylists', 'customPlaylists']);
+
+                        $affectedPlaylists = collect();
+                        foreach ($records as $channel) {
+                            if ($channel->playlist) {
+                                $affectedPlaylists->push($channel->playlist);
+                                foreach ($channel->playlist->mergedPlaylists as $merged) {
+                                    $affectedPlaylists->push($merged);
                                 }
                             }
-                            $affectedPlaylists->unique(fn ($p) => $p->getTable().'-'.$p->id)
-                                ->each(fn ($p) => EpgCacheService::clearPlaylistEpgCacheFile($p));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('EPG Channel mapping removed'))
-                                ->body(__('Channel mapping removed for the selected channels.'))
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-uturn-left')
-                        ->color('warning')
-                        ->modalIcon('heroicon-o-arrow-uturn-left')
-                        ->modalDescription(__('Clear EPG mappings for the selected channels.'))
-                        ->modalSubmitActionLabel(__('Reset now')),
-                    BulkAction::make('find-replace')
-                        ->label(__('Find & Replace'))
-                        ->schema(function (): array {
-                            $savedPatterns = [];
-                            $savedPatternRules = [];
-                            $counter = 0;
-                            foreach (Playlist::where('user_id', auth()->id())->get() as $playlist) {
-                                foreach ($playlist->find_replace_rules ?? [] as $rule) {
-                                    if (is_array($rule) && ($rule['target'] ?? 'channels') === 'channels') {
-                                        $savedPatterns[$counter] = "{$playlist->name} - ".($rule['name'] ?? 'Unnamed');
-                                        $savedPatternRules[$counter] = $rule;
-                                        $counter++;
-                                    }
+                            foreach ($channel->customPlaylists as $custom) {
+                                $affectedPlaylists->push($custom);
+                            }
+                        }
+                        $affectedPlaylists->unique(fn ($p) => $p->getTable().'-'.$p->id)
+                            ->each(fn ($p) => EpgCacheService::clearPlaylistEpgCacheFile($p));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('EPG Channel mapping removed'))
+                            ->body(__('Channel mapping removed for the selected channels.'))
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-uturn-left')
+                    ->color('warning')
+                    ->modalIcon('heroicon-o-arrow-uturn-left')
+                    ->modalDescription(__('Clear EPG mappings for the selected channels.'))
+                    ->modalSubmitActionLabel(__('Reset now')),
+                BulkAction::make('enable-epg-mapping')
+                    ->label(__('Enable EPG mapping'))
+                    ->action(function (Collection $records, array $data): void {
+                        $records->each(fn ($channel) => $channel->update([
+                            'epg_map_enabled' => true,
+                        ]));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('EPG map re-enabled for selected channels'))
+                            ->body(__('The EPG map has been re-enabled for the selected channels.'))
+                            ->send();
+                    })
+                    ->hidden(fn () => ! $addToCustom)
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-calendar')
+                    ->modalIcon('heroicon-o-calendar')
+                    ->modalDescription(__('Allow mapping EPG to selected channels when running EPG mapping jobs.'))
+                    ->modalSubmitActionLabel(__('Enable now')),
+                BulkAction::make('disable-epg-mapping')
+                    ->label(__('Disable EPG mapping'))
+                    ->color('warning')
+                    ->action(function (Collection $records, array $data): void {
+                        $records->each(fn ($channel) => $channel->update([
+                            'epg_map_enabled' => false,
+                        ]));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('EPG map disabled for selected channels'))
+                            ->body(__('The EPG map has been disabled for the selected channels.'))
+                            ->send();
+                    })
+                    ->hidden(fn () => ! $addToCustom)
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-calendar')
+                    ->modalIcon('heroicon-o-calendar')
+                    ->modalDescription(__('Don\\\'t map EPG to selected channels when running EPG mapping jobs.'))
+                    ->modalSubmitActionLabel(__('Disable now')),
+                BulkAction::make('set-timeshift')
+                    ->label(__('Set Timeshift'))
+                    ->schema([
+                        TextInput::make('shift')
+                            ->label(__('Timeshift value'))
+                            ->helperText(__('Set the timeshift (in hours) for the selected channels. Use 0 to disable catch-up.'))
+                            ->type('number')
+                            ->rules(['integer', 'min:0'])
+                            ->default(0)
+                            ->required(),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        $value = (int) $data['shift'];
+                        foreach ($records->chunk(100) as $chunk) {
+                            Channel::whereIn('id', $chunk->pluck('id'))->update(['shift' => $value]);
+                        }
+                    })->after(function (array $data) {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Timeshift updated'))
+                            ->body("Timeshift set to {$data['shift']} for the selected channels.")
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-clock')
+                    ->modalIcon('heroicon-o-clock')
+                    ->modalDescription(__('Set the timeshift value for the selected channels. Use 0 to disable catch-up.'))
+                    ->modalSubmitActionLabel(__('Set timeshift')),
+            ]),
+
+            // -- Find & Replace --
+            self::bulkActionSection('Find & Replace', [
+                BulkAction::make('find-replace')
+                    ->label(__('Find & Replace'))
+                    ->schema(function (): array {
+                        $savedPatterns = [];
+                        $savedPatternRules = [];
+                        $counter = 0;
+                        foreach (Playlist::where('user_id', auth()->id())->get() as $playlist) {
+                            foreach ($playlist->find_replace_rules ?? [] as $rule) {
+                                if (is_array($rule) && ($rule['target'] ?? 'channels') === 'channels') {
+                                    $savedPatterns[$counter] = "{$playlist->name} - ".($rule['name'] ?? 'Unnamed');
+                                    $savedPatternRules[$counter] = $rule;
+                                    $counter++;
                                 }
                             }
+                        }
 
-                            return [
-                                Select::make('saved_pattern')
-                                    ->label(__('Load saved pattern'))
-                                    ->searchable()
-                                    ->placeholder(__('Select a saved pattern...'))
-                                    ->options($savedPatterns)
-                                    ->hidden(empty($savedPatterns))
-                                    ->live()
-                                    ->afterStateUpdated(function (?string $state, Set $set) use ($savedPatternRules): void {
-                                        if ($state === null || $state === '') {
-                                            return;
-                                        }
-                                        $rule = $savedPatternRules[(int) $state] ?? null;
-                                        if (! $rule) {
-                                            return;
-                                        }
-                                        $set('use_regex', $rule['use_regex'] ?? true);
-                                        $set('column', $rule['column'] ?? 'title');
-                                        $set('find_replace', $rule['find_replace'] ?? '');
-                                        $set('replace_with', $rule['replace_with'] ?? '');
-                                    })
-                                    ->dehydrated(false),
-                                Toggle::make('use_regex')
-                                    ->label(__('Use Regex'))
-                                    ->live()
-                                    ->helperText(__('Use regex patterns to find and replace. If disabled, will use direct string comparison.'))
-                                    ->default(true),
-                                Select::make('column')
-                                    ->label(__('Column to modify'))
-                                    ->options([
-                                        'title' => 'Channel Title',
-                                        'name' => 'Channel Name (tvg-name)',
-                                    ])
-                                    ->default('title')
-                                    ->required()
-                                    ->columnSpan(1),
-                                TextInput::make('find_replace')
-                                    ->label(fn (Get $get) => ! $get('use_regex') ? 'String to replace' : 'Pattern to replace')
-                                    ->required()
-                                    ->placeholder(
-                                        fn (Get $get) => $get('use_regex')
-                                            ? '^(US- |UK- |CA- )'
-                                            : 'US -'
-                                    )->helperText(
-                                        fn (Get $get) => ! $get('use_regex')
-                                            ? 'This is the string you want to find and replace.'
-                                            : 'This is the regex pattern you want to find. Make sure to use valid regex syntax.'
-                                    ),
-                                TextInput::make('replace_with')
-                                    ->label(__('Replace with (optional)'))
-                                    ->placeholder(__('Leave empty to remove')),
-                            ];
-                        })
-                        ->action(function (Collection $records, array $data): void {
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new ChannelFindAndReplace(
-                                    user_id: auth()->id(), // The ID of the user who owns the content
-                                    use_regex: $data['use_regex'] ?? true,
-                                    column: $data['column'] ?? 'title',
-                                    find_replace: $data['find_replace'] ?? null,
-                                    replace_with: $data['replace_with'] ?? '',
-                                    channels: $records
-                                ));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Find & Replace started'))
-                                ->body(__('Find & Replace working in the background. You will be notified once the process is complete.'))
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-magnifying-glass')
-                        ->color('gray')
-                        ->modalIcon('heroicon-o-magnifying-glass')
-                        ->modalDescription(__('Select what you would like to find and replace in the selected channels.'))
-                        ->modalSubmitActionLabel(__('Replace now')),
-                    BulkAction::make('find-replace-reset')
-                        ->label(__('Undo Find & Replace'))
-                        ->schema([
+                        return [
+                            Select::make('saved_pattern')
+                                ->label(__('Load saved pattern'))
+                                ->searchable()
+                                ->placeholder(__('Select a saved pattern...'))
+                                ->options($savedPatterns)
+                                ->hidden(empty($savedPatterns))
+                                ->live()
+                                ->afterStateUpdated(function (?string $state, Set $set) use ($savedPatternRules): void {
+                                    if ($state === null || $state === '') {
+                                        return;
+                                    }
+                                    $rule = $savedPatternRules[(int) $state] ?? null;
+                                    if (! $rule) {
+                                        return;
+                                    }
+                                    $set('use_regex', $rule['use_regex'] ?? true);
+                                    $set('column', $rule['column'] ?? 'title');
+                                    $set('find_replace', $rule['find_replace'] ?? '');
+                                    $set('replace_with', $rule['replace_with'] ?? '');
+                                })
+                                ->dehydrated(false),
+                            Toggle::make('use_regex')
+                                ->label(__('Use Regex'))
+                                ->live()
+                                ->helperText(__('Use regex patterns to find and replace. If disabled, will use direct string comparison.'))
+                                ->default(true),
                             Select::make('column')
-                                ->label(__('Column to reset'))
+                                ->label(__('Column to modify'))
                                 ->options([
                                     'title' => 'Channel Title',
                                     'name' => 'Channel Name (tvg-name)',
-                                    'logo' => 'Channel Logo (tvg-logo)',
-                                    'url' => 'Custom URL (tvg-url)',
                                 ])
                                 ->default('title')
                                 ->required()
                                 ->columnSpan(1),
-                        ])
-                        ->action(function (Collection $records, array $data): void {
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new ChannelFindAndReplaceReset(
-                                    user_id: auth()->id(), // The ID of the user who owns the content
-                                    column: $data['column'] ?? 'title',
-                                    channels: $records
-                                ));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Find & Replace reset started'))
-                                ->body(__('Find & Replace reset working in the background. You will be notified once the process is complete.'))
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-uturn-left')
-                        ->color('warning')
-                        ->modalIcon('heroicon-o-arrow-uturn-left')
-                        ->modalDescription(__('Reset Find & Replace results back to playlist defaults for the selected channels. This will remove any custom values set in the selected column.'))
-                        ->modalSubmitActionLabel(__('Reset now')),
-                    BulkAction::make('enable-epg-mapping')
-                        ->label(__('Enable EPG mapping'))
-                        ->action(function (Collection $records, array $data): void {
-                            $records->each(fn ($channel) => $channel->update([
-                                'epg_map_enabled' => true,
-                            ]));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('EPG map re-enabled for selected channels'))
-                                ->body(__('The EPG map has been re-enabled for the selected channels.'))
-                                ->send();
-                        })
-                        ->hidden(fn () => ! $addToCustom)
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-calendar')
-                        ->modalIcon('heroicon-o-calendar')
-                        ->modalDescription(__('Allow mapping EPG to selected channels when running EPG mapping jobs.'))
-                        ->modalSubmitActionLabel(__('Enable now')),
-                    BulkAction::make('disable-epg-mapping')
-                        ->label(__('Disable EPG mapping'))
-                        ->color('warning')
-                        ->action(function (Collection $records, array $data): void {
-                            $records->each(fn ($channel) => $channel->update([
-                                'epg_map_enabled' => false,
-                            ]));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('EPG map disabled for selected channels'))
-                                ->body(__('The EPG map has been disabled for the selected channels.'))
-                                ->send();
-                        })
-                        ->hidden(fn () => ! $addToCustom)
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-calendar')
-                        ->modalIcon('heroicon-o-calendar')
-                        ->modalDescription(__('Don\\\'t map EPG to selected channels when running EPG mapping jobs.'))
-                        ->modalSubmitActionLabel(__('Disable now')),
-                    BulkAction::make('enable-merge')
-                        ->label(__('Enable Merge'))
-                        ->action(function (Collection $records, array $data): void {
-                            $records->each(fn ($channel) => $channel->update([
-                                'can_merge' => true,
-                            ]));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Merge re-enabled for selected channels'))
-                                ->body(__('The merge has been re-enabled for the selected channels. They can now be merged during "Merge Same ID" jobs.'))
-                                ->send();
-                        })
-                        ->hidden(fn () => ! $addToCustom)
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrows-pointing-in')
-                        ->modalIcon('heroicon-o-arrows-pointing-in')
-                        ->modalDescription(__('Allow merging for selected channels when running "Merge Same ID" jobs.'))
-                        ->modalSubmitActionLabel(__('Enable now')),
-                    BulkAction::make('disable-merge')
-                        ->label(__('Disable Merge'))
-                        ->color('warning')
-                        ->action(function (Collection $records, array $data): void {
-                            $records->each(fn ($channel) => $channel->update([
-                                'can_merge' => false,
-                            ]));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Merge disabled for selected channels'))
-                                ->body(__('The merge has been disabled for the selected channels. They will not be merged during "Merge Same ID" jobs.'))
-                                ->send();
-                        })
-                        ->hidden(fn () => ! $addToCustom)
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrows-pointing-in')
-                        ->modalIcon('heroicon-o-arrows-pointing-in')
-                        ->modalDescription(__('Don\\\'t allow merging for selected channels when running "Merge Same ID" jobs.'))
-                        ->modalSubmitActionLabel(__('Disable now')),
-                    BulkAction::make('set-timeshift')
-                        ->label(__('Set Timeshift'))
-                        ->schema([
-                            TextInput::make('shift')
-                                ->label(__('Timeshift value'))
-                                ->helperText(__('Set the timeshift (in hours) for the selected channels. Use 0 to disable catch-up.'))
-                                ->type('number')
-                                ->rules(['integer', 'min:0'])
-                                ->default(0)
-                                ->required(),
-                        ])
-                        ->action(function (Collection $records, array $data): void {
-                            $value = (int) $data['shift'];
-                            foreach ($records->chunk(100) as $chunk) {
-                                Channel::whereIn('id', $chunk->pluck('id'))->update(['shift' => $value]);
-                            }
-                        })->after(function (array $data) {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Timeshift updated'))
-                                ->body("Timeshift set to {$data['shift']} for the selected channels.")
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-clock')
-                        ->modalIcon('heroicon-o-clock')
-                        ->modalDescription(__('Set the timeshift value for the selected channels. Use 0 to disable catch-up.'))
-                        ->modalSubmitActionLabel(__('Set timeshift')),
-                    BulkAction::make('probe-streams')
-                        ->label(__('Probe Streams'))
-                        ->action(function (Collection $records): void {
-                            dispatch(new ProbeChannelStreams(
-                                channelIds: $records->pluck('id')->all(),
+                            TextInput::make('find_replace')
+                                ->label(fn (Get $get) => ! $get('use_regex') ? 'String to replace' : 'Pattern to replace')
+                                ->required()
+                                ->placeholder(
+                                    fn (Get $get) => $get('use_regex')
+                                        ? '^(US- |UK- |CA- )'
+                                        : 'US -'
+                                )->helperText(
+                                    fn (Get $get) => ! $get('use_regex')
+                                        ? 'This is the string you want to find and replace.'
+                                        : 'This is the regex pattern you want to find. Make sure to use valid regex syntax.'
+                                ),
+                            TextInput::make('replace_with')
+                                ->label(__('Replace with (optional)'))
+                                ->placeholder(__('Leave empty to remove')),
+                        ];
+                    })
+                    ->action(function (Collection $records, array $data): void {
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new ChannelFindAndReplace(
+                                user_id: auth()->id(), // The ID of the user who owns the content
+                                use_regex: $data['use_regex'] ?? true,
+                                column: $data['column'] ?? 'title',
+                                find_replace: $data['find_replace'] ?? null,
+                                replace_with: $data['replace_with'] ?? '',
+                                channels: $records
                             ));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Stream probing started'))
-                                ->body(__('Stream probing is running in the background. You will be notified once the process is complete.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-signal')
-                        ->modalIcon('heroicon-o-signal')
-                        ->modalDescription(__('Probe the selected channels with ffprobe to collect stream metadata (codec, resolution, bitrate). This data enables fast channel switching in Emby.'))
-                        ->modalSubmitActionLabel(__('Start probing')),
-                    BulkAction::make('enable-probing')
-                        ->label(__('Enable Probing'))
-                        ->action(function (Collection $records): void {
-                            foreach ($records->chunk(100) as $chunk) {
-                                Channel::whereIn('id', $chunk->pluck('id'))->update(['probe_enabled' => true]);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Stream probing enabled'))
-                                ->body(__('Stream probing has been enabled for the selected channels.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-signal')
-                        ->modalIcon('heroicon-o-signal')
-                        ->modalDescription(__('Enable stream probing for the selected channels. They will be included in stream probing jobs.'))
-                        ->modalSubmitActionLabel(__('Enable now')),
-                    BulkAction::make('disable-probing')
-                        ->label(__('Disable Probing'))
-                        ->color('warning')
-                        ->action(function (Collection $records): void {
-                            foreach ($records->chunk(100) as $chunk) {
-                                Channel::whereIn('id', $chunk->pluck('id'))->update(['probe_enabled' => false]);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Stream probing disabled'))
-                                ->body(__('Stream probing has been disabled for the selected channels.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-signal-slash')
-                        ->modalIcon('heroicon-o-signal-slash')
-                        ->modalDescription(__('Disable stream probing for the selected channels. They will be excluded from stream probing jobs.'))
-                        ->modalSubmitActionLabel(__('Disable now')),
-                    BulkAction::make('enable')
-                        ->label(__('Enable selected'))
-                        ->action(function (Collection $records): void {
-                            foreach ($records->chunk(100) as $chunk) {
-                                Channel::whereIn('id', $chunk->pluck('id'))->update(['enabled' => true]);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Selected channels enabled'))
-                                ->body(__('The selected channels have been enabled.'))
-                                ->send();
-                            dispatch(new SyncPlexDvrJob(trigger: 'channel_bulk_enable'));
-                        })
-                        ->color('success')
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-check-circle')
-                        ->modalIcon('heroicon-o-check-circle')
-                        ->modalDescription(__('Enable the selected channel(s) now?'))
-                        ->modalSubmitActionLabel(__('Yes, enable now')),
-                    BulkAction::make('disable')
-                        ->label(__('Disable selected'))
-                        ->action(function (Collection $records): void {
-                            foreach ($records->chunk(100) as $chunk) {
-                                Channel::whereIn('id', $chunk->pluck('id'))->update(['enabled' => false]);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Selected channels disabled'))
-                                ->body(__('The selected channels have been disabled.'))
-                                ->send();
-                            dispatch(new SyncPlexDvrJob(trigger: 'channel_bulk_disable'));
-                        })
-                        ->color('danger')
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-x-circle')
-                        ->modalIcon('heroicon-o-x-circle')
-                        ->modalDescription(__('Disable the selected channel(s) now?'))
-                        ->modalSubmitActionLabel(__('Yes, disable now')),
-                ]),
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Find & Replace started'))
+                            ->body(__('Find & Replace working in the background. You will be notified once the process is complete.'))
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-magnifying-glass')
+                    ->color('gray')
+                    ->modalIcon('heroicon-o-magnifying-glass')
+                    ->modalDescription(__('Select what you would like to find and replace in the selected channels.'))
+                    ->modalSubmitActionLabel(__('Replace now')),
+                BulkAction::make('find-replace-reset')
+                    ->label(__('Undo Find & Replace'))
+                    ->schema([
+                        Select::make('column')
+                            ->label(__('Column to reset'))
+                            ->options([
+                                'title' => 'Channel Title',
+                                'name' => 'Channel Name (tvg-name)',
+                                'logo' => 'Channel Logo (tvg-logo)',
+                                'url' => 'Custom URL (tvg-url)',
+                            ])
+                            ->default('title')
+                            ->required()
+                            ->columnSpan(1),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new ChannelFindAndReplaceReset(
+                                user_id: auth()->id(), // The ID of the user who owns the content
+                                column: $data['column'] ?? 'title',
+                                channels: $records
+                            ));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Find & Replace reset started'))
+                            ->body(__('Find & Replace reset working in the background. You will be notified once the process is complete.'))
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-uturn-left')
+                    ->color('warning')
+                    ->modalIcon('heroicon-o-arrow-uturn-left')
+                    ->modalDescription(__('Reset Find & Replace results back to playlist defaults for the selected channels. This will remove any custom values set in the selected column.'))
+                    ->modalSubmitActionLabel(__('Reset now')),
+            ]),
+
+            // -- Streaming --
+            self::bulkActionSection('Streaming', [
+                BulkAction::make('enable-merge')
+                    ->label(__('Enable Merge'))
+                    ->action(function (Collection $records, array $data): void {
+                        $records->each(fn ($channel) => $channel->update([
+                            'can_merge' => true,
+                        ]));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Merge re-enabled for selected channels'))
+                            ->body(__('The merge has been re-enabled for the selected channels. They can now be merged during "Merge Same ID" jobs.'))
+                            ->send();
+                    })
+                    ->hidden(fn () => ! $addToCustom)
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrows-pointing-in')
+                    ->modalIcon('heroicon-o-arrows-pointing-in')
+                    ->modalDescription(__('Allow merging for selected channels when running "Merge Same ID" jobs.'))
+                    ->modalSubmitActionLabel(__('Enable now')),
+                BulkAction::make('disable-merge')
+                    ->label(__('Disable Merge'))
+                    ->color('warning')
+                    ->action(function (Collection $records, array $data): void {
+                        $records->each(fn ($channel) => $channel->update([
+                            'can_merge' => false,
+                        ]));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Merge disabled for selected channels'))
+                            ->body(__('The merge has been disabled for the selected channels. They will not be merged during "Merge Same ID" jobs.'))
+                            ->send();
+                    })
+                    ->hidden(fn () => ! $addToCustom)
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrows-pointing-in')
+                    ->modalIcon('heroicon-o-arrows-pointing-in')
+                    ->modalDescription(__('Don\\\'t allow merging for selected channels when running "Merge Same ID" jobs.'))
+                    ->modalSubmitActionLabel(__('Disable now')),
+                BulkAction::make('failover')
+                    ->label(__('Add as failover'))
+                    ->schema(function (Collection $records) {
+                        $existingFailoverIds = $records->pluck('id')->toArray();
+                        $initialMasterOptions = [];
+                        foreach ($records as $record) {
+                            $displayTitle = $record->title_custom ?: $record->title;
+                            $playlistName = $record->getEffectivePlaylist()->name ?? 'Unknown';
+                            $initialMasterOptions[$record->id] = "{$displayTitle} [{$playlistName}]";
+                        }
+
+                        return [
+                            ToggleButtons::make('master_source')
+                                ->label(__('Choose master from?'))
+                                ->options([
+                                    'selected' => 'Selected Channels',
+                                    'searched' => 'Channel Search',
+                                ])
+                                ->icons([
+                                    'selected' => 'heroicon-o-check',
+                                    'searched' => 'heroicon-o-magnifying-glass',
+                                ])
+                                ->default('selected')
+                                ->live()
+                                ->grouped(),
+                            Select::make('selected_master_id')
+                                ->label(__('Select master channel'))
+                                ->helperText(__('From the selected channels'))
+                                ->options($initialMasterOptions)
+                                ->required()
+                                ->hidden(fn (Get $get) => $get('master_source') !== 'selected')
+                                ->searchable(),
+                            Select::make('master_channel_id')
+                                ->label(__('Search for master channel'))
+                                ->searchable()
+                                ->required()
+                                ->hidden(fn (Get $get) => $get('master_source') !== 'searched')
+                                ->getSearchResultsUsing(function (string $search) use ($existingFailoverIds) {
+                                    $searchLower = strtolower($search);
+                                    $channels = auth()->user()->channels()
+                                        ->withoutEagerLoads()
+                                        ->with('playlist')
+                                        ->whereNotIn('id', $existingFailoverIds)
+                                        ->where(function ($query) use ($searchLower) {
+                                            $query->whereRaw('LOWER(title) LIKE ?', ["%{$searchLower}%"])
+                                                ->orWhereRaw('LOWER(title_custom) LIKE ?', ["%{$searchLower}%"])
+                                                ->orWhereRaw('LOWER(name) LIKE ?', ["%{$searchLower}%"])
+                                                ->orWhereRaw('LOWER(name_custom) LIKE ?', ["%{$searchLower}%"])
+                                                ->orWhereRaw('LOWER(stream_id) LIKE ?', ["%{$searchLower}%"])
+                                                ->orWhereRaw('LOWER(stream_id_custom) LIKE ?', ["%{$searchLower}%"]);
+                                        })
+                                        ->limit(50) // Keep a reasonable limit
+                                        ->get();
+
+                                    // Create options array
+                                    $options = [];
+                                    foreach ($channels as $channel) {
+                                        $displayTitle = $channel->title_custom ?: $channel->title;
+                                        $playlistName = $channel->getEffectivePlaylist()->name ?? 'Unknown';
+                                        $options[$channel->id] = "{$displayTitle} [{$playlistName}]";
+                                    }
+
+                                    return $options;
+                                })
+                                ->helperText(__('To use as the master for the selected channel.'))
+                                ->required(),
+                        ];
+                    })
+                    ->action(function (Collection $records, array $data): void {
+                        // Filter out the master channel from the records to be added as failovers
+                        $masterRecordId = $data['master_source'] === 'selected'
+                            ? $data['selected_master_id']
+                            : $data['master_channel_id'];
+                        $failoverRecords = $records->filter(function ($record) use ($masterRecordId) {
+                            return (int) $record->id !== (int) $masterRecordId;
+                        });
+
+                        foreach ($failoverRecords as $record) {
+                            ChannelFailover::updateOrCreate([
+                                'channel_id' => $masterRecordId,
+                                'channel_failover_id' => $record->id,
+                            ]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Channels as failover'))
+                            ->body(__('The selected channels have been added as failovers.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-path-rounded-square')
+                    ->modalIcon('heroicon-o-arrow-path-rounded-square')
+                    ->modalDescription(__('Add the selected channel(s) to the chosen channel as failover sources.'))
+                    ->modalSubmitActionLabel(__('Add failovers now')),
+            ]),
+
+            // -- Probing --
+            self::bulkActionSection('Probing', [
+                BulkAction::make('enable-probing')
+                    ->label(__('Enable Probing'))
+                    ->action(function (Collection $records): void {
+                        foreach ($records->chunk(100) as $chunk) {
+                            Channel::whereIn('id', $chunk->pluck('id'))->update(['probe_enabled' => true]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Stream probing enabled'))
+                            ->body(__('Stream probing has been enabled for the selected channels.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-signal')
+                    ->modalIcon('heroicon-o-signal')
+                    ->modalDescription(__('Enable stream probing for the selected channels. They will be included in stream probing jobs.'))
+                    ->modalSubmitActionLabel(__('Enable now')),
+                BulkAction::make('disable-probing')
+                    ->label(__('Disable Probing'))
+                    ->color('warning')
+                    ->action(function (Collection $records): void {
+                        foreach ($records->chunk(100) as $chunk) {
+                            Channel::whereIn('id', $chunk->pluck('id'))->update(['probe_enabled' => false]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Stream probing disabled'))
+                            ->body(__('Stream probing has been disabled for the selected channels.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-signal-slash')
+                    ->modalIcon('heroicon-o-signal-slash')
+                    ->modalDescription(__('Disable stream probing for the selected channels. They will be excluded from stream probing jobs.'))
+                    ->modalSubmitActionLabel(__('Disable now')),
+                BulkAction::make('probe-streams')
+                    ->label(__('Probe Streams'))
+                    ->action(function (Collection $records): void {
+                        dispatch(new ProbeChannelStreams(
+                            channelIds: $records->pluck('id')->all(),
+                        ));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Stream probing started'))
+                            ->body(__('Stream probing is running in the background. You will be notified once the process is complete.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-signal')
+                    ->modalIcon('heroicon-o-signal')
+                    ->modalDescription(__('Probe the selected channels with ffprobe to collect stream metadata (codec, resolution, bitrate). This data enables fast channel switching in Emby.'))
+                    ->modalSubmitActionLabel(__('Start probing')),
+            ]),
+
+            // -- Enable / Disable --
+            self::bulkActionSection('Enable / Disable', [
+                BulkAction::make('enable')
+                    ->label(__('Enable selected'))
+                    ->action(function (Collection $records): void {
+                        foreach ($records->chunk(100) as $chunk) {
+                            Channel::whereIn('id', $chunk->pluck('id'))->update(['enabled' => true]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Selected channels enabled'))
+                            ->body(__('The selected channels have been enabled.'))
+                            ->send();
+                        dispatch(new SyncPlexDvrJob(trigger: 'channel_bulk_enable'));
+                    })
+                    ->color('success')
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-check-circle')
+                    ->modalIcon('heroicon-o-check-circle')
+                    ->modalDescription(__('Enable the selected channel(s) now?'))
+                    ->modalSubmitActionLabel(__('Yes, enable now')),
+                BulkAction::make('disable')
+                    ->label(__('Disable selected'))
+                    ->action(function (Collection $records): void {
+                        foreach ($records->chunk(100) as $chunk) {
+                            Channel::whereIn('id', $chunk->pluck('id'))->update(['enabled' => false]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Selected channels disabled'))
+                            ->body(__('The selected channels have been disabled.'))
+                            ->send();
+                        dispatch(new SyncPlexDvrJob(trigger: 'channel_bulk_disable'));
+                    })
+                    ->color('danger')
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-x-circle')
+                    ->modalIcon('heroicon-o-x-circle')
+                    ->modalDescription(__('Disable the selected channel(s) now?'))
+                    ->modalSubmitActionLabel(__('Yes, disable now')),
+            ]),
         ];
     }
 

--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -503,7 +503,7 @@ class ChannelResource extends Resource implements CopilotResource
      * Create a compact section for the bulk actions modal, ensuring each
      * action closes the parent modal when it completes.
      */
-    private static function bulkActionSection(string $heading, array $actions): Section
+    private static function bulkActionSection(string $heading, array $actions): Fieldset
     {
         foreach ($actions as $action) {
             if ($action instanceof BulkAction) {
@@ -511,10 +511,9 @@ class ChannelResource extends Resource implements CopilotResource
             }
         }
 
-        return Section::make(__($heading))
+        return Fieldset::make(__($heading))
             ->columns(2)
             ->columnSpanFull()
-            ->compact()
             ->schema($actions);
     }
 

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2735,7 +2735,7 @@ class PlaylistResource extends Resource implements CopilotResource
             ->default(false);
     }
 
-    private static function actionSection(string $heading, array $actions): Section
+    private static function actionSection(string $heading, array $actions): Fieldset
     {
         foreach ($actions as $action) {
             if ($action instanceof Action) {
@@ -2743,10 +2743,9 @@ class PlaylistResource extends Resource implements CopilotResource
             }
         }
 
-        return Section::make(__($heading))
+        return Fieldset::make(__($heading))
             ->columns(2)
             ->columnSpanFull()
-            ->compact()
             ->schema($actions);
     }
 

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -383,336 +383,7 @@ class PlaylistResource extends Resource implements CopilotResource
             ->recordActions([
                 ModalActionGroup::make('Playlist Actions')
                     ->modalHeading(fn ($record) => 'Actions for '.$record->name)
-                    ->gridColumns(3)
-                    ->schema([
-                        Action::make('process')
-                            ->label(__('Sync and Process'))
-                            ->icon('heroicon-o-arrow-path')
-                            ->action(function ($record) {
-                                // For media server playlists, dispatch the media server sync job
-                                if (in_array($record->source_type, [PlaylistSourceType::Emby, PlaylistSourceType::Jellyfin, PlaylistSourceType::Plex])) {
-                                    $integration = MediaServerIntegration::where('playlist_id', $record->id)->first();
-                                    if ($integration) {
-                                        app('Illuminate\Contracts\Bus\Dispatcher')
-                                            ->dispatch(new SyncMediaServer($integration->id));
-
-                                        return;
-                                    }
-                                }
-
-                                // For regular playlists, use the standard M3U import process
-                                $record->update([
-                                    'status' => Status::Processing,
-                                    'progress' => 0,
-                                    'vod_progress' => 0,
-                                ]);
-                                app('Illuminate\Contracts\Bus\Dispatcher')
-                                    ->dispatch(new ProcessM3uImport($record, force: true));
-                            })->after(function ($record) {
-                                $isMediaServer = in_array($record->source_type, [PlaylistSourceType::Emby, PlaylistSourceType::Jellyfin]);
-                                $message = $isMediaServer
-                                    ? 'Media server content is being synced in the background. Depending on the size of your library, this may take several minutes. You will be notified on completion.'
-                                    : 'Playlist is being processed in the background. Depending on the size of your playlist, this may take a while. You will be notified on completion.';
-
-                                Notification::make()
-                                    ->success()
-                                    ->title($isMediaServer ? 'Media server sync started' : 'Playlist is processing')
-                                    ->body($message)
-                                    ->duration(10000)
-                                    ->send();
-                            })
-                            ->disabled(fn ($record): bool => $record->isProcessing())
-                            ->requiresConfirmation()
-                            ->icon('heroicon-o-arrow-path')
-                            ->modalIcon('heroicon-o-arrow-path')
-                            ->modalDescription(function ($record) {
-                                $isMediaServer = in_array($record->source_type, [PlaylistSourceType::Emby, PlaylistSourceType::Jellyfin]);
-
-                                return $isMediaServer
-                                    ? 'Sync content from the media server now? This will fetch all movies, series, and episodes from your media server library.'
-                                    : 'Process playlist now?';
-                            })
-                            ->modalSubmitActionLabel(__('Yes, sync now'))
-                            ->hidden(fn ($record): bool => $record->is_network_playlist),
-                        Action::make('reset_processing')
-                            ->label(__('Reset Processing State'))
-                            ->icon('heroicon-o-arrow-path')
-                            ->color('warning')
-                            ->requiresConfirmation()
-                            ->modalHeading(__('Reset Processing State'))
-                            ->modalDescription(__('This will clear any stuck processing locks and allow new syncs to run. Use this if syncs appear stuck.'))
-                            ->modalSubmitActionLabel(__('Reset'))
-                            ->action(function (Playlist $record) {
-                                // Clear processing flag
-                                $record->update([
-                                    'processing' => [
-                                        'live_processing' => false,
-                                        'vod_processing' => false,
-                                        'series_processing' => false,
-                                    ],
-                                ]);
-
-                                Notification::make()
-                                    ->success()
-                                    ->title(__('Processing state reset'))
-                                    ->body(__('The playlist is no longer processing. You can now run new syncs.'))
-                                    ->send();
-                            })
-                            ->visible(fn (Playlist $record) => $record->isProcessing() && ! ($record->is_network_playlist || $record->isMediaServerPlaylist())),
-                        Action::make('process_series')
-                            ->label(__('Fetch Series Metadata'))
-                            ->icon('heroicon-o-arrow-down-tray')
-                            ->action(function ($record) {
-                                $record->update([
-                                    'status' => Status::Processing,
-                                    'series_progress' => 0,
-                                ]);
-                                app('Illuminate\Contracts\Bus\Dispatcher')
-                                    ->dispatch(new ProcessM3uImportSeries($record, force: true));
-                            })->after(function () {
-                                Notification::make()
-                                    ->success()
-                                    ->title(__('Playlist is fetching metadata for Series'))
-                                    ->body(__('Playlist Series are being processed in the background. Depending on the number of enabled Series, this may take a while. You will be notified on completion.'))
-                                    ->duration(10000)
-                                    ->send();
-                            })
-                            ->disabled(fn ($record): bool => $record->isProcessing())
-                            ->hidden(fn ($record): bool => ! $record->xtream || $record->is_network_playlist)
-                            ->requiresConfirmation()
-                            ->icon('heroicon-o-arrow-down-tray')
-                            ->modalIcon('heroicon-o-arrow-down-tray')
-                            ->modalDescription(__('Fetch Series metadata for this playlist now? Only enabled Series will be included.'))
-                            ->modalSubmitActionLabel(__('Yes, process now')),
-                        Action::make('process_vod')
-                            ->label(__('Fetch VOD Metadata'))
-                            ->icon('heroicon-o-arrow-down-tray')
-                            ->action(function ($record) {
-                                $record->update([
-                                    'status' => Status::Processing,
-                                    'progress' => 0,
-                                ]);
-                                app('Illuminate\Contracts\Bus\Dispatcher')
-                                    ->dispatch(new ProcessVodChannels(playlist: $record));
-                            })->after(function () {
-                                Notification::make()
-                                    ->success()
-                                    ->title(__('Playlist is fetching metadata for VOD channels'))
-                                    ->body(__('Playlist VOD channels are being processed in the background. Depending on the number of enabled VOD channels, this may take a while. You will be notified on completion.'))
-                                    ->duration(10000)
-                                    ->send();
-                            })
-                            ->disabled(fn ($record): bool => $record->isProcessing())
-                            ->hidden(fn ($record): bool => ! $record->xtream || $record->is_network_playlist)
-                            ->requiresConfirmation()
-                            ->icon('heroicon-o-arrow-down-tray')
-                            ->modalIcon('heroicon-o-arrow-down-tray')
-                            ->modalDescription(__('Fetch VOD metadata for this playlist now? Only enabled VOD channels will be included.'))
-                            ->modalSubmitActionLabel(__('Yes, process now')),
-                        Action::make('Download M3U')
-                            ->label(__('Download M3U'))
-                            ->icon('heroicon-o-arrow-down-tray')
-                            ->url(fn ($record) => PlaylistFacade::getUrls($record)['m3u'])
-                            ->openUrlInNewTab(),
-                        EpgCacheService::getEpgTableAction(),
-                        Action::make('HDHomeRun URL')
-                            ->label(__('HDHomeRun URL'))
-                            ->icon('heroicon-o-arrow-top-right-on-square')
-                            ->url(fn ($record) => PlaylistFacade::getUrls($record)['hdhr'])
-                            ->openUrlInNewTab()
-                            ->hidden(fn ($record): bool => $record->is_network_playlist),
-                        Action::make('Public URL')
-                            ->label(__('Public URL'))
-                            ->icon('heroicon-o-arrow-top-right-on-square')
-                            ->url(fn ($record) => '/playlist/v/'.$record->uuid)
-                            ->openUrlInNewTab(),
-                        Action::make('Duplicate')
-                            ->label(__('Duplicate'))
-                            ->schema([
-                                TextInput::make('name')
-                                    ->label(__('Playlist name'))
-                                    ->required()
-                                    ->helperText(__('This will be the name of the duplicated playlist.')),
-                            ])
-                            ->action(function ($record, $data) {
-                                app('Illuminate\Contracts\Bus\Dispatcher')
-                                    ->dispatch(new DuplicatePlaylist($record, $data['name']));
-                            })->after(function () {
-                                Notification::make()
-                                    ->success()
-                                    ->title(__('Playlist is being duplicated'))
-                                    ->body(__('Playlist is being duplicated in the background. You will be notified on completion.'))
-                                    ->duration(3000)
-                                    ->send();
-                            })
-                            ->hidden(fn ($record): bool => $record->isMediaServerPlaylist())
-                            ->requiresConfirmation()
-                            ->icon('heroicon-o-document-duplicate')
-                            ->modalIcon('heroicon-o-document-duplicate')
-                            ->modalDescription(__('Duplicate playlist now?'))
-                            ->modalSubmitActionLabel(__('Yes, duplicate now'))
-                            ->hidden(fn ($record): bool => $record->is_network_playlist || $record->isMediaServerPlaylist()),
-
-                        Action::make('Copy Changes')
-                            ->label(__('Copy Changes'))
-                            ->schema([
-                                Select::make('target_playlist_id')
-                                    ->label(__('Target Playlist'))
-                                    ->options(function ($record) {
-                                        return Playlist::where('id', '!=', $record->id)
-                                            ->where('user_id', auth()->id())
-                                            ->orderBy('name')
-                                            ->pluck('name', 'id')
-                                            ->toArray();
-                                    })
-                                    ->searchable()
-                                    ->required(),
-                                Select::make('channel_match_attributes')
-                                    ->label(__('Channel Match Attributes'))
-                                    ->options([
-                                        'name' => 'Name',
-                                        'title' => 'Title',
-                                        'url' => 'URL',
-                                        'stream_id' => 'TVG-ID/Stream ID',
-                                        'station_id' => 'Station ID (tvc-guide-stationid)',
-                                        'logo_internal' => 'Logo (tvg-logo)',
-                                        'channel' => 'Channel Number (tvg-chno/num)',
-                                    ])
-                                    ->hintIcon(
-                                        'heroicon-s-information-circle',
-                                        tooltip: 'Select the channel attributes to match channels between the source and target playlists. Channels will be matched based on these attributes. If multiple attributes are selected, all must match for a channel to be considered the same.',
-                                    )
-                                    ->multiple()
-                                    ->required()
-                                    ->default(['url'])
-                                    ->columnSpanFull(),
-                                Toggle::make('create_missing_channels')
-                                    ->label(__('Create Missing Channels'))
-                                    ->live()
-                                    ->hintIcon(
-                                        'heroicon-s-information-circle',
-                                        tooltip: 'If enabled, missing channels will be created in the target playlist. If disabled, only existing matched channels will be updated.',
-                                    )
-                                    ->default(false),
-                                Toggle::make('all_attributes')
-                                    ->label(__('All Attributes'))
-                                    ->live()
-                                    ->hintIcon(
-                                        'heroicon-s-information-circle',
-                                        tooltip: 'If enabled, all channel attributes will be copied to the target playlist. If disabled, only the selected attributes below will be copied.',
-                                    )
-                                    ->default(true),
-                                Select::make('channel_attributes')
-                                    ->label(__('Channel Attributes to Copy'))
-                                    ->options([
-                                        'enabled' => 'Enabled Status',
-                                        'name' => 'Name',
-                                        'title' => 'Title',
-                                        'logo_internal' => 'Logo (tvg-logo)',
-                                        'stream_id' => 'TVG-ID/Stream ID',
-                                        'station_id' => 'Station ID (tvc-guide-stationid)',
-                                        'group' => 'Group (group-title)',
-                                        'shift' => 'Shift (tvg-shift)',
-                                        'channel' => 'Channel Number (tvg-chno/num)',
-                                        'sort' => 'Sort Order',
-                                    ])
-                                    ->multiple()
-                                    ->required()
-                                    ->helperText(__('Select the channel attributes you want to copy to the target playlist.'))
-                                    ->hidden(fn ($get) => (bool) $get('all_attributes')),
-                                Toggle::make('overwrite')
-                                    ->label(__('Overwrite Existing Attributes'))
-                                    ->hintIcon(
-                                        'heroicon-s-information-circle',
-                                        tooltip: 'If enabled, existing custom attributes in the target playlist will be overwritten. If disabled, only empty custom attributes will be updated.',
-                                    )
-                                    ->default(true),
-                            ])
-                            ->action(function ($record, $data) {
-                                app('Illuminate\Contracts\Bus\Dispatcher')
-                                    ->dispatch(new CopyAttributesToPlaylist(
-                                        source: $record,
-                                        targetId: $data['target_playlist_id'],
-                                        channelAttributes: $data['channel_attributes'] ?? [],
-                                        channelMatchAttributes: $data['channel_match_attributes'] ?? ['url'],
-                                        createIfMissing: $data['create_missing_channels'] ?? false,
-                                        allAttributes: $data['all_attributes'] ?? false,
-                                        overwrite: $data['overwrite'] ?? false,
-                                    ));
-                            })->after(function () {
-                                Notification::make()
-                                    ->success()
-                                    ->title(__('Playlist settings are being copied'))
-                                    ->body(__('Playlist settings are being copied in the background. You will be notified on completion.'))
-                                    ->duration(3000)
-                                    ->send();
-                            })
-                            ->hidden(fn ($record): bool => $record->isMediaServerPlaylist())
-                            ->requiresConfirmation()
-                            ->icon('heroicon-o-clipboard-document')
-                            ->modalIcon('heroicon-o-clipboard-document')
-                            ->modalDescription(__('Select the target playlist and channel attributes to copy'))
-                            ->modalSubmitActionLabel(__('Copy now'))
-                            ->hidden(fn ($record): bool => $record->is_network_playlist || $record->isMediaServerPlaylist()),
-
-                        Action::make('view_sync_logs')
-                            ->label(__('View Sync Logs'))
-                            ->color('gray')
-                            ->icon('heroicon-m-arrows-right-left')
-                            ->url(function (Playlist $record): string {
-                                return "/playlists/{$record->id}/playlist-sync-statuses";
-                            })
-                            ->openUrlInNewTab(false)
-                            ->hidden(fn (Playlist $record): bool => $record->is_network_playlist || $record->isMediaServerPlaylist()),
-                        Action::make('reset')
-                            ->label(__('Reset status'))
-                            ->icon('heroicon-o-arrow-uturn-left')
-                            ->color('warning')
-                            ->action(function ($record) {
-                                $record->update([
-                                    'status' => Status::Pending,
-                                    'processing' => [
-                                        'live_processing' => false,
-                                        'vod_processing' => false,
-                                        'series_processing' => false,
-                                    ],
-                                    'progress' => 0,
-                                    'series_progress' => 0,
-                                    'vod_progress' => 0,
-                                    'channels' => 0,
-                                    'synced' => null,
-                                    'errors' => null,
-                                ]);
-                            })->after(function () {
-                                Notification::make()
-                                    ->success()
-                                    ->title(__('Playlist status reset'))
-                                    ->body(__('Playlist status has been reset.'))
-                                    ->duration(3000)
-                                    ->send();
-                            })
-                            ->requiresConfirmation()
-                            ->icon('heroicon-o-arrow-uturn-left')
-                            ->modalIcon('heroicon-o-arrow-uturn-left')
-                            ->modalDescription(__('Reset playlist status so it can be processed again. Only perform this action if you are having problems with the playlist syncing.'))
-                            ->modalSubmitActionLabel(__('Yes, reset now'))
-                            ->hidden(fn ($record): bool => $record->is_network_playlist || $record->isMediaServerPlaylist()),
-                        Action::make('purge_series')
-                            ->label(__('Purge Series'))
-                            ->icon('heroicon-s-trash')
-                            ->color('danger')
-                            ->action(function ($record) {
-                                $record->series()->delete();
-                            })
-                            ->requiresConfirmation()
-                            ->icon('heroicon-s-trash')
-                            ->modalIcon('heroicon-s-trash')
-                            ->modalDescription(__('This action will permanently delete all series associated with the playlist. Proceed with caution.'))
-                            ->modalSubmitActionLabel(__('Purge now'))
-                            ->hidden(fn ($record): bool => ! $record->xtream),
-                        DeleteAction::make()
-                            ->disabled(fn ($record): bool => $record->isProcessing()),
-                    ])->button()->hiddenLabel()->size('sm'),
+                    ->schema(self::getPlaylistActionSchema())->button()->hiddenLabel()->size('sm'),
                 EditAction::make()->button()->hiddenLabel()->size('sm'),
                 ViewAction::make()
                     ->button()->hiddenLabel()->size('sm'),
@@ -3062,5 +2733,366 @@ class PlaylistResource extends Resource implements CopilotResource
         return Toggle::make($name)
             ->inline(false)
             ->default(false);
+    }
+
+    private static function actionSection(string $heading, array $actions): Section
+    {
+        foreach ($actions as $action) {
+            if ($action instanceof Action) {
+                $action->cancelParentActions();
+            }
+        }
+
+        return Section::make(__($heading))
+            ->columns(2)
+            ->columnSpanFull()
+            ->compact()
+            ->schema($actions);
+    }
+
+    private static function getPlaylistActionSchema(): array
+    {
+        return [
+            // -- Processing --
+            self::actionSection('Processing', [
+                Action::make('process')
+                    ->label(__('Sync and Process'))
+                    ->icon('heroicon-o-arrow-path')
+                    ->action(function ($record) {
+                        // For media server playlists, dispatch the media server sync job
+                        if (in_array($record->source_type, [PlaylistSourceType::Emby, PlaylistSourceType::Jellyfin, PlaylistSourceType::Plex])) {
+                            $integration = MediaServerIntegration::where('playlist_id', $record->id)->first();
+                            if ($integration) {
+                                app('Illuminate\Contracts\Bus\Dispatcher')
+                                    ->dispatch(new SyncMediaServer($integration->id));
+
+                                return;
+                            }
+                        }
+
+                        // For regular playlists, use the standard M3U import process
+                        $record->update([
+                            'status' => Status::Processing,
+                            'progress' => 0,
+                            'vod_progress' => 0,
+                        ]);
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new ProcessM3uImport($record, force: true));
+                    })->after(function ($record) {
+                        $isMediaServer = in_array($record->source_type, [PlaylistSourceType::Emby, PlaylistSourceType::Jellyfin]);
+                        $message = $isMediaServer
+                            ? 'Media server content is being synced in the background. Depending on the size of your library, this may take several minutes. You will be notified on completion.'
+                            : 'Playlist is being processed in the background. Depending on the size of your playlist, this may take a while. You will be notified on completion.';
+
+                        Notification::make()
+                            ->success()
+                            ->title($isMediaServer ? 'Media server sync started' : 'Playlist is processing')
+                            ->body($message)
+                            ->duration(10000)
+                            ->send();
+                    })
+                    ->disabled(fn ($record): bool => $record->isProcessing())
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-path')
+                    ->modalIcon('heroicon-o-arrow-path')
+                    ->modalDescription(function ($record) {
+                        $isMediaServer = in_array($record->source_type, [PlaylistSourceType::Emby, PlaylistSourceType::Jellyfin]);
+
+                        return $isMediaServer
+                            ? 'Sync content from the media server now? This will fetch all movies, series, and episodes from your media server library.'
+                            : 'Process playlist now?';
+                    })
+                    ->modalSubmitActionLabel(__('Yes, sync now'))
+                    ->hidden(fn ($record): bool => $record->is_network_playlist),
+                Action::make('reset_processing')
+                    ->label(__('Reset Processing State'))
+                    ->icon('heroicon-o-arrow-path')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalHeading(__('Reset Processing State'))
+                    ->modalDescription(__('This will clear any stuck processing locks and allow new syncs to run. Use this if syncs appear stuck.'))
+                    ->modalSubmitActionLabel(__('Reset'))
+                    ->action(function (Playlist $record) {
+                        // Clear processing flag
+                        $record->update([
+                            'processing' => [
+                                'live_processing' => false,
+                                'vod_processing' => false,
+                                'series_processing' => false,
+                            ],
+                        ]);
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Processing state reset'))
+                            ->body(__('The playlist is no longer processing. You can now run new syncs.'))
+                            ->send();
+                    })
+                    ->visible(fn (Playlist $record) => $record->isProcessing() && ! ($record->is_network_playlist || $record->isMediaServerPlaylist())),
+                Action::make('process_series')
+                    ->label(__('Fetch Series Metadata'))
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->action(function ($record) {
+                        $record->update([
+                            'status' => Status::Processing,
+                            'series_progress' => 0,
+                        ]);
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new ProcessM3uImportSeries($record, force: true));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Playlist is fetching metadata for Series'))
+                            ->body(__('Playlist Series are being processed in the background. Depending on the number of enabled Series, this may take a while. You will be notified on completion.'))
+                            ->duration(10000)
+                            ->send();
+                    })
+                    ->disabled(fn ($record): bool => $record->isProcessing())
+                    ->hidden(fn ($record): bool => ! $record->xtream || $record->is_network_playlist)
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->modalIcon('heroicon-o-arrow-down-tray')
+                    ->modalDescription(__('Fetch Series metadata for this playlist now? Only enabled Series will be included.'))
+                    ->modalSubmitActionLabel(__('Yes, process now')),
+                Action::make('process_vod')
+                    ->label(__('Fetch VOD Metadata'))
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->action(function ($record) {
+                        $record->update([
+                            'status' => Status::Processing,
+                            'progress' => 0,
+                        ]);
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new ProcessVodChannels(playlist: $record));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Playlist is fetching metadata for VOD channels'))
+                            ->body(__('Playlist VOD channels are being processed in the background. Depending on the number of enabled VOD channels, this may take a while. You will be notified on completion.'))
+                            ->duration(10000)
+                            ->send();
+                    })
+                    ->disabled(fn ($record): bool => $record->isProcessing())
+                    ->hidden(fn ($record): bool => ! $record->xtream || $record->is_network_playlist)
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->modalIcon('heroicon-o-arrow-down-tray')
+                    ->modalDescription(__('Fetch VOD metadata for this playlist now? Only enabled VOD channels will be included.'))
+                    ->modalSubmitActionLabel(__('Yes, process now')),
+            ]),
+
+            // -- Downloads & Links --
+            self::actionSection('Downloads & Links', [
+                Action::make('Download M3U')
+                    ->label(__('Download M3U'))
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->url(fn ($record) => PlaylistFacade::getUrls($record)['m3u'])
+                    ->openUrlInNewTab(),
+                EpgCacheService::getEpgTableAction()
+                    ->cancelParentActions(),
+                Action::make('HDHomeRun URL')
+                    ->label(__('HDHomeRun URL'))
+                    ->icon('heroicon-o-arrow-top-right-on-square')
+                    ->url(fn ($record) => PlaylistFacade::getUrls($record)['hdhr'])
+                    ->openUrlInNewTab()
+                    ->hidden(fn ($record): bool => $record->is_network_playlist),
+                Action::make('Public URL')
+                    ->label(__('Public URL'))
+                    ->icon('heroicon-o-arrow-top-right-on-square')
+                    ->url(fn ($record) => '/playlist/v/'.$record->uuid)
+                    ->openUrlInNewTab(),
+            ]),
+
+            // -- Playlist Management --
+            self::actionSection('Playlist Management', [
+                Action::make('Duplicate')
+                    ->label(__('Duplicate'))
+                    ->schema([
+                        TextInput::make('name')
+                            ->label(__('Playlist name'))
+                            ->required()
+                            ->helperText(__('This will be the name of the duplicated playlist.')),
+                    ])
+                    ->action(function ($record, $data) {
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new DuplicatePlaylist($record, $data['name']));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Playlist is being duplicated'))
+                            ->body(__('Playlist is being duplicated in the background. You will be notified on completion.'))
+                            ->duration(3000)
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-document-duplicate')
+                    ->modalIcon('heroicon-o-document-duplicate')
+                    ->modalDescription(__('Duplicate playlist now?'))
+                    ->modalSubmitActionLabel(__('Yes, duplicate now'))
+                    ->hidden(fn ($record): bool => $record->is_network_playlist || $record->isMediaServerPlaylist()),
+                Action::make('Copy Changes')
+                    ->label(__('Copy Changes'))
+                    ->schema([
+                        Select::make('target_playlist_id')
+                            ->label(__('Target Playlist'))
+                            ->options(function ($record) {
+                                return Playlist::where('id', '!=', $record->id)
+                                    ->where('user_id', auth()->id())
+                                    ->orderBy('name')
+                                    ->pluck('name', 'id')
+                                    ->toArray();
+                            })
+                            ->searchable()
+                            ->required(),
+                        Select::make('channel_match_attributes')
+                            ->label(__('Channel Match Attributes'))
+                            ->options([
+                                'name' => 'Name',
+                                'title' => 'Title',
+                                'url' => 'URL',
+                                'stream_id' => 'TVG-ID/Stream ID',
+                                'station_id' => 'Station ID (tvc-guide-stationid)',
+                                'logo_internal' => 'Logo (tvg-logo)',
+                                'channel' => 'Channel Number (tvg-chno/num)',
+                            ])
+                            ->hintIcon(
+                                'heroicon-s-information-circle',
+                                tooltip: 'Select the channel attributes to match channels between the source and target playlists. Channels will be matched based on these attributes. If multiple attributes are selected, all must match for a channel to be considered the same.',
+                            )
+                            ->multiple()
+                            ->required()
+                            ->default(['url'])
+                            ->columnSpanFull(),
+                        Toggle::make('create_missing_channels')
+                            ->label(__('Create Missing Channels'))
+                            ->live()
+                            ->hintIcon(
+                                'heroicon-s-information-circle',
+                                tooltip: 'If enabled, missing channels will be created in the target playlist. If disabled, only existing matched channels will be updated.',
+                            )
+                            ->default(false),
+                        Toggle::make('all_attributes')
+                            ->label(__('All Attributes'))
+                            ->live()
+                            ->hintIcon(
+                                'heroicon-s-information-circle',
+                                tooltip: 'If enabled, all channel attributes will be copied to the target playlist. If disabled, only the selected attributes below will be copied.',
+                            )
+                            ->default(true),
+                        Select::make('channel_attributes')
+                            ->label(__('Channel Attributes to Copy'))
+                            ->options([
+                                'enabled' => 'Enabled Status',
+                                'name' => 'Name',
+                                'title' => 'Title',
+                                'logo_internal' => 'Logo (tvg-logo)',
+                                'stream_id' => 'TVG-ID/Stream ID',
+                                'station_id' => 'Station ID (tvc-guide-stationid)',
+                                'group' => 'Group (group-title)',
+                                'shift' => 'Shift (tvg-shift)',
+                                'channel' => 'Channel Number (tvg-chno/num)',
+                                'sort' => 'Sort Order',
+                            ])
+                            ->multiple()
+                            ->required()
+                            ->helperText(__('Select the channel attributes you want to copy to the target playlist.'))
+                            ->hidden(fn ($get) => (bool) $get('all_attributes')),
+                        Toggle::make('overwrite')
+                            ->label(__('Overwrite Existing Attributes'))
+                            ->hintIcon(
+                                'heroicon-s-information-circle',
+                                tooltip: 'If enabled, existing custom attributes in the target playlist will be overwritten. If disabled, only empty custom attributes will be updated.',
+                            )
+                            ->default(true),
+                    ])
+                    ->action(function ($record, $data) {
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new CopyAttributesToPlaylist(
+                                source: $record,
+                                targetId: $data['target_playlist_id'],
+                                channelAttributes: $data['channel_attributes'] ?? [],
+                                channelMatchAttributes: $data['channel_match_attributes'] ?? ['url'],
+                                createIfMissing: $data['create_missing_channels'] ?? false,
+                                allAttributes: $data['all_attributes'] ?? false,
+                                overwrite: $data['overwrite'] ?? false,
+                            ));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Playlist settings are being copied'))
+                            ->body(__('Playlist settings are being copied in the background. You will be notified on completion.'))
+                            ->duration(3000)
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-clipboard-document')
+                    ->modalIcon('heroicon-o-clipboard-document')
+                    ->modalDescription(__('Select the target playlist and channel attributes to copy'))
+                    ->modalSubmitActionLabel(__('Copy now'))
+                    ->hidden(fn ($record): bool => $record->is_network_playlist || $record->isMediaServerPlaylist()),
+                Action::make('view_sync_logs')
+                    ->label(__('View Sync Logs'))
+                    ->color('gray')
+                    ->icon('heroicon-m-arrows-right-left')
+                    ->url(function (Playlist $record): string {
+                        return "/playlists/{$record->id}/playlist-sync-statuses";
+                    })
+                    ->openUrlInNewTab(false)
+                    ->hidden(fn (Playlist $record): bool => $record->is_network_playlist || $record->isMediaServerPlaylist()),
+            ]),
+
+            // -- Reset & Delete --
+            self::actionSection('Reset & Delete', [
+                Action::make('reset')
+                    ->label(__('Reset status'))
+                    ->icon('heroicon-o-arrow-uturn-left')
+                    ->color('warning')
+                    ->action(function ($record) {
+                        $record->update([
+                            'status' => Status::Pending,
+                            'processing' => [
+                                'live_processing' => false,
+                                'vod_processing' => false,
+                                'series_processing' => false,
+                            ],
+                            'progress' => 0,
+                            'series_progress' => 0,
+                            'vod_progress' => 0,
+                            'channels' => 0,
+                            'synced' => null,
+                            'errors' => null,
+                        ]);
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Playlist status reset'))
+                            ->body(__('Playlist status has been reset.'))
+                            ->duration(3000)
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-uturn-left')
+                    ->modalIcon('heroicon-o-arrow-uturn-left')
+                    ->modalDescription(__('Reset playlist status so it can be processed again. Only perform this action if you are having problems with the playlist syncing.'))
+                    ->modalSubmitActionLabel(__('Yes, reset now'))
+                    ->hidden(fn ($record): bool => $record->is_network_playlist || $record->isMediaServerPlaylist()),
+                Action::make('purge_series')
+                    ->label(__('Purge Series'))
+                    ->icon('heroicon-s-trash')
+                    ->color('danger')
+                    ->action(function ($record) {
+                        $record->series()->delete();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-s-trash')
+                    ->modalIcon('heroicon-s-trash')
+                    ->modalDescription(__('This action will permanently delete all series associated with the playlist. Proceed with caution.'))
+                    ->modalSubmitActionLabel(__('Purge now'))
+                    ->hidden(fn ($record): bool => ! $record->xtream),
+                DeleteAction::make()
+                    ->cancelParentActions()
+                    ->disabled(fn ($record): bool => $record->isProcessing()),
+            ]),
+        ];
     }
 }

--- a/app/Filament/Resources/Series/SeriesResource.php
+++ b/app/Filament/Resources/Series/SeriesResource.php
@@ -474,347 +474,391 @@ class SeriesResource extends Resource implements CopilotResource
             BulkModalActionGroup::make('Bulk series actions')
                 ->modalHeading(__('Bulk series actions'))
                 ->gridColumns(2)
-                ->schema([
-                    PlaylistService::getAddToPlaylistBulkAction('add', 'series')
-                        ->hidden(fn () => ! $addToCustom),
-                    BulkAction::make('move')
-                        ->label(__('Move Series to Category'))
-                        ->schema([
-                            Select::make('category')
-                                ->required()
-                                ->live()
-                                ->label(__('Category'))
-                                ->helperText(__('Select the category you would like to move the series to.'))
-                                ->options(
-                                    fn () => Category::query()
-                                        ->with(['playlist'])
-                                        ->where(['user_id' => auth()->id()])
-                                        ->get(['name', 'id', 'playlist_id'])
-                                        ->transform(fn ($category) => [
-                                            'id' => $category->id,
-                                            'name' => $category->name.' ('.$category->playlist->name.')',
-                                        ])->pluck('name', 'id')
-                                )->searchable(),
-                        ])
-                        ->action(function (Collection $records, array $data): void {
-                            $category = Category::findOrFail($data['category']);
-                            foreach ($records as $record) {
-                                // Update the series to the new category
-                                // This will change the category_id for the series in the database
-                                // to reflect the new category
-                                if ($category->playlist_id !== $record->playlist_id) {
-                                    Notification::make()
-                                        ->warning()
-                                        ->title(__('Warning'))
-                                        ->body("Cannot move \"{$category->name}\" to \"{$record->name}\" as they belong to different playlists.")
-                                        ->persistent()
-                                        ->send();
+                ->schema(self::getBulkActionSchema($addToCustom)),
+        ];
+    }
 
-                                    continue;
-                                }
-                                $record->update([
-                                    'category_id' => $category->id,
-                                ]);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Series moved to category'))
-                                ->body(__('The category series have been moved to the chosen category.'))
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrows-right-left')
-                        ->modalIcon('heroicon-o-arrows-right-left')
-                        ->modalDescription(__('Move the category series to another category.'))
-                        ->modalSubmitActionLabel(__('Move now')),
-                    BulkAction::make('process')
-                        ->label(__('Fetch Series Metadata'))
-                        ->icon('heroicon-o-arrow-down-tray')
-                        ->schema([
-                            Toggle::make('overwrite_existing')
-                                ->label(__('Overwrite Existing Metadata'))
-                                ->helperText(__('Overwrite existing metadata? Episodes and seasons will always be fetched/updated.'))
-                                ->default(false),
-                        ])
-                        ->action(function ($records, array $data) {
-                            foreach ($records as $record) {
-                                app('Illuminate\Contracts\Bus\Dispatcher')
-                                    ->dispatch(new ProcessM3uImportSeriesEpisodes(
-                                        playlistSeries: $record,
-                                        overwrite_existing: $data['overwrite_existing'] ?? false,
-                                    ));
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Series are being processed'))
-                                ->body(__('You will be notified once complete.'))
-                                ->duration(10000)
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-down-tray')
-                        ->modalIcon('heroicon-o-arrow-down-tray')
-                        ->modalDescription(__('Process selected series now? This will fetch all episodes and seasons for this series. This may take a while depending on the number of series selected.'))
-                        ->modalSubmitActionLabel(__('Yes, process now')),
-                    BulkAction::make('set_poster_url')
-                        ->label(__('Set poster URL'))
-                        ->schema([
-                            TextInput::make('cover')
-                                ->label(__('Series poster URL'))
-                                ->url()
-                                ->nullable()
-                                ->helperText(__('Leave empty to remove custom poster URL and use placeholder fallback.'))
-                                ->suffixActions([
-                                    AssetPickerAction::upload('cover'),
-                                    AssetPickerAction::browse('cover'),
-                                ]),
-                        ])
-                        ->action(function (Collection $records, array $data): void {
-                            Series::whereIn('id', $records->pluck('id')->toArray())
-                                ->update([
-                                    'cover' => empty($data['cover']) ? null : $data['cover'],
-                                ]);
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Poster URL updated'))
-                                ->body(__('The poster URL has been updated for the selected series.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-link')
-                        ->modalIcon('heroicon-o-link')
-                        ->modalDescription(__('Apply a single poster URL to all selected series. Leave empty to remove custom posters.'))
-                        ->modalSubmitActionLabel(__('Apply URL')),
-                    BulkAction::make('refresh_logo_cache')
-                        ->label(__('Refresh poster cache (selected)'))
-                        ->action(function (Collection $records): void {
-                            $urls = $records
-                                ->pluck('cover')
-                                ->filter()
-                                ->values()
-                                ->toArray();
+    /**
+     * Create a compact section for the bulk actions modal, ensuring each
+     * action closes the parent modal when it completes.
+     */
+    private static function bulkActionSection(string $heading, array $actions): Section
+    {
+        foreach ($actions as $action) {
+            if ($action instanceof BulkAction) {
+                $action->cancelParentActions();
+            }
+        }
 
-                            $cleared = LogoCacheService::clearByUrls($urls);
+        return Section::make(__($heading))
+            ->columns(2)
+            ->columnSpanFull()
+            ->compact()
+            ->schema($actions);
+    }
 
-                            Notification::make()
-                                ->success()
-                                ->title(__('Selected series cache refreshed'))
-                                ->body("Removed {$cleared} cache file(s) for selected series posters.")
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-path')
-                        ->modalIcon('heroicon-o-arrow-path')
-                        ->modalDescription(__('Clear cached poster images for selected series so they are fetched again on the next request.'))
-                        ->modalSubmitActionLabel(__('Refresh selected cache')),
-                    BulkAction::make('fetch_tmdb_ids')
-                        ->label(__('Fetch TMDB/TVDB IDs'))
-                        ->icon('heroicon-o-magnifying-glass')
-                        ->schema([
-                            Toggle::make('overwrite_existing')
-                                ->label(__('Overwrite Existing IDs'))
-                                ->helperText(__('Overwrite existing TMDB/TVDB/IMDB IDs? If disabled, it will only fetch IDs for series that don\\\'t already have them.'))
-                                ->default(false),
-                        ])
-                        ->action(function ($records, $data) {
-                            $settings = app(GeneralSettings::class);
-                            if (empty($settings->tmdb_api_key)) {
+    /**
+     * Build the sectioned schema for the bulk actions modal.
+     */
+    private static function getBulkActionSchema(bool $addToCustom): array
+    {
+        return [
+            // -- Playlist & Groups --
+            self::bulkActionSection('Playlist & Groups', [
+                PlaylistService::getAddToPlaylistBulkAction('add', 'series')
+                    ->hidden(fn () => ! $addToCustom),
+                BulkAction::make('move')
+                    ->label(__('Move Series to Category'))
+                    ->schema([
+                        Select::make('category')
+                            ->required()
+                            ->live()
+                            ->label(__('Category'))
+                            ->helperText(__('Select the category you would like to move the series to.'))
+                            ->options(
+                                fn () => Category::query()
+                                    ->with(['playlist'])
+                                    ->where(['user_id' => auth()->id()])
+                                    ->get(['name', 'id', 'playlist_id'])
+                                    ->transform(fn ($category) => [
+                                        'id' => $category->id,
+                                        'name' => $category->name.' ('.$category->playlist->name.')',
+                                    ])->pluck('name', 'id')
+                            )->searchable(),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        $category = Category::findOrFail($data['category']);
+                        foreach ($records as $record) {
+                            // Update the series to the new category
+                            // This will change the category_id for the series in the database
+                            // to reflect the new category
+                            if ($category->playlist_id !== $record->playlist_id) {
                                 Notification::make()
-                                    ->danger()
-                                    ->title(__('TMDB API Key Required'))
-                                    ->body(__('Please configure your TMDB API key in Settings > TMDB before using this feature.'))
-                                    ->duration(10000)
+                                    ->warning()
+                                    ->title(__('Warning'))
+                                    ->body("Cannot move \"{$category->name}\" to \"{$record->name}\" as they belong to different playlists.")
+                                    ->persistent()
                                     ->send();
 
-                                return;
+                                continue;
                             }
+                            $record->update([
+                                'category_id' => $category->id,
+                            ]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Series moved to category'))
+                            ->body(__('The category series have been moved to the chosen category.'))
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrows-right-left')
+                    ->modalIcon('heroicon-o-arrows-right-left')
+                    ->modalDescription(__('Move the category series to another category.'))
+                    ->modalSubmitActionLabel(__('Move now')),
+            ]),
 
-                            $seriesIds = $records->pluck('id')->toArray();
+            // -- Poster --
+            self::bulkActionSection('Poster', [
+                BulkAction::make('set_poster_url')
+                    ->label(__('Set poster URL'))
+                    ->schema([
+                        TextInput::make('cover')
+                            ->label(__('Series poster URL'))
+                            ->url()
+                            ->nullable()
+                            ->helperText(__('Leave empty to remove custom poster URL and use placeholder fallback.'))
+                            ->suffixActions([
+                                AssetPickerAction::upload('cover'),
+                                AssetPickerAction::browse('cover'),
+                            ]),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        Series::whereIn('id', $records->pluck('id')->toArray())
+                            ->update([
+                                'cover' => empty($data['cover']) ? null : $data['cover'],
+                            ]);
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Poster URL updated'))
+                            ->body(__('The poster URL has been updated for the selected series.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-link')
+                    ->modalIcon('heroicon-o-link')
+                    ->modalDescription(__('Apply a single poster URL to all selected series. Leave empty to remove custom posters.'))
+                    ->modalSubmitActionLabel(__('Apply URL')),
+                BulkAction::make('refresh_logo_cache')
+                    ->label(__('Refresh poster cache (selected)'))
+                    ->action(function (Collection $records): void {
+                        $urls = $records
+                            ->pluck('cover')
+                            ->filter()
+                            ->values()
+                            ->toArray();
 
+                        $cleared = LogoCacheService::clearByUrls($urls);
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Selected series cache refreshed'))
+                            ->body("Removed {$cleared} cache file(s) for selected series posters.")
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-path')
+                    ->modalIcon('heroicon-o-arrow-path')
+                    ->modalDescription(__('Clear cached poster images for selected series so they are fetched again on the next request.'))
+                    ->modalSubmitActionLabel(__('Refresh selected cache')),
+            ]),
+
+            // -- Series Metadata --
+            self::bulkActionSection('Series Metadata', [
+                BulkAction::make('process')
+                    ->label(__('Fetch Series Metadata'))
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->schema([
+                        Toggle::make('overwrite_existing')
+                            ->label(__('Overwrite Existing Metadata'))
+                            ->helperText(__('Overwrite existing metadata? Episodes and seasons will always be fetched/updated.'))
+                            ->default(false),
+                    ])
+                    ->action(function ($records, array $data) {
+                        foreach ($records as $record) {
                             app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new FetchTmdbIds(
-                                    vodChannelIds: null,
-                                    seriesIds: $seriesIds,
-                                    overwriteExisting: $data['overwrite_existing'] ?? false,
-                                    user: auth()->user(),
+                                ->dispatch(new ProcessM3uImportSeriesEpisodes(
+                                    playlistSeries: $record,
+                                    overwrite_existing: $data['overwrite_existing'] ?? false,
                                 ));
-
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Series are being processed'))
+                            ->body(__('You will be notified once complete.'))
+                            ->duration(10000)
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->modalIcon('heroicon-o-arrow-down-tray')
+                    ->modalDescription(__('Process selected series now? This will fetch all episodes and seasons for this series. This may take a while depending on the number of series selected.'))
+                    ->modalSubmitActionLabel(__('Yes, process now')),
+                BulkAction::make('fetch_tmdb_ids')
+                    ->label(__('Fetch TMDB/TVDB IDs'))
+                    ->icon('heroicon-o-magnifying-glass')
+                    ->schema([
+                        Toggle::make('overwrite_existing')
+                            ->label(__('Overwrite Existing IDs'))
+                            ->helperText(__('Overwrite existing TMDB/TVDB/IMDB IDs? If disabled, it will only fetch IDs for series that don\\\'t already have them.'))
+                            ->default(false),
+                    ])
+                    ->action(function ($records, $data) {
+                        $settings = app(GeneralSettings::class);
+                        if (empty($settings->tmdb_api_key)) {
                             Notification::make()
-                                ->success()
-                                ->title('Fetching TMDB/TVDB IDs for '.count($seriesIds).' series')
-                                ->body(__('The TMDB ID lookup has been started. You will be notified when it is complete.'))
+                                ->danger()
+                                ->title(__('TMDB API Key Required'))
+                                ->body(__('Please configure your TMDB API key in Settings > TMDB before using this feature.'))
                                 ->duration(10000)
                                 ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->modalIcon('heroicon-o-magnifying-glass')
-                        ->modalDescription(__('Search TMDB for matching TV series and populate TMDB/TVDB/IMDB IDs for the selected series? This enables Trash Guides compatibility for Sonarr.'))
-                        ->modalSubmitActionLabel(__('Yes, fetch IDs now')),
-                    BulkAction::make('sync')
-                        ->label(__('Sync Series .strm files'))
-                        ->action(function ($records) {
-                            foreach ($records as $record) {
-                                app('Illuminate\Contracts\Bus\Dispatcher')
-                                    ->dispatch(new SyncSeriesStrmFiles(
-                                        series: $record,
-                                    ));
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('.strm files are being synced for selected series'))
-                                ->body(__('You will be notified once complete.'))
-                                ->duration(10000)
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-document-arrow-down')
-                        ->modalIcon('heroicon-o-document-arrow-down')
-                        ->modalDescription(__('Sync selected series .strm files now? This will generate .strm files for the selected series at the path set for the series.'))
-                        ->modalSubmitActionLabel(__('Yes, sync now')),
 
-                    BulkAction::make('find-replace')
-                        ->label(__('Find & Replace'))
-                        ->schema(function (): array {
-                            $savedPatterns = [];
-                            $savedPatternRules = [];
-                            $counter = 0;
-                            foreach (Playlist::where('user_id', auth()->id())->get() as $playlist) {
-                                foreach ($playlist->find_replace_rules ?? [] as $rule) {
-                                    if (is_array($rule) && ($rule['target'] ?? 'channels') === 'series') {
-                                        $savedPatterns[$counter] = "{$playlist->name} - ".($rule['name'] ?? 'Unnamed');
-                                        $savedPatternRules[$counter] = $rule;
-                                        $counter++;
-                                    }
+                            return;
+                        }
+
+                        $seriesIds = $records->pluck('id')->toArray();
+
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new FetchTmdbIds(
+                                vodChannelIds: null,
+                                seriesIds: $seriesIds,
+                                overwriteExisting: $data['overwrite_existing'] ?? false,
+                                user: auth()->user(),
+                            ));
+
+                        Notification::make()
+                            ->success()
+                            ->title('Fetching TMDB/TVDB IDs for '.count($seriesIds).' series')
+                            ->body(__('The TMDB ID lookup has been started. You will be notified when it is complete.'))
+                            ->duration(10000)
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->modalIcon('heroicon-o-magnifying-glass')
+                    ->modalDescription(__('Search TMDB for matching TV series and populate TMDB/TVDB/IMDB IDs for the selected series? This enables Trash Guides compatibility for Sonarr.'))
+                    ->modalSubmitActionLabel(__('Yes, fetch IDs now')),
+                BulkAction::make('sync')
+                    ->label(__('Sync Series .strm files'))
+                    ->action(function ($records) {
+                        foreach ($records as $record) {
+                            app('Illuminate\Contracts\Bus\Dispatcher')
+                                ->dispatch(new SyncSeriesStrmFiles(
+                                    series: $record,
+                                ));
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('.strm files are being synced for selected series'))
+                            ->body(__('You will be notified once complete.'))
+                            ->duration(10000)
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-document-arrow-down')
+                    ->modalIcon('heroicon-o-document-arrow-down')
+                    ->modalDescription(__('Sync selected series .strm files now? This will generate .strm files for the selected series at the path set for the series.'))
+                    ->modalSubmitActionLabel(__('Yes, sync now')),
+            ]),
+
+            // -- Find & Replace --
+            self::bulkActionSection('Find & Replace', [
+                BulkAction::make('find-replace')
+                    ->label(__('Find & Replace'))
+                    ->schema(function (): array {
+                        $savedPatterns = [];
+                        $savedPatternRules = [];
+                        $counter = 0;
+                        foreach (Playlist::where('user_id', auth()->id())->get() as $playlist) {
+                            foreach ($playlist->find_replace_rules ?? [] as $rule) {
+                                if (is_array($rule) && ($rule['target'] ?? 'channels') === 'series') {
+                                    $savedPatterns[$counter] = "{$playlist->name} - ".($rule['name'] ?? 'Unnamed');
+                                    $savedPatternRules[$counter] = $rule;
+                                    $counter++;
                                 }
                             }
+                        }
 
-                            return [
-                                Select::make('saved_pattern')
-                                    ->label(__('Load saved pattern'))
-                                    ->searchable()
-                                    ->placeholder(__('Select a saved pattern...'))
-                                    ->options($savedPatterns)
-                                    ->hidden(empty($savedPatterns))
-                                    ->live()
-                                    ->afterStateUpdated(function (?string $state, Set $set) use ($savedPatternRules): void {
-                                        if ($state === null || $state === '') {
-                                            return;
-                                        }
-                                        $rule = $savedPatternRules[(int) $state] ?? null;
-                                        if (! $rule) {
-                                            return;
-                                        }
-                                        $set('use_regex', $rule['use_regex'] ?? true);
-                                        $set('column', $rule['column'] ?? 'name');
-                                        $set('find_replace', $rule['find_replace'] ?? '');
-                                        $set('replace_with', $rule['replace_with'] ?? '');
-                                    })
-                                    ->dehydrated(false),
-                                Toggle::make('use_regex')
-                                    ->label(__('Use Regex'))
-                                    ->live()
-                                    ->helperText(__('Use regex patterns to find and replace. If disabled, will use direct string comparison.'))
-                                    ->default(true),
-                                Select::make('column')
-                                    ->label(__('Column to modify'))
-                                    ->options([
-                                        'name' => 'Series Name',
-                                        'genre' => 'Genre',
-                                        'plot' => 'Plot',
-                                    ])
-                                    ->default('name')
-                                    ->required()
-                                    ->columnSpan(1),
-                                TextInput::make('find_replace')
-                                    ->label(fn (Get $get) => ! $get('use_regex') ? 'String to replace' : 'Pattern to replace')
-                                    ->required()
-                                    ->placeholder(
-                                        fn (Get $get) => $get('use_regex')
-                                            ? '^(US- |UK- |CA- )'
-                                            : 'US -'
-                                    )->helperText(
-                                        fn (Get $get) => ! $get('use_regex')
-                                            ? 'This is the string you want to find and replace.'
-                                            : 'This is the regex pattern you want to find. Make sure to use valid regex syntax.'
-                                    ),
-                                TextInput::make('replace_with')
-                                    ->label(__('Replace with (optional)'))
-                                    ->placeholder(__('Leave empty to remove')),
-                            ];
-                        })
-                        ->action(function (Collection $records, array $data): void {
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new SeriesFindAndReplace(
-                                    user_id: auth()->id(), // The ID of the user who owns the content
-                                    use_regex: $data['use_regex'] ?? true,
-                                    column: $data['column'] ?? 'title',
-                                    find_replace: $data['find_replace'] ?? null,
-                                    replace_with: $data['replace_with'] ?? '',
-                                    series: $records
-                                ));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Find & Replace started'))
-                                ->body(__('Find & Replace working in the background. You will be notified once the process is complete.'))
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-magnifying-glass')
-                        ->color('gray')
-                        ->modalIcon('heroicon-o-magnifying-glass')
-                        ->modalDescription(__('Select what you would like to find and replace in the selected epg channels.'))
-                        ->modalSubmitActionLabel(__('Replace now')),
+                        return [
+                            Select::make('saved_pattern')
+                                ->label(__('Load saved pattern'))
+                                ->searchable()
+                                ->placeholder(__('Select a saved pattern...'))
+                                ->options($savedPatterns)
+                                ->hidden(empty($savedPatterns))
+                                ->live()
+                                ->afterStateUpdated(function (?string $state, Set $set) use ($savedPatternRules): void {
+                                    if ($state === null || $state === '') {
+                                        return;
+                                    }
+                                    $rule = $savedPatternRules[(int) $state] ?? null;
+                                    if (! $rule) {
+                                        return;
+                                    }
+                                    $set('use_regex', $rule['use_regex'] ?? true);
+                                    $set('column', $rule['column'] ?? 'name');
+                                    $set('find_replace', $rule['find_replace'] ?? '');
+                                    $set('replace_with', $rule['replace_with'] ?? '');
+                                })
+                                ->dehydrated(false),
+                            Toggle::make('use_regex')
+                                ->label(__('Use Regex'))
+                                ->live()
+                                ->helperText(__('Use regex patterns to find and replace. If disabled, will use direct string comparison.'))
+                                ->default(true),
+                            Select::make('column')
+                                ->label(__('Column to modify'))
+                                ->options([
+                                    'name' => 'Series Name',
+                                    'genre' => 'Genre',
+                                    'plot' => 'Plot',
+                                ])
+                                ->default('name')
+                                ->required()
+                                ->columnSpan(1),
+                            TextInput::make('find_replace')
+                                ->label(fn (Get $get) => ! $get('use_regex') ? 'String to replace' : 'Pattern to replace')
+                                ->required()
+                                ->placeholder(
+                                    fn (Get $get) => $get('use_regex')
+                                        ? '^(US- |UK- |CA- )'
+                                        : 'US -'
+                                )->helperText(
+                                    fn (Get $get) => ! $get('use_regex')
+                                        ? 'This is the string you want to find and replace.'
+                                        : 'This is the regex pattern you want to find. Make sure to use valid regex syntax.'
+                                ),
+                            TextInput::make('replace_with')
+                                ->label(__('Replace with (optional)'))
+                                ->placeholder(__('Leave empty to remove')),
+                        ];
+                    })
+                    ->action(function (Collection $records, array $data): void {
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new SeriesFindAndReplace(
+                                user_id: auth()->id(), // The ID of the user who owns the content
+                                use_regex: $data['use_regex'] ?? true,
+                                column: $data['column'] ?? 'title',
+                                find_replace: $data['find_replace'] ?? null,
+                                replace_with: $data['replace_with'] ?? '',
+                                series: $records
+                            ));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Find & Replace started'))
+                            ->body(__('Find & Replace working in the background. You will be notified once the process is complete.'))
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-magnifying-glass')
+                    ->color('gray')
+                    ->modalIcon('heroicon-o-magnifying-glass')
+                    ->modalDescription(__('Select what you would like to find and replace in the selected epg channels.'))
+                    ->modalSubmitActionLabel(__('Replace now')),
+            ]),
 
-                    BulkAction::make('enable')
-                        ->label(__('Enable selected'))
-                        ->action(function (Collection $records): void {
-                            foreach ($records->chunk(100) as $chunk) {
-                                Series::whereIn('id', $chunk->pluck('id'))->update(['enabled' => true]);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Selected series enabled'))
-                                ->body(__('The selected series have been enabled.'))
-                                ->send();
-                        })
-                        ->color('success')
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-check-circle')
-                        ->modalIcon('heroicon-o-check-circle')
-                        ->modalDescription(__('Enable the selected channel(s) now?'))
-                        ->modalSubmitActionLabel(__('Yes, enable now')),
-                    BulkAction::make('disable')
-                        ->label(__('Disable selected'))
-                        ->action(function (Collection $records): void {
-                            foreach ($records->chunk(100) as $chunk) {
-                                Series::whereIn('id', $chunk->pluck('id'))->update(['enabled' => false]);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Selected series disabled'))
-                                ->body(__('The selected series have been disabled.'))
-                                ->send();
-                        })
-                        ->color('warning')
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-x-circle')
-                        ->modalIcon('heroicon-o-x-circle')
-                        ->modalDescription(__('Disable the selected channel(s) now?'))
-                        ->modalSubmitActionLabel(__('Yes, disable now')),
-                    DeleteBulkAction::make(),
-                ]),
+            // -- Enable / Disable --
+            self::bulkActionSection('Enable / Disable', [
+                BulkAction::make('enable')
+                    ->label(__('Enable selected'))
+                    ->action(function (Collection $records): void {
+                        foreach ($records->chunk(100) as $chunk) {
+                            Series::whereIn('id', $chunk->pluck('id'))->update(['enabled' => true]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Selected series enabled'))
+                            ->body(__('The selected series have been enabled.'))
+                            ->send();
+                    })
+                    ->color('success')
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-check-circle')
+                    ->modalIcon('heroicon-o-check-circle')
+                    ->modalDescription(__('Enable the selected channel(s) now?'))
+                    ->modalSubmitActionLabel(__('Yes, enable now')),
+                BulkAction::make('disable')
+                    ->label(__('Disable selected'))
+                    ->action(function (Collection $records): void {
+                        foreach ($records->chunk(100) as $chunk) {
+                            Series::whereIn('id', $chunk->pluck('id'))->update(['enabled' => false]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Selected series disabled'))
+                            ->body(__('The selected series have been disabled.'))
+                            ->send();
+                    })
+                    ->color('warning')
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-x-circle')
+                    ->modalIcon('heroicon-o-x-circle')
+                    ->modalDescription(__('Disable the selected channel(s) now?'))
+                    ->modalSubmitActionLabel(__('Yes, disable now')),
+                DeleteBulkAction::make(),
+            ]),
         ];
     }
 

--- a/app/Filament/Resources/Series/SeriesResource.php
+++ b/app/Filament/Resources/Series/SeriesResource.php
@@ -49,6 +49,7 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
@@ -482,7 +483,7 @@ class SeriesResource extends Resource implements CopilotResource
      * Create a compact section for the bulk actions modal, ensuring each
      * action closes the parent modal when it completes.
      */
-    private static function bulkActionSection(string $heading, array $actions): Section
+    private static function bulkActionSection(string $heading, array $actions): Fieldset
     {
         foreach ($actions as $action) {
             if ($action instanceof BulkAction) {
@@ -490,10 +491,9 @@ class SeriesResource extends Resource implements CopilotResource
             }
         }
 
-        return Section::make(__($heading))
+        return Fieldset::make(__($heading))
             ->columns(2)
             ->columnSpanFull()
-            ->compact()
             ->schema($actions);
     }
 

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -677,7 +677,7 @@ class VodResource extends Resource implements CopilotResource
      * Create a compact section for the bulk actions modal, ensuring each
      * action closes the parent modal when it completes.
      */
-    private static function bulkActionSection(string $heading, array $actions): Section
+    private static function bulkActionSection(string $heading, array $actions): Fieldset
     {
         foreach ($actions as $action) {
             if ($action instanceof BulkAction) {
@@ -685,10 +685,9 @@ class VodResource extends Resource implements CopilotResource
             }
         }
 
-        return Section::make(__($heading))
+        return Fieldset::make(__($heading))
             ->columns(2)
             ->columnSpanFull()
-            ->compact()
             ->schema($actions);
     }
 

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -669,587 +669,637 @@ class VodResource extends Resource implements CopilotResource
             BulkModalActionGroup::make('Bulk VOD actions')
                 ->modalHeading(__('Bulk VOD actions'))
                 ->gridColumns(2)
-                ->schema([
-                    PlaylistService::getAddToPlaylistBulkAction('add', 'vod')
-                        ->hidden(fn () => ! $addToCustom),
-                    BulkAction::make('move')
-                        ->label(__('Move to Group'))
+                ->schema(self::getBulkActionSchema($addToCustom, $includeRecount)),
+        ];
+    }
+
+    /**
+     * Create a compact section for the bulk actions modal, ensuring each
+     * action closes the parent modal when it completes.
+     */
+    private static function bulkActionSection(string $heading, array $actions): Section
+    {
+        foreach ($actions as $action) {
+            if ($action instanceof BulkAction) {
+                $action->cancelParentActions();
+            }
+        }
+
+        return Section::make(__($heading))
+            ->columns(2)
+            ->columnSpanFull()
+            ->compact()
+            ->schema($actions);
+    }
+
+    /**
+     * Build the sectioned schema for the bulk actions modal.
+     */
+    private static function getBulkActionSchema(bool $addToCustom, bool $includeRecount): array
+    {
+        return [
+            // -- Playlist & Groups --
+            self::bulkActionSection('Playlist & Groups', [
+                PlaylistService::getAddToPlaylistBulkAction('add', 'vod')
+                    ->hidden(fn () => ! $addToCustom),
+                BulkAction::make('move')
+                    ->label(__('Move to Group'))
+                    ->schema([
+                        Select::make('playlist')
+                            ->required()
+                            ->live()
+                            ->afterStateUpdated(function (Set $set) {
+                                $set('group', null);
+                            })
+                            ->label(__('Playlist'))
+                            ->helperText(__('Select a playlist - only VODs in the selected playlist will be moved. Any VODs selected from another playlist will be ignored.'))
+                            ->options(Playlist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
+                            ->searchable(),
+                        Select::make('group')
+                            ->required()
+                            ->live()
+                            ->label(__('Group'))
+                            ->helperText(fn (Get $get) => $get('playlist') === null ? 'Select a playlist first...' : 'Select the group you would like to move the items to.')
+                            ->options(fn (Get $get) => Group::where([
+                                'type' => 'vod',
+                                'user_id' => auth()->id(),
+                                'playlist_id' => $get('playlist'),
+                            ])->get(['name', 'id'])->pluck('name', 'id'))
+                            ->searchable()
+                            ->disabled(fn (Get $get) => $get('playlist') === null),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        $filtered = $records->where('playlist_id', $data['playlist']);
+                        $group = Group::findOrFail($data['group']);
+                        foreach ($filtered as $record) {
+                            $record->update([
+                                'group' => $group->name,
+                                'group_id' => $group->id,
+                            ]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('VODs moved to group'))
+                            ->body(__('The selected VODs have been moved to the chosen group.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrows-right-left')
+                    ->modalIcon('heroicon-o-arrows-right-left')
+                    ->modalDescription(__('Move the selected VOD(s) to the chosen group.'))
+                    ->modalSubmitActionLabel(__('Move now')),
+                ...($includeRecount ? [
+                    BulkAction::make('recount')
+                        ->label(__('Recount Channels'))
+                        ->icon('heroicon-o-hashtag')
                         ->schema([
-                            Select::make('playlist')
-                                ->required()
-                                ->live()
-                                ->afterStateUpdated(function (Set $set) {
-                                    $set('group', null);
-                                })
-                                ->label(__('Playlist'))
-                                ->helperText(__('Select a playlist - only VODs in the selected playlist will be moved. Any VODs selected from another playlist will be ignored.'))
-                                ->options(Playlist::where(['user_id' => auth()->id()])->get(['name', 'id'])->pluck('name', 'id'))
-                                ->searchable(),
-                            Select::make('group')
-                                ->required()
-                                ->live()
-                                ->label(__('Group'))
-                                ->helperText(fn (Get $get) => $get('playlist') === null ? 'Select a playlist first...' : 'Select the group you would like to move the items to.')
-                                ->options(fn (Get $get) => Group::where([
-                                    'type' => 'vod',
-                                    'user_id' => auth()->id(),
-                                    'playlist_id' => $get('playlist'),
-                                ])->get(['name', 'id'])->pluck('name', 'id'))
-                                ->searchable()
-                                ->disabled(fn (Get $get) => $get('playlist') === null),
+                            TextInput::make('start')
+                                ->label(__('Start Number'))
+                                ->numeric()
+                                ->default(1)
+                                ->required(),
                         ])
                         ->action(function (Collection $records, array $data): void {
-                            $filtered = $records->where('playlist_id', $data['playlist']);
-                            $group = Group::findOrFail($data['group']);
-                            foreach ($filtered as $record) {
-                                $record->update([
-                                    'group' => $group->name,
-                                    'group_id' => $group->id,
-                                ]);
-                            }
-                        })->after(function () {
+                            $start = (int) $data['start'];
+                            SortFacade::bulkRecountChannels($records, $start);
+                        })
+                        ->after(function ($livewire) {
                             Notification::make()
                                 ->success()
-                                ->title(__('VODs moved to group'))
-                                ->body(__('The selected VODs have been moved to the chosen group.'))
+                                ->title(__('Channels Recounted'))
+                                ->body(__('The selected channels have been recounted.'))
                                 ->send();
                         })
-                        ->deselectRecordsAfterCompletion()
                         ->requiresConfirmation()
-                        ->icon('heroicon-o-arrows-right-left')
-                        ->modalIcon('heroicon-o-arrows-right-left')
-                        ->modalDescription(__('Move the selected VOD(s) to the chosen group.'))
-                        ->modalSubmitActionLabel(__('Move now')),
-                    BulkAction::make('preferred_logo')
-                        ->label(__('Update preferred icon'))
-                        ->schema([
-                            Select::make('logo_type')
-                                ->label(__('Preferred Icon'))
-                                ->helperText(__('Prefer logo from channel or EPG.'))
-                                ->options([
-                                    'channel' => 'Channel',
-                                    'epg' => 'EPG',
-                                ])
-                                ->searchable(),
+                        ->modalIcon('heroicon-o-hashtag')
+                        ->modalDescription(__('Recount the selected channels sequentially? Channel numbers will be assigned based on the current sort order.')),
+                ] : []),
+            ]),
 
-                        ])
-                        ->action(function (Collection $records, array $data): void {
-                            Channel::whereIn('id', $records->pluck('id')->toArray())
-                                ->update([
-                                    'logo_type' => $data['logo_type'],
-                                ]);
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Preferred icon updated'))
-                                ->body(__('The preferred icon has been updated.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-photo')
-                        ->modalIcon('heroicon-o-photo')
-                        ->modalDescription(__('Update the preferred icon for the selected channel(s).'))
-                        ->modalSubmitActionLabel(__('Update now')),
-                    BulkAction::make('set_logo_override_url')
-                        ->label(__('Set logo override URL'))
-                        ->schema([
-                            TextInput::make('logo')
-                                ->label(__('Logo override URL'))
-                                ->url()
-                                ->nullable()
-                                ->helperText(__('Leave empty to remove the custom logo and use provider/EPG logo.'))
-                                ->suffixActions([
-                                    AssetPickerAction::upload('logo'),
-                                    AssetPickerAction::browse('logo'),
-                                ]),
-                        ])
-                        ->action(function (Collection $records, array $data): void {
-                            Channel::whereIn('id', $records->pluck('id')->toArray())
-                                ->update([
-                                    'logo' => empty($data['logo']) ? null : $data['logo'],
-                                ]);
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Logo override updated'))
-                                ->body(__('The logo override URL has been updated for the selected VOD channels.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-link')
-                        ->modalIcon('heroicon-o-link')
-                        ->modalDescription(__('Apply a single logo override URL to all selected VOD channels. Leave empty to remove overrides.'))
-                        ->modalSubmitActionLabel(__('Apply URL')),
-                    BulkAction::make('refresh_logo_cache')
-                        ->label(__('Refresh logo cache (selected)'))
-                        ->action(function (Collection $records): void {
-                            $urls = [];
-
-                            foreach ($records as $record) {
-                                $urls[] = $record->logo;
-                                $urls[] = $record->logo_internal;
-                                $urls[] = $record->epgChannel?->icon_custom;
-                                $urls[] = $record->epgChannel?->icon;
-                                $urls[] = $record->info['movie_image'] ?? null;
-                                $urls[] = $record->info['cover_big'] ?? null;
-                            }
-
-                            $cleared = LogoCacheService::clearByUrls($urls);
-
-                            Notification::make()
-                                ->success()
-                                ->title(__('Selected VOD cache refreshed'))
-                                ->body("Removed {$cleared} cache file(s) for selected VOD resources.")
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-path')
-                        ->modalIcon('heroicon-o-arrow-path')
-                        ->modalDescription(__('Clear cached logos and poster images for selected VOD channels so they are fetched again on the next request.'))
-                        ->modalSubmitActionLabel(__('Refresh selected cache')),
-                    BulkAction::make('failover')
-                        ->label(__('Add as failover'))
-                        ->schema(function (Collection $records) {
-                            $existingFailoverIds = $records->pluck('id')->toArray();
-                            $initialMasterOptions = [];
-                            foreach ($records as $record) {
-                                $displayTitle = $record->title_custom ?: $record->title;
-                                $playlistName = $record->getEffectivePlaylist()->name ?? 'Unknown';
-                                $initialMasterOptions[$record->id] = "{$displayTitle} [{$playlistName}]";
-                            }
-
-                            return [
-                                ToggleButtons::make('master_source')
-                                    ->label(__('Choose master from?'))
-                                    ->options([
-                                        'selected' => 'Selected Channels',
-                                        'searched' => 'Channel Search',
-                                    ])
-                                    ->icons([
-                                        'selected' => 'heroicon-o-check',
-                                        'searched' => 'heroicon-o-magnifying-glass',
-                                    ])
-                                    ->default('selected')
-                                    ->live()
-                                    ->grouped(),
-                                Select::make('selected_master_id')
-                                    ->label(__('Select master channel'))
-                                    ->helperText(__('From the selected channels'))
-                                    ->options($initialMasterOptions)
-                                    ->required()
-                                    ->hidden(fn (Get $get) => $get('master_source') !== 'selected')
-                                    ->searchable(),
-                                Select::make('master_channel_id')
-                                    ->label(__('Search for master channel'))
-                                    ->searchable()
-                                    ->required()
-                                    ->hidden(fn (Get $get) => $get('master_source') !== 'searched')
-                                    ->getSearchResultsUsing(function (string $search) use ($existingFailoverIds) {
-                                        $searchLower = strtolower($search);
-                                        $channels = auth()->user()->channels()
-                                            ->withoutEagerLoads()
-                                            ->with('playlist')
-                                            ->whereNotIn('id', $existingFailoverIds)
-                                            ->where(function ($query) use ($searchLower) {
-                                                $query->whereRaw('LOWER(title) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(title_custom) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(name) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(name_custom) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(stream_id) LIKE ?', ["%{$searchLower}%"])
-                                                    ->orWhereRaw('LOWER(stream_id_custom) LIKE ?', ["%{$searchLower}%"]);
-                                            })
-                                            ->limit(50) // Keep a reasonable limit
-                                            ->get();
-
-                                        // Create options array
-                                        $options = [];
-                                        foreach ($channels as $channel) {
-                                            $displayTitle = $channel->title_custom ?: $channel->title;
-                                            $playlistName = $channel->getEffectivePlaylist()->name ?? 'Unknown';
-                                            $options[$channel->id] = "{$displayTitle} [{$playlistName}]";
-                                        }
-
-                                        return $options;
-                                    })
-                                    ->helperText(__('To use as the master for the selected channel.'))
-                                    ->required(),
-                            ];
-                        })
-                        ->action(function (Collection $records, array $data): void {
-                            // Filter out the master channel from the records to be added as failovers
-                            $masterRecordId = $data['master_source'] === 'selected'
-                                ? $data['selected_master_id']
-                                : $data['master_channel_id'];
-                            $failoverRecords = $records->filter(function ($record) use ($masterRecordId) {
-                                return (int) $record->id !== (int) $masterRecordId;
-                            });
-
-                            foreach ($failoverRecords as $record) {
-                                ChannelFailover::updateOrCreate([
-                                    'channel_id' => $masterRecordId,
-                                    'channel_failover_id' => $record->id,
-                                ]);
-                            }
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Channels as failover'))
-                                ->body(__('The selected channels have been added as failovers.'))
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-path-rounded-square')
-                        ->modalIcon('heroicon-o-arrow-path-rounded-square')
-                        ->modalDescription(__('Add the selected channel(s) to the chosen channel as failover sources.'))
-                        ->modalSubmitActionLabel(__('Add failovers now')),
-                    ...($includeRecount ? [
-                        BulkAction::make('recount')
-                            ->label(__('Recount Channels'))
-                            ->icon('heroicon-o-hashtag')
-                            ->schema([
-                                TextInput::make('start')
-                                    ->label(__('Start Number'))
-                                    ->numeric()
-                                    ->default(1)
-                                    ->required(),
+            // -- Logo --
+            self::bulkActionSection('Logo', [
+                BulkAction::make('preferred_logo')
+                    ->label(__('Update preferred icon'))
+                    ->schema([
+                        Select::make('logo_type')
+                            ->label(__('Preferred Icon'))
+                            ->helperText(__('Prefer logo from channel or EPG.'))
+                            ->options([
+                                'channel' => 'Channel',
+                                'epg' => 'EPG',
                             ])
-                            ->action(function (Collection $records, array $data): void {
-                                $start = (int) $data['start'];
-                                SortFacade::bulkRecountChannels($records, $start);
-                            })
-                            ->after(function ($livewire) {
-                                Notification::make()
-                                    ->success()
-                                    ->title(__('Channels Recounted'))
-                                    ->body(__('The selected channels have been recounted.'))
-                                    ->send();
-                            })
-                            ->requiresConfirmation()
-                            ->modalIcon('heroicon-o-hashtag')
-                            ->modalDescription(__('Recount the selected channels sequentially? Channel numbers will be assigned based on the current sort order.')),
-                    ] : []),
-                    BulkAction::make('process_vod')
-                        ->label(__('Fetch Metadata'))
-                        ->icon('heroicon-o-arrow-down-tray')
-                        ->schema([
-                            Toggle::make('overwrite_existing')
-                                ->label(__('Overwrite Existing Metadata'))
-                                ->helperText(__('Overwrite existing metadata? If disabled, it will only fetch and process metadata if it does not already exist.'))
-                                ->default(false),
-                        ])
-                        ->action(function ($records, $data) {
-                            $count = 0;
-                            foreach ($records as $record) {
-                                if ($record->is_vod) {
-                                    $count++;
-                                    app('Illuminate\Contracts\Bus\Dispatcher')
-                                        ->dispatch(new ProcessVodChannels(
-                                            channel: $record,
-                                            force: $data['overwrite_existing'] ?? false
-                                        ));
-                                }
-                            }
+                            ->searchable(),
 
-                            Notification::make()
-                                ->success()
-                                ->title("Fetching VOD metadata for {$count} channel(s)")
-                                ->body(__('The VOD metadata fetching and processing has been started. You will be notified when it is complete.'))
-                                ->duration(10000)
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-down-tray')
-                        ->modalIcon('heroicon-o-arrow-down-tray')
-                        ->modalDescription(__('Fetch and process VOD metadata for the selected channels? Only enabled VOD channels will be processed.'))
-                        ->modalSubmitActionLabel(__('Yes, process now')),
-                    BulkAction::make('fetch_tmdb_ids')
-                        ->label(__('Fetch TMDB IDs'))
-                        ->icon('heroicon-o-magnifying-glass')
-                        ->schema([
-                            Toggle::make('overwrite_existing')
-                                ->label(__('Overwrite Existing IDs'))
-                                ->helperText(__('Overwrite existing TMDB/IMDB IDs? If disabled, it will only fetch IDs for items that don\\\'t already have them.'))
-                                ->default(false),
-                        ])
-                        ->action(function ($records, $data) {
-                            $settings = app(GeneralSettings::class);
-                            if (empty($settings->tmdb_api_key)) {
-                                Notification::make()
-                                    ->danger()
-                                    ->title(__('TMDB API Key Required'))
-                                    ->body(__('Please configure your TMDB API key in Settings > TMDB before using this feature.'))
-                                    ->duration(10000)
-                                    ->send();
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        Channel::whereIn('id', $records->pluck('id')->toArray())
+                            ->update([
+                                'logo_type' => $data['logo_type'],
+                            ]);
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Preferred icon updated'))
+                            ->body(__('The preferred icon has been updated.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-photo')
+                    ->modalIcon('heroicon-o-photo')
+                    ->modalDescription(__('Update the preferred icon for the selected channel(s).'))
+                    ->modalSubmitActionLabel(__('Update now')),
+                BulkAction::make('set_logo_override_url')
+                    ->label(__('Set logo override URL'))
+                    ->schema([
+                        TextInput::make('logo')
+                            ->label(__('Logo override URL'))
+                            ->url()
+                            ->nullable()
+                            ->helperText(__('Leave empty to remove the custom logo and use provider/EPG logo.'))
+                            ->suffixActions([
+                                AssetPickerAction::upload('logo'),
+                                AssetPickerAction::browse('logo'),
+                            ]),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        Channel::whereIn('id', $records->pluck('id')->toArray())
+                            ->update([
+                                'logo' => empty($data['logo']) ? null : $data['logo'],
+                            ]);
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Logo override updated'))
+                            ->body(__('The logo override URL has been updated for the selected VOD channels.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-link')
+                    ->modalIcon('heroicon-o-link')
+                    ->modalDescription(__('Apply a single logo override URL to all selected VOD channels. Leave empty to remove overrides.'))
+                    ->modalSubmitActionLabel(__('Apply URL')),
+                BulkAction::make('refresh_logo_cache')
+                    ->label(__('Refresh logo cache (selected)'))
+                    ->action(function (Collection $records): void {
+                        $urls = [];
 
-                                return;
-                            }
+                        foreach ($records as $record) {
+                            $urls[] = $record->logo;
+                            $urls[] = $record->logo_internal;
+                            $urls[] = $record->epgChannel?->icon_custom;
+                            $urls[] = $record->epgChannel?->icon;
+                            $urls[] = $record->info['movie_image'] ?? null;
+                            $urls[] = $record->info['cover_big'] ?? null;
+                        }
 
-                            $vodIds = $records->pluck('id')->toArray();
+                        $cleared = LogoCacheService::clearByUrls($urls);
 
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new FetchTmdbIds(
-                                    vodChannelIds: $vodIds,
-                                    seriesIds: null,
-                                    overwriteExisting: $data['overwrite_existing'] ?? false,
-                                    user: auth()->user(),
-                                ));
+                        Notification::make()
+                            ->success()
+                            ->title(__('Selected VOD cache refreshed'))
+                            ->body("Removed {$cleared} cache file(s) for selected VOD resources.")
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-path')
+                    ->modalIcon('heroicon-o-arrow-path')
+                    ->modalDescription(__('Clear cached logos and poster images for selected VOD channels so they are fetched again on the next request.'))
+                    ->modalSubmitActionLabel(__('Refresh selected cache')),
+            ]),
 
-                            Notification::make()
-                                ->success()
-                                ->title('Fetching TMDB IDs for '.count($vodIds).' VOD channel(s)')
-                                ->body(__('The TMDB ID lookup has been started. You will be notified when it is complete.'))
-                                ->duration(10000)
-                                ->send();
-                        })
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->modalIcon('heroicon-o-magnifying-glass')
-                        ->modalDescription(__('Search TMDB for matching movies and populate TMDB/IMDB IDs for the selected VOD channels? This enables Trash Guides compatibility for Radarr/Sonarr.'))
-                        ->modalSubmitActionLabel(__('Yes, fetch IDs now')),
-                    BulkAction::make('sync')
-                        ->label(__('Sync VOD .strm files'))
-                        ->action(function ($records) {
-                            foreach ($records as $record) {
+            // -- VOD Metadata --
+            self::bulkActionSection('VOD Metadata', [
+                BulkAction::make('process_vod')
+                    ->label(__('Fetch Metadata'))
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->schema([
+                        Toggle::make('overwrite_existing')
+                            ->label(__('Overwrite Existing Metadata'))
+                            ->helperText(__('Overwrite existing metadata? If disabled, it will only fetch and process metadata if it does not already exist.'))
+                            ->default(false),
+                    ])
+                    ->action(function ($records, $data) {
+                        $count = 0;
+                        foreach ($records as $record) {
+                            if ($record->is_vod) {
+                                $count++;
                                 app('Illuminate\Contracts\Bus\Dispatcher')
-                                    ->dispatch(new SyncVodStrmFiles(
+                                    ->dispatch(new ProcessVodChannels(
                                         channel: $record,
+                                        force: $data['overwrite_existing'] ?? false
                                     ));
                             }
-                        })->after(function () {
+                        }
+
+                        Notification::make()
+                            ->success()
+                            ->title("Fetching VOD metadata for {$count} channel(s)")
+                            ->body(__('The VOD metadata fetching and processing has been started. You will be notified when it is complete.'))
+                            ->duration(10000)
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->modalIcon('heroicon-o-arrow-down-tray')
+                    ->modalDescription(__('Fetch and process VOD metadata for the selected channels? Only enabled VOD channels will be processed.'))
+                    ->modalSubmitActionLabel(__('Yes, process now')),
+                BulkAction::make('fetch_tmdb_ids')
+                    ->label(__('Fetch TMDB IDs'))
+                    ->icon('heroicon-o-magnifying-glass')
+                    ->schema([
+                        Toggle::make('overwrite_existing')
+                            ->label(__('Overwrite Existing IDs'))
+                            ->helperText(__('Overwrite existing TMDB/IMDB IDs? If disabled, it will only fetch IDs for items that don\\\'t already have them.'))
+                            ->default(false),
+                    ])
+                    ->action(function ($records, $data) {
+                        $settings = app(GeneralSettings::class);
+                        if (empty($settings->tmdb_api_key)) {
                             Notification::make()
-                                ->success()
-                                ->title(__('.strm files are being synced for selected VOD channels'))
-                                ->body(__('You will be notified once complete.'))
+                                ->danger()
+                                ->title(__('TMDB API Key Required'))
+                                ->body(__('Please configure your TMDB API key in Settings > TMDB before using this feature.'))
                                 ->duration(10000)
                                 ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-document-arrow-down')
-                        ->modalIcon('heroicon-o-document-arrow-down')
-                        ->modalDescription(__('Sync selected VOD .strm files now? This will generate .strm files for the selected VOD channels at the path set for the channels.'))
-                        ->modalSubmitActionLabel(__('Yes, sync now')),
-                    BulkAction::make('find-replace')
-                        ->label(__('Find & Replace'))
-                        ->schema(function (): array {
-                            $savedPatterns = [];
-                            $savedPatternRules = [];
-                            $counter = 0;
-                            foreach (Playlist::where('user_id', auth()->id())->get() as $playlist) {
-                                foreach ($playlist->find_replace_rules ?? [] as $rule) {
-                                    if (is_array($rule) && ($rule['target'] ?? 'channels') === 'channels') {
-                                        $savedPatterns[$counter] = "{$playlist->name} - ".($rule['name'] ?? 'Unnamed');
-                                        $savedPatternRules[$counter] = $rule;
-                                        $counter++;
-                                    }
+
+                            return;
+                        }
+
+                        $vodIds = $records->pluck('id')->toArray();
+
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new FetchTmdbIds(
+                                vodChannelIds: $vodIds,
+                                seriesIds: null,
+                                overwriteExisting: $data['overwrite_existing'] ?? false,
+                                user: auth()->user(),
+                            ));
+
+                        Notification::make()
+                            ->success()
+                            ->title('Fetching TMDB IDs for '.count($vodIds).' VOD channel(s)')
+                            ->body(__('The TMDB ID lookup has been started. You will be notified when it is complete.'))
+                            ->duration(10000)
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->modalIcon('heroicon-o-magnifying-glass')
+                    ->modalDescription(__('Search TMDB for matching movies and populate TMDB/IMDB IDs for the selected VOD channels? This enables Trash Guides compatibility for Radarr/Sonarr.'))
+                    ->modalSubmitActionLabel(__('Yes, fetch IDs now')),
+                BulkAction::make('sync')
+                    ->label(__('Sync VOD .strm files'))
+                    ->action(function ($records) {
+                        foreach ($records as $record) {
+                            app('Illuminate\Contracts\Bus\Dispatcher')
+                                ->dispatch(new SyncVodStrmFiles(
+                                    channel: $record,
+                                ));
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('.strm files are being synced for selected VOD channels'))
+                            ->body(__('You will be notified once complete.'))
+                            ->duration(10000)
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-document-arrow-down')
+                    ->modalIcon('heroicon-o-document-arrow-down')
+                    ->modalDescription(__('Sync selected VOD .strm files now? This will generate .strm files for the selected VOD channels at the path set for the channels.'))
+                    ->modalSubmitActionLabel(__('Yes, sync now')),
+            ]),
+
+            // -- Find & Replace --
+            self::bulkActionSection('Find & Replace', [
+                BulkAction::make('find-replace')
+                    ->label(__('Find & Replace'))
+                    ->schema(function (): array {
+                        $savedPatterns = [];
+                        $savedPatternRules = [];
+                        $counter = 0;
+                        foreach (Playlist::where('user_id', auth()->id())->get() as $playlist) {
+                            foreach ($playlist->find_replace_rules ?? [] as $rule) {
+                                if (is_array($rule) && ($rule['target'] ?? 'channels') === 'channels') {
+                                    $savedPatterns[$counter] = "{$playlist->name} - ".($rule['name'] ?? 'Unnamed');
+                                    $savedPatternRules[$counter] = $rule;
+                                    $counter++;
                                 }
                             }
+                        }
 
-                            return [
-                                Select::make('saved_pattern')
-                                    ->label(__('Load saved pattern'))
-                                    ->searchable()
-                                    ->placeholder(__('Select a saved pattern...'))
-                                    ->options($savedPatterns)
-                                    ->hidden(empty($savedPatterns))
-                                    ->live()
-                                    ->afterStateUpdated(function (?string $state, Set $set) use ($savedPatternRules): void {
-                                        if ($state === null || $state === '') {
-                                            return;
-                                        }
-                                        $rule = $savedPatternRules[(int) $state] ?? null;
-                                        if (! $rule) {
-                                            return;
-                                        }
-                                        $set('use_regex', $rule['use_regex'] ?? true);
-                                        $set('column', $rule['column'] ?? 'title');
-                                        $set('find_replace', $rule['find_replace'] ?? '');
-                                        $set('replace_with', $rule['replace_with'] ?? '');
-                                    })
-                                    ->dehydrated(false),
-                                Toggle::make('use_regex')
-                                    ->label(__('Use Regex'))
-                                    ->live()
-                                    ->helperText(__('Use regex patterns to find and replace. If disabled, will use direct string comparison.'))
-                                    ->default(true),
-                                Select::make('column')
-                                    ->label(__('Column to modify'))
-                                    ->options([
-                                        'title' => 'Channel Title',
-                                        'name' => 'Channel Name (tvg-name)',
-                                        'info->description' => 'Description (metadata)',
-                                        'info->genre' => 'Genre (metadata)',
-                                    ])
-                                    ->default('title')
-                                    ->required()
-                                    ->columnSpan(1),
-                                TextInput::make('find_replace')
-                                    ->label(fn (Get $get) => ! $get('use_regex') ? 'String to replace' : 'Pattern to replace')
-                                    ->required()
-                                    ->placeholder(
-                                        fn (Get $get) => $get('use_regex')
-                                            ? '^(US- |UK- |CA- )'
-                                            : 'US -'
-                                    )->helperText(
-                                        fn (Get $get) => ! $get('use_regex')
-                                            ? 'This is the string you want to find and replace.'
-                                            : 'This is the regex pattern you want to find. Make sure to use valid regex syntax.'
-                                    ),
-                                TextInput::make('replace_with')
-                                    ->label(__('Replace with (optional)'))
-                                    ->placeholder(__('Leave empty to remove')),
-                            ];
-                        })
-                        ->action(function (Collection $records, array $data): void {
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new ChannelFindAndReplace(
-                                    user_id: auth()->id(), // The ID of the user who owns the content
-                                    use_regex: $data['use_regex'] ?? true,
-                                    column: $data['column'] ?? 'title',
-                                    find_replace: $data['find_replace'] ?? null,
-                                    replace_with: $data['replace_with'] ?? '',
-                                    channels: $records
-                                ));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Find & Replace started'))
-                                ->body(__('Find & Replace working in the background. You will be notified once the process is complete.'))
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-magnifying-glass')
-                        ->color('gray')
-                        ->modalIcon('heroicon-o-magnifying-glass')
-                        ->modalDescription(__('Select what you would like to find and replace in the selected channels.'))
-                        ->modalSubmitActionLabel(__('Replace now')),
-                    BulkAction::make('find-replace-reset')
-                        ->label(__('Undo Find & Replace'))
-                        ->schema([
+                        return [
+                            Select::make('saved_pattern')
+                                ->label(__('Load saved pattern'))
+                                ->searchable()
+                                ->placeholder(__('Select a saved pattern...'))
+                                ->options($savedPatterns)
+                                ->hidden(empty($savedPatterns))
+                                ->live()
+                                ->afterStateUpdated(function (?string $state, Set $set) use ($savedPatternRules): void {
+                                    if ($state === null || $state === '') {
+                                        return;
+                                    }
+                                    $rule = $savedPatternRules[(int) $state] ?? null;
+                                    if (! $rule) {
+                                        return;
+                                    }
+                                    $set('use_regex', $rule['use_regex'] ?? true);
+                                    $set('column', $rule['column'] ?? 'title');
+                                    $set('find_replace', $rule['find_replace'] ?? '');
+                                    $set('replace_with', $rule['replace_with'] ?? '');
+                                })
+                                ->dehydrated(false),
+                            Toggle::make('use_regex')
+                                ->label(__('Use Regex'))
+                                ->live()
+                                ->helperText(__('Use regex patterns to find and replace. If disabled, will use direct string comparison.'))
+                                ->default(true),
                             Select::make('column')
-                                ->label(__('Column to reset'))
+                                ->label(__('Column to modify'))
                                 ->options([
                                     'title' => 'Channel Title',
                                     'name' => 'Channel Name (tvg-name)',
-                                    'logo' => 'Channel Logo (tvg-logo)',
-                                    'url' => 'Custom URL (tvg-url)',
+                                    'info->description' => 'Description (metadata)',
+                                    'info->genre' => 'Genre (metadata)',
                                 ])
                                 ->default('title')
                                 ->required()
                                 ->columnSpan(1),
-                        ])
-                        ->action(function (Collection $records, array $data): void {
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new ChannelFindAndReplaceReset(
-                                    user_id: auth()->id(), // The ID of the user who owns the content
-                                    column: $data['column'] ?? 'title',
-                                    channels: $records
-                                ));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Find & Replace reset started'))
-                                ->body(__('Find & Replace reset working in the background. You will be notified once the process is complete.'))
-                                ->send();
-                        })
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrow-uturn-left')
-                        ->color('warning')
-                        ->modalIcon('heroicon-o-arrow-uturn-left')
-                        ->modalDescription(__('Reset Find & Replace results back to playlist defaults for the selected channels. This will remove any custom values set in the selected column.'))
-                        ->modalSubmitActionLabel(__('Reset now')),
-                    BulkAction::make('enable-merge')
-                        ->label(__('Enable Merge'))
-                        ->action(function (Collection $records, array $data): void {
-                            $records->each(fn ($channel) => $channel->update([
-                                'can_merge' => true,
-                            ]));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Merge re-enabled for selected channels'))
-                                ->body(__('The merge has been re-enabled for the selected channels. They can now be merged during "Merge Same ID" jobs.'))
-                                ->send();
-                        })
-                        ->hidden(fn () => ! $addToCustom)
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrows-pointing-in')
-                        ->modalIcon('heroicon-o-arrows-pointing-in')
-                        ->modalDescription(__('Allow merging for selected channels when running "Merge Same ID" jobs.'))
-                        ->modalSubmitActionLabel(__('Enable now')),
-                    BulkAction::make('disable-merge')
-                        ->label(__('Disable Merge'))
-                        ->color('warning')
-                        ->action(function (Collection $records, array $data): void {
-                            $records->each(fn ($channel) => $channel->update([
-                                'can_merge' => false,
-                            ]));
-                        })->after(function () {
-                            Notification::make()
-                                ->success()
-                                ->title(__('Merge disabled for selected channels'))
-                                ->body(__('The merge has been disabled for the selected channels. They will not be merged during "Merge Same ID" jobs.'))
-                                ->send();
-                        })
-                        ->hidden(fn () => ! $addToCustom)
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-arrows-pointing-in')
-                        ->modalIcon('heroicon-o-arrows-pointing-in')
-                        ->modalDescription(__('Don\\\'t allow merging for selected channels when running "Merge Same ID" jobs.'))
-                        ->modalSubmitActionLabel(__('Disable now')),
-                    BulkAction::make('enable')
-                        ->label(__('Enable selected'))
-                        ->action(function (Collection $records): void {
-                            foreach ($records->chunk(100) as $chunk) {
-                                Channel::whereIn('id', $chunk->pluck('id'))->update(['enabled' => true]);
-                            }
-                        })->after(function () {
-                            dispatch(new SyncPlexDvrJob(trigger: 'vod_bulk_enable'));
-                            Notification::make()
-                                ->success()
-                                ->title(__('Selected channels enabled'))
-                                ->body(__('The selected channels have been enabled.'))
-                                ->send();
-                        })
-                        ->color('success')
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-check-circle')
-                        ->modalIcon('heroicon-o-check-circle')
-                        ->modalDescription(__('Enable the selected channel(s) now?'))
-                        ->modalSubmitActionLabel(__('Yes, enable now')),
-                    BulkAction::make('disable')
-                        ->label(__('Disable selected'))
-                        ->action(function (Collection $records): void {
-                            foreach ($records->chunk(100) as $chunk) {
-                                Channel::whereIn('id', $chunk->pluck('id'))->update(['enabled' => false]);
-                            }
-                        })->after(function () {
-                            dispatch(new SyncPlexDvrJob(trigger: 'vod_bulk_disable'));
-                            Notification::make()
-                                ->success()
-                                ->title(__('Selected channels disabled'))
-                                ->body(__('The selected channels have been disabled.'))
-                                ->send();
-                        })
-                        ->color('danger')
-                        ->deselectRecordsAfterCompletion()
-                        ->requiresConfirmation()
-                        ->icon('heroicon-o-x-circle')
-                        ->modalIcon('heroicon-o-x-circle')
-                        ->modalDescription(__('Disable the selected channel(s) now?'))
-                        ->modalSubmitActionLabel(__('Yes, disable now')),
-                    DeleteBulkAction::make()
-                        ->modalIcon('heroicon-o-trash')
-                        ->modalDescription(__('Are you sure you want to delete the selected VOD channels? This action cannot be undone.'))
-                        ->modalSubmitActionLabel(__('Yes, delete VODs')),
-                ]),
+                            TextInput::make('find_replace')
+                                ->label(fn (Get $get) => ! $get('use_regex') ? 'String to replace' : 'Pattern to replace')
+                                ->required()
+                                ->placeholder(
+                                    fn (Get $get) => $get('use_regex')
+                                        ? '^(US- |UK- |CA- )'
+                                        : 'US -'
+                                )->helperText(
+                                    fn (Get $get) => ! $get('use_regex')
+                                        ? 'This is the string you want to find and replace.'
+                                        : 'This is the regex pattern you want to find. Make sure to use valid regex syntax.'
+                                ),
+                            TextInput::make('replace_with')
+                                ->label(__('Replace with (optional)'))
+                                ->placeholder(__('Leave empty to remove')),
+                        ];
+                    })
+                    ->action(function (Collection $records, array $data): void {
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new ChannelFindAndReplace(
+                                user_id: auth()->id(), // The ID of the user who owns the content
+                                use_regex: $data['use_regex'] ?? true,
+                                column: $data['column'] ?? 'title',
+                                find_replace: $data['find_replace'] ?? null,
+                                replace_with: $data['replace_with'] ?? '',
+                                channels: $records
+                            ));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Find & Replace started'))
+                            ->body(__('Find & Replace working in the background. You will be notified once the process is complete.'))
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-magnifying-glass')
+                    ->color('gray')
+                    ->modalIcon('heroicon-o-magnifying-glass')
+                    ->modalDescription(__('Select what you would like to find and replace in the selected channels.'))
+                    ->modalSubmitActionLabel(__('Replace now')),
+                BulkAction::make('find-replace-reset')
+                    ->label(__('Undo Find & Replace'))
+                    ->schema([
+                        Select::make('column')
+                            ->label(__('Column to reset'))
+                            ->options([
+                                'title' => 'Channel Title',
+                                'name' => 'Channel Name (tvg-name)',
+                                'logo' => 'Channel Logo (tvg-logo)',
+                                'url' => 'Custom URL (tvg-url)',
+                            ])
+                            ->default('title')
+                            ->required()
+                            ->columnSpan(1),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new ChannelFindAndReplaceReset(
+                                user_id: auth()->id(), // The ID of the user who owns the content
+                                column: $data['column'] ?? 'title',
+                                channels: $records
+                            ));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Find & Replace reset started'))
+                            ->body(__('Find & Replace reset working in the background. You will be notified once the process is complete.'))
+                            ->send();
+                    })
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-uturn-left')
+                    ->color('warning')
+                    ->modalIcon('heroicon-o-arrow-uturn-left')
+                    ->modalDescription(__('Reset Find & Replace results back to playlist defaults for the selected channels. This will remove any custom values set in the selected column.'))
+                    ->modalSubmitActionLabel(__('Reset now')),
+            ]),
+
+            // -- Streaming --
+            self::bulkActionSection('Streaming', [
+                BulkAction::make('enable-merge')
+                    ->label(__('Enable Merge'))
+                    ->action(function (Collection $records, array $data): void {
+                        $records->each(fn ($channel) => $channel->update([
+                            'can_merge' => true,
+                        ]));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Merge re-enabled for selected channels'))
+                            ->body(__('The merge has been re-enabled for the selected channels. They can now be merged during "Merge Same ID" jobs.'))
+                            ->send();
+                    })
+                    ->hidden(fn () => ! $addToCustom)
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrows-pointing-in')
+                    ->modalIcon('heroicon-o-arrows-pointing-in')
+                    ->modalDescription(__('Allow merging for selected channels when running "Merge Same ID" jobs.'))
+                    ->modalSubmitActionLabel(__('Enable now')),
+                BulkAction::make('disable-merge')
+                    ->label(__('Disable Merge'))
+                    ->color('warning')
+                    ->action(function (Collection $records, array $data): void {
+                        $records->each(fn ($channel) => $channel->update([
+                            'can_merge' => false,
+                        ]));
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Merge disabled for selected channels'))
+                            ->body(__('The merge has been disabled for the selected channels. They will not be merged during "Merge Same ID" jobs.'))
+                            ->send();
+                    })
+                    ->hidden(fn () => ! $addToCustom)
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrows-pointing-in')
+                    ->modalIcon('heroicon-o-arrows-pointing-in')
+                    ->modalDescription(__('Don\\\'t allow merging for selected channels when running "Merge Same ID" jobs.'))
+                    ->modalSubmitActionLabel(__('Disable now')),
+                BulkAction::make('failover')
+                    ->label(__('Add as failover'))
+                    ->schema(function (Collection $records) {
+                        $existingFailoverIds = $records->pluck('id')->toArray();
+                        $initialMasterOptions = [];
+                        foreach ($records as $record) {
+                            $displayTitle = $record->title_custom ?: $record->title;
+                            $playlistName = $record->getEffectivePlaylist()->name ?? 'Unknown';
+                            $initialMasterOptions[$record->id] = "{$displayTitle} [{$playlistName}]";
+                        }
+
+                        return [
+                            ToggleButtons::make('master_source')
+                                ->label(__('Choose master from?'))
+                                ->options([
+                                    'selected' => 'Selected Channels',
+                                    'searched' => 'Channel Search',
+                                ])
+                                ->icons([
+                                    'selected' => 'heroicon-o-check',
+                                    'searched' => 'heroicon-o-magnifying-glass',
+                                ])
+                                ->default('selected')
+                                ->live()
+                                ->grouped(),
+                            Select::make('selected_master_id')
+                                ->label(__('Select master channel'))
+                                ->helperText(__('From the selected channels'))
+                                ->options($initialMasterOptions)
+                                ->required()
+                                ->hidden(fn (Get $get) => $get('master_source') !== 'selected')
+                                ->searchable(),
+                            Select::make('master_channel_id')
+                                ->label(__('Search for master channel'))
+                                ->searchable()
+                                ->required()
+                                ->hidden(fn (Get $get) => $get('master_source') !== 'searched')
+                                ->getSearchResultsUsing(function (string $search) use ($existingFailoverIds) {
+                                    $searchLower = strtolower($search);
+                                    $channels = auth()->user()->channels()
+                                        ->withoutEagerLoads()
+                                        ->with('playlist')
+                                        ->whereNotIn('id', $existingFailoverIds)
+                                        ->where(function ($query) use ($searchLower) {
+                                            $query->whereRaw('LOWER(title) LIKE ?', ["%{$searchLower}%"])
+                                                ->orWhereRaw('LOWER(title_custom) LIKE ?', ["%{$searchLower}%"])
+                                                ->orWhereRaw('LOWER(name) LIKE ?', ["%{$searchLower}%"])
+                                                ->orWhereRaw('LOWER(name_custom) LIKE ?', ["%{$searchLower}%"])
+                                                ->orWhereRaw('LOWER(stream_id) LIKE ?', ["%{$searchLower}%"])
+                                                ->orWhereRaw('LOWER(stream_id_custom) LIKE ?', ["%{$searchLower}%"]);
+                                        })
+                                        ->limit(50) // Keep a reasonable limit
+                                        ->get();
+
+                                    // Create options array
+                                    $options = [];
+                                    foreach ($channels as $channel) {
+                                        $displayTitle = $channel->title_custom ?: $channel->title;
+                                        $playlistName = $channel->getEffectivePlaylist()->name ?? 'Unknown';
+                                        $options[$channel->id] = "{$displayTitle} [{$playlistName}]";
+                                    }
+
+                                    return $options;
+                                })
+                                ->helperText(__('To use as the master for the selected channel.'))
+                                ->required(),
+                        ];
+                    })
+                    ->action(function (Collection $records, array $data): void {
+                        // Filter out the master channel from the records to be added as failovers
+                        $masterRecordId = $data['master_source'] === 'selected'
+                            ? $data['selected_master_id']
+                            : $data['master_channel_id'];
+                        $failoverRecords = $records->filter(function ($record) use ($masterRecordId) {
+                            return (int) $record->id !== (int) $masterRecordId;
+                        });
+
+                        foreach ($failoverRecords as $record) {
+                            ChannelFailover::updateOrCreate([
+                                'channel_id' => $masterRecordId,
+                                'channel_failover_id' => $record->id,
+                            ]);
+                        }
+                    })->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Channels as failover'))
+                            ->body(__('The selected channels have been added as failovers.'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-arrow-path-rounded-square')
+                    ->modalIcon('heroicon-o-arrow-path-rounded-square')
+                    ->modalDescription(__('Add the selected channel(s) to the chosen channel as failover sources.'))
+                    ->modalSubmitActionLabel(__('Add failovers now')),
+            ]),
+
+            // -- Enable / Disable --
+            self::bulkActionSection('Enable / Disable', [
+                BulkAction::make('enable')
+                    ->label(__('Enable selected'))
+                    ->action(function (Collection $records): void {
+                        foreach ($records->chunk(100) as $chunk) {
+                            Channel::whereIn('id', $chunk->pluck('id'))->update(['enabled' => true]);
+                        }
+                    })->after(function () {
+                        dispatch(new SyncPlexDvrJob(trigger: 'vod_bulk_enable'));
+                        Notification::make()
+                            ->success()
+                            ->title(__('Selected channels enabled'))
+                            ->body(__('The selected channels have been enabled.'))
+                            ->send();
+                    })
+                    ->color('success')
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-check-circle')
+                    ->modalIcon('heroicon-o-check-circle')
+                    ->modalDescription(__('Enable the selected channel(s) now?'))
+                    ->modalSubmitActionLabel(__('Yes, enable now')),
+                BulkAction::make('disable')
+                    ->label(__('Disable selected'))
+                    ->action(function (Collection $records): void {
+                        foreach ($records->chunk(100) as $chunk) {
+                            Channel::whereIn('id', $chunk->pluck('id'))->update(['enabled' => false]);
+                        }
+                    })->after(function () {
+                        dispatch(new SyncPlexDvrJob(trigger: 'vod_bulk_disable'));
+                        Notification::make()
+                            ->success()
+                            ->title(__('Selected channels disabled'))
+                            ->body(__('The selected channels have been disabled.'))
+                            ->send();
+                    })
+                    ->color('danger')
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-x-circle')
+                    ->modalIcon('heroicon-o-x-circle')
+                    ->modalDescription(__('Disable the selected channel(s) now?'))
+                    ->modalSubmitActionLabel(__('Yes, disable now')),
+                DeleteBulkAction::make()
+                    ->modalIcon('heroicon-o-trash')
+                    ->modalDescription(__('Are you sure you want to delete the selected VOD channels? This action cannot be undone.'))
+                    ->modalSubmitActionLabel(__('Yes, delete VODs')),
+            ]),
         ];
     }
 

--- a/tests/Feature/ChannelBulkProbingActionsTest.php
+++ b/tests/Feature/ChannelBulkProbingActionsTest.php
@@ -6,6 +6,7 @@ use App\Models\Channel;
 use App\Models\Playlist;
 use App\Models\User;
 use Filament\Actions\BulkAction;
+use Filament\Schemas\Components\Component;
 
 beforeEach(function () {
     $this->user = User::factory()->create();
@@ -15,8 +16,8 @@ beforeEach(function () {
 
 /**
  * Return the flat list of BulkAction names from the BulkModalActionGroup schema.
- * The group wraps its child actions inside a Grid component, so we need to
- * introspect two levels of raw properties (action schema → Grid childComponents).
+ * The schema may contain Section components (each with its own child actions)
+ * or a Grid wrapping flat BulkActions. This helper handles both layouts.
  */
 function getChannelBulkActionNames(): array
 {
@@ -25,19 +26,21 @@ function getChannelBulkActionNames(): array
 
     // The HasSchema trait stores the raw schema in $this->schema.
     $schemaProp = new ReflectionProperty($group, 'schema');
-    $outerSchema = $schemaProp->getValue($group); // [Grid]
+    $outerSchema = $schemaProp->getValue($group);
 
-    $grid = $outerSchema[0];
+    $childProp = new ReflectionProperty(Component::class, 'childComponents');
+    $names = [];
 
-    // Grid (HasChildComponents) stores its children in $this->childComponents['default'].
-    $childProp = new ReflectionProperty($grid, 'childComponents');
-    $children = $childProp->getValue($grid)['default'] ?? [];
+    foreach ($outerSchema as $component) {
+        $children = $childProp->getValue($component)['default'] ?? [];
+        foreach ($children as $child) {
+            if ($child instanceof BulkAction) {
+                $names[] = $child->getName();
+            }
+        }
+    }
 
-    return collect($children)
-        ->filter(fn ($c) => $c instanceof BulkAction)
-        ->map(fn ($c) => $c->getName())
-        ->values()
-        ->all();
+    return $names;
 }
 
 it('registers enable-probing bulk action inside the channel BulkModalActionGroup', function () {


### PR DESCRIPTION
## Summary

- Groups the flat list of bulk actions into labelled sections across Channels, VOD, and Series resources for easier navigation
- Updates `BulkModalActionGroup` to auto-detect flat vs sectioned layouts (backward compatible)
- Adds `bulkActionSection()` helper to each resource that wraps actions in a compact `Section` with 2-column grid and calls `cancelParentActions()` on each action

### Channels (7 sections)
Playlist & Groups, Logo, EPG, Find & Replace, Streaming, Probing, Enable / Disable

### VOD (6 sections)
Playlist & Groups, Logo, VOD Metadata, Find & Replace, Streaming, Enable / Disable

### Series (5 sections)
Playlist & Groups, Poster, Series Metadata, Find & Replace, Enable / Disable

## Test plan
- [x] Open bulk actions modal on Channels, VOD, and Series pages and verify section headers display correctly
- [x] Confirm actions within each section still open their own modals and execute correctly
- [x] Verify the modal closes after completing a bulk action (cancelParentActions works through sections)