### PR TITLE
fix(import): honor enable_channels in M3U sync closure (#1047)

### DIFF
--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -866,11 +866,13 @@ class ProcessM3uImport implements ShouldQueue
 
                 // Extract the channels and groups from the m3u
                 $excludeFileTypes = $playlist->import_prefs['ignored_file_types'] ?? [];
+                $liveEnabledByDefault = $playlist->enable_channels ?? false;
                 $collection = LazyCollection::make(function () use (
                     $filePath,
                     $channelFields,
                     $excludeFileTypes,
                     $autoSort,
+                    $liveEnabledByDefault,
                 ) {
                     // Keep track of channel number
                     $channelNo = 0;
@@ -897,7 +899,6 @@ class ProcessM3uImport implements ShouldQueue
                     // NOTE: max line length is set to 65536 to prevent memory issues
                     $this->m3uParser = new M3uParser;
                     $this->m3uParser->addDefaultTags();
-                    $liveEnabledByDefault = $playlist->enable_channels ?? false;
                     $count = 0;
                     foreach ($this->m3uParser->parseFile($filePath, max_length: 65536) as $item) {
                         // Increment channel number

--- a/tests/Feature/ProcessM3uImportEnableChannelsTest.php
+++ b/tests/Feature/ProcessM3uImportEnableChannelsTest.php
@@ -7,6 +7,8 @@ use App\Models\User;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\DB;
 
+// Isolate the jobs connection to a temp database so parallel test processes
+// don't interfere with each other via the shared jobs.sqlite file.
 beforeEach(function () {
     $this->tempJobsDb = sys_get_temp_dir().'/jobs_test_'.uniqid().'.sqlite';
     touch($this->tempJobsDb);
@@ -55,23 +57,18 @@ it('marks imported m3u channels as enabled when playlist auto-enable is on', fun
         ]);
     });
 
+    // Prevent ProcessM3uImportChunk / ProcessM3uImportComplete from being dispatched
+    // while still allowing processChannelCollection() to write Job staging records.
     Bus::fake();
 
-    $job = new ProcessM3uImport($playlist, force: true, isNew: false);
-    expect((bool) $playlist->fresh()->enable_channels)->toBeTrue();
-    expect((bool) $job->playlist->enable_channels)->toBeTrue();
+    (new ProcessM3uImport($playlist, force: true, isNew: false))->handle();
 
-    $method = new ReflectionMethod($job, 'processM3uPlus');
-    $method->invoke($job);
+    $importJobs = Job::all();
+    expect($importJobs)->not->toBeEmpty();
 
-    $importJob = Job::query()->first();
+    $allEnabled = $importJobs
+        ->flatMap(fn (Job $job): array => $job->payload)
+        ->every(fn (array $channel): bool => (bool) ($channel['enabled'] ?? false));
 
-    expect($importJob)->not->toBeNull();
-
-    $payload = $importJob->payload;
-    expect($payload)->toBeArray()
-        ->and($payload)->not->toBeEmpty();
-
-    $allEnabled = collect($payload)->every(fn (array $channel): bool => (bool) ($channel['enabled'] ?? false));
-    $this->assertTrue($allEnabled, 'Unexpected payload: '.json_encode($payload));
+    expect($allEnabled)->toBeTrue();
 });

--- a/tests/Feature/ProcessM3uImportEnableChannelsTest.php
+++ b/tests/Feature/ProcessM3uImportEnableChannelsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Jobs\ProcessM3uImport;
+use App\Models\Job;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function () {
+    $this->tempJobsDb = sys_get_temp_dir().'/jobs_test_'.uniqid().'.sqlite';
+    touch($this->tempJobsDb);
+
+    config(['database.connections.jobs.database' => $this->tempJobsDb]);
+    DB::purge('jobs');
+
+    $migration = require database_path('migrations/2025_02_13_215803_create_jobs_table.php');
+    $migration->up();
+});
+
+afterEach(function () {
+    DB::purge('jobs');
+    config(['database.connections.jobs.database' => database_path('jobs.sqlite')]);
+
+    if (isset($this->tempJobsDb) && file_exists($this->tempJobsDb)) {
+        @unlink($this->tempJobsDb);
+    }
+
+    if (isset($this->tempM3uPath) && file_exists($this->tempM3uPath)) {
+        @unlink($this->tempM3uPath);
+    }
+});
+
+it('marks imported m3u channels as enabled when playlist auto-enable is on', function () {
+    $user = User::factory()->create();
+
+    $this->tempM3uPath = sys_get_temp_dir().'/playlist_import_'.uniqid('', true).'.m3u';
+    file_put_contents($this->tempM3uPath, implode("\n", [
+        '#EXTM3U',
+        '#EXTINF:-1 tvg-id="demo-1" tvg-name="Demo One" group-title="News",Demo One',
+        'http://example.test/stream/1',
+        '#EXTINF:-1 tvg-id="demo-2" tvg-name="Demo Two" group-title="News",Demo Two',
+        'http://example.test/stream/2',
+    ]));
+
+    $playlist = Playlist::withoutEvents(function () use ($user) {
+        return Playlist::factory()->for($user)->create([
+            'name' => 'M3U Auto Enable Regression Test',
+            'url' => $this->tempM3uPath,
+            'xtream' => false,
+            'enable_channels' => true,
+            'enable_vod_channels' => false,
+            'import_prefs' => [],
+            'auto_sort' => false,
+        ]);
+    });
+
+    Bus::fake();
+
+    $job = new ProcessM3uImport($playlist, force: true, isNew: false);
+    expect((bool) $playlist->fresh()->enable_channels)->toBeTrue();
+    expect((bool) $job->playlist->enable_channels)->toBeTrue();
+
+    $method = new ReflectionMethod($job, 'processM3uPlus');
+    $method->invoke($job);
+
+    $importJob = Job::query()->first();
+
+    expect($importJob)->not->toBeNull();
+
+    $payload = $importJob->payload;
+    expect($payload)->toBeArray()
+        ->and($payload)->not->toBeEmpty();
+
+    $allEnabled = collect($payload)->every(fn (array $channel): bool => (bool) ($channel['enabled'] ?? false));
+    $this->assertTrue($allEnabled, 'Unexpected payload: '.json_encode($payload));
+});


### PR DESCRIPTION
This pull request refactors how the `enable_channels` setting is handled during M3U playlist imports and adds a new feature test to ensure that channels are correctly marked as enabled when the playlist's auto-enable option is set. The main changes include moving the `liveEnabledByDefault` assignment, updating its usage, and adding a comprehensive regression test.

**Refactoring and Logic Improvements:**

* Moved the assignment of `liveEnabledByDefault` in `processM3uPlus()` to ensure it is set before passing as a parameter to the channel collection generator, preventing possible logic errors or redundant assignments. [[1]](diffhunk://#diff-9070faec98963b6f8aaac409fccf64f4e2bbc822c4723658c3b471dd6e49e564R869-R875) [[2]](diffhunk://#diff-9070faec98963b6f8aaac409fccf64f4e2bbc822c4723658c3b471dd6e49e564L900)

**Testing:**

* Added a new feature test in `tests/Feature/ProcessM3uImportEnableChannelsTest.php` that verifies all imported channels are marked as enabled when the playlist's `enable_channels` setting is true, ensuring regression coverage for this behavior.