### PR TITLE
Feat/epg structural phase ab

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -140,6 +140,9 @@ class AppServiceProvider extends ServiceProvider
         // Setup the middleware
         $this->setupMiddleware();
 
+        // Configure PDO open flags for SQLite connections (PHP 8.4 compat)
+        $this->configureSqliteOpenFlags();
+
         // Set WAL mode on SQLite connections
         $this->setWalModeOnSqlite();
 
@@ -320,6 +323,34 @@ class AppServiceProvider extends ServiceProvider
             $route = app('router')->getRoutes()->getByName('filament-copilot.stream');
             $route?->middleware(EnsureUserCanUseCopilot::class);
         });
+    }
+
+    /**
+     * Apply the correct PDO open-flag constants for SQLite connections.
+     *
+     * PHP 8.4 moved the SQLite-specific PDO constants from the global PDO class
+     * into the Pdo\Sqlite sub-class. This method detects which set is available
+     * and writes the resolved values into the runtime config so that database.php
+     * can remain a clean, expression-free array.
+     */
+    private function configureSqliteOpenFlags(): void
+    {
+        $openFlagsAttr = defined('Pdo\\Sqlite::ATTR_OPEN_FLAGS')
+            ? constant('Pdo\\Sqlite::ATTR_OPEN_FLAGS')
+            : PDO::SQLITE_ATTR_OPEN_FLAGS;
+
+        $openMode = (defined('Pdo\\Sqlite::OPEN_READWRITE')
+            ? constant('Pdo\\Sqlite::OPEN_READWRITE')
+            : PDO::SQLITE_OPEN_READWRITE)
+            | (defined('Pdo\\Sqlite::OPEN_CREATE')
+                ? constant('Pdo\\Sqlite::OPEN_CREATE')
+                : PDO::SQLITE_OPEN_CREATE);
+
+        foreach (['sqlite', 'jobs'] as $connection) {
+            $options = config("database.connections.{$connection}.options", []);
+            $options[$openFlagsAttr] = $openMode;
+            config(["database.connections.{$connection}.options" => $options]);
+        }
     }
 
     /**

--- a/app/Services/EpgCacheService.php
+++ b/app/Services/EpgCacheService.php
@@ -29,7 +29,7 @@ use XMLReader;
  */
 class EpgCacheService
 {
-    private const CACHE_VERSION = 'v1';
+    private const CACHE_VERSION = 'v2';
 
     private const CHANNELS_FILE = 'channels.json';
 
@@ -277,10 +277,15 @@ class EpgCacheService
                         'desc' => '',
                         'category' => '',
                         'episode_num' => '',
+                        'episode_nums' => [],
                         'rating' => '',
                         'icon' => '',
                         'images' => [],
                         'new' => false,
+                        'previously_shown' => false,
+                        'premiere' => false,
+                        'urls' => [],
+                        'production_year' => null,
                     ];
 
                     while (@$innerReader->read()) {
@@ -321,8 +326,40 @@ class EpgCacheService
                                 case 'new':
                                     $programme['new'] = true;
                                     break;
+                                case 'previously-shown':
+                                    $programme['previously_shown'] = true;
+                                    break;
+                                case 'premiere':
+                                    $programme['premiere'] = true;
+                                    break;
                                 case 'episode-num':
-                                    $programme['episode_num'] = trim($innerReader->readString() ?: '');
+                                    $episodeNumValue = trim($innerReader->readString() ?: '');
+                                    $episodeNumSystem = trim((string) ($innerReader->getAttribute('system') ?: ''));
+                                    if ($episodeNumValue !== '') {
+                                        if ($programme['episode_num'] === '') {
+                                            $programme['episode_num'] = $episodeNumValue;
+                                        }
+                                        $programme['episode_nums'][] = [
+                                            'system' => $episodeNumSystem,
+                                            'value' => $episodeNumValue,
+                                        ];
+                                    }
+                                    break;
+                                case 'url':
+                                    $urlValue = trim($innerReader->readString() ?: '');
+                                    $urlSystem = mb_strtolower(trim((string) ($innerReader->getAttribute('system') ?: '')));
+                                    if ($urlValue !== '') {
+                                        $programme['urls'][] = [
+                                            'system' => $urlSystem,
+                                            'value' => $urlValue,
+                                        ];
+                                    }
+                                    break;
+                                case 'date':
+                                    $dateValue = trim($innerReader->readString() ?: '');
+                                    if ($programme['production_year'] === null && preg_match('/^(\d{4})/', $dateValue, $matches)) {
+                                        $programme['production_year'] = (int) $matches[1];
+                                    }
                                     break;
                                 case 'rating':
                                     while (@$innerReader->read()) {
@@ -692,10 +729,15 @@ class EpgCacheService
                     'desc' => '',
                     'category' => '',
                     'episode_num' => '',
+                    'episode_nums' => [],
                     'rating' => '',
                     'icon' => '',
                     'images' => [], // New: store program artwork
                     'new' => false,
+                    'previously_shown' => false,
+                    'premiere' => false,
+                    'urls' => [],
+                    'production_year' => null,
                 ];
 
                 while (@$innerReader->read()) {
@@ -737,8 +779,40 @@ class EpgCacheService
                             case 'new':
                                 $programme['new'] = true;
                                 break;
+                            case 'previously-shown':
+                                $programme['previously_shown'] = true;
+                                break;
+                            case 'premiere':
+                                $programme['premiere'] = true;
+                                break;
                             case 'episode-num':
-                                $programme['episode_num'] = trim($innerReader->readString() ?: '');
+                                $episodeNumValue = trim($innerReader->readString() ?: '');
+                                $episodeNumSystem = trim((string) ($innerReader->getAttribute('system') ?: ''));
+                                if ($episodeNumValue !== '') {
+                                    if ($programme['episode_num'] === '') {
+                                        $programme['episode_num'] = $episodeNumValue;
+                                    }
+                                    $programme['episode_nums'][] = [
+                                        'system' => $episodeNumSystem,
+                                        'value' => $episodeNumValue,
+                                    ];
+                                }
+                                break;
+                            case 'url':
+                                $urlValue = trim($innerReader->readString() ?: '');
+                                $urlSystem = mb_strtolower(trim((string) ($innerReader->getAttribute('system') ?: '')));
+                                if ($urlValue !== '') {
+                                    $programme['urls'][] = [
+                                        'system' => $urlSystem,
+                                        'value' => $urlValue,
+                                    ];
+                                }
+                                break;
+                            case 'date':
+                                $dateValue = trim($innerReader->readString() ?: '');
+                                if ($programme['production_year'] === null && preg_match('/^(\d{4})/', $dateValue, $matches)) {
+                                    $programme['production_year'] = (int) $matches[1];
+                                }
                                 break;
                             case 'rating':
                                 // Read rating value

--- a/app/Services/EpgCacheService.php
+++ b/app/Services/EpgCacheService.php
@@ -31,6 +31,9 @@ class EpgCacheService
 {
     private const CACHE_VERSION = 'v2';
 
+    /** Older cache versions that are still served for reads until the next sync writes v2. */
+    private const PREVIOUS_CACHE_VERSIONS = ['v1'];
+
     private const CHANNELS_FILE = 'channels.json';
 
     private const METADATA_FILE = 'metadata.json';
@@ -46,11 +49,44 @@ class EpgCacheService
     }
 
     /**
-     * Get cache file path
+     * Get cache file path for write operations (always current version).
      */
     private function getCacheFilePath(Epg $epg, string $filename): string
     {
         return $this->getCacheDir($epg).'/'.$filename;
+    }
+
+    /**
+     * Returns the directory of the best available cache: current version first,
+     * then each legacy version in order. Falls back to the current version path
+     * (which may not yet exist) when no cache has been written yet.
+     *
+     * Used by read operations so existing v1 caches continue to be served until
+     * the next scheduled sync writes a fresh v2 cache.
+     */
+    private function getActiveCacheDir(Epg $epg): string
+    {
+        $currentDir = $this->getCacheDir($epg);
+        if (Storage::disk('local')->exists($currentDir.'/'.self::METADATA_FILE)) {
+            return $currentDir;
+        }
+
+        foreach (self::PREVIOUS_CACHE_VERSIONS as $version) {
+            $legacyDir = "epg-cache/{$epg->uuid}/{$version}";
+            if (Storage::disk('local')->exists($legacyDir.'/'.self::METADATA_FILE)) {
+                return $legacyDir;
+            }
+        }
+
+        return $currentDir;
+    }
+
+    /**
+     * Get cache file path for read operations (uses the active/best available version).
+     */
+    private function getActiveCacheFilePath(Epg $epg, string $filename): string
+    {
+        return $this->getActiveCacheDir($epg).'/'.$filename;
     }
 
     /**
@@ -64,7 +100,7 @@ class EpgCacheService
             return false;
         }
 
-        $metadataPath = $this->getCacheFilePath($epg, self::METADATA_FILE);
+        $metadataPath = $this->getActiveCacheFilePath($epg, self::METADATA_FILE);
 
         if (! Storage::disk('local')->exists($metadataPath)) {
             return false;
@@ -162,6 +198,104 @@ class EpgCacheService
             Log::error("Failed to cache EPG data for {$epg->name}: {$e->getMessage()}");
 
             return false;
+        }
+    }
+
+    /**
+     * Apply a single XMLTV programme child element's value to the $programme array.
+     *
+     * Shared by both the single-pass writer and the stream generator to avoid
+     * maintaining two identical switch blocks.
+     *
+     * @param  array<string, mixed>  $programme
+     */
+    private function applyProgrammeElement(XMLReader $reader, string $elementName, array &$programme): void
+    {
+        switch ($elementName) {
+            case 'title':
+                $programme['title'] = trim($reader->readString() ?: '');
+                break;
+            case 'sub-title':
+                $programme['subtitle'] = trim($reader->readString() ?: '');
+                break;
+            case 'desc':
+                $programme['desc'] = trim($reader->readString() ?: '');
+                break;
+            case 'category':
+                if (! $programme['category']) {
+                    $programme['category'] = trim($reader->readString() ?: '');
+                }
+                break;
+            case 'icon':
+                if (! $programme['icon']) {
+                    $programme['icon'] = trim($reader->getAttribute('src') ?: '');
+                } else {
+                    $imageUrl = trim($reader->getAttribute('src') ?: '');
+                    if ($imageUrl) {
+                        $programme['images'][] = [
+                            'url' => $imageUrl,
+                            'type' => trim($reader->getAttribute('type') ?: 'poster'),
+                            'width' => (int) ($reader->getAttribute('width') ?: 0),
+                            'height' => (int) ($reader->getAttribute('height') ?: 0),
+                            'orient' => trim($reader->getAttribute('orient') ?: 'P'),
+                            'size' => (int) ($reader->getAttribute('size') ?: 1),
+                        ];
+                    }
+                }
+                break;
+            case 'new':
+                $programme['new'] = true;
+                break;
+            case 'previously-shown':
+                // The <previously-shown> element may carry start/channel attributes;
+                // only the boolean presence is recorded — attributes are intentionally ignored.
+                $programme['previously_shown'] = true;
+                break;
+            case 'premiere':
+                // The <premiere> element may carry text content (a description);
+                // only the boolean presence is recorded — content is intentionally ignored.
+                $programme['premiere'] = true;
+                break;
+            case 'episode-num':
+                $episodeNumValue = trim($reader->readString() ?: '');
+                $episodeNumSystem = trim((string) ($reader->getAttribute('system') ?: ''));
+                if ($episodeNumValue !== '') {
+                    if ($programme['episode_num'] === '') {
+                        $programme['episode_num'] = $episodeNumValue;
+                    }
+                    $programme['episode_nums'][] = [
+                        'system' => $episodeNumSystem,
+                        'value' => $episodeNumValue,
+                    ];
+                }
+                break;
+            case 'url':
+                $urlValue = trim($reader->readString() ?: '');
+                $urlSystem = mb_strtolower(trim((string) ($reader->getAttribute('system') ?: '')));
+                // Validate to prevent storing malformed or unsafe URL values from untrusted EPG feeds.
+                if ($urlValue !== '' && filter_var($urlValue, FILTER_VALIDATE_URL)) {
+                    $programme['urls'][] = [
+                        'system' => $urlSystem,
+                        'value' => $urlValue,
+                    ];
+                }
+                break;
+            case 'date':
+                $dateValue = trim($reader->readString() ?: '');
+                if ($programme['production_year'] === null && preg_match('/^(\d{4})/', $dateValue, $matches)) {
+                    $programme['production_year'] = (int) $matches[1];
+                }
+                break;
+            case 'rating':
+                while (@$reader->read()) {
+                    if ($reader->nodeType == XMLReader::ELEMENT && $reader->name === 'value') {
+                        $programme['rating'] = trim($reader->readString() ?: '');
+                        break;
+                    } elseif ($reader->nodeType == XMLReader::END_ELEMENT && $reader->name === 'rating') {
+                        break;
+                    }
+                }
+                break;
         }
     }
 
@@ -290,88 +424,7 @@ class EpgCacheService
 
                     while (@$innerReader->read()) {
                         if ($innerReader->nodeType == XMLReader::ELEMENT) {
-                            switch ($innerReader->name) {
-                                case 'title':
-                                    $programme['title'] = trim($innerReader->readString() ?: '');
-                                    break;
-                                case 'sub-title':
-                                    $programme['subtitle'] = trim($innerReader->readString() ?: '');
-                                    break;
-                                case 'desc':
-                                    $programme['desc'] = trim($innerReader->readString() ?: '');
-                                    break;
-                                case 'category':
-                                    if (! $programme['category']) {
-                                        $programme['category'] = trim($innerReader->readString() ?: '');
-                                    }
-                                    break;
-                                case 'icon':
-                                    if (! $programme['icon']) {
-                                        $programme['icon'] = trim($innerReader->getAttribute('src') ?: '');
-                                    } else {
-                                        $imageUrl = trim($innerReader->getAttribute('src') ?: '');
-                                        if ($imageUrl) {
-                                            $imageData = [
-                                                'url' => $imageUrl,
-                                                'type' => trim($innerReader->getAttribute('type') ?: 'poster'),
-                                                'width' => (int) ($innerReader->getAttribute('width') ?: 0),
-                                                'height' => (int) ($innerReader->getAttribute('height') ?: 0),
-                                                'orient' => trim($innerReader->getAttribute('orient') ?: 'P'),
-                                                'size' => (int) ($innerReader->getAttribute('size') ?: 1),
-                                            ];
-                                            $programme['images'][] = $imageData;
-                                        }
-                                    }
-                                    break;
-                                case 'new':
-                                    $programme['new'] = true;
-                                    break;
-                                case 'previously-shown':
-                                    $programme['previously_shown'] = true;
-                                    break;
-                                case 'premiere':
-                                    $programme['premiere'] = true;
-                                    break;
-                                case 'episode-num':
-                                    $episodeNumValue = trim($innerReader->readString() ?: '');
-                                    $episodeNumSystem = trim((string) ($innerReader->getAttribute('system') ?: ''));
-                                    if ($episodeNumValue !== '') {
-                                        if ($programme['episode_num'] === '') {
-                                            $programme['episode_num'] = $episodeNumValue;
-                                        }
-                                        $programme['episode_nums'][] = [
-                                            'system' => $episodeNumSystem,
-                                            'value' => $episodeNumValue,
-                                        ];
-                                    }
-                                    break;
-                                case 'url':
-                                    $urlValue = trim($innerReader->readString() ?: '');
-                                    $urlSystem = mb_strtolower(trim((string) ($innerReader->getAttribute('system') ?: '')));
-                                    if ($urlValue !== '') {
-                                        $programme['urls'][] = [
-                                            'system' => $urlSystem,
-                                            'value' => $urlValue,
-                                        ];
-                                    }
-                                    break;
-                                case 'date':
-                                    $dateValue = trim($innerReader->readString() ?: '');
-                                    if ($programme['production_year'] === null && preg_match('/^(\d{4})/', $dateValue, $matches)) {
-                                        $programme['production_year'] = (int) $matches[1];
-                                    }
-                                    break;
-                                case 'rating':
-                                    while (@$innerReader->read()) {
-                                        if ($innerReader->nodeType == XMLReader::ELEMENT && $innerReader->name === 'value') {
-                                            $programme['rating'] = trim($innerReader->readString() ?: '');
-                                            break;
-                                        } elseif ($innerReader->nodeType == XMLReader::END_ELEMENT && $innerReader->name === 'rating') {
-                                            break;
-                                        }
-                                    }
-                                    break;
-                            }
+                            $this->applyProgrammeElement($innerReader, $innerReader->name, $programme);
                         }
                     }
                     $innerReader->close();
@@ -683,9 +736,12 @@ class EpgCacheService
     }
 
     /**
-     * Stream parse programmes from EPG file using generators
+     * Stream parse programmes from EPG file using generators.
+     *
+     * Visibility is protected (not private) to allow subclassing in tests
+     * without resorting to reflection.
      */
-    private function parseProgrammesStream(string $filePath): Generator
+    protected function parseProgrammesStream(string $filePath): Generator
     {
         $programReader = new XMLReader;
         $programReader->open('compress.zlib://'.$filePath);
@@ -742,90 +798,7 @@ class EpgCacheService
 
                 while (@$innerReader->read()) {
                     if ($innerReader->nodeType == XMLReader::ELEMENT) {
-                        switch ($innerReader->name) {
-                            case 'title':
-                                $programme['title'] = trim($innerReader->readString() ?: '');
-                                break;
-                            case 'sub-title':
-                                $programme['subtitle'] = trim($innerReader->readString() ?: '');
-                                break;
-                            case 'desc':
-                                $programme['desc'] = trim($innerReader->readString() ?: '');
-                                break;
-                            case 'category':
-                                if (! $programme['category']) {
-                                    $programme['category'] = trim($innerReader->readString() ?: '');
-                                }
-                                break;
-                            case 'icon':
-                                if (! $programme['icon']) {
-                                    $programme['icon'] = trim($innerReader->getAttribute('src') ?: '');
-                                } else {
-                                    // New: Parse additional XMLTV icon tags for program artwork
-                                    $imageUrl = trim($innerReader->getAttribute('src') ?: '');
-                                    if ($imageUrl) {
-                                        $imageData = [
-                                            'url' => $imageUrl,
-                                            'type' => trim($innerReader->getAttribute('type') ?: 'poster'),
-                                            'width' => (int) ($innerReader->getAttribute('width') ?: 0),
-                                            'height' => (int) ($innerReader->getAttribute('height') ?: 0),
-                                            'orient' => trim($innerReader->getAttribute('orient') ?: 'P'),
-                                            'size' => (int) ($innerReader->getAttribute('size') ?: 1),
-                                        ];
-                                        $programme['images'][] = $imageData;
-                                    }
-                                }
-                                break;
-                            case 'new':
-                                $programme['new'] = true;
-                                break;
-                            case 'previously-shown':
-                                $programme['previously_shown'] = true;
-                                break;
-                            case 'premiere':
-                                $programme['premiere'] = true;
-                                break;
-                            case 'episode-num':
-                                $episodeNumValue = trim($innerReader->readString() ?: '');
-                                $episodeNumSystem = trim((string) ($innerReader->getAttribute('system') ?: ''));
-                                if ($episodeNumValue !== '') {
-                                    if ($programme['episode_num'] === '') {
-                                        $programme['episode_num'] = $episodeNumValue;
-                                    }
-                                    $programme['episode_nums'][] = [
-                                        'system' => $episodeNumSystem,
-                                        'value' => $episodeNumValue,
-                                    ];
-                                }
-                                break;
-                            case 'url':
-                                $urlValue = trim($innerReader->readString() ?: '');
-                                $urlSystem = mb_strtolower(trim((string) ($innerReader->getAttribute('system') ?: '')));
-                                if ($urlValue !== '') {
-                                    $programme['urls'][] = [
-                                        'system' => $urlSystem,
-                                        'value' => $urlValue,
-                                    ];
-                                }
-                                break;
-                            case 'date':
-                                $dateValue = trim($innerReader->readString() ?: '');
-                                if ($programme['production_year'] === null && preg_match('/^(\d{4})/', $dateValue, $matches)) {
-                                    $programme['production_year'] = (int) $matches[1];
-                                }
-                                break;
-                            case 'rating':
-                                // Read rating value
-                                while (@$innerReader->read()) {
-                                    if ($innerReader->nodeType == XMLReader::ELEMENT && $innerReader->name === 'value') {
-                                        $programme['rating'] = trim($innerReader->readString() ?: '');
-                                        break;
-                                    } elseif ($innerReader->nodeType == XMLReader::END_ELEMENT && $innerReader->name === 'rating') {
-                                        break;
-                                    }
-                                }
-                                break;
-                        }
+                        $this->applyProgrammeElement($innerReader, $innerReader->name, $programme);
                     }
                 }
                 $innerReader->close();
@@ -885,7 +858,7 @@ class EpgCacheService
      */
     public function getCachedChannels(Epg $epg, int $page = 1, int $perPage = 50): array
     {
-        $channelsPath = $this->getCacheFilePath($epg, self::CHANNELS_FILE);
+        $channelsPath = $this->getActiveCacheFilePath($epg, self::CHANNELS_FILE);
 
         if (! Storage::disk('local')->exists($channelsPath)) {
             return [
@@ -967,7 +940,7 @@ class EpgCacheService
      */
     public function getCachedProgrammes(Epg $epg, string $date, array $channelIds = []): array
     {
-        $programmesPath = $this->getCacheFilePath($epg, "programmes-{$date}.jsonl");
+        $programmesPath = $this->getActiveCacheFilePath($epg, "programmes-{$date}.jsonl");
 
         if (! Storage::disk('local')->exists($programmesPath)) {
             return [];
@@ -1057,7 +1030,7 @@ class EpgCacheService
      */
     private function streamCachedProgrammesForDate(Epg $epg, string $date, array $channelIds = []): Generator
     {
-        $programmesPath = $this->getCacheFilePath($epg, "programmes-{$date}.jsonl");
+        $programmesPath = $this->getActiveCacheFilePath($epg, "programmes-{$date}.jsonl");
         if (! Storage::disk('local')->exists($programmesPath)) {
             return;
         }
@@ -1115,7 +1088,7 @@ class EpgCacheService
      */
     public function getCacheMetadata(Epg $epg): ?array
     {
-        $metadataPath = $this->getCacheFilePath($epg, self::METADATA_FILE);
+        $metadataPath = $this->getActiveCacheFilePath($epg, self::METADATA_FILE);
         if (! Storage::disk('local')->exists($metadataPath)) {
             return null;
         }
@@ -1135,8 +1108,6 @@ class EpgCacheService
      */
     public function clearCache(Epg $epg): bool
     {
-        // Get the cache directory
-        $cacheDir = $this->getCacheDir($epg);
         try {
             // Flag EPG as not cached
             $epg->update([
@@ -1145,8 +1116,13 @@ class EpgCacheService
                 'cache_progress' => 0,
             ]);
 
-            // Delete cache directory
-            Storage::disk('local')->deleteDirectory($cacheDir);
+            // Delete current version directory
+            Storage::disk('local')->deleteDirectory($this->getCacheDir($epg));
+
+            // Also delete any legacy version directories so stale data is not left on disk
+            foreach (self::PREVIOUS_CACHE_VERSIONS as $version) {
+                Storage::disk('local')->deleteDirectory("epg-cache/{$epg->uuid}/{$version}");
+            }
 
             // Log cache clearing
             Log::debug("Cleared cache for EPG {$epg->name}");

--- a/app/Services/TmdbService.php
+++ b/app/Services/TmdbService.php
@@ -504,9 +504,12 @@ class TmdbService
      * Supported sources: imdb_id, tvdb_id, tmdb_id.
      * Returns a normalized payload with `_media_type` = tv|movie.
      *
+     * @param  string|null  $mediaType  Optional hint ('tv' or 'movie') used only when
+     *                                  $source is 'tmdb_id' to skip probing the wrong
+     *                                  endpoint and avoid a wasted API call.
      * @return array<string, mixed>|null
      */
-    public function findByExternalId(string $id, string $source): ?array
+    public function findByExternalId(string $id, string $source, ?string $mediaType = null): ?array
     {
         if (! $this->isConfigured()) {
             return null;
@@ -518,25 +521,31 @@ class TmdbService
             return null;
         }
 
-        // Native TMDB IDs are not supported by /find.
+        // Native TMDB IDs are not supported by /find — probe the details endpoints directly.
+        // getTvSeriesDetails() / getMovieDetails() each call waitForRateLimit() internally,
+        // so we intentionally skip the explicit waitForRateLimit() call here.
         if ($source === 'tmdb_id') {
             $tmdbId = (int) preg_replace('/\D+/', '', $id);
             if ($tmdbId <= 0) {
                 return null;
             }
 
-            $tvDetails = $this->getTvSeriesDetails($tmdbId);
-            if (is_array($tvDetails)) {
-                $tvDetails['_media_type'] = 'tv';
+            if ($mediaType !== 'movie') {
+                $tvDetails = $this->getTvSeriesDetails($tmdbId);
+                if (is_array($tvDetails)) {
+                    $tvDetails['_media_type'] = 'tv';
 
-                return $tvDetails;
+                    return $tvDetails;
+                }
             }
 
-            $movieDetails = $this->getMovieDetails($tmdbId);
-            if (is_array($movieDetails)) {
-                $movieDetails['_media_type'] = 'movie';
+            if ($mediaType !== 'tv') {
+                $movieDetails = $this->getMovieDetails($tmdbId);
+                if (is_array($movieDetails)) {
+                    $movieDetails['_media_type'] = 'movie';
 
-                return $movieDetails;
+                    return $movieDetails;
+                }
             }
 
             return null;
@@ -628,7 +637,7 @@ class TmdbService
                 'api_key' => $this->apiKey,
                 'query' => $this->normalizeTitle($query),
                 'language' => $this->language,
-                'include_adult' => false,
+                'include_adult' => 'false',
             ]);
 
             if (! $response->successful()) {
@@ -698,7 +707,7 @@ class TmdbService
      * @param  array<string, mixed>  $result
      * @return array<string, mixed>
      */
-    protected function normalizeFindResult(array $result, string $mediaType): array
+    private function normalizeFindResult(array $result, string $mediaType): array
     {
         $posterUrl = null;
         if (! empty($result['poster_path'])) {

--- a/app/Services/TmdbService.php
+++ b/app/Services/TmdbService.php
@@ -499,6 +499,235 @@ class TmdbService
     }
 
     /**
+     * Resolve a TMDB entity by external ID.
+     *
+     * Supported sources: imdb_id, tvdb_id, tmdb_id.
+     * Returns a normalized payload with `_media_type` = tv|movie.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function findByExternalId(string $id, string $source): ?array
+    {
+        if (! $this->isConfigured()) {
+            return null;
+        }
+
+        $id = trim($id);
+        $source = trim($source);
+        if ($id === '') {
+            return null;
+        }
+
+        // Native TMDB IDs are not supported by /find.
+        if ($source === 'tmdb_id') {
+            $tmdbId = (int) preg_replace('/\D+/', '', $id);
+            if ($tmdbId <= 0) {
+                return null;
+            }
+
+            $tvDetails = $this->getTvSeriesDetails($tmdbId);
+            if (is_array($tvDetails)) {
+                $tvDetails['_media_type'] = 'tv';
+
+                return $tvDetails;
+            }
+
+            $movieDetails = $this->getMovieDetails($tmdbId);
+            if (is_array($movieDetails)) {
+                $movieDetails['_media_type'] = 'movie';
+
+                return $movieDetails;
+            }
+
+            return null;
+        }
+
+        if (! in_array($source, ['imdb_id', 'tvdb_id'], true)) {
+            return null;
+        }
+
+        $this->waitForRateLimit();
+
+        try {
+            $response = Http::timeout(15)->get(
+                self::BASE_URL.'/find/'.urlencode($id),
+                [
+                    'api_key' => $this->apiKey,
+                    'external_source' => $source,
+                    'language' => $this->language,
+                ]
+            );
+
+            if (! $response->successful()) {
+                Log::warning('TMDB find by external id failed', [
+                    'id' => $id,
+                    'source' => $source,
+                    'status' => $response->status(),
+                ]);
+
+                return null;
+            }
+
+            $payload = $response->json();
+            $tvResults = $payload['tv_results'] ?? [];
+            $movieResults = $payload['movie_results'] ?? [];
+
+            $tvResult = $tvResults[0] ?? null;
+            $movieResult = $movieResults[0] ?? null;
+
+            if (! is_array($tvResult) && ! is_array($movieResult)) {
+                return null;
+            }
+
+            if (is_array($tvResult) && ! is_array($movieResult)) {
+                return $this->normalizeFindResult($tvResult, 'tv');
+            }
+
+            if (! is_array($tvResult) && is_array($movieResult)) {
+                return $this->normalizeFindResult($movieResult, 'movie');
+            }
+
+            // If both exist, pick the more popular entry.
+            $tvPopularity = (float) ($tvResult['popularity'] ?? 0);
+            $moviePopularity = (float) ($movieResult['popularity'] ?? 0);
+
+            return $tvPopularity >= $moviePopularity
+                ? $this->normalizeFindResult($tvResult, 'tv')
+                : $this->normalizeFindResult($movieResult, 'movie');
+        } catch (\Throwable $e) {
+            Log::error('TMDB find by external id error', [
+                'id' => $id,
+                'source' => $source,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Search across movie + TV in one call and return the best normalized hit.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function searchMulti(string $query): ?array
+    {
+        if (! $this->isConfigured()) {
+            return null;
+        }
+
+        $query = trim($query);
+        if ($query === '') {
+            return null;
+        }
+
+        $this->waitForRateLimit();
+
+        try {
+            $response = Http::timeout(15)->get(self::BASE_URL.'/search/multi', [
+                'api_key' => $this->apiKey,
+                'query' => $this->normalizeTitle($query),
+                'language' => $this->language,
+                'include_adult' => false,
+            ]);
+
+            if (! $response->successful()) {
+                Log::warning('TMDB multi search failed', [
+                    'query' => $query,
+                    'status' => $response->status(),
+                ]);
+
+                return null;
+            }
+
+            $results = collect($response->json('results', []))
+                ->filter(fn (array $row): bool => in_array($row['media_type'] ?? '', ['tv', 'movie'], true))
+                ->values()
+                ->all();
+
+            if (empty($results)) {
+                return null;
+            }
+
+            $tvCandidates = array_values(array_filter($results, fn (array $row): bool => ($row['media_type'] ?? '') === 'tv'));
+            $movieCandidates = array_values(array_filter($results, fn (array $row): bool => ($row['media_type'] ?? '') === 'movie'));
+
+            $tvMatch = ! empty($tvCandidates)
+                ? $this->findBestMatch($tvCandidates, $query, null, 'name', 'first_air_date', 'tv')
+                : null;
+            $movieMatch = ! empty($movieCandidates)
+                ? $this->findBestMatch($movieCandidates, $query, null, 'title', 'release_date', 'movie')
+                : null;
+
+            $best = null;
+            if ($tvMatch && $movieMatch) {
+                $tvConfidence = (int) ($tvMatch['_confidence'] ?? 0);
+                $movieConfidence = (int) ($movieMatch['_confidence'] ?? 0);
+
+                if ($tvConfidence === $movieConfidence) {
+                    $tvPopularity = (float) ($tvMatch['popularity'] ?? 0);
+                    $moviePopularity = (float) ($movieMatch['popularity'] ?? 0);
+                    $best = $tvPopularity >= $moviePopularity ? $tvMatch : $movieMatch;
+                } else {
+                    $best = $tvConfidence > $movieConfidence ? $tvMatch : $movieMatch;
+                }
+            } else {
+                $best = $tvMatch ?? $movieMatch;
+            }
+
+            if (! is_array($best)) {
+                $best = $results[0];
+            }
+
+            $mediaType = $best['media_type'] ?? (isset($best['name']) ? 'tv' : 'movie');
+
+            return $this->normalizeFindResult($best, $mediaType);
+        } catch (\Throwable $e) {
+            Log::error('TMDB multi search error', [
+                'query' => $query,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Normalize a TMDB result payload to the shape expected by plugin enrichers.
+     *
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    protected function normalizeFindResult(array $result, string $mediaType): array
+    {
+        $posterUrl = null;
+        if (! empty($result['poster_path'])) {
+            $posterUrl = 'https://image.tmdb.org/t/p/w500'.$result['poster_path'];
+        }
+
+        $backdropUrl = null;
+        if (! empty($result['backdrop_path'])) {
+            $backdropUrl = 'https://image.tmdb.org/t/p/original'.$result['backdrop_path'];
+        }
+
+        return [
+            'tmdb_id' => $result['id'] ?? null,
+            'name' => $result['name'] ?? null,
+            'title' => $result['title'] ?? null,
+            'original_name' => $result['original_name'] ?? null,
+            'original_title' => $result['original_title'] ?? null,
+            'first_air_date' => $result['first_air_date'] ?? null,
+            'release_date' => $result['release_date'] ?? null,
+            'overview' => $result['overview'] ?? null,
+            'poster_url' => $posterUrl,
+            'backdrop_url' => $backdropUrl,
+            'popularity' => $result['popularity'] ?? null,
+            '_media_type' => $mediaType,
+            '_confidence' => $result['_confidence'] ?? null,
+        ];
+    }
+
+    /**
      * Get full TV series details from TMDB.
      * Returns poster, overview, genres, rating, etc.
      *

--- a/config/database.php
+++ b/config/database.php
@@ -1,16 +1,5 @@
 <?php
 
-$sqliteOpenFlagsAttribute = defined('Pdo\\Sqlite::ATTR_OPEN_FLAGS')
-    ? constant('Pdo\\Sqlite::ATTR_OPEN_FLAGS')
-    : PDO::SQLITE_ATTR_OPEN_FLAGS;
-
-$sqliteOpenMode = (defined('Pdo\\Sqlite::OPEN_READWRITE')
-    ? constant('Pdo\\Sqlite::OPEN_READWRITE')
-    : PDO::SQLITE_OPEN_READWRITE)
-    | (defined('Pdo\\Sqlite::OPEN_CREATE')
-        ? constant('Pdo\\Sqlite::OPEN_CREATE')
-        : PDO::SQLITE_OPEN_CREATE);
-
 return [
 
     /*
@@ -46,10 +35,6 @@ return [
             'database' => database_path('database.sqlite'),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
-            // Add these options for better concurrency
-            'options' => [
-                $sqliteOpenFlagsAttribute => $sqliteOpenMode,
-            ],
             'journal_mode' => 'WAL',
             'synchronous' => 'NORMAL',
             'cache_size' => 10000,
@@ -70,10 +55,6 @@ return [
             'database' => database_path('jobs.sqlite'),
             'prefix' => '',
             'foreign_key_constraints' => true,
-            // Add these options for better concurrency
-            'options' => [
-                $sqliteOpenFlagsAttribute => $sqliteOpenMode,
-            ],
             'journal_mode' => 'WAL',
             'synchronous' => 'NORMAL',
             'cache_size' => 10000,

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,16 @@
 <?php
 
+$sqliteOpenFlagsAttribute = defined('Pdo\\Sqlite::ATTR_OPEN_FLAGS')
+    ? constant('Pdo\\Sqlite::ATTR_OPEN_FLAGS')
+    : PDO::SQLITE_ATTR_OPEN_FLAGS;
+
+$sqliteOpenMode = (defined('Pdo\\Sqlite::OPEN_READWRITE')
+    ? constant('Pdo\\Sqlite::OPEN_READWRITE')
+    : PDO::SQLITE_OPEN_READWRITE)
+    | (defined('Pdo\\Sqlite::OPEN_CREATE')
+        ? constant('Pdo\\Sqlite::OPEN_CREATE')
+        : PDO::SQLITE_OPEN_CREATE);
+
 return [
 
     /*
@@ -37,7 +48,7 @@ return [
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
             // Add these options for better concurrency
             'options' => [
-                PDO::SQLITE_ATTR_OPEN_FLAGS => PDO::SQLITE_OPEN_READWRITE | PDO::SQLITE_OPEN_CREATE,
+                $sqliteOpenFlagsAttribute => $sqliteOpenMode,
             ],
             'journal_mode' => 'WAL',
             'synchronous' => 'NORMAL',
@@ -61,7 +72,7 @@ return [
             'foreign_key_constraints' => true,
             // Add these options for better concurrency
             'options' => [
-                PDO::SQLITE_ATTR_OPEN_FLAGS => PDO::SQLITE_OPEN_READWRITE | PDO::SQLITE_OPEN_CREATE,
+                $sqliteOpenFlagsAttribute => $sqliteOpenMode,
             ],
             'journal_mode' => 'WAL',
             'synchronous' => 'NORMAL',

--- a/tests/Feature/TmdbServiceTest.php
+++ b/tests/Feature/TmdbServiceTest.php
@@ -4,6 +4,7 @@ use App\Services\TmdbService;
 use App\Settings\GeneralSettings;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\RateLimiter;
 
 uses(RefreshDatabase::class);
 
@@ -14,6 +15,10 @@ beforeEach(function () {
     $this->settings->tmdb_language = 'en-US';
     $this->settings->tmdb_rate_limit = 40;
     $this->settings->tmdb_confidence_threshold = 80;
+
+    // Avoid Redis dependency from TmdbService::waitForRateLimit() in tests.
+    RateLimiter::shouldReceive('tooManyAttempts')->andReturnFalse();
+    RateLimiter::shouldReceive('hit')->andReturnNull();
 });
 
 it('returns null when API key is not configured', function () {
@@ -169,4 +174,97 @@ it('handles API errors gracefully', function () {
     $result = $service->searchMovie('The Matrix');
 
     expect($result)->toBeNull();
+});
+
+it('can resolve an external imdb id via TMDB find', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/find/tt0090390*' => Http::response([
+            'tv_results' => [
+                [
+                    'id' => 4592,
+                    'name' => 'ALF',
+                    'original_name' => 'ALF',
+                    'first_air_date' => '1986-09-22',
+                    'poster_path' => '/alf-poster.jpg',
+                    'backdrop_path' => '/alf-backdrop.jpg',
+                    'popularity' => 45.2,
+                ],
+            ],
+            'movie_results' => [],
+        ], 200),
+    ]);
+
+    $service = new TmdbService($this->settings);
+    $result = $service->findByExternalId('tt0090390', 'imdb_id');
+
+    expect($result)->not->toBeNull()
+        ->and($result['tmdb_id'])->toBe(4592)
+        ->and($result['_media_type'])->toBe('tv');
+});
+
+it('can resolve a raw tmdb id by probing details endpoints', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/tv/4592*' => Http::response([
+            'id' => 4592,
+            'name' => 'ALF',
+            'original_name' => 'ALF',
+            'overview' => 'Alien life form sitcom.',
+            'poster_path' => '/alf-poster.jpg',
+            'backdrop_path' => '/alf-backdrop.jpg',
+            'first_air_date' => '1986-09-22',
+            'genres' => [],
+            'external_ids' => [
+                'imdb_id' => 'tt0090390',
+                'tvdb_id' => 78020,
+            ],
+            'credits' => ['cast' => [], 'crew' => []],
+            'videos' => ['results' => []],
+        ], 200),
+    ]);
+
+    $service = new TmdbService($this->settings);
+    $result = $service->findByExternalId('4592', 'tmdb_id');
+
+    expect($result)->not->toBeNull()
+        ->and($result['tmdb_id'])->toBe(4592)
+        ->and($result['_media_type'])->toBe('tv')
+        ->and($result['name'])->toBe('ALF');
+});
+
+it('can search across multi endpoint and return media type', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/search/multi*' => Http::response([
+            'results' => [
+                [
+                    'id' => 4592,
+                    'media_type' => 'tv',
+                    'name' => 'ALF',
+                    'original_name' => 'ALF',
+                    'overview' => 'Alien life form sitcom.',
+                    'first_air_date' => '1986-09-22',
+                    'poster_path' => '/alf-poster.jpg',
+                    'backdrop_path' => '/alf-backdrop.jpg',
+                    'popularity' => 45.2,
+                ],
+                [
+                    'id' => 9999,
+                    'media_type' => 'movie',
+                    'title' => 'Different Movie',
+                    'original_title' => 'Different Movie',
+                    'release_date' => '2020-01-01',
+                    'poster_path' => '/movie-poster.jpg',
+                    'backdrop_path' => '/movie-backdrop.jpg',
+                    'popularity' => 20.0,
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $service = new TmdbService($this->settings);
+    $result = $service->searchMulti('ALF');
+
+    expect($result)->not->toBeNull()
+        ->and($result['tmdb_id'])->toBe(4592)
+        ->and($result['_media_type'])->toBe('tv')
+        ->and($result['name'])->toBe('ALF');
 });

--- a/tests/Feature/TmdbServiceTest.php
+++ b/tests/Feature/TmdbServiceTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
 
     // Avoid Redis dependency from TmdbService::waitForRateLimit() in tests.
     RateLimiter::shouldReceive('tooManyAttempts')->andReturnFalse();
-    RateLimiter::shouldReceive('hit')->andReturnNull();
+    RateLimiter::shouldReceive('hit')->andReturn(1);
 });
 
 it('returns null when API key is not configured', function () {
@@ -176,6 +176,10 @@ it('handles API errors gracefully', function () {
     expect($result)->toBeNull();
 });
 
+// ---------------------------------------------------------------------------
+// findByExternalId
+// ---------------------------------------------------------------------------
+
 it('can resolve an external imdb id via TMDB find', function () {
     Http::fake([
         'https://api.themoviedb.org/3/find/tt0090390*' => Http::response([
@@ -202,7 +206,84 @@ it('can resolve an external imdb id via TMDB find', function () {
         ->and($result['_media_type'])->toBe('tv');
 });
 
-it('can resolve a raw tmdb id by probing details endpoints', function () {
+it('can resolve an external tvdb id via TMDB find', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/find/78020*' => Http::response([
+            'tv_results' => [
+                [
+                    'id' => 4592,
+                    'name' => 'ALF',
+                    'original_name' => 'ALF',
+                    'first_air_date' => '1986-09-22',
+                    'poster_path' => '/alf-poster.jpg',
+                    'backdrop_path' => '/alf-backdrop.jpg',
+                    'popularity' => 45.2,
+                ],
+            ],
+            'movie_results' => [],
+        ], 200),
+    ]);
+
+    $service = new TmdbService($this->settings);
+    $result = $service->findByExternalId('78020', 'tvdb_id');
+
+    expect($result)->not->toBeNull()
+        ->and($result['tmdb_id'])->toBe(4592)
+        ->and($result['_media_type'])->toBe('tv');
+});
+
+it('returns null for an unsupported source', function () {
+    $service = new TmdbService($this->settings);
+    $result = $service->findByExternalId('12345', 'unknown_source');
+
+    expect($result)->toBeNull();
+});
+
+it('returns null when findByExternalId id is empty', function () {
+    $service = new TmdbService($this->settings);
+
+    expect($service->findByExternalId('', 'imdb_id'))->toBeNull();
+    expect($service->findByExternalId('   ', 'imdb_id'))->toBeNull();
+});
+
+it('picks higher popularity when find returns both tv and movie results', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/find/tt0090390*' => Http::response([
+            'tv_results' => [
+                [
+                    'id' => 4592,
+                    'name' => 'ALF',
+                    'original_name' => 'ALF',
+                    'first_air_date' => '1986-09-22',
+                    'poster_path' => '/alf-poster.jpg',
+                    'backdrop_path' => '/alf-backdrop.jpg',
+                    'popularity' => 45.2,
+                ],
+            ],
+            'movie_results' => [
+                [
+                    'id' => 9999,
+                    'title' => 'ALF The Movie',
+                    'original_title' => 'ALF The Movie',
+                    'release_date' => '1996-01-01',
+                    'poster_path' => '/alf-movie.jpg',
+                    'backdrop_path' => '/alf-movie-backdrop.jpg',
+                    'popularity' => 10.1,
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $service = new TmdbService($this->settings);
+    $result = $service->findByExternalId('tt0090390', 'imdb_id');
+
+    // TV result has higher popularity (45.2 > 10.1) so it should win
+    expect($result)->not->toBeNull()
+        ->and($result['tmdb_id'])->toBe(4592)
+        ->and($result['_media_type'])->toBe('tv');
+});
+
+it('can resolve a raw tmdb id by probing TV details endpoint', function () {
     Http::fake([
         'https://api.themoviedb.org/3/tv/4592*' => Http::response([
             'id' => 4592,
@@ -230,6 +311,64 @@ it('can resolve a raw tmdb id by probing details endpoints', function () {
         ->and($result['_media_type'])->toBe('tv')
         ->and($result['name'])->toBe('ALF');
 });
+
+it('falls back to movie endpoint when tmdb_id does not match a TV series', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/tv/603*' => Http::response(['success' => false], 404),
+        'https://api.themoviedb.org/3/movie/603*' => Http::response([
+            'id' => 603,
+            'title' => 'The Matrix',
+            'original_title' => 'The Matrix',
+            'overview' => 'A computer hacker learns the truth.',
+            'poster_path' => '/matrix.jpg',
+            'backdrop_path' => '/matrix-backdrop.jpg',
+            'release_date' => '1999-03-30',
+            'genres' => [],
+            'external_ids' => ['imdb_id' => 'tt0133093'],
+            'credits' => ['cast' => [], 'crew' => []],
+            'videos' => ['results' => []],
+        ], 200),
+    ]);
+
+    $service = new TmdbService($this->settings);
+    $result = $service->findByExternalId('603', 'tmdb_id');
+
+    expect($result)->not->toBeNull()
+        ->and($result['tmdb_id'])->toBe(603)
+        ->and($result['_media_type'])->toBe('movie')
+        ->and($result['title'])->toBe('The Matrix');
+});
+
+it('skips tv probe when mediaType hint is movie', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/movie/603*' => Http::response([
+            'id' => 603,
+            'title' => 'The Matrix',
+            'original_title' => 'The Matrix',
+            'overview' => 'A computer hacker learns the truth.',
+            'poster_path' => '/matrix.jpg',
+            'backdrop_path' => '/matrix-backdrop.jpg',
+            'release_date' => '1999-03-30',
+            'genres' => [],
+            'external_ids' => ['imdb_id' => 'tt0133093'],
+            'credits' => ['cast' => [], 'crew' => []],
+            'videos' => ['results' => []],
+        ], 200),
+    ]);
+
+    $service = new TmdbService($this->settings);
+    $result = $service->findByExternalId('603', 'tmdb_id', 'movie');
+
+    expect($result)->not->toBeNull()
+        ->and($result['_media_type'])->toBe('movie');
+
+    // The TV endpoint must NOT have been called
+    Http::assertNotSent(fn ($request) => str_contains((string) $request->url(), '/tv/603'));
+});
+
+// ---------------------------------------------------------------------------
+// searchMulti
+// ---------------------------------------------------------------------------
 
 it('can search across multi endpoint and return media type', function () {
     Http::fake([
@@ -267,4 +406,75 @@ it('can search across multi endpoint and return media type', function () {
         ->and($result['tmdb_id'])->toBe(4592)
         ->and($result['_media_type'])->toBe('tv')
         ->and($result['name'])->toBe('ALF');
+});
+
+it('returns null when searchMulti finds no tv or movie results', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/search/multi*' => Http::response([
+            'results' => [
+                // Only a person result — should be filtered out
+                ['id' => 1, 'media_type' => 'person', 'name' => 'Some Actor'],
+            ],
+        ], 200),
+    ]);
+
+    $service = new TmdbService($this->settings);
+    $result = $service->searchMulti('Some Actor');
+
+    expect($result)->toBeNull();
+});
+
+it('returns null when searchMulti query is empty', function () {
+    $service = new TmdbService($this->settings);
+
+    expect($service->searchMulti(''))->toBeNull();
+    expect($service->searchMulti('   '))->toBeNull();
+});
+
+it('breaks ties in searchMulti by popularity when confidence scores are equal', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/search/multi*' => Http::response([
+            'results' => [
+                [
+                    'id' => 100,
+                    'media_type' => 'tv',
+                    'name' => 'Test Show',
+                    'original_name' => 'Test Show',
+                    'overview' => 'A test show.',
+                    'first_air_date' => '2000-01-01',
+                    'poster_path' => null,
+                    'backdrop_path' => null,
+                    'popularity' => 5.0,
+                ],
+                [
+                    'id' => 200,
+                    'media_type' => 'movie',
+                    'title' => 'Test Show',
+                    'original_title' => 'Test Show',
+                    'overview' => 'A test movie.',
+                    'release_date' => '2000-06-01',
+                    'poster_path' => null,
+                    'backdrop_path' => null,
+                    'popularity' => 80.0,
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $service = new TmdbService($this->settings);
+    $result = $service->searchMulti('Test Show');
+
+    // Both have the same title match → same confidence; movie wins on popularity (80 > 5)
+    expect($result)->not->toBeNull()
+        ->and($result['tmdb_id'])->toBe(200)
+        ->and($result['_media_type'])->toBe('movie');
+});
+
+it('returns null when searchMulti is not configured', function () {
+    $settings = new GeneralSettings;
+    $settings->tmdb_api_key = null;
+
+    $service = new TmdbService($settings);
+
+    expect($service->searchMulti('ALF'))->toBeNull();
 });

--- a/tests/Unit/EpgCacheServiceXmltvSignalsTest.php
+++ b/tests/Unit/EpgCacheServiceXmltvSignalsTest.php
@@ -2,6 +2,43 @@
 
 use App\Services\EpgCacheService;
 
+// ---------------------------------------------------------------------------
+// Helper: anonymous subclass that exposes parseProgrammesStream publicly so
+// tests can call it without resorting to reflection.
+// ---------------------------------------------------------------------------
+function makeTestEpgCacheService(): EpgCacheService
+{
+    return new class extends EpgCacheService
+    {
+        public function exposeParseProgrammesStream(string $filePath): Generator
+        {
+            return $this->parseProgrammesStream($filePath);
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture lifecycle: resolve the path inside the app context, not at load time.
+// ---------------------------------------------------------------------------
+beforeEach(function () {
+    $this->testGzPath = storage_path('framework/testing/epg-signals.xml.gz');
+
+    $directory = dirname($this->testGzPath);
+    if (! is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+});
+
+afterEach(function () {
+    if (file_exists($this->testGzPath)) {
+        unlink($this->testGzPath);
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 it('parses structural XMLTV signals into programme payloads', function () {
     $xml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
@@ -22,19 +59,10 @@ it('parses structural XMLTV signals into programme payloads', function () {
 </tv>
 XML;
 
-    $path = storage_path('framework/testing/epg-signals.xml.gz');
-    $directory = dirname($path);
-    if (! is_dir($directory)) {
-        mkdir($directory, 0755, true);
-    }
-    file_put_contents($path, gzencode($xml));
+    file_put_contents($this->testGzPath, gzencode($xml));
 
-    $service = new EpgCacheService;
-    $method = new ReflectionMethod($service, 'parseProgrammesStream');
-    $method->setAccessible(true);
-
-    $generator = $method->invoke($service, $path);
-    $programmes = iterator_to_array($generator, false);
+    $service = makeTestEpgCacheService();
+    $programmes = iterator_to_array($service->exposeParseProgrammesStream($this->testGzPath), false);
 
     expect($programmes)->toHaveCount(1);
 
@@ -54,6 +82,53 @@ XML;
             ['system' => 'tvdb', 'value' => 'https://thetvdb.com/series/alf'],
         ])
         ->and($programme['production_year'])->toBe(2024);
+});
 
-    @unlink($path);
+it('rejects malformed or unsafe url values from epg feeds', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <programme start="20260421090000 +0000" stop="20260421093000 +0000" channel="demo.channel">
+    <title>Test Programme</title>
+    <url system="safe">https://www.imdb.com/title/tt0090390/</url>
+    <url system="bad-scheme">javascript:alert(1)</url>
+    <url system="not-a-url">not-a-url-at-all</url>
+  </programme>
+</tv>
+XML;
+
+    file_put_contents($this->testGzPath, gzencode($xml));
+
+    $service = makeTestEpgCacheService();
+    $programmes = iterator_to_array($service->exposeParseProgrammesStream($this->testGzPath), false);
+
+    expect($programmes)->toHaveCount(1);
+
+    // Only the valid HTTPS URL should be stored; javascript: and bare strings are rejected
+    expect($programmes[0]['urls'])->toBe([
+        ['system' => 'safe', 'value' => 'https://www.imdb.com/title/tt0090390/'],
+    ]);
+});
+
+it('sets previously_shown and premiere to false by default', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <programme start="20260421100000 +0000" stop="20260421103000 +0000" channel="demo.channel">
+    <title>Plain Programme</title>
+  </programme>
+</tv>
+XML;
+
+    file_put_contents($this->testGzPath, gzencode($xml));
+
+    $service = makeTestEpgCacheService();
+    $programmes = iterator_to_array($service->exposeParseProgrammesStream($this->testGzPath), false);
+
+    expect($programmes)->toHaveCount(1)
+        ->and($programmes[0]['previously_shown'])->toBeFalse()
+        ->and($programmes[0]['premiere'])->toBeFalse()
+        ->and($programmes[0]['urls'])->toBe([])
+        ->and($programmes[0]['episode_nums'])->toBe([])
+        ->and($programmes[0]['production_year'])->toBeNull();
 });

--- a/tests/Unit/EpgCacheServiceXmltvSignalsTest.php
+++ b/tests/Unit/EpgCacheServiceXmltvSignalsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Services\EpgCacheService;
+
+it('parses structural XMLTV signals into programme payloads', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <programme start="20260421080000 +0000" stop="20260421084500 +0000" channel="demo.channel">
+    <title lang="de">SOKO Stuttgart</title>
+    <sub-title lang="de">Auf Streife</sub-title>
+    <desc>Test episode</desc>
+    <category>Movie</category>
+    <episode-num system="xmltv_ns">0.4.0/1</episode-num>
+    <episode-num system="onscreen">S01E05</episode-num>
+    <previously-shown />
+    <premiere />
+    <url system="imdb">https://www.imdb.com/title/tt0090390/</url>
+    <url system="tvdb">https://thetvdb.com/series/alf</url>
+    <date>2024</date>
+  </programme>
+</tv>
+XML;
+
+    $path = storage_path('framework/testing/epg-signals.xml.gz');
+    $directory = dirname($path);
+    if (! is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+    file_put_contents($path, gzencode($xml));
+
+    $service = new EpgCacheService;
+    $method = new ReflectionMethod($service, 'parseProgrammesStream');
+    $method->setAccessible(true);
+
+    $generator = $method->invoke($service, $path);
+    $programmes = iterator_to_array($generator, false);
+
+    expect($programmes)->toHaveCount(1);
+
+    $programme = $programmes[0];
+
+    expect($programme['title'])->toBe('SOKO Stuttgart')
+        ->and($programme['subtitle'])->toBe('Auf Streife')
+        ->and($programme['episode_num'])->toBe('0.4.0/1')
+        ->and($programme['episode_nums'])->toBe([
+            ['system' => 'xmltv_ns', 'value' => '0.4.0/1'],
+            ['system' => 'onscreen', 'value' => 'S01E05'],
+        ])
+        ->and($programme['previously_shown'])->toBeTrue()
+        ->and($programme['premiere'])->toBeTrue()
+        ->and($programme['urls'])->toBe([
+            ['system' => 'imdb', 'value' => 'https://www.imdb.com/title/tt0090390/'],
+            ['system' => 'tvdb', 'value' => 'https://thetvdb.com/series/alf'],
+        ])
+        ->and($programme['production_year'])->toBe(2024);
+
+    @unlink($path);
+});


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across the EPG cache, TMDB service, and database configuration. The most significant changes include improved parsing and enrichment of EPG XMLTV data, new TMDB service methods for resolving and searching external IDs, and better compatibility for SQLite database flags. Comprehensive tests have been added to ensure the correctness of these features.

**EPG XMLTV Parsing Improvements**
- The `EpgCacheService` now extracts additional metadata from XMLTV, including multiple episode numbers with their systems, `previously_shown`, `premiere`, URLs with their systems, and production year. This enables more accurate and feature-rich EPG data. [[1]](diffhunk://#diff-9a25f3f98b2a473551562944eeb9d647009afcd397570b18985c32b5bfab13fbR280-R288) [[2]](diffhunk://#diff-9a25f3f98b2a473551562944eeb9d647009afcd397570b18985c32b5bfab13fbR329-R362) [[3]](diffhunk://#diff-9a25f3f98b2a473551562944eeb9d647009afcd397570b18985c32b5bfab13fbR732-R740) [[4]](diffhunk://#diff-9a25f3f98b2a473551562944eeb9d647009afcd397570b18985c32b5bfab13fbR782-R815)
- The cache version in `EpgCacheService` was bumped to `v2` to reflect these schema changes.

**TMDB Service Enhancements**
- Added `findByExternalId` to resolve TMDB entities by external IDs (IMDB, TVDB, or TMDB IDs), returning normalized results with media type.
- Added `searchMulti`, which searches across TV and movie endpoints and returns the best match, normalized with media type.
- Introduced a `normalizeFindResult` helper to standardize TMDB payloads for plugin enrichers.

**Database Configuration Compatibility**
- Improved SQLite database configuration in `config/database.php` to handle both old and new PDO constants for open flags, increasing compatibility across PHP versions. [[1]](diffhunk://#diff-e4382b565f69d02de16eef89c8d5ca2b60a679ffca90ab8b7d85fbd78f30075bR3-R13) [[2]](diffhunk://#diff-e4382b565f69d02de16eef89c8d5ca2b60a679ffca90ab8b7d85fbd78f30075bL40-R51) [[3]](diffhunk://#diff-e4382b565f69d02de16eef89c8d5ca2b60a679ffca90ab8b7d85fbd78f30075bL64-R75)

**Testing**
- Added new feature and unit tests for the TMDB service's external ID resolution and multi-search, and for EPG XMLTV parsing of structural signals. These tests ensure correct parsing of episode numbers, URLs, and other signals, and verify TMDB integration logic. [[1]](diffhunk://#diff-a41d78d54a86f6a514a973fdf1c2d631bf332bfc43a35f82553de3b65f1c0d52R178-R270) [[2]](diffhunk://#diff-4465064833508b6d31fb247f496c4944b78b0d3f6708d07acbba278603e7ff20R1-R59)
- Mocked rate limiting in TMDB service tests to avoid Redis dependencies.

These changes collectively improve the metadata quality and integration capabilities of the application.