### PR TITLE
Visibility-aware auto-refresh with selectable interval on Stream Monitor

### DIFF
--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -59,7 +59,9 @@ class M3uProxyStreamMonitor extends Page
 
     public $systemStats = [];
 
-    public $refreshInterval = 5; // seconds
+    public $refreshInterval = 5; // seconds (default; the client persists its own choice in localStorage)
+
+    public ?string $lastUpdatedAt = null;
 
     public $connectionError = null;
 
@@ -94,6 +96,8 @@ class M3uProxyStreamMonitor extends Page
         ];
 
         $this->systemStats = []; // populate if external API provides system metrics
+
+        $this->lastUpdatedAt = now()->toIso8601String();
     }
 
     protected function getHeaderActions(): array
@@ -453,6 +457,7 @@ class M3uProxyStreamMonitor extends Page
             'globalStats' => $this->globalStats,
             'systemStats' => $this->systemStats,
             'refreshInterval' => $this->refreshInterval,
+            'lastUpdatedAt' => $this->lastUpdatedAt,
             'connectionError' => $this->connectionError,
         ];
     }

--- a/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
+++ b/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
@@ -1,15 +1,38 @@
 <x-filament-panels::page>
-    <div x-data="{ 
-        refreshInterval: {{ $refreshInterval }},
-        autoRefresh: true,
-        intervalId: null
-    }" x-init="
-        intervalId = setInterval(() => {
-            if (autoRefresh) {
+    @php
+        $intervalOptions = [0 => 'Off', 3 => '3s', 5 => '5s', 10 => '10s', 30 => '30s'];
+    @endphp
+    <div x-data="{
+        intervalSeconds: Number(localStorage.getItem('streamMonitor.refreshInterval') ?? {{ $refreshInterval }}),
+        intervalId: null,
+        startPolling() {
+            this.stopPolling();
+            if (this.intervalSeconds <= 0) return;
+            this.intervalId = setInterval(() => {
+                if (document.visibilityState === 'visible') {
+                    $wire.refreshData();
+                }
+            }, this.intervalSeconds * 1000);
+        },
+        stopPolling() {
+            if (this.intervalId) {
+                clearInterval(this.intervalId);
+                this.intervalId = null;
+            }
+        }
+    }"
+    x-init="
+        startPolling();
+        $watch('intervalSeconds', value => {
+            localStorage.setItem('streamMonitor.refreshInterval', value);
+            startPolling();
+        });
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'visible' && intervalSeconds > 0) {
                 $wire.refreshData();
             }
-        }, refreshInterval * 1000);
-    " x-on:before-unload.window="clearInterval(intervalId)">
+        });
+    " x-on:before-unload.window="stopPolling()">
         
         <!-- Global Statistics Cards -->
         <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
@@ -67,21 +90,25 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
             </x-filament::card>
         </div>
 
-        <!-- Auto-refresh toggle -->
+        <!-- Auto-refresh controls -->
         <div class="mb-4 flex items-center justify-between">
             <div class="flex items-center space-x-4">
-                <label class="flex items-center">
-                    <x-filament::input.checkbox x-model="autoRefresh" />
-                    <span class="ml-2 text-sm text-gray-600 dark:text-gray-400">Auto-refresh every {{ $refreshInterval }}s</span>
+                <label class="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400">
+                    <span>Auto-refresh</span>
+                    <x-filament::input.wrapper>
+                        <x-filament::input.select x-model.number="intervalSeconds" aria-label="Auto-refresh interval">
+                            @foreach($intervalOptions as $seconds => $label)
+                                <option value="{{ $seconds }}">{{ $label }}</option>
+                            @endforeach
+                        </x-filament::input.select>
+                    </x-filament::input.wrapper>
                 </label>
 
                 <x-filament::badge size="sm">
-                    Last updated: <span x-text="new Date().toLocaleTimeString()"></span>
+                    Last updated:
+                    <span x-text="@js($lastUpdatedAt) ? new Date(@js($lastUpdatedAt)).toLocaleTimeString() : '—'"></span>
                 </x-filament::badge>
             </div>
-
-            
-
         </div>
 
         <!-- Streams List -->


### PR DESCRIPTION
## Summary
- Replaces the binary Auto-refresh checkbox with an interval dropdown (Off / 3s / 5s / 10s / 30s) that persists the user's choice to `localStorage`.
- Pauses background polling while the tab is hidden (`document.visibilityState`) and triggers an immediate refresh when the tab becomes visible again — so returning to the page shows fresh data without waiting for the next interval and hidden tabs don't hammer the proxy.
- Replaces the client-side `new Date().toLocaleTimeString()` label (which always rendered "now" regardless of whether data actually updated) with a server-set `lastUpdatedAt` stamped at the end of `refreshData()` and formatted client-side, so the badge reflects the real last successful load.

## Why
The previous UI had two papercuts: the checkbox offered no way to slow/stop polling for quieter pages, and the "Last updated" badge wasn't tied to the actual refresh cycle — it updated on every render tick, so it always looked fresh even when the page had sat on a stale snapshot. Pairing the dropdown with visibility-aware polling also avoids idle background tabs quietly polling the m3u-proxy every few seconds.

## Test plan
- [x] Load the Stream Monitor; confirm the dropdown defaults to 5s and the timer starts.
- [x] Change the dropdown to a different value, reload the page, and confirm the previous selection is restored from `localStorage`.
- [x] Select "Off" and confirm no background polling occurs (no periodic `refreshData` calls in the network tab).
- [x] Switch tabs for 15s+ and return; confirm a refresh fires on return and the "Last updated" badge updates.
- [x] Confirm "Last updated" only changes when a refresh completes (not on every Livewire re-render).