### PR TITLE
Verify stream ownership before Stream Monitor failover/stop actions

### DIFF
--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -210,7 +210,7 @@ class M3uProxyStreamMonitor extends Page
     private function authorizeStreamAction(string $streamId): bool
     {
         if (str_starts_with($streamId, 'broadcast:')) {
-            $networkUuid = substr($streamId, 10);
+            $networkUuid = substr($streamId, strlen('broadcast:'));
             $owned = Network::where('uuid', $networkUuid)
                 ->where('user_id', auth()->id())
                 ->exists();

--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -17,6 +17,7 @@ use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Support\Enums\Size;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Shared Stream Monitor (External API-backed)
@@ -122,6 +123,10 @@ class M3uProxyStreamMonitor extends Page
 
     public function triggerFailover(string $streamId): void
     {
+        if (! $this->authorizeStreamAction($streamId)) {
+            return;
+        }
+
         try {
             $success = $this->apiService->triggerFailover($streamId);
             if ($success) {
@@ -148,6 +153,10 @@ class M3uProxyStreamMonitor extends Page
 
     public function stopStream(string $streamId): void
     {
+        if (! $this->authorizeStreamAction($streamId)) {
+            return;
+        }
+
         try {
             // Support stopping broadcasts via a special stream ID prefix
             if (str_starts_with($streamId, 'broadcast:')) {
@@ -192,6 +201,38 @@ class M3uProxyStreamMonitor extends Page
         }
 
         $this->refreshData();
+    }
+
+    /**
+     * Verify the authenticated user owns the stream or broadcast referenced by $streamId.
+     * Emits a user-facing notification and logs a warning on failure.
+     */
+    private function authorizeStreamAction(string $streamId): bool
+    {
+        if (str_starts_with($streamId, 'broadcast:')) {
+            $networkUuid = substr($streamId, 10);
+            $owned = Network::where('uuid', $networkUuid)
+                ->where('user_id', auth()->id())
+                ->exists();
+        } else {
+            $visible = $this->apiService->fetchActiveStreams();
+            $owned = collect($visible['streams'] ?? [])
+                ->contains(fn ($s) => ($s['stream_id'] ?? null) === $streamId);
+        }
+
+        if (! $owned) {
+            Log::warning('Unauthorized stream-monitor action blocked', [
+                'user_id' => auth()->id(),
+                'stream_id' => $streamId,
+            ]);
+
+            Notification::make()
+                ->title(__('Not authorized to manage this stream.'))
+                ->danger()
+                ->send();
+        }
+
+        return $owned;
     }
 
     protected function getActiveStreams(): array

--- a/tests/Feature/StreamMonitorActionAuthorizationTest.php
+++ b/tests/Feature/StreamMonitorActionAuthorizationTest.php
@@ -12,29 +12,27 @@ beforeEach(function () {
     $this->attacker = User::factory()->create(['permissions' => ['use_proxy']]);
 
     $this->ownerPlaylist = Playlist::factory()->for($this->owner)->createQuietly();
-    $this->attackerPlaylist = Playlist::factory()->for($this->attacker)->createQuietly();
+
+    $this->bindProxyMock = function (callable $configure): void {
+        $service = Mockery::mock(M3uProxyService::class);
+
+        $service->shouldReceive('fetchActiveClients')->andReturn([
+            'success' => true,
+            'clients' => [],
+        ]);
+        $service->shouldReceive('fetchBroadcasts')->andReturn([
+            'success' => true,
+            'broadcasts' => [],
+        ]);
+
+        $configure($service);
+
+        app()->instance(M3uProxyService::class, $service);
+    };
 });
 
-function bindProxyMock(callable $configure): void
-{
-    $service = Mockery::mock(M3uProxyService::class);
-
-    $service->shouldReceive('fetchActiveClients')->andReturn([
-        'success' => true,
-        'clients' => [],
-    ]);
-    $service->shouldReceive('fetchBroadcasts')->andReturn([
-        'success' => true,
-        'broadcasts' => [],
-    ]);
-
-    $configure($service);
-
-    app()->instance(M3uProxyService::class, $service);
-}
-
 it('blocks triggerFailover for a stream the user does not own', function () {
-    bindProxyMock(function ($service) {
+    ($this->bindProxyMock)(function ($service) {
         $service->shouldReceive('fetchActiveStreams')->andReturn([
             'success' => true,
             'streams' => [],
@@ -52,7 +50,7 @@ it('blocks triggerFailover for a stream the user does not own', function () {
 it('allows triggerFailover for a stream the user owns', function () {
     $streamId = 'stream-owned-by-me';
 
-    bindProxyMock(function ($service) use ($streamId) {
+    ($this->bindProxyMock)(function ($service) use ($streamId) {
         $service->shouldReceive('fetchActiveStreams')->andReturn([
             'success' => true,
             'streams' => [
@@ -82,7 +80,7 @@ it('allows triggerFailover for a stream the user owns', function () {
 });
 
 it('blocks stopStream for a stream the user does not own', function () {
-    bindProxyMock(function ($service) {
+    ($this->bindProxyMock)(function ($service) {
         $service->shouldReceive('fetchActiveStreams')->andReturn([
             'success' => true,
             'streams' => [],
@@ -97,10 +95,42 @@ it('blocks stopStream for a stream the user does not own', function () {
         ->assertNotified();
 });
 
+it('allows stopStream for a stream the user owns', function () {
+    $streamId = 'stream-owned-by-me';
+
+    ($this->bindProxyMock)(function ($service) use ($streamId) {
+        $service->shouldReceive('fetchActiveStreams')->andReturn([
+            'success' => true,
+            'streams' => [
+                [
+                    'stream_id' => $streamId,
+                    'metadata' => ['playlist_uuid' => $this->ownerPlaylist->uuid],
+                    'original_url' => 'http://example.com/s',
+                    'current_url' => 'http://example.com/s',
+                    'stream_type' => 'hls',
+                    'is_active' => true,
+                    'client_count' => 1,
+                    'total_bytes_served' => 0,
+                    'created_at' => now()->toIso8601String(),
+                    'has_failover' => false,
+                    'error_count' => 0,
+                    'total_segments_served' => 0,
+                ],
+            ],
+        ]);
+        $service->shouldReceive('stopStream')->with($streamId)->once()->andReturn(true);
+    });
+
+    $this->actingAs($this->owner);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->call('stopStream', $streamId);
+});
+
 it('blocks stopStream for a broadcast belonging to another user', function () {
     $otherUsersNetwork = Network::factory()->create(['user_id' => $this->owner->id]);
 
-    bindProxyMock(function ($service) {
+    ($this->bindProxyMock)(function ($service) {
         $service->shouldReceive('fetchActiveStreams')->andReturn([
             'success' => true,
             'streams' => [],
@@ -119,7 +149,7 @@ it('blocks stopStream for a broadcast belonging to another user', function () {
 it('allows stopStream for a broadcast the user owns', function () {
     $myNetwork = Network::factory()->create(['user_id' => $this->owner->id]);
 
-    bindProxyMock(function ($service) use ($myNetwork) {
+    ($this->bindProxyMock)(function ($service) use ($myNetwork) {
         $service->shouldReceive('fetchActiveStreams')->andReturn([
             'success' => true,
             'streams' => [],

--- a/tests/Feature/StreamMonitorActionAuthorizationTest.php
+++ b/tests/Feature/StreamMonitorActionAuthorizationTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Filament\Pages\M3uProxyStreamMonitor;
+use App\Models\Network;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->owner = User::factory()->create(['permissions' => ['use_proxy']]);
+    $this->attacker = User::factory()->create(['permissions' => ['use_proxy']]);
+
+    $this->ownerPlaylist = Playlist::factory()->for($this->owner)->createQuietly();
+    $this->attackerPlaylist = Playlist::factory()->for($this->attacker)->createQuietly();
+});
+
+function bindProxyMock(callable $configure): void
+{
+    $service = Mockery::mock(M3uProxyService::class);
+
+    $service->shouldReceive('fetchActiveClients')->andReturn([
+        'success' => true,
+        'clients' => [],
+    ]);
+    $service->shouldReceive('fetchBroadcasts')->andReturn([
+        'success' => true,
+        'broadcasts' => [],
+    ]);
+
+    $configure($service);
+
+    app()->instance(M3uProxyService::class, $service);
+}
+
+it('blocks triggerFailover for a stream the user does not own', function () {
+    bindProxyMock(function ($service) {
+        $service->shouldReceive('fetchActiveStreams')->andReturn([
+            'success' => true,
+            'streams' => [],
+        ]);
+        $service->shouldNotReceive('triggerFailover');
+    });
+
+    $this->actingAs($this->attacker);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->call('triggerFailover', 'stream-owned-by-someone-else')
+        ->assertNotified();
+});
+
+it('allows triggerFailover for a stream the user owns', function () {
+    $streamId = 'stream-owned-by-me';
+
+    bindProxyMock(function ($service) use ($streamId) {
+        $service->shouldReceive('fetchActiveStreams')->andReturn([
+            'success' => true,
+            'streams' => [
+                [
+                    'stream_id' => $streamId,
+                    'metadata' => ['playlist_uuid' => $this->ownerPlaylist->uuid],
+                    'original_url' => 'http://example.com/s',
+                    'current_url' => 'http://example.com/s',
+                    'stream_type' => 'hls',
+                    'is_active' => true,
+                    'client_count' => 1,
+                    'total_bytes_served' => 0,
+                    'created_at' => now()->toIso8601String(),
+                    'has_failover' => false,
+                    'error_count' => 0,
+                    'total_segments_served' => 0,
+                ],
+            ],
+        ]);
+        $service->shouldReceive('triggerFailover')->with($streamId)->once()->andReturn(true);
+    });
+
+    $this->actingAs($this->owner);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->call('triggerFailover', $streamId);
+});
+
+it('blocks stopStream for a stream the user does not own', function () {
+    bindProxyMock(function ($service) {
+        $service->shouldReceive('fetchActiveStreams')->andReturn([
+            'success' => true,
+            'streams' => [],
+        ]);
+        $service->shouldNotReceive('stopStream');
+    });
+
+    $this->actingAs($this->attacker);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->call('stopStream', 'stream-owned-by-someone-else')
+        ->assertNotified();
+});
+
+it('blocks stopStream for a broadcast belonging to another user', function () {
+    $otherUsersNetwork = Network::factory()->create(['user_id' => $this->owner->id]);
+
+    bindProxyMock(function ($service) {
+        $service->shouldReceive('fetchActiveStreams')->andReturn([
+            'success' => true,
+            'streams' => [],
+        ]);
+        $service->shouldNotReceive('stopBroadcast');
+        $service->shouldNotReceive('stopStream');
+    });
+
+    $this->actingAs($this->attacker);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->call('stopStream', 'broadcast:'.$otherUsersNetwork->uuid)
+        ->assertNotified();
+});
+
+it('allows stopStream for a broadcast the user owns', function () {
+    $myNetwork = Network::factory()->create(['user_id' => $this->owner->id]);
+
+    bindProxyMock(function ($service) use ($myNetwork) {
+        $service->shouldReceive('fetchActiveStreams')->andReturn([
+            'success' => true,
+            'streams' => [],
+        ]);
+        $service->shouldReceive('stopBroadcast')->with($myNetwork->uuid)->once()->andReturn(true);
+    });
+
+    $this->actingAs($this->owner);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->call('stopStream', 'broadcast:'.$myNetwork->uuid);
+});


### PR DESCRIPTION
## Summary
- Adds an ownership guard to `triggerFailover` and `stopStream` on the Stream Monitor page so a user can only act on streams/broadcasts they own.
- Stream ownership is checked against the filtered `fetchActiveStreams()` set (which already scopes by `getAllPlaylistUuids()`); broadcast ownership is checked against `Network::user_id`.
- Blocked calls emit a Filament notification and a `Log::warning('Unauthorized stream-monitor action blocked', ...)` entry with `user_id` and `stream_id`.

## Why
Both Livewire actions forwarded the caller-supplied `$streamId` straight to the proxy service with no check that the caller owned the stream. A user with `use_proxy` could call either action against any stream ID (including broadcast UUIDs) by issuing the Livewire call from devtools, affecting another user's stream.

The guard lives at the Livewire boundary so the service stays reusable. It fails closed — if ownership can't be verified, the action is blocked.

## Verified in browser (live)
Against the deployed container running this branch:

| Path | Result |
| --- | --- |
| `triggerFailover('fake-stream-id-...')` | Blocked, "Not authorized to manage this stream." notif, warning logged |
| `stopStream('broadcast:00000000-...')` | Blocked, notif + warning logged |
| `triggerFailover('<own stream>')` | Allowed, success notif, status badge flipped `Failover Ready` → `Failover Active` |

## Test plan
- [x] Sanity-check the page still loads and lists only streams/broadcasts you own
- [x] Click `Trigger Failover` / `Remove Stream` on your own stream — happy path works
- [x] Open devtools on a second account and try `Livewire.all().find(c => c.name.endsWith('M3uProxyStreamMonitor')).$wire.call('triggerFailover', '<someone-else-stream-id>')` — should show the "Not authorized" notification and leave a warning in `storage/logs/laravel-*.log`