### PR TITLE
feat: improve streamlink default args for stream profiles

### DIFF
--- a/app/Filament/Resources/StreamProfiles/StreamProfileResource.php
+++ b/app/Filament/Resources/StreamProfiles/StreamProfileResource.php
@@ -12,6 +12,7 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
@@ -76,6 +77,21 @@ class StreamProfileResource extends Resource implements CopilotResource
                     ->default('ffmpeg')
                     ->required()
                     ->live()
+                    ->afterStateUpdated(function (?string $state, Get $get, Set $set): void {
+                        // Keep user-entered values, but replace untouched defaults
+                        // when switching backend during profile creation/editing.
+                        $currentArgs = trim((string) ($get('args') ?? ''));
+
+                        $knownDefaults = [
+                            self::defaultArgsForBackend('ffmpeg'),
+                            self::defaultArgsForBackend('streamlink'),
+                            self::defaultArgsForBackend('ytdlp'),
+                        ];
+
+                        if ($currentArgs === '' || in_array($currentArgs, $knownDefaults, true)) {
+                            $set('args', self::defaultArgsForBackend($state));
+                        }
+                    })
                     ->columnSpanFull()
                     ->helperText(__('FFmpeg re-encodes the stream. Streamlink and yt-dlp extract and deliver streams directly from supported platforms (Twitch, YouTube, etc.) without re-encoding.')),
 
@@ -101,16 +117,8 @@ class StreamProfileResource extends Resource implements CopilotResource
                             })
                             ->openUrlInNewTab(true)
                     )
-                    ->default(fn (Get $get): string => match ($get('backend')) {
-                        'streamlink' => 'best',
-                        'ytdlp' => 'bestvideo+bestaudio/best',
-                        default => '-i {input_url} -c:v libx264 -preset faster -crf {crf|23} -maxrate {maxrate|2500k} -bufsize {bufsize|5000k} -c:a aac -b:a {audio_bitrate|192k} -f mpegts {output_args|pipe:1}',
-                    })
-                    ->placeholder(fn (Get $get): string => match ($get('backend')) {
-                        'streamlink' => 'best',
-                        'ytdlp' => 'bestvideo+bestaudio/best',
-                        default => '-i {input_url} -c:v libx264 -preset faster -crf {crf|23} -maxrate {maxrate|2500k} -bufsize {bufsize|5000k} -c:a aac -b:a {audio_bitrate|192k} -f mpegts {output_args|pipe:1}',
-                    })
+                    ->default(fn (Get $get): string => self::defaultArgsForBackend($get('backend')))
+                    ->placeholder(fn (Get $get): string => self::defaultArgsForBackend($get('backend')))
                     ->helperText(fn (Get $get): string => match ($get('backend')) {
                         'streamlink' => __('Quality selector (best, worst, 720p, etc.) followed by optional Streamlink flags. Example: best --hls-live-edge 3'),
                         'ytdlp' => __('yt-dlp format selector followed by optional flags. Example: bestvideo+bestaudio/best --no-playlist'),
@@ -148,6 +156,15 @@ class StreamProfileResource extends Resource implements CopilotResource
                         default => __('The container format FFmpeg will produce. Must match the -f muxer argument in your FFmpeg template above.'),
                     }),
             ]);
+    }
+
+    public static function defaultArgsForBackend(?string $backend): string
+    {
+        return match ($backend) {
+            'streamlink' => 'best --hls-live-edge 3',
+            'ytdlp' => 'bestvideo+bestaudio/best',
+            default => '-i {input_url} -c:v libx264 -preset faster -crf {crf|23} -maxrate {maxrate|2500k} -bufsize {bufsize|5000k} -c:a aac -b:a {audio_bitrate|192k} -f mpegts {output_args|pipe:1}',
+        };
     }
 
     public static function table(Table $table): Table

--- a/tests/Unit/StreamProfileResourceDefaultsTest.php
+++ b/tests/Unit/StreamProfileResourceDefaultsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Filament\Resources\StreamProfiles\StreamProfileResource;
+
+test('streamlink backend has optimized default args', function () {
+    expect(StreamProfileResource::defaultArgsForBackend('streamlink'))
+        ->toBe('best --hls-live-edge 3');
+});
+
+test('ytdlp backend keeps expected default args', function () {
+    expect(StreamProfileResource::defaultArgsForBackend('ytdlp'))
+        ->toBe('bestvideo+bestaudio/best');
+});
+
+test('ffmpeg backend keeps expected default args', function () {
+    expect(StreamProfileResource::defaultArgsForBackend('ffmpeg'))
+        ->toContain('-i {input_url}')
+        ->toContain('-f mpegts {output_args|pipe:1}');
+});


### PR DESCRIPTION
This pull request refactors how default arguments are managed for different streaming backends in the `StreamProfileResource` form, making the logic more maintainable and consistent. It introduces a new helper method for backend defaults, updates the form behavior to use this method, and adds unit tests to ensure correct defaults for each backend.

**Backend default argument handling:**

* Added a new static method `defaultArgsForBackend` to `StreamProfileResource` to centralize and standardize the default arguments for each backend (`ffmpeg`, `streamlink`, `ytdlp`).
* Updated the form's `args` field to use `defaultArgsForBackend` for both its default value and placeholder, simplifying and unifying the logic.
* Improved the backend switch behavior: when the user changes the backend, the form now only updates the `args` field if it still contains a default value (or is empty), preserving user-entered customizations.

**Testing:**

* Added a new unit test file `StreamProfileResourceDefaultsTest.php` to verify that each backend returns the correct default arguments via `defaultArgsForBackend`.

**Code maintenance:**

* Imported the `Set` utility to support the new backend switching logic in the form.