### PR TITLE
fix: Top nav dropdowns not clickable

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -44,7 +44,7 @@
 }
 
 .fi-dropdown-panel {
-    z-index: 20; /* Ensure dropdowns appear above other elements */
+    z-index: 40; /* Ensure dropdowns appear above the topbar (z-30) */
 }
 
 /* Force inclusion of commonly used Alpine.js classes for Tailwind v4 */

--- a/resources/css/globals/global.scss
+++ b/resources/css/globals/global.scss
@@ -40,9 +40,12 @@ body::before {
 /* ── Glass topbar ─────────────────────────────────────────── */
 /* backdrop-filter on the element itself creates a stacking context that traps
    child dropdowns in Safari/Edge. Using a ::before pseudo-element keeps the
-   blur effect without scoping children's z-index to the topbar container. */
+   blur effect without scoping children's z-index to the topbar container.
+   Note: do NOT add transform here — it creates a containing block for
+   position:fixed descendants, which breaks Floating UI dropdown positioning.
+   Filament's default position:sticky already provides the containing block
+   needed for the ::before pseudo-element. */
 .fi-topbar-ctn {
-    transform: translateZ(0);
     background-color: rgba(255, 255, 255, 0.75) !important;
 
     &::before {

--- a/resources/css/globals/global.scss
+++ b/resources/css/globals/global.scss
@@ -48,6 +48,21 @@ body::before {
 .fi-topbar-ctn {
     background-color: rgba(255, 255, 255, 0.75) !important;
 
+    .fi-global-search {
+        transform: translateZ(0);
+        flex-shrink: 0;
+    }
+
+    .fi-topbar-end {
+        @media screen and (min-width: 1024px) {
+            min-width: 300px;
+        }
+    }
+
+    .fi-dropdown.fi-user-menu {
+        flex-shrink: 0;
+    }
+
     &::before {
         content: '';
         position: absolute;

--- a/tests/Feature/JobsTableSchemaTest.php
+++ b/tests/Feature/JobsTableSchemaTest.php
@@ -11,7 +11,27 @@
 
 use App\Models\Job;
 use App\Providers\AppServiceProvider;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+
+// Isolate the jobs connection to a temp database so parallel test processes
+// don't interfere with each other via the shared jobs.sqlite file.
+beforeEach(function () {
+    $this->tempJobsDb = sys_get_temp_dir().'/jobs_test_'.uniqid().'.sqlite';
+    touch($this->tempJobsDb);
+    config(['database.connections.jobs.database' => $this->tempJobsDb]);
+    DB::purge('jobs');
+
+    // Set up the correct schema via the custom migration
+    $migration = require database_path('migrations/2025_02_13_215803_create_jobs_table.php');
+    $migration->up();
+});
+
+afterEach(function () {
+    DB::purge('jobs');
+    config(['database.connections.jobs.database' => database_path('jobs.sqlite')]);
+    @unlink($this->tempJobsDb);
+});
 
 test('custom jobs table has correct schema with title column', function () {
     // The jobs table on the 'jobs' connection should have our custom columns


### PR DESCRIPTION
## Summary

- Removes `transform: translateZ(0)` from `.fi-topbar-ctn` — it was creating a containing block for `position: fixed` descendants, which broke Floating UI dropdown positioning in the top navigation
- Bumps `.fi-dropdown-panel` z-index from 20 to 40 so dropdowns render above the sticky topbar (z-30)

## Context

Commit ce887a83 moved the glass blur effect to a `::before` pseudo-element (good), but also added `transform: translateZ(0)` for GPU optimization. The `transform` property creates a containing block for fixed-position descendants per the CSS spec, which caused Filament's top nav dropdown panels (using Floating UI's `strategy: "fixed"`) to be positioned relative to the topbar instead of the viewport.

Filament's default `position: sticky` on `.fi-topbar-ctn` already provides the containing block needed for the `::before` pseudo-element, so the `transform` was unnecessary.