### PR TITLE
Make m3u-proxy fetches more resilient and error-aware

### DIFF
--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -14,6 +14,7 @@ use App\Models\PlaylistAlias;
 use App\Models\StreamProfile;
 use App\Settings\GeneralSettings;
 use Exception;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -1513,7 +1514,10 @@ class M3uProxyService
 
         try {
             $endpoint = $this->apiBaseUrl.'/streams';
-            $response = Http::timeout(5)->acceptJson()
+            $response = Http::connectTimeout(2)
+                ->timeout(3)
+                ->retry(2, 100, fn (Exception $e) => $e instanceof ConnectionException, throw: false)
+                ->acceptJson()
                 ->withHeaders($this->apiToken ? [
                     'X-API-Token' => $this->apiToken,
                 ] : [])
@@ -1538,15 +1542,26 @@ class M3uProxyService
 
             return [
                 'success' => false,
-                'error' => 'M3U Proxy returned status '.$response->status(),
+                'error_category' => 'http',
+                'error' => 'M3U Proxy returned HTTP '.$response->status(),
                 'streams' => [],
             ];
-        } catch (Exception $e) {
-            Log::warning('Failed to fetch active streams from m3u-proxy: '.$e->getMessage());
+        } catch (ConnectionException $e) {
+            Log::warning('m3u-proxy connection error on /streams: '.$e->getMessage());
 
             return [
                 'success' => false,
-                'error' => 'Unable to connect to m3u-proxy: '.$e->getMessage(),
+                'error_category' => 'connection',
+                'error' => 'M3U Proxy unreachable (timeout or connection refused)',
+                'streams' => [],
+            ];
+        } catch (Exception $e) {
+            Log::warning('Unexpected error fetching active streams from m3u-proxy: '.$e->getMessage());
+
+            return [
+                'success' => false,
+                'error_category' => 'unknown',
+                'error' => 'Unexpected error fetching streams: '.$e->getMessage(),
                 'streams' => [],
             ];
         }
@@ -1568,7 +1583,10 @@ class M3uProxyService
 
         try {
             $endpoint = $this->apiBaseUrl.'/clients';
-            $response = Http::timeout(5)->acceptJson()
+            $response = Http::connectTimeout(2)
+                ->timeout(3)
+                ->retry(2, 100, fn (Exception $e) => $e instanceof ConnectionException, throw: false)
+                ->acceptJson()
                 ->withHeaders($this->apiToken ? [
                     'X-API-Token' => $this->apiToken,
                 ] : [])
@@ -1587,15 +1605,26 @@ class M3uProxyService
 
             return [
                 'success' => false,
-                'error' => 'M3U Proxy returned status '.$response->status(),
+                'error_category' => 'http',
+                'error' => 'M3U Proxy returned HTTP '.$response->status(),
                 'clients' => [],
             ];
-        } catch (Exception $e) {
-            Log::warning('Failed to fetch active clients from m3u-proxy: '.$e->getMessage());
+        } catch (ConnectionException $e) {
+            Log::warning('m3u-proxy connection error on /clients: '.$e->getMessage());
 
             return [
                 'success' => false,
-                'error' => 'Unable to connect to m3u-proxy: '.$e->getMessage(),
+                'error_category' => 'connection',
+                'error' => 'M3U Proxy unreachable (timeout or connection refused)',
+                'clients' => [],
+            ];
+        } catch (Exception $e) {
+            Log::warning('Unexpected error fetching active clients from m3u-proxy: '.$e->getMessage());
+
+            return [
+                'success' => false,
+                'error_category' => 'unknown',
+                'error' => 'Unexpected error fetching clients: '.$e->getMessage(),
                 'clients' => [],
             ];
         }
@@ -1617,7 +1646,10 @@ class M3uProxyService
 
         try {
             $endpoint = $this->apiBaseUrl.'/broadcast';
-            $response = Http::timeout(5)->acceptJson()
+            $response = Http::connectTimeout(2)
+                ->timeout(3)
+                ->retry(2, 100, fn (Exception $e) => $e instanceof ConnectionException, throw: false)
+                ->acceptJson()
                 ->withHeaders($this->apiToken ? [
                     'X-API-Token' => $this->apiToken,
                 ] : [])
@@ -1645,15 +1677,26 @@ class M3uProxyService
 
             return [
                 'success' => false,
-                'error' => 'M3U Proxy returned status '.$response->status(),
+                'error_category' => 'http',
+                'error' => 'M3U Proxy returned HTTP '.$response->status(),
                 'broadcasts' => [],
             ];
-        } catch (Exception $e) {
-            Log::warning('Failed to fetch broadcasts from m3u-proxy: '.$e->getMessage());
+        } catch (ConnectionException $e) {
+            Log::warning('m3u-proxy connection error on /broadcast: '.$e->getMessage());
 
             return [
                 'success' => false,
-                'error' => 'Unable to connect to m3u-proxy: '.$e->getMessage(),
+                'error_category' => 'connection',
+                'error' => 'M3U Proxy unreachable (timeout or connection refused)',
+                'broadcasts' => [],
+            ];
+        } catch (Exception $e) {
+            Log::warning('Unexpected error fetching broadcasts from m3u-proxy: '.$e->getMessage());
+
+            return [
+                'success' => false,
+                'error_category' => 'unknown',
+                'error' => 'Unexpected error fetching broadcasts: '.$e->getMessage(),
                 'broadcasts' => [],
             ];
         }

