### PR TITLE
feat: support grouped plugin settings sections

### DIFF
--- a/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
+++ b/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
@@ -26,24 +26,42 @@ class ListStreamProfiles extends ListRecords
                 ->label(__('Generate Default Profiles'))
                 ->requiresConfirmation()
                 ->action(function () {
+                    $userId = auth()->id();
                     $defaultProfiles = [
                         [
-                            'user_id' => auth()->id(),
+                            'user_id' => $userId,
                             'name' => 'Default Live Profile',
                             'description' => 'Optimized for live streaming content with CBR encoding.',
-                            'args' => '-fflags +genpts+discardcorrupt+igndts -i {input_url} -c:v libx264 -preset faster -b:v {bitrate|2000k} -maxrate {maxrate|2500k} -bufsize {bufsize|2500k} -c:a aac -b:a {audio_bitrate|128k} -f mpegts {output_args|pipe:1}',
+                            'backend' => 'ffmpeg',
                             'format' => 'ts',
+                            'args' => '-fflags +genpts+discardcorrupt+igndts -i {input_url} -c:v libx264 -preset faster -b:v {bitrate|2000k} -maxrate {maxrate|2500k} -bufsize {bufsize|2500k} -c:a aac -b:a {audio_bitrate|128k} -f mpegts {output_args|pipe:1}',
                         ],
                         [
-                            'user_id' => auth()->id(),
+                            'user_id' => $userId,
                             'name' => 'Default HLS Profile',
                             'description' => 'Optimized for live streaming with low latency, better buffering, and CBR encoding.',
-                            'args' => '-fflags +genpts+discardcorrupt+igndts -i {input_url} -c:v libx264 -preset faster -b:v {bitrate|2000k} -maxrate {maxrate|2500k} -bufsize {bufsize|2500k} -c:a aac -b:a {audio_bitrate|128k} -hls_time 2 -hls_list_size 30 -hls_flags program_date_time -f hls {output_args|index.m3u8}',
+                            'backend' => 'ffmpeg',
                             'format' => 'm3u8',
+                            'args' => '-fflags +genpts+discardcorrupt+igndts -i {input_url} -c:v libx264 -preset faster -b:v {bitrate|2000k} -maxrate {maxrate|2500k} -bufsize {bufsize|2500k} -c:a aac -b:a {audio_bitrate|128k} -hls_time 2 -hls_list_size 30 -hls_flags program_date_time -f hls {output_args|index.m3u8}',
                         ],
-
+                        [
+                            'user_id' => $userId,
+                            'name' => 'Default Streamlink Profile',
+                            'description' => 'For platforms like Twitch and YouTube — extracts the stream directly without re-encoding.',
+                            'backend' => 'streamlink',
+                            'format' => 'ts',
+                            'args' => StreamProfileResource::defaultArgsForBackend('streamlink'),
+                        ],
+                        [
+                            'user_id' => $userId,
+                            'name' => 'Default yt-dlp Profile',
+                            'description' => 'For platforms supported by yt-dlp — extracts the best available quality without re-encoding.',
+                            'backend' => 'ytdlp',
+                            'format' => 'ts',
+                            'args' => StreamProfileResource::defaultArgsForBackend('ytdlp'),
+                        ],
                     ];
-                    foreach ($defaultProfiles as $index => $defaultProfile) {
+                    foreach ($defaultProfiles as $defaultProfile) {
                         StreamProfile::query()->create($defaultProfile);
                     }
                 })

--- a/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
+++ b/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
@@ -50,7 +50,7 @@ class ListStreamProfiles extends ListRecords
                             'description' => 'For platforms like Twitch and YouTube — extracts the stream directly without re-encoding.',
                             'backend' => 'streamlink',
                             'format' => 'ts',
-                            'args' => StreamProfileResource::defaultArgsForBackend('streamlink'),
+                            'args' => 'best --hls-live-edge 3',
                         ],
                         [
                             'user_id' => $userId,
@@ -58,7 +58,7 @@ class ListStreamProfiles extends ListRecords
                             'description' => 'For platforms supported by yt-dlp — extracts the best available quality without re-encoding.',
                             'backend' => 'ytdlp',
                             'format' => 'ts',
-                            'args' => StreamProfileResource::defaultArgsForBackend('ytdlp'),
+                            'args' => 'bestvideo+bestaudio/best',
                         ],
                     ];
                     foreach ($defaultProfiles as $defaultProfile) {

--- a/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
+++ b/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
@@ -58,7 +58,7 @@ class ListStreamProfiles extends ListRecords
                             'description' => 'For platforms supported by yt-dlp — extracts the best available quality without re-encoding.',
                             'backend' => 'ytdlp',
                             'format' => 'ts',
-                            'args' => 'bestvideo+bestaudio/best',
+                            'args' => 'bestvideo+bestaudio/best --no-playlist',
                         ],
                     ];
                     foreach ($defaultProfiles as $defaultProfile) {

--- a/app/Filament/Resources/StreamProfiles/StreamProfileResource.php
+++ b/app/Filament/Resources/StreamProfiles/StreamProfileResource.php
@@ -103,12 +103,12 @@ class StreamProfileResource extends Resource implements CopilotResource
                     )
                     ->default(fn (Get $get): string => match ($get('backend')) {
                         'streamlink' => 'best',
-                        'ytdlp' => 'bestvideo+bestaudio/best',
+                        'ytdlp' => 'bestvideo+bestaudio/best --no-playlist',
                         default => '-i {input_url} -c:v libx264 -preset faster -crf {crf|23} -maxrate {maxrate|2500k} -bufsize {bufsize|5000k} -c:a aac -b:a {audio_bitrate|192k} -f mpegts {output_args|pipe:1}',
                     })
                     ->placeholder(fn (Get $get): string => match ($get('backend')) {
                         'streamlink' => 'best',
-                        'ytdlp' => 'bestvideo+bestaudio/best',
+                        'ytdlp' => 'bestvideo+bestaudio/best --no-playlist',
                         default => '-i {input_url} -c:v libx264 -preset faster -crf {crf|23} -maxrate {maxrate|2500k} -bufsize {bufsize|5000k} -c:a aac -b:a {audio_bitrate|192k} -f mpegts {output_args|pipe:1}',
                     })
                     ->helperText(fn (Get $get): string => match ($get('backend')) {

--- a/app/Plugins/PluginSchemaMapper.php
+++ b/app/Plugins/PluginSchemaMapper.php
@@ -117,6 +117,12 @@ class PluginSchemaMapper
             ->required($required);
     }
 
+    /**
+     * Build a Filament Section component for a `section` field definition.
+     * Nested sections (sections within sections) are fully supported — each section's
+     * `fields` array is processed recursively through componentsForFields(), so any depth
+     * of nesting works for both rendering and defaults/rules flattening.
+     */
     private function sectionComponent(array $field, string $prefix = '', array $existing = []): Section
     {
         $label = $field['label'] ?? Str::headline((string) ($field['id'] ?? 'Section'));

--- a/app/Plugins/PluginSchemaMapper.php
+++ b/app/Plugins/PluginSchemaMapper.php
@@ -8,6 +8,7 @@ use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Section;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Schema;
@@ -55,6 +56,15 @@ class PluginSchemaMapper
         $defaults = [];
 
         foreach ($fields as $field) {
+            if (($field['type'] ?? null) === 'section') {
+                $defaults = [
+                    ...$defaults,
+                    ...$this->defaultsForFields($field['fields'] ?? [], $existing),
+                ];
+
+                continue;
+            }
+
             $fieldId = $field['id'] ?? null;
             if (! $fieldId) {
                 continue;
@@ -69,18 +79,23 @@ class PluginSchemaMapper
     private function componentsForFields(array $fields, string $prefix = '', array $existing = []): array
     {
         return collect($fields)
-            ->filter(fn (array $field): bool => filled($field['id'] ?? null))
+            ->filter(fn (array $field): bool => ($field['type'] ?? null) === 'section' || filled($field['id'] ?? null))
             ->map(fn (array $field) => $this->componentForField($field, $prefix, $existing))
             ->all();
     }
 
     private function componentForField(array $field, string $prefix = '', array $existing = [])
     {
-        $name = $prefix.($field['id'] ?? '');
         $type = $field['type'] ?? 'text';
         $label = $field['label'] ?? Str::headline((string) ($field['id'] ?? 'value'));
         $helperText = $field['helper_text'] ?? null;
         $required = (bool) ($field['required'] ?? false);
+
+        if ($type === 'section') {
+            return $this->sectionComponent($field, $prefix, $existing);
+        }
+
+        $name = $prefix.($field['id'] ?? '');
         $defaultKey = $field['default_from_setting'] ?? ($field['id'] ?? '');
         $default = Arr::get($existing, $defaultKey, $field['default'] ?? null);
 
@@ -100,6 +115,40 @@ class PluginSchemaMapper
             ->default($default)
             ->helperText($helperText)
             ->required($required);
+    }
+
+    private function sectionComponent(array $field, string $prefix = '', array $existing = []): Section
+    {
+        $label = $field['label'] ?? Str::headline((string) ($field['id'] ?? 'Section'));
+        $description = $field['description'] ?? $field['helper_text'] ?? null;
+        $columns = (int) ($field['columns'] ?? 1);
+
+        $section = Section::make($label)
+            ->schema($this->componentsForFields($field['fields'] ?? [], $prefix, $existing))
+            ->columnSpanFull();
+
+        if (filled($description)) {
+            $section->description($description);
+        }
+
+        if (! empty($field['icon'])) {
+            $section->icon((string) $field['icon']);
+        }
+
+        if ((bool) ($field['compact'] ?? false)) {
+            $section->compact();
+        }
+
+        if ((bool) ($field['collapsible'] ?? false)) {
+            $section->collapsible();
+            $section->collapsed((bool) ($field['collapsed'] ?? false));
+        }
+
+        if ($columns > 1) {
+            $section->columns($columns);
+        }
+
+        return $section;
     }
 
     private function staticSelectComponent(string $name, array $field): Select
@@ -154,6 +203,15 @@ class PluginSchemaMapper
         $rules = [];
 
         foreach ($fields as $field) {
+            if (($field['type'] ?? null) === 'section') {
+                $rules = [
+                    ...$rules,
+                    ...$this->rulesForFields($field['fields'] ?? [], $prefix),
+                ];
+
+                continue;
+            }
+
             $fieldId = $field['id'] ?? null;
             if (! $fieldId) {
                 continue;

--- a/app/Plugins/PluginValidator.php
+++ b/app/Plugins/PluginValidator.php
@@ -542,15 +542,42 @@ class PluginValidator
     private function validateFieldDefinition(array $field, array $fieldTypes, string $group): array
     {
         $errors = [];
+        $type = $field['type'] ?? 'text';
         $fieldId = $field['id'] ?? null;
 
         if (blank($fieldId)) {
             return ["{$group} field is missing [id]"];
         }
 
-        $type = $field['type'] ?? 'text';
         if (! in_array($type, $fieldTypes, true)) {
             $errors[] = "{$group}.{$fieldId} uses unsupported type [{$type}]";
+        }
+
+        if ($type === 'section') {
+            if (blank($field['label'] ?? null)) {
+                $errors[] = "{$group}.{$fieldId} section fields require [label]";
+            }
+
+            if (! is_array($field['fields'] ?? null) || ($field['fields'] ?? []) === []) {
+                $errors[] = "{$group}.{$fieldId} section fields require non-empty [fields]";
+
+                return $errors;
+            }
+
+            foreach ($field['fields'] as $nestedField) {
+                if (! is_array($nestedField)) {
+                    $errors[] = "{$group}.{$fieldId} section fields must be objects";
+
+                    continue;
+                }
+
+                $errors = [
+                    ...$errors,
+                    ...$this->validateFieldDefinition($nestedField, $fieldTypes, "{$group}.{$fieldId}"),
+                ];
+            }
+
+            return $errors;
         }
 
         if (in_array($type, ['select', 'model_select'], true) && blank($field['label'] ?? null)) {

--- a/app/Plugins/PluginValidator.php
+++ b/app/Plugins/PluginValidator.php
@@ -545,39 +545,44 @@ class PluginValidator
         $type = $field['type'] ?? 'text';
         $fieldId = $field['id'] ?? null;
 
-        if (blank($fieldId)) {
-            return ["{$group} field is missing [id]"];
-        }
-
-        if (! in_array($type, $fieldTypes, true)) {
-            $errors[] = "{$group}.{$fieldId} uses unsupported type [{$type}]";
-        }
-
         if ($type === 'section') {
+            // Sections do not require an [id]; fall back to the label for readable error paths.
+            // Nested sections (sections within sections) are supported via recursive validation.
+            $qualifier = $fieldId ?? ($field['label'] ?? 'section');
+            $qualifiedGroup = "{$group}.{$qualifier}";
+
             if (blank($field['label'] ?? null)) {
-                $errors[] = "{$group}.{$fieldId} section fields require [label]";
+                $errors[] = "{$qualifiedGroup} section fields require [label]";
             }
 
             if (! is_array($field['fields'] ?? null) || ($field['fields'] ?? []) === []) {
-                $errors[] = "{$group}.{$fieldId} section fields require non-empty [fields]";
+                $errors[] = "{$qualifiedGroup} section fields require non-empty [fields]";
 
                 return $errors;
             }
 
             foreach ($field['fields'] as $nestedField) {
                 if (! is_array($nestedField)) {
-                    $errors[] = "{$group}.{$fieldId} section fields must be objects";
+                    $errors[] = "{$qualifiedGroup} section fields must be objects";
 
                     continue;
                 }
 
                 $errors = [
                     ...$errors,
-                    ...$this->validateFieldDefinition($nestedField, $fieldTypes, "{$group}.{$fieldId}"),
+                    ...$this->validateFieldDefinition($nestedField, $fieldTypes, $qualifiedGroup),
                 ];
             }
 
             return $errors;
+        }
+
+        if (blank($fieldId)) {
+            return ["{$group} field is missing [id]"];
+        }
+
+        if (! in_array($type, $fieldTypes, true)) {
+            $errors[] = "{$group}.{$fieldId} uses unsupported type [{$type}]";
         }
 
         if (in_array($type, ['select', 'model_select'], true) && blank($field['label'] ?? null)) {

--- a/config/database.php
+++ b/config/database.php
@@ -36,9 +36,13 @@ return [
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
             // Add these options for better concurrency
-            'options' => [
-                PDO::SQLITE_ATTR_OPEN_FLAGS => PDO::SQLITE_OPEN_READWRITE | PDO::SQLITE_OPEN_CREATE,
-            ],
+            'options' => defined('PDO::SQLITE_ATTR_OPEN_FLAGS')
+                && defined('PDO::SQLITE_OPEN_READWRITE')
+                && defined('PDO::SQLITE_OPEN_CREATE')
+                ? [
+                    constant('PDO::SQLITE_ATTR_OPEN_FLAGS') => constant('PDO::SQLITE_OPEN_READWRITE') | constant('PDO::SQLITE_OPEN_CREATE'),
+                ]
+                : [],
             'journal_mode' => 'WAL',
             'synchronous' => 'NORMAL',
             'cache_size' => 10000,
@@ -60,9 +64,13 @@ return [
             'prefix' => '',
             'foreign_key_constraints' => true,
             // Add these options for better concurrency
-            'options' => [
-                PDO::SQLITE_ATTR_OPEN_FLAGS => PDO::SQLITE_OPEN_READWRITE | PDO::SQLITE_OPEN_CREATE,
-            ],
+            'options' => defined('PDO::SQLITE_ATTR_OPEN_FLAGS')
+                && defined('PDO::SQLITE_OPEN_READWRITE')
+                && defined('PDO::SQLITE_OPEN_CREATE')
+                ? [
+                    constant('PDO::SQLITE_ATTR_OPEN_FLAGS') => constant('PDO::SQLITE_OPEN_READWRITE') | constant('PDO::SQLITE_OPEN_CREATE'),
+                ]
+                : [],
             'journal_mode' => 'WAL',
             'synchronous' => 'NORMAL',
             'cache_size' => 10000,

--- a/config/plugins.php
+++ b/config/plugins.php
@@ -182,6 +182,7 @@ return [
     ],
 
     'field_types' => [
+        'section',
         'boolean',
         'number',
         'text',

--- a/tests/Feature/PluginSettingsSchemaGroupingTest.php
+++ b/tests/Feature/PluginSettingsSchemaGroupingTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use App\Models\Plugin;
+use App\Plugins\PluginSchemaMapper;
+use App\Plugins\PluginValidator;
+use Filament\Schemas\Components\Section;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+it('renders grouped plugin settings sections and keeps nested rules flat', function () {
+    $plugin = new Plugin([
+        'settings_schema' => [
+            [
+                'id' => 'core_setup',
+                'type' => 'section',
+                'label' => 'Core Setup',
+                'description' => 'Primary plugin configuration.',
+                'collapsible' => true,
+                'collapsed' => false,
+                'fields' => [
+                    [
+                        'id' => 'stream_profile_id',
+                        'type' => 'number',
+                        'label' => 'Stream Profile',
+                        'default' => 5,
+                    ],
+                    [
+                        'id' => 'channel_group',
+                        'type' => 'text',
+                        'label' => 'Channel Group',
+                        'default' => 'Twitch Live',
+                    ],
+                ],
+            ],
+        ],
+        'settings' => [
+            'stream_profile_id' => 7,
+        ],
+    ]);
+
+    $mapper = app(PluginSchemaMapper::class);
+
+    $components = $mapper->settingsComponents($plugin);
+    expect($components)->toHaveCount(1);
+    expect($components[0])->toBeInstanceOf(Section::class);
+    expect($components[0]->getHeading())->toBe('Core Setup');
+
+    $defaults = $mapper->defaultsForFields($plugin->settings_schema, $plugin->settings);
+    expect($defaults['stream_profile_id'])->toBe(7);
+    expect($defaults['channel_group'])->toBe('Twitch Live');
+
+    $rules = $mapper->settingsRules($plugin);
+    expect($rules)->toHaveKey('settings.stream_profile_id');
+    expect($rules)->toHaveKey('settings.channel_group');
+});
+
+it('validates plugin manifests that use grouped settings sections', function () {
+    $pluginId = 'grouped-schema-'.Str::lower(Str::random(6));
+    $sourcePath = storage_path('app/testing-plugin-sources/'.$pluginId);
+    $classSegment = Str::studly(str_replace('-', ' ', $pluginId));
+
+    File::deleteDirectory($sourcePath);
+    File::ensureDirectoryExists($sourcePath);
+
+    $manifest = [
+        'id' => $pluginId,
+        'name' => 'Grouped Schema Fixture',
+        'version' => '0.1.0',
+        'description' => 'Temporary grouped settings fixture.',
+        'api_version' => config('plugins.api_version'),
+        'entrypoint' => 'Plugin.php',
+        'class' => "AppLocalPlugins\\{$classSegment}\\Plugin",
+        'capabilities' => [],
+        'hooks' => [],
+        'permissions' => [],
+        'settings' => [
+            [
+                'id' => 'core_setup',
+                'type' => 'section',
+                'label' => 'Core Setup',
+                'collapsible' => true,
+                'collapsed' => false,
+                'fields' => [
+                    [
+                        'id' => 'monitored_channels',
+                        'type' => 'textarea',
+                        'label' => 'Monitored Channels',
+                        'default' => '',
+                    ],
+                    [
+                        'id' => 'stream_profile_id',
+                        'type' => 'number',
+                        'label' => 'Stream Profile',
+                        'required' => true,
+                    ],
+                ],
+            ],
+        ],
+        'actions' => [],
+        'schema' => [
+            'tables' => [],
+        ],
+        'data_ownership' => [
+            'plugin_id' => $pluginId,
+            'table_prefix' => 'plugin_'.str_replace('-', '_', $pluginId).'_',
+            'tables' => [],
+            'directories' => [],
+            'files' => [],
+            'default_cleanup_policy' => 'preserve',
+        ],
+    ];
+
+    $pluginSource = <<<PHP
+<?php
+
+namespace AppLocalPlugins\\{$classSegment};
+
+use App\Plugins\Contracts\PluginInterface;
+use App\Plugins\Support\PluginActionResult;
+use App\Plugins\Support\PluginExecutionContext;
+
+class Plugin implements PluginInterface
+{
+    public function runAction(string \$action, array \$payload, PluginExecutionContext \$context): PluginActionResult
+    {
+        return PluginActionResult::success('ok');
+    }
+}
+PHP;
+
+    try {
+        File::put(
+            $sourcePath.'/plugin.json',
+            json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL,
+        );
+        File::put($sourcePath.'/Plugin.php', $pluginSource);
+
+        $result = app(PluginValidator::class)->validatePath($sourcePath);
+
+        expect($result->valid)->toBeTrue();
+        expect($result->errors)->toBe([]);
+    } finally {
+        File::deleteDirectory($sourcePath);
+    }
+});

--- a/tests/Feature/PluginSettingsSchemaGroupingTest.php
+++ b/tests/Feature/PluginSettingsSchemaGroupingTest.php
@@ -54,6 +54,117 @@ it('renders grouped plugin settings sections and keeps nested rules flat', funct
     expect($rules)->toHaveKey('settings.channel_group');
 });
 
+it('rejects a section missing a label', function () {
+    $mapper = app(PluginValidator::class);
+
+    $fieldTypes = config('plugins.field_types');
+
+    $errors = (new ReflectionMethod($mapper, 'validateFieldDefinition'))
+        ->invoke($mapper, [
+            'id' => 'my_section',
+            'type' => 'section',
+            'fields' => [['id' => 'foo', 'type' => 'text']],
+        ], $fieldTypes, 'settings');
+
+    expect($errors)->toContain('settings.my_section section fields require [label]');
+});
+
+it('rejects a section with an empty fields array', function () {
+    $mapper = app(PluginValidator::class);
+
+    $fieldTypes = config('plugins.field_types');
+
+    $errors = (new ReflectionMethod($mapper, 'validateFieldDefinition'))
+        ->invoke($mapper, [
+            'id' => 'my_section',
+            'type' => 'section',
+            'label' => 'My Section',
+            'fields' => [],
+        ], $fieldTypes, 'settings');
+
+    expect($errors)->toContain('settings.my_section section fields require non-empty [fields]');
+});
+
+it('rejects a section containing a non-array nested field', function () {
+    $mapper = app(PluginValidator::class);
+
+    $fieldTypes = config('plugins.field_types');
+
+    $errors = (new ReflectionMethod($mapper, 'validateFieldDefinition'))
+        ->invoke($mapper, [
+            'id' => 'my_section',
+            'type' => 'section',
+            'label' => 'My Section',
+            'fields' => ['not-an-array'],
+        ], $fieldTypes, 'settings');
+
+    expect($errors)->toContain('settings.my_section section fields must be objects');
+});
+
+it('allows a section without an id, using the label as the error path identifier', function () {
+    $validator = app(PluginValidator::class);
+
+    $fieldTypes = config('plugins.field_types');
+
+    $errors = (new ReflectionMethod($validator, 'validateFieldDefinition'))
+        ->invoke($validator, [
+            'type' => 'section',
+            'label' => 'Unlabelled Section',
+            'fields' => [['id' => 'foo', 'type' => 'text']],
+        ], $fieldTypes, 'settings');
+
+    expect($errors)->toBe([]);
+});
+
+it('renders nested sections and flattens their fields for defaults and rules', function () {
+    $plugin = new Plugin([
+        'settings_schema' => [
+            [
+                'id' => 'outer',
+                'type' => 'section',
+                'label' => 'Outer Section',
+                'fields' => [
+                    [
+                        'id' => 'top_level_field',
+                        'type' => 'text',
+                        'label' => 'Top Level',
+                        'default' => 'top',
+                    ],
+                    [
+                        'id' => 'inner',
+                        'type' => 'section',
+                        'label' => 'Inner Section',
+                        'fields' => [
+                            [
+                                'id' => 'nested_field',
+                                'type' => 'text',
+                                'label' => 'Nested',
+                                'default' => 'deep',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        'settings' => [],
+    ]);
+
+    $mapper = app(PluginSchemaMapper::class);
+
+    $components = $mapper->settingsComponents($plugin);
+    expect($components)->toHaveCount(1);
+    expect($components[0])->toBeInstanceOf(Section::class);
+    expect($components[0]->getHeading())->toBe('Outer Section');
+
+    $defaults = $mapper->defaultsForFields($plugin->settings_schema, []);
+    expect($defaults)->toHaveKey('top_level_field', 'top')
+        ->and($defaults)->toHaveKey('nested_field', 'deep');
+
+    $rules = $mapper->settingsRules($plugin);
+    expect($rules)->toHaveKey('settings.top_level_field')
+        ->and($rules)->toHaveKey('settings.nested_field');
+});
+
 it('validates plugin manifests that use grouped settings sections', function () {
     $pluginId = 'grouped-schema-'.Str::lower(Str::random(6));
     $sourcePath = storage_path('app/testing-plugin-sources/'.$pluginId);

--- a/tests/Unit/StreamProfileResourceDefaultsTest.php
+++ b/tests/Unit/StreamProfileResourceDefaultsTest.php
@@ -9,7 +9,7 @@ test('streamlink backend has optimized default args', function () {
 
 test('ytdlp backend keeps expected default args', function () {
     expect(StreamProfileResource::defaultArgsForBackend('ytdlp'))
-        ->toBe('bestvideo+bestaudio/best');
+        ->toBe('bestvideo+bestaudio/best --no-playlist');
 });
 
 test('ffmpeg backend keeps expected default args', function () {


### PR DESCRIPTION
This pull request introduces support for grouped plugin settings sections using a new `section` field type in plugin schemas. It updates the schema mapping, validation, and database configuration to handle these grouped sections, and adds comprehensive tests to ensure correct rendering, default value handling, and validation. The most important changes are grouped below:

**Plugin Schema Section Support:**

* Added a new `section` field type to the allowed plugin field types in `config/plugins.php`, enabling grouping of related settings fields.
* Updated `PluginSchemaMapper.php` to handle `section` fields:
  - Recursively processes nested fields for defaults and rules, ensuring that grouped fields are correctly flattened for validation and value extraction. [[1]](diffhunk://#diff-b17968b672649ebd369841386011eba352a61ebfeb99bed655feddfae7d94a6eR59-R67) [[2]](diffhunk://#diff-b17968b672649ebd369841386011eba352a61ebfeb99bed655feddfae7d94a6eR206-R214)
  - Adjusted component mapping to generate `Section` UI components for grouped fields, with support for labels, descriptions, icons, columns, and collapsible/compact options. [[1]](diffhunk://#diff-b17968b672649ebd369841386011eba352a61ebfeb99bed655feddfae7d94a6eL72-R98) [[2]](diffhunk://#diff-b17968b672649ebd369841386011eba352a61ebfeb99bed655feddfae7d94a6eR120-R153)
* Enhanced `PluginValidator.php` to validate `section` fields, requiring a non-empty label and fields array, and recursively validating nested fields.

**Testing:**

* Added a feature test (`PluginSettingsSchemaGroupingTest.php`) to verify that grouped sections are rendered as `Section` components, defaults are correctly mapped, rules remain flat, and manifests using sections are validated successfully.

**Database Configuration Robustness:**

* Improved SQLite database configuration in `config/database.php` to check for constant definitions before setting PDO options, preventing errors in environments where these constants may not be defined. [[1]](diffhunk://#diff-e4382b565f69d02de16eef89c8d5ca2b60a679ffca90ab8b7d85fbd78f30075bL39-R45) [[2]](diffhunk://#diff-e4382b565f69d02de16eef89c8d5ca2b60a679ffca90ab8b7d85fbd78f30075bL63-R73)