--- a/tests/Feature/M3uProxyServiceFetchResilienceTest.php
+++ b/tests/Feature/M3uProxyServiceFetchResilienceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\User;
+use App\Services\M3uProxyService;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config()->set('proxy.m3u_proxy_host', 'http://test-proxy.example');
+    config()->set('proxy.m3u_proxy_port', null);
+
+    $this->user = User::factory()->create(['permissions' => ['use_proxy']]);
+    $this->actingAs($this->user);
+});
+
+it('classifies connection failures and returns an empty collection', function (string $method, string $path, string $collectionKey) {
+    Http::fake(['*'.$path => Http::failedConnection()]);
+
+    $result = app(M3uProxyService::class)->{$method}();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['error_category'])->toBe('connection')
+        ->and($result[$collectionKey])->toBe([])
+        ->and($result['error'])->toContain('M3U Proxy unreachable');
+})->with([
+    'streams' => ['fetchActiveStreams', '/streams', 'streams'],
+    'clients' => ['fetchActiveClients', '/clients', 'clients'],
+    'broadcasts' => ['fetchBroadcasts', '/broadcast', 'broadcasts'],
+]);
+
+it('classifies HTTP errors as http category', function (string $method, string $path, string $collectionKey) {
+    Http::fake(['*'.$path => Http::response('', 503)]);
+
+    $result = app(M3uProxyService::class)->{$method}();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['error_category'])->toBe('http')
+        ->and($result[$collectionKey])->toBe([])
+        ->and($result['error'])->toContain('503');
+})->with([
+    'streams' => ['fetchActiveStreams', '/streams', 'streams'],
+    'clients' => ['fetchActiveClients', '/clients', 'clients'],
+    'broadcasts' => ['fetchBroadcasts', '/broadcast', 'broadcasts'],
+]);
+
+it('retries on connection failure before giving up', function () {
+    Http::fake(['*/streams' => Http::failedConnection()]);
+
+    app(M3uProxyService::class)->fetchActiveStreams();
+
+    Http::assertSentCount(2);
+});
+
+it('does not retry on HTTP errors', function () {
+    Http::fake(['*/clients' => Http::response('boom', 500)]);
+
+    app(M3uProxyService::class)->fetchActiveClients();
+
+    Http::assertSentCount(1);
+});
+
+it('sends the api token header when configured', function () {
+    config()->set('proxy.m3u_proxy_token', 'secret-token');
+
+    Http::fake(['*/streams' => Http::response(['streams' => []], 200)]);
+
+    app(M3uProxyService::class)->fetchActiveStreams();
+
+    Http::assertSent(fn (Request $request) => $request->hasHeader('X-API-Token', 'secret-token'));
+});


### PR DESCRIPTION
## Summary
- Replaces the blind `Http::timeout(5)` on `fetchActiveStreams`, `fetchActiveClients`, and `fetchBroadcasts` with `connectTimeout(2)` + `timeout(3)`.
- Adds `retry(2, 100, when: ConnectionException)` so transient connection blips self-heal without also retrying on HTTP 4xx/5xx.
- Adds a dedicated `catch (ConnectionException $e)` path in each of the three fetchers, separate from the generic `Exception` catch, and tags responses with an `error_category` field (`connection` / `http` / `unknown`) alongside a clearer user-facing `error` string.

## Why
On the Stream Monitor page, `getActiveStreams()` runs all three fetchers sequentially on every 5s poll. If the proxy is slow or down, the blind 5s timeout × 3 blocks the Livewire poll for up to 15s and the UI shows a generic "Unable to connect to m3u-proxy: \<curl gunk\>" whether the proxy is down, slow, or returning 5xx.

## Verified against the live container
Stopped the `m3u-proxy` container and called `refreshData()` from the Stream Monitor:

| Scenario | Time | Observation |
| --- | --- | --- |
| Happy path refresh | 94ms | Normal |
| Proxy down (3 failing fetches, each with ConnectionException retry) | **~390ms** | Replaces the ~15s blind-timeout worst case |
| UI `connectionError` string | "M3U Proxy unreachable (timeout or connection refused)" | Categorised, not a raw cURL dump |
| Logs | `m3u-proxy connection error on /streams` / `/clients` / `/broadcast` | Endpoint-scoped so triage is easier |
| Recovery after restart | Instant | No stale error state |

## Tests
Added `tests/Feature/M3uProxyServiceFetchResilienceTest.php` (9 tests):
- Dataset-driven: each of the three fetchers returns `error_category=connection` on connection failure and `error_category=http` on HTTP 5xx.
- `Http::assertSentCount(2)` confirms retry fires on ConnectionException.
- `Http::assertSentCount(1)` confirms HTTP errors do **not** retry.
- `X-API-Token` header is still sent when configured.

## Test plan
- [x] Open the Stream Monitor with the proxy up — should look and behave exactly as before
- [x] Stop the `m3u-proxy` container — page should surface "M3U Proxy unreachable (timeout or connection refused)" within ~400ms rather than freezing for ~15s
- [x] Restart the `m3u-proxy` container — stream list should repopulate on the next poll with no stuck error banner