### PR TITLE
✨ feat: DVR recording engine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,7 @@ storage/logs/*
 
 # Data directories
 data/
+local/
 db-dumps/
 database/*.sqlite*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,10 @@ COPY package.json package-lock.json ./
 
 # Install all dependencies including dev deps (Vite is needed for build)
 # Note: NODE_ENV must NOT be set to production here, or npm ci will skip devDependencies
-RUN npm ci --silent
+# npm ci uses the lock file, which may contain only the glibc optional dep
+# (@rollup/rollup-linux-x64-gnu). Running npm rebuild afterwards forces npm to
+# resolve and install the correct musl variant for this Alpine environment.
+RUN npm ci --silent && npm rebuild
 
 # Copy only files needed for the build
 COPY vite.config.js postcss.config.js ./

--- a/app/Console/Commands/EnrichDvrRecordings.php
+++ b/app/Console/Commands/EnrichDvrRecordings.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\DvrRecordingStatus;
+use App\Jobs\EnrichDvrMetadata;
+use App\Jobs\IntegrateDvrRecordingToVod;
+use App\Models\DvrRecording;
+use Illuminate\Console\Command;
+
+class EnrichDvrRecordings extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'dvr:enrich
+                            {--id= : Enrich a specific recording by ID}
+                            {--all : Re-enrich all completed recordings, even those already enriched}
+                            {--integrate-only : Skip metadata enrichment, only re-run VOD integration}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Enrich completed DVR recordings with metadata and integrate them into the VOD library';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $query = DvrRecording::where('status', DvrRecordingStatus::Completed)
+            ->whereNotNull('file_path');
+
+        if ($this->option('id')) {
+            $query->where('id', (int) $this->option('id'));
+        } elseif (! $this->option('all')) {
+            // Default: only recordings missing metadata or missing a VOD entry
+            $query->where(function ($q) {
+                $q->whereNull('metadata')
+                    ->orWhereJsonLength('metadata', 0)
+                    ->orWhereDoesntHave('vodChannel')
+                    ->orWhereDoesntHave('vodEpisode');
+            });
+        }
+
+        $recordings = $query->get();
+
+        if ($recordings->isEmpty()) {
+            $this->info('No recordings to enrich.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Dispatching enrichment for {$recordings->count()} recording(s)...");
+
+        $integrateOnly = $this->option('integrate-only');
+
+        foreach ($recordings as $recording) {
+            $label = "[{$recording->id}] {$recording->title}";
+
+            if ($integrateOnly || ! empty($recording->metadata)) {
+                // Metadata already present (or skipped) — go straight to VOD integration
+                IntegrateDvrRecordingToVod::dispatch($recording->id)->onQueue('dvr-post');
+                $this->line("  → Queued VOD integration for {$label}");
+            } else {
+                // Full enrichment pipeline: metadata → VOD integration
+                $setting = $recording->dvrSetting;
+                if ($setting && $setting->enable_metadata_enrichment) {
+                    EnrichDvrMetadata::dispatch($recording->id)->onQueue('dvr-meta');
+                    $this->line("  → Queued metadata enrichment for {$label}");
+                } else {
+                    IntegrateDvrRecordingToVod::dispatch($recording->id)->onQueue('dvr-post');
+                    $this->line("  → Queued VOD integration (enrichment disabled) for {$label}");
+                }
+            }
+        }
+
+        $this->info('Done.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Enums/DvrRecordingStatus.php
+++ b/app/Enums/DvrRecordingStatus.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Enums;
+
+enum DvrRecordingStatus: string
+{
+    case Scheduled = 'scheduled';
+    case Recording = 'recording';
+    case PostProcessing = 'post_processing';
+    case Completed = 'completed';
+    case Failed = 'failed';
+    case Cancelled = 'cancelled';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Scheduled => __('Scheduled'),
+            self::Recording => __('Recording'),
+            self::PostProcessing => __('Post Processing'),
+            self::Completed => __('Completed'),
+            self::Failed => __('Failed'),
+            self::Cancelled => __('Cancelled'),
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Scheduled => 'info',
+            self::Recording => 'warning',
+            self::PostProcessing => 'warning',
+            self::Completed => 'success',
+            self::Failed => 'danger',
+            self::Cancelled => 'gray',
+        };
+    }
+
+    public function getIcon(): string
+    {
+        return match ($this) {
+            self::Scheduled => 'heroicon-o-clock',
+            self::Recording => 'heroicon-o-signal',
+            self::PostProcessing => 'heroicon-o-cog-6-tooth',
+            self::Completed => 'heroicon-o-check-circle',
+            self::Failed => 'heroicon-o-x-circle',
+            self::Cancelled => 'heroicon-o-minus-circle',
+        };
+    }
+}

--- a/app/Enums/DvrRuleType.php
+++ b/app/Enums/DvrRuleType.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Enums;
+
+enum DvrRuleType: string
+{
+    case Once = 'once';
+    case Series = 'series';
+    case Manual = 'manual';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Once => __('Once'),
+            self::Series => __('Series'),
+            self::Manual => __('Manual'),
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Once => 'info',
+            self::Series => 'success',
+            self::Manual => 'warning',
+        };
+    }
+
+    public function getIcon(): string
+    {
+        return match ($this) {
+            self::Once => 'heroicon-o-play',
+            self::Series => 'heroicon-o-queue-list',
+            self::Manual => 'heroicon-o-hand-raised',
+        };
+    }
+}

--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -4,6 +4,7 @@ namespace App\Filament\Pages;
 
 use App\Facades\LogoFacade;
 use App\Models\Channel;
+use App\Models\DvrRecording;
 use App\Models\Episode;
 use App\Models\Network;
 use App\Models\Playlist;
@@ -472,27 +473,48 @@ class M3uProxyStreamMonitor extends Page
             }
         }
 
-        // Append any active network broadcasts (simplified output)
+        // Append any active network and DVR broadcasts (simplified output)
         if (! empty($apiBroadcasts['success']) && ! empty($apiBroadcasts['broadcasts'])) {
-            $broadcastNetworkUuids = collect($apiBroadcasts['broadcasts'])
-                ->pluck('network_id')
-                ->filter()
-                ->unique()
-                ->values();
-            $networksByUuid = Network::whereIn('uuid', $broadcastNetworkUuids)
-                ->get(['uuid', 'name'])
-                ->keyBy('uuid');
+            $broadcastList = collect($apiBroadcasts['broadcasts']);
+
+            // Separate DVR broadcasts from network broadcasts by metadata type
+            $dvrBroadcasts = $broadcastList->filter(fn ($b) => ($b['metadata']['type'] ?? null) === 'dvr');
+            $networkBroadcasts = $broadcastList->filter(fn ($b) => ($b['metadata']['type'] ?? null) !== 'dvr');
+
+            // Pre-fetch Network models for network broadcasts
+            $broadcastNetworkUuids = $networkBroadcasts->pluck('network_id')->filter()->unique()->values();
+            $networksByUuid = $broadcastNetworkUuids->isNotEmpty()
+                ? Network::whereIn('uuid', $broadcastNetworkUuids)->get(['uuid', 'name'])->keyBy('uuid')
+                : collect();
+
+            // Pre-fetch DvrRecording models for DVR broadcasts
+            $dvrRecordingUuids = $dvrBroadcasts->pluck('metadata.recording_id')->filter()->unique()->values();
+            $dvrRecordingsByUuid = $dvrRecordingUuids->isNotEmpty()
+                ? DvrRecording::whereIn('uuid', $dvrRecordingUuids)->get(['uuid', 'title'])->keyBy('uuid')
+                : collect();
 
             foreach ($apiBroadcasts['broadcasts'] as $bcast) {
-                $network = $networksByUuid[$bcast['network_id']] ?? null;
-
+                $isDvr = ($bcast['metadata']['type'] ?? null) === 'dvr';
                 $startedAt = isset($bcast['started_at']) ? Carbon::parse($bcast['started_at'], 'UTC') : null;
                 $uptime = $startedAt ? $startedAt->diffForHumans(null, true) : 'N/A';
 
+                if ($isDvr) {
+                    $recordingUuid = $bcast['metadata']['recording_id'] ?? $bcast['network_id'];
+                    $dvrRecording = $dvrRecordingsByUuid[$recordingUuid] ?? null;
+                    $title = $dvrRecording?->title ?? ($bcast['metadata']['title'] ?? 'DVR Recording');
+                    $model = ['title' => $title, 'logo' => null, 'is_dvr' => true];
+                } else {
+                    $network = $networksByUuid[$bcast['network_id']] ?? null;
+                    $model = [
+                        'title' => $network ? $network->name : ('Network '.$bcast['network_id']),
+                        'logo' => null,
+                    ];
+                }
+
                 $streams[] = [
                     'stream_id' => 'broadcast:'.$bcast['network_id'],
-                    'source_url' => $network ? $network->hls_url : ($bcast['stream_url'] ?? ''),
-                    'current_url' => $network ? $network->hls_url : ($bcast['stream_url'] ?? ''),
+                    'source_url' => $bcast['stream_url'] ?? '',
+                    'current_url' => $bcast['stream_url'] ?? '',
                     'format' => 'HLS',
                     'status' => (($bcast['status'] ?? '') === 'running') ? 'active' : 'idle',
                     'client_count' => 0,
@@ -501,10 +523,7 @@ class M3uProxyStreamMonitor extends Page
                     'uptime' => $uptime,
                     'started_at' => $startedAt ? $startedAt->format('Y-m-d H:i:s') : null,
                     'process_running' => (($bcast['status'] ?? '') === 'running'),
-                    'model' => [
-                        'title' => $network ? $network->name : ('Network '.$bcast['network_id']),
-                        'logo' => null,
-                    ],
+                    'model' => $model,
                     'clients' => [],
                     'has_failover' => false,
                     'error_count' => 0,
@@ -513,6 +532,7 @@ class M3uProxyStreamMonitor extends Page
                     'transcoding_format' => null,
                     'using_failover' => false,
                     'broadcast' => true,
+                    'is_dvr' => $isDvr,
                     'alias_name' => null,
                 ];
             }

--- a/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
+++ b/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Filament\Resources\DvrRecordingRules;
+
+use App\Enums\DvrRuleType;
+use App\Models\Channel;
+use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
+use BackedEnum;
+use Filament\Actions;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Auth;
+
+class DvrRecordingRuleResource extends Resource
+{
+    protected static ?string $model = DvrRecordingRule::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedQueueList;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('DVR');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Recording Rules');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('Recording Rule');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('Recording Rules');
+    }
+
+    public static function getNavigationSort(): ?int
+    {
+        return 2;
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('dvr_setting_id')
+                    ->label(__('DVR Setting (Playlist)'))
+                    ->options(fn () => DvrSetting::with('playlist')
+                        ->where('user_id', Auth::id())
+                        ->get()
+                        ->mapWithKeys(fn (DvrSetting $s) => [$s->id => $s->playlist?->name ?? "DVR #{$s->id}"]))
+                    ->required()
+                    ->searchable(),
+
+                Select::make('type')
+                    ->label(__('Rule Type'))
+                    ->options(DvrRuleType::class)
+                    ->default(DvrRuleType::Once->value)
+                    ->required()
+                    ->live(),
+
+                Select::make('channel_id')
+                    ->label(__('Channel'))
+                    ->options(fn () => Channel::query()
+                        ->orderBy('title')
+                        ->pluck('title', 'id'))
+                    ->searchable()
+                    ->nullable(),
+
+                TextInput::make('series_title')
+                    ->label(__('Series Title'))
+                    ->placeholder(__('e.g. Breaking Bad'))
+                    ->visible(fn (Get $get): bool => $get('type') === DvrRuleType::Series->value)
+                    ->requiredIf('type', DvrRuleType::Series->value),
+
+                DateTimePicker::make('manual_start')
+                    ->label(__('Manual Start'))
+                    ->visible(fn (Get $get): bool => $get('type') === DvrRuleType::Manual->value)
+                    ->requiredIf('type', DvrRuleType::Manual->value),
+
+                DateTimePicker::make('manual_end')
+                    ->label(__('Manual End'))
+                    ->visible(fn (Get $get): bool => $get('type') === DvrRuleType::Manual->value)
+                    ->requiredIf('type', DvrRuleType::Manual->value)
+                    ->after('manual_start'),
+
+                Toggle::make('new_only')
+                    ->label(__('New Episodes Only'))
+                    ->visible(fn (Get $get): bool => $get('type') === DvrRuleType::Series->value)
+                    ->default(false),
+
+                TextInput::make('start_early_seconds')
+                    ->label(__('Start Early (seconds)'))
+                    ->numeric()
+                    ->minValue(0)
+                    ->placeholder(__('Leave blank to use playlist default')),
+
+                TextInput::make('end_late_seconds')
+                    ->label(__('End Late (seconds)'))
+                    ->numeric()
+                    ->minValue(0)
+                    ->placeholder(__('Leave blank to use playlist default')),
+
+                TextInput::make('keep_last')
+                    ->label(__('Keep Last N Recordings'))
+                    ->numeric()
+                    ->minValue(1)
+                    ->placeholder(__('Leave blank to keep all')),
+
+                TextInput::make('priority')
+                    ->label(__('Priority'))
+                    ->numeric()
+                    ->default(50)
+                    ->required(),
+
+                Toggle::make('enabled')
+                    ->label(__('Enabled'))
+                    ->default(true)
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('type')
+                    ->label(__('Type'))
+                    ->badge()
+                    ->sortable(),
+
+                TextColumn::make('series_title')
+                    ->label(__('Title / Pattern'))
+                    ->description(fn (DvrRecordingRule $record): string => match ($record->type) {
+                        DvrRuleType::Once => __('One-time recording'),
+                        DvrRuleType::Manual => $record->manual_start?->format('d M Y H:i') ?? '—',
+                        default => '',
+                    })
+                    ->placeholder('—')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('channel.title')
+                    ->label(__('Channel'))
+                    ->searchable()
+                    ->sortable()
+                    ->placeholder('—'),
+
+                TextColumn::make('dvrSetting.playlist.name')
+                    ->label(__('Playlist'))
+                    ->sortable()
+                    ->toggleable(),
+
+                IconColumn::make('new_only')
+                    ->label(__('New Only'))
+                    ->boolean()
+                    ->toggleable(),
+
+                IconColumn::make('enabled')
+                    ->label(__('Enabled'))
+                    ->boolean()
+                    ->sortable(),
+
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('type')
+                    ->options(DvrRuleType::class),
+            ])
+            ->recordActions([
+                Actions\EditAction::make(),
+                Actions\DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                Actions\CreateAction::make(),
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDvrRecordingRules::route('/'),
+            'create' => Pages\CreateDvrRecordingRule::route('/create'),
+            'edit' => Pages\EditDvrRecordingRule::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
+++ b/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
@@ -9,7 +9,6 @@ use App\Models\DvrSetting;
 use App\Traits\HasUserFiltering;
 use BackedEnum;
 use Filament\Actions;
-use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -19,6 +18,7 @@ use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\ToggleColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
@@ -61,6 +61,12 @@ class DvrRecordingRuleResource extends Resource
     {
         return $schema
             ->components([
+                Toggle::make('enabled')
+                    ->label(__('Enabled'))
+                    ->default(true)
+                    ->columnSpanFull()
+                    ->required(),
+
                 Select::make('dvr_setting_id')
                     ->label(__('DVR Setting (Playlist)'))
                     ->options(fn () => DvrSetting::with('playlist')
@@ -131,22 +137,25 @@ class DvrRecordingRuleResource extends Resource
                     ->numeric()
                     ->default(50)
                     ->required(),
-
-                Toggle::make('enabled')
-                    ->label(__('Enabled'))
-                    ->default(true)
-                    ->required(),
             ]);
     }
 
     public static function table(Table $table): Table
     {
         return $table
+            ->filtersTriggerAction(function ($action) {
+                return $action->button()->label(__('Filters'));
+            })
             ->defaultSort('created_at', 'desc')
             ->columns([
                 TextColumn::make('type')
                     ->label(__('Type'))
                     ->badge()
+                    ->sortable(),
+
+                ToggleColumn::make('enabled')
+                    ->label(__('Enabled'))
+                    ->toggleable()
                     ->sortable(),
 
                 TextColumn::make('series_title')
@@ -176,11 +185,6 @@ class DvrRecordingRuleResource extends Resource
                     ->boolean()
                     ->toggleable(),
 
-                IconColumn::make('enabled')
-                    ->label(__('Enabled'))
-                    ->boolean()
-                    ->sortable(),
-
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()
@@ -191,13 +195,13 @@ class DvrRecordingRuleResource extends Resource
                     ->options(DvrRuleType::class),
             ])
             ->recordActions([
-                ActionGroup::make([
-                    Actions\EditAction::make(),
-                    Actions\DeleteAction::make(),
-                ])->button()->hiddenLabel()->size('sm'),
+                Actions\DeleteAction::make()->button()
+                    ->hiddenLabel()->size('sm'),
+                Actions\EditAction::make()->button()
+                    ->hiddenLabel()->size('sm')
+                    ->slideOver(),
             ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
-                Actions\CreateAction::make(),
                 Actions\BulkActionGroup::make([
                     Actions\DeleteBulkAction::make(),
                 ]),
@@ -213,8 +217,8 @@ class DvrRecordingRuleResource extends Resource
     {
         return [
             'index' => Pages\ListDvrRecordingRules::route('/'),
-            'create' => Pages\CreateDvrRecordingRule::route('/create'),
-            'edit' => Pages\EditDvrRecordingRule::route('/{record}/edit'),
+            // 'create' => Pages\CreateDvrRecordingRule::route('/create'),
+            // 'edit' => Pages\EditDvrRecordingRule::route('/{record}/edit'),
         ];
     }
 }

--- a/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
+++ b/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
@@ -6,6 +6,7 @@ use App\Enums\DvrRuleType;
 use App\Models\Channel;
 use App\Models\DvrRecordingRule;
 use App\Models\DvrSetting;
+use App\Traits\HasUserFiltering;
 use BackedEnum;
 use Filament\Actions;
 use Filament\Actions\ActionGroup;
@@ -25,6 +26,8 @@ use Illuminate\Support\Facades\Auth;
 
 class DvrRecordingRuleResource extends Resource
 {
+    use HasUserFiltering;
+
     protected static ?string $model = DvrRecordingRule::class;
 
     protected static string|BackedEnum|null $navigationIcon = null;
@@ -77,6 +80,7 @@ class DvrRecordingRuleResource extends Resource
                 Select::make('channel_id')
                     ->label(__('Channel'))
                     ->options(fn () => Channel::query()
+                        ->where('user_id', Auth::id())
                         ->orderBy('title')
                         ->pluck('title', 'id'))
                     ->searchable()

--- a/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
+++ b/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
@@ -83,6 +83,19 @@ class DvrRecordingRuleResource extends Resource
                     ->required()
                     ->live(),
 
+                DateTimePicker::make('manual_start')
+                    ->label(__('Manual Start'))
+                    ->native(false)
+                    ->visible(fn (Get $get): bool => self::isRuleType($get('type'), DvrRuleType::Manual))
+                    ->requiredIf('type', DvrRuleType::Manual->value),
+
+                DateTimePicker::make('manual_end')
+                    ->label(__('Manual End'))
+                    ->native(false)
+                    ->visible(fn (Get $get): bool => self::isRuleType($get('type'), DvrRuleType::Manual))
+                    ->requiredIf('type', DvrRuleType::Manual->value)
+                    ->after('manual_start'),
+
                 Select::make('channel_id')
                     ->label(__('Channel'))
                     ->options(fn () => Channel::query()
@@ -95,23 +108,12 @@ class DvrRecordingRuleResource extends Resource
                 TextInput::make('series_title')
                     ->label(__('Series Title'))
                     ->placeholder(__('e.g. Breaking Bad'))
-                    ->visible(fn (Get $get): bool => $get('type') === DvrRuleType::Series->value)
+                    ->visible(fn (Get $get): bool => self::isRuleType($get('type'), DvrRuleType::Series))
                     ->requiredIf('type', DvrRuleType::Series->value),
-
-                DateTimePicker::make('manual_start')
-                    ->label(__('Manual Start'))
-                    ->visible(fn (Get $get): bool => $get('type') === DvrRuleType::Manual->value)
-                    ->requiredIf('type', DvrRuleType::Manual->value),
-
-                DateTimePicker::make('manual_end')
-                    ->label(__('Manual End'))
-                    ->visible(fn (Get $get): bool => $get('type') === DvrRuleType::Manual->value)
-                    ->requiredIf('type', DvrRuleType::Manual->value)
-                    ->after('manual_start'),
 
                 Toggle::make('new_only')
                     ->label(__('New Episodes Only'))
-                    ->visible(fn (Get $get): bool => $get('type') === DvrRuleType::Series->value)
+                    ->visible(fn (Get $get): bool => self::isRuleType($get('type'), DvrRuleType::Series))
                     ->default(false),
 
                 TextInput::make('start_early_seconds')
@@ -206,6 +208,17 @@ class DvrRecordingRuleResource extends Resource
                     Actions\DeleteBulkAction::make(),
                 ]),
             ]);
+    }
+
+    /**
+     * Compare a form field value against a rule type, handling both enum instances and backing strings.
+     *
+     * Filament may return a DvrRuleType enum instance (when editing an existing record)
+     * or the raw string backing value (when creating or after a live() Select change).
+     */
+    private static function isRuleType(mixed $value, DvrRuleType $type): bool
+    {
+        return $value === $type || $value === $type->value;
     }
 
     public static function getRelations(): array

--- a/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
+++ b/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
@@ -8,6 +8,7 @@ use App\Models\DvrRecordingRule;
 use App\Models\DvrSetting;
 use BackedEnum;
 use Filament\Actions;
+use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -15,9 +16,9 @@ use Filament\Forms\Components\Toggle;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
-use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Support\Facades\Auth;
@@ -26,7 +27,7 @@ class DvrRecordingRuleResource extends Resource
 {
     protected static ?string $model = DvrRecordingRule::class;
 
-    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedQueueList;
+    protected static string|BackedEnum|null $navigationIcon = null;
 
     public static function getNavigationGroup(): ?string
     {
@@ -186,9 +187,11 @@ class DvrRecordingRuleResource extends Resource
                     ->options(DvrRuleType::class),
             ])
             ->recordActions([
-                Actions\EditAction::make(),
-                Actions\DeleteAction::make(),
-            ])
+                ActionGroup::make([
+                    Actions\EditAction::make(),
+                    Actions\DeleteAction::make(),
+                ])->button()->hiddenLabel()->size('sm'),
+            ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
                 Actions\CreateAction::make(),
                 Actions\BulkActionGroup::make([

--- a/app/Filament/Resources/DvrRecordingRules/Pages/CreateDvrRecordingRule.php
+++ b/app/Filament/Resources/DvrRecordingRules/Pages/CreateDvrRecordingRule.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DvrRecordingRules\Pages;
+
+use App\Filament\Resources\DvrRecordingRules\DvrRecordingRuleResource;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Support\Facades\Auth;
+
+class CreateDvrRecordingRule extends CreateRecord
+{
+    protected static string $resource = DvrRecordingRuleResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['user_id'] = Auth::id();
+
+        return $data;
+    }
+}

--- a/app/Filament/Resources/DvrRecordingRules/Pages/EditDvrRecordingRule.php
+++ b/app/Filament/Resources/DvrRecordingRules/Pages/EditDvrRecordingRule.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DvrRecordingRules\Pages;
+
+use App\Filament\Resources\DvrRecordingRules\DvrRecordingRuleResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDvrRecordingRule extends EditRecord
+{
+    protected static string $resource = DvrRecordingRuleResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DvrRecordingRules/Pages/ListDvrRecordingRules.php
+++ b/app/Filament/Resources/DvrRecordingRules/Pages/ListDvrRecordingRules.php
@@ -13,7 +13,8 @@ class ListDvrRecordingRules extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->slideOver(),
         ];
     }
 }

--- a/app/Filament/Resources/DvrRecordingRules/Pages/ListDvrRecordingRules.php
+++ b/app/Filament/Resources/DvrRecordingRules/Pages/ListDvrRecordingRules.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DvrRecordingRules\Pages;
+
+use App\Filament\Resources\DvrRecordingRules\DvrRecordingRuleResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDvrRecordingRules extends ListRecords
+{
+    protected static string $resource = DvrRecordingRuleResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
+++ b/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
@@ -106,6 +106,9 @@ class DvrRecordingResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->filtersTriggerAction(function ($action) {
+                return $action->button()->label(__('Filters'));
+            })
             ->defaultSort('scheduled_start', 'desc')
             ->columns([
                 TextColumn::make('title')

--- a/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
+++ b/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
@@ -6,6 +6,7 @@ use App\Enums\DvrRecordingStatus;
 use App\Jobs\PostProcessDvrRecording;
 use App\Jobs\StopDvrRecording;
 use App\Models\DvrRecording;
+use App\Traits\HasUserFiltering;
 use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -25,6 +26,8 @@ use Filament\Tables\Table;
 
 class DvrRecordingResource extends Resource
 {
+    use HasUserFiltering;
+
     protected static ?string $model = DvrRecording::class;
 
     protected static string|BackedEnum|null $navigationIcon = null;

--- a/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
+++ b/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
@@ -8,7 +8,9 @@ use App\Jobs\StopDvrRecording;
 use App\Models\DvrRecording;
 use BackedEnum;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\ViewAction;
 use Filament\Infolists\Components\TextEntry;
@@ -16,8 +18,8 @@ use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
-use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 
@@ -25,7 +27,7 @@ class DvrRecordingResource extends Resource
 {
     protected static ?string $model = DvrRecording::class;
 
-    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedVideoCamera;
+    protected static string|BackedEnum|null $navigationIcon = null;
 
     public static function getNavigationGroup(): ?string
     {
@@ -66,6 +68,9 @@ class DvrRecordingResource extends Resource
                     TextEntry::make('title')->columnSpanFull(),
                     TextEntry::make('subtitle'),
                     TextEntry::make('status')->badge(),
+                    TextEntry::make('post_processing_step')
+                        ->label(__('Current Step'))
+                        ->hidden(fn ($record) => ! $record->post_processing_step),
                     TextEntry::make('channel.title')->label(__('Channel')),
                     TextEntry::make('dvrSetting.playlist.name')->label(__('Playlist')),
                     TextEntry::make('scheduled_start')->dateTime(),
@@ -106,7 +111,8 @@ class DvrRecordingResource extends Resource
                     ->description(fn (DvrRecording $record): string => $record->subtitle ?? ''),
                 TextColumn::make('status')
                     ->badge()
-                    ->sortable(),
+                    ->sortable()
+                    ->description(fn (DvrRecording $record): ?string => $record->post_processing_step),
                 TextColumn::make('channel.title')
                     ->label(__('Channel'))
                     ->searchable()
@@ -146,40 +152,44 @@ class DvrRecordingResource extends Resource
                     ->options(DvrRecordingStatus::class),
             ])
             ->recordActions([
-                ViewAction::make(),
-                Action::make('retry')
-                    ->label(__('Retry Post-Processing'))
-                    ->icon('heroicon-o-arrow-path')
-                    ->color('warning')
-                    ->visible(fn (DvrRecording $record): bool => $record->status === DvrRecordingStatus::Failed)
-                    ->requiresConfirmation()
-                    ->action(function (DvrRecording $record): void {
-                        $record->update(['status' => DvrRecordingStatus::PostProcessing, 'error_message' => null]);
-                        PostProcessDvrRecording::dispatch($record);
+                ActionGroup::make([
+                    ViewAction::make(),
+                    Action::make('retry')
+                        ->label(__('Retry Post-Processing'))
+                        ->icon('heroicon-o-arrow-path')
+                        ->color('warning')
+                        ->visible(fn (DvrRecording $record): bool => $record->status === DvrRecordingStatus::Failed)
+                        ->requiresConfirmation()
+                        ->action(function (DvrRecording $record): void {
+                            $record->update(['status' => DvrRecordingStatus::PostProcessing, 'error_message' => null]);
+                            PostProcessDvrRecording::dispatch($record);
 
-                        Notification::make()
-                            ->success()
-                            ->title(__('Post-processing queued'))
-                            ->send();
-                    }),
-                Action::make('cancel')
-                    ->label(__('Cancel'))
-                    ->icon('heroicon-o-x-circle')
-                    ->color('danger')
-                    ->visible(fn (DvrRecording $record): bool => in_array(
-                        $record->status,
-                        [DvrRecordingStatus::Scheduled, DvrRecordingStatus::Recording]
-                    ))
-                    ->requiresConfirmation()
-                    ->action(function (DvrRecording $record): void {
-                        StopDvrRecording::dispatch($record->id);
+                            Notification::make()
+                                ->success()
+                                ->title(__('Post-processing queued'))
+                                ->send();
+                        }),
+                    Action::make('cancel')
+                        ->label(__('Cancel'))
+                        ->icon('heroicon-o-x-circle')
+                        ->color('danger')
+                        ->visible(fn (DvrRecording $record): bool => in_array(
+                            $record->status,
+                            [DvrRecordingStatus::Scheduled, DvrRecordingStatus::Recording]
+                        ))
+                        ->requiresConfirmation()
+                        ->action(function (DvrRecording $record): void {
+                            StopDvrRecording::dispatch($record->id);
 
-                        Notification::make()
-                            ->success()
-                            ->title(__('Recording cancellation queued'))
-                            ->send();
-                    }),
-            ])
+                            Notification::make()
+                                ->success()
+                                ->title(__('Recording cancellation queued'))
+                                ->send();
+                        }),
+                    DeleteAction::make()
+                        ->modalDescription(__('Are you sure you want to delete this recording? The file on disk and any linked VOD entry will also be removed.')),
+                ])->button()->hiddenLabel()->size('sm'),
+            ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),

--- a/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
+++ b/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Filament\Resources\DvrRecordings;
+
+use App\Enums\DvrRecordingStatus;
+use App\Jobs\PostProcessDvrRecording;
+use App\Jobs\StopDvrRecording;
+use App\Models\DvrRecording;
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\ViewAction;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class DvrRecordingResource extends Resource
+{
+    protected static ?string $model = DvrRecording::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedVideoCamera;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('DVR');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Recordings');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('DVR Recording');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('DVR Recordings');
+    }
+
+    public static function getNavigationSort(): ?int
+    {
+        return 1;
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return $schema->components([
+            Section::make(__('Recording Details'))
+                ->columns(2)
+                ->schema([
+                    TextEntry::make('title')->columnSpanFull(),
+                    TextEntry::make('subtitle'),
+                    TextEntry::make('status')->badge(),
+                    TextEntry::make('channel.title')->label(__('Channel')),
+                    TextEntry::make('dvrSetting.playlist.name')->label(__('Playlist')),
+                    TextEntry::make('scheduled_start')->dateTime(),
+                    TextEntry::make('scheduled_end')->dateTime(),
+                    TextEntry::make('actual_start')->dateTime(),
+                    TextEntry::make('actual_end')->dateTime(),
+                    TextEntry::make('duration_seconds')
+                        ->label(__('Duration'))
+                        ->formatStateUsing(fn (?int $state): string => $state
+                            ? gmdate('H:i:s', $state)
+                            : '—'),
+                    TextEntry::make('file_size_bytes')
+                        ->label(__('File Size'))
+                        ->formatStateUsing(fn (?int $state): string => $state
+                            ? number_format($state / 1024 / 1024, 1).' MB'
+                            : '—'),
+                    TextEntry::make('file_path')->columnSpanFull(),
+                    TextEntry::make('error_message')
+                        ->label(__('Error'))
+                        ->columnSpanFull()
+                        ->hidden(fn ($record) => ! $record->error_message),
+                    TextEntry::make('description')
+                        ->label(__('Description'))
+                        ->columnSpanFull()
+                        ->hidden(fn ($record) => ! $record->description),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->defaultSort('scheduled_start', 'desc')
+            ->columns([
+                TextColumn::make('title')
+                    ->searchable()
+                    ->sortable()
+                    ->description(fn (DvrRecording $record): string => $record->subtitle ?? ''),
+                TextColumn::make('status')
+                    ->badge()
+                    ->sortable(),
+                TextColumn::make('channel.title')
+                    ->label(__('Channel'))
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('dvrSetting.playlist.name')
+                    ->label(__('Playlist'))
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('scheduled_start')
+                    ->dateTime()
+                    ->sortable(),
+                TextColumn::make('scheduled_end')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('duration_seconds')
+                    ->label(__('Duration'))
+                    ->formatStateUsing(fn (?int $state): string => $state
+                        ? gmdate('H:i:s', $state)
+                        : '—')
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('file_size_bytes')
+                    ->label(__('Size'))
+                    ->formatStateUsing(fn (?int $state): string => $state
+                        ? number_format($state / 1024 / 1024, 1).' MB'
+                        : '—')
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(DvrRecordingStatus::class),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+                Action::make('retry')
+                    ->label(__('Retry Post-Processing'))
+                    ->icon('heroicon-o-arrow-path')
+                    ->color('warning')
+                    ->visible(fn (DvrRecording $record): bool => $record->status === DvrRecordingStatus::Failed)
+                    ->requiresConfirmation()
+                    ->action(function (DvrRecording $record): void {
+                        $record->update(['status' => DvrRecordingStatus::PostProcessing, 'error_message' => null]);
+                        PostProcessDvrRecording::dispatch($record);
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Post-processing queued'))
+                            ->send();
+                    }),
+                Action::make('cancel')
+                    ->label(__('Cancel'))
+                    ->icon('heroicon-o-x-circle')
+                    ->color('danger')
+                    ->visible(fn (DvrRecording $record): bool => in_array(
+                        $record->status,
+                        [DvrRecordingStatus::Scheduled, DvrRecordingStatus::Recording]
+                    ))
+                    ->requiresConfirmation()
+                    ->action(function (DvrRecording $record): void {
+                        StopDvrRecording::dispatch($record->id);
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Recording cancellation queued'))
+                            ->send();
+                    }),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDvrRecordings::route('/'),
+            'view' => Pages\ViewDvrRecording::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
+++ b/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
@@ -160,6 +160,29 @@ class DvrRecordingResource extends Resource
             ->recordActions([
                 ActionGroup::make([
                     ViewAction::make(),
+                    Action::make('watch')
+                        ->label(__('Watch'))
+                        ->icon('heroicon-o-play-circle')
+                        ->color('success')
+                        ->visible(fn (DvrRecording $record): bool => in_array($record->status, [
+                            DvrRecordingStatus::Recording,
+                            DvrRecordingStatus::Completed,
+                        ]) && $record->dvrSetting?->playlist)
+                        ->url(function (DvrRecording $record): string {
+                            $playlist = $record->dvrSetting->playlist;
+                            $username = $record->user->name;
+                            $ext = $record->status === DvrRecordingStatus::Completed
+                                ? ($record->dvrSetting->dvr_output_format ?? 'mp4')
+                                : 'm3u8';
+
+                            return route('dvr.recording.stream', [
+                                'username' => $username,
+                                'password' => $playlist->uuid,
+                                'uuid' => $record->uuid,
+                                'format' => $ext,
+                            ]);
+                        })
+                        ->openUrlInNewTab(),
                     Action::make('retry')
                         ->label(__('Retry Post-Processing'))
                         ->icon('heroicon-o-arrow-path')

--- a/app/Filament/Resources/DvrRecordings/Pages/ListDvrRecordings.php
+++ b/app/Filament/Resources/DvrRecordings/Pages/ListDvrRecordings.php
@@ -3,17 +3,9 @@
 namespace App\Filament\Resources\DvrRecordings\Pages;
 
 use App\Filament\Resources\DvrRecordings\DvrRecordingResource;
-use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 
 class ListDvrRecordings extends ListRecords
 {
     protected static string $resource = DvrRecordingResource::class;
-
-    protected function getHeaderActions(): array
-    {
-        return [
-            Actions\CreateAction::make(),
-        ];
-    }
 }

--- a/app/Filament/Resources/DvrRecordings/Pages/ListDvrRecordings.php
+++ b/app/Filament/Resources/DvrRecordings/Pages/ListDvrRecordings.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DvrRecordings\Pages;
+
+use App\Filament\Resources\DvrRecordings\DvrRecordingResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDvrRecordings extends ListRecords
+{
+    protected static string $resource = DvrRecordingResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DvrRecordings/Pages/ViewDvrRecording.php
+++ b/app/Filament/Resources/DvrRecordings/Pages/ViewDvrRecording.php
@@ -2,10 +2,64 @@
 
 namespace App\Filament\Resources\DvrRecordings\Pages;
 
+use App\Enums\DvrRecordingStatus;
 use App\Filament\Resources\DvrRecordings\DvrRecordingResource;
+use App\Jobs\PostProcessDvrRecording;
+use App\Jobs\StopDvrRecording;
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewDvrRecording extends ViewRecord
 {
     protected static string $resource = DvrRecordingResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('back')
+                ->label(__('Back to Recordings'))
+                ->url(DvrRecordingResource::getUrl('index'))
+                ->icon('heroicon-s-arrow-left')
+                ->color('gray'),
+            Action::make('retry')
+                ->label(__('Retry Post-Processing'))
+                ->icon('heroicon-o-arrow-path')
+                ->color('warning')
+                ->visible(fn (): bool => $this->record->status === DvrRecordingStatus::Failed)
+                ->requiresConfirmation()
+                ->action(function (): void {
+                    $this->record->update(['status' => DvrRecordingStatus::PostProcessing, 'error_message' => null]);
+                    PostProcessDvrRecording::dispatch($this->record);
+
+                    Notification::make()
+                        ->success()
+                        ->title(__('Post-processing queued'))
+                        ->send();
+
+                    $this->refreshFormData(['status', 'error_message', 'post_processing_step']);
+                }),
+            Action::make('cancel')
+                ->label(__('Cancel Recording'))
+                ->icon('heroicon-o-x-circle')
+                ->color('danger')
+                ->visible(fn (): bool => in_array(
+                    $this->record->status,
+                    [DvrRecordingStatus::Scheduled, DvrRecordingStatus::Recording]
+                ))
+                ->requiresConfirmation()
+                ->action(function (): void {
+                    StopDvrRecording::dispatch($this->record->id);
+
+                    Notification::make()
+                        ->success()
+                        ->title(__('Recording cancellation queued'))
+                        ->send();
+                }),
+            DeleteAction::make()
+                ->modalDescription(__('Are you sure you want to delete this recording? The file on disk and any linked VOD entry will also be removed.'))
+                ->successRedirectUrl(DvrRecordingResource::getUrl('index')),
+        ];
+    }
 }

--- a/app/Filament/Resources/DvrRecordings/Pages/ViewDvrRecording.php
+++ b/app/Filament/Resources/DvrRecordings/Pages/ViewDvrRecording.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\DvrRecordings\Pages;
+
+use App\Filament\Resources\DvrRecordings\DvrRecordingResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewDvrRecording extends ViewRecord
+{
+    protected static string $resource = DvrRecordingResource::class;
+}

--- a/app/Filament/Resources/Playlists/Pages/EditPlaylist.php
+++ b/app/Filament/Resources/Playlists/Pages/EditPlaylist.php
@@ -84,8 +84,7 @@ class EditPlaylist extends EditRecord
 
         if ($dvr) {
             $data['dvr_enabled'] = $dvr->enabled;
-            $data['dvr_use_proxy'] = $dvr->use_proxy;
-            $data['dvr_ffmpeg_path'] = $dvr->ffmpeg_path;
+            $data['dvr_output_format'] = $dvr->dvr_output_format ?? 'ts';
             $data['dvr_storage_path'] = $dvr->storage_path;
             $data['dvr_max_concurrent_recordings'] = $dvr->max_concurrent_recordings;
             $data['dvr_default_start_early_seconds'] = $dvr->default_start_early_seconds;
@@ -93,10 +92,9 @@ class EditPlaylist extends EditRecord
             $data['dvr_retention_days'] = $dvr->retention_days;
             $data['dvr_global_disk_quota_gb'] = $dvr->global_disk_quota_gb;
             $data['dvr_enable_metadata_enrichment'] = $dvr->enable_metadata_enrichment;
-            $data['dvr_tmdb_api_key'] = $dvr->tmdb_api_key;
         } else {
             $data['dvr_enabled'] = false;
-            $data['dvr_use_proxy'] = false;
+            $data['dvr_output_format'] = 'ts';
             $data['dvr_enable_metadata_enrichment'] = true;
         }
 
@@ -138,8 +136,8 @@ class EditPlaylist extends EditRecord
             [
                 'user_id' => $record->user_id,
                 'enabled' => $data['dvr_enabled'] ?? false,
-                'use_proxy' => $data['dvr_use_proxy'] ?? false,
-                'ffmpeg_path' => $data['dvr_ffmpeg_path'] ?? null,
+                'use_proxy' => true,
+                'dvr_output_format' => $data['dvr_output_format'] ?? 'ts',
                 'storage_path' => $data['dvr_storage_path'] ?? null,
                 'max_concurrent_recordings' => $data['dvr_max_concurrent_recordings'] ?? 2,
                 'default_start_early_seconds' => $data['dvr_default_start_early_seconds'] ?? 30,
@@ -147,7 +145,6 @@ class EditPlaylist extends EditRecord
                 'retention_days' => $data['dvr_retention_days'] ?? 0,
                 'global_disk_quota_gb' => $data['dvr_global_disk_quota_gb'] ?? 0,
                 'enable_metadata_enrichment' => $data['dvr_enable_metadata_enrichment'] ?? true,
-                'tmdb_api_key' => $data['dvr_tmdb_api_key'] ?? null,
             ]
         );
     }

--- a/app/Filament/Resources/Playlists/Pages/EditPlaylist.php
+++ b/app/Filament/Resources/Playlists/Pages/EditPlaylist.php
@@ -84,6 +84,7 @@ class EditPlaylist extends EditRecord
 
         if ($dvr) {
             $data['dvr_enabled'] = $dvr->enabled;
+            $data['dvr_use_proxy'] = $dvr->use_proxy;
             $data['dvr_ffmpeg_path'] = $dvr->ffmpeg_path;
             $data['dvr_storage_path'] = $dvr->storage_path;
             $data['dvr_max_concurrent_recordings'] = $dvr->max_concurrent_recordings;
@@ -95,6 +96,7 @@ class EditPlaylist extends EditRecord
             $data['dvr_tmdb_api_key'] = $dvr->tmdb_api_key;
         } else {
             $data['dvr_enabled'] = false;
+            $data['dvr_use_proxy'] = false;
             $data['dvr_enable_metadata_enrichment'] = true;
         }
 
@@ -136,6 +138,7 @@ class EditPlaylist extends EditRecord
             [
                 'user_id' => $record->user_id,
                 'enabled' => $data['dvr_enabled'] ?? false,
+                'use_proxy' => $data['dvr_use_proxy'] ?? false,
                 'ffmpeg_path' => $data['dvr_ffmpeg_path'] ?? null,
                 'storage_path' => $data['dvr_storage_path'] ?? null,
                 'max_concurrent_recordings' => $data['dvr_max_concurrent_recordings'] ?? 2,

--- a/app/Filament/Resources/Playlists/Pages/EditPlaylist.php
+++ b/app/Filament/Resources/Playlists/Pages/EditPlaylist.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\MediaServerIntegrations\MediaServerIntegrationResourc
 use App\Filament\Resources\Networks\NetworkResource;
 use App\Filament\Resources\Playlists\PlaylistResource;
 use App\Filament\Resources\Playlists\Widgets\ImportProgress;
+use App\Models\DvrSetting;
 use App\Models\Playlist;
 use Filament\Actions\ViewAction;
 use Filament\Resources\Pages\EditRecord;
@@ -67,5 +68,84 @@ class EditPlaylist extends EditRecord
     protected function getSteps(): array
     {
         return PlaylistResource::getFormSteps();
+    }
+
+    /**
+     * Populate dvr_ prefixed fields from the dvrSetting HasOne relationship.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        /** @var Playlist $record */
+        $record = $this->getRecord();
+        $dvr = $record->dvrSetting;
+
+        if ($dvr) {
+            $data['dvr_enabled'] = $dvr->enabled;
+            $data['dvr_ffmpeg_path'] = $dvr->ffmpeg_path;
+            $data['dvr_storage_path'] = $dvr->storage_path;
+            $data['dvr_max_concurrent_recordings'] = $dvr->max_concurrent_recordings;
+            $data['dvr_default_start_early_seconds'] = $dvr->default_start_early_seconds;
+            $data['dvr_default_end_late_seconds'] = $dvr->default_end_late_seconds;
+            $data['dvr_retention_days'] = $dvr->retention_days;
+            $data['dvr_global_disk_quota_gb'] = $dvr->global_disk_quota_gb;
+            $data['dvr_enable_metadata_enrichment'] = $dvr->enable_metadata_enrichment;
+            $data['dvr_tmdb_api_key'] = $dvr->tmdb_api_key;
+        } else {
+            $data['dvr_enabled'] = false;
+            $data['dvr_enable_metadata_enrichment'] = true;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Strip dvr_ prefixed fields so Filament doesn't try to save them to the playlists table.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        foreach (array_keys($data) as $key) {
+            if (str_starts_with($key, 'dvr_')) {
+                unset($data[$key]);
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Save dvr_ prefixed fields back to the dvrSetting HasOne relationship.
+     */
+    protected function afterSave(): void
+    {
+        /** @var Playlist $record */
+        $record = $this->getRecord();
+        $data = $this->form->getRawState();
+
+        if (! isset($data['dvr_enabled'])) {
+            return;
+        }
+
+        DvrSetting::updateOrCreate(
+            ['playlist_id' => $record->id],
+            [
+                'user_id' => $record->user_id,
+                'enabled' => $data['dvr_enabled'] ?? false,
+                'ffmpeg_path' => $data['dvr_ffmpeg_path'] ?? null,
+                'storage_path' => $data['dvr_storage_path'] ?? null,
+                'max_concurrent_recordings' => $data['dvr_max_concurrent_recordings'] ?? 2,
+                'default_start_early_seconds' => $data['dvr_default_start_early_seconds'] ?? 30,
+                'default_end_late_seconds' => $data['dvr_default_end_late_seconds'] ?? 60,
+                'retention_days' => $data['dvr_retention_days'] ?? 0,
+                'global_disk_quota_gb' => $data['dvr_global_disk_quota_gb'] ?? 0,
+                'enable_metadata_enrichment' => $data['dvr_enable_metadata_enrichment'] ?? true,
+                'tmdb_api_key' => $data['dvr_tmdb_api_key'] ?? null,
+            ]
+        );
     }
 }

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -44,6 +44,7 @@ use App\Services\DateFormatService;
 use App\Services\EpgCacheService;
 use App\Services\M3uProxyService;
 use App\Services\ProfileService;
+use App\Settings\GeneralSettings;
 use App\Tables\Columns\ProgressColumn;
 use App\Traits\HasUserFiltering;
 use Carbon\Carbon;
@@ -2810,22 +2811,22 @@ class PlaylistResource extends Resource implements CopilotResource
                             ->default(false)
                             ->inline(false)
                             ->live(),
-                        Toggle::make('dvr_use_proxy')
-                            ->label(__('Use Proxy for Recordings'))
-                            ->helperText(__('Route recording streams through the m3u-proxy. This allows other clients to watch the same channel while it is being recorded.'))
-                            ->default(false)
-                            ->inline(false)
+                        Select::make('dvr_output_format')
+                            ->label(__('Output Format'))
+                            ->helperText(__('Container format for the final recording file. All options use stream copy (no re-encoding) — only the container changes.'))
+                            ->options([
+                                'ts' => 'MPEG-TS (.ts) — fastest, direct segment join, no remuxing',
+                                'mp4' => 'MP4 (.mp4) — best compatibility with media players',
+                                'mkv' => 'MKV (.mkv) — flexible container, good player support',
+                            ])
+                            ->default('ts')
+                            ->required()
                             ->hidden(fn (Get $get): bool => ! $get('dvr_enabled')),
                         Grid::make()
                             ->columns(2)
                             ->columnSpanFull()
                             ->hidden(fn (Get $get): bool => ! $get('dvr_enabled'))
                             ->schema([
-                                TextInput::make('dvr_ffmpeg_path')
-                                    ->label(__('FFmpeg Path'))
-                                    ->helperText(__('Override the default FFmpeg binary path. Leave blank to use the system default.'))
-                                    ->placeholder('/usr/bin/ffmpeg')
-                                    ->maxLength(255),
                                 TextInput::make('dvr_storage_path')
                                     ->label(__('Storage Path'))
                                     ->helperText(__('Subdirectory within the DVR storage disk for this playlist\'s recordings.'))
@@ -2876,12 +2877,25 @@ class PlaylistResource extends Resource implements CopilotResource
                                     ->default(true)
                                     ->inline(false)
                                     ->live(),
-                                TextInput::make('dvr_tmdb_api_key')
-                                    ->label(__('TMDB API Key'))
-                                    ->helperText(__('Your TMDB API key for metadata enrichment. Required for TMDB lookups. Leave blank to fall back to TVMaze only.'))
-                                    ->password()
-                                    ->revealable()
-                                    ->maxLength(255)
+                                Placeholder::make('dvr_tmdb_status')
+                                    ->label(__('TMDB'))
+                                    ->content(function (): HtmlString {
+                                        $hasKey = ! empty(app(GeneralSettings::class)->tmdb_api_key);
+
+                                        if ($hasKey) {
+                                            return new HtmlString(
+                                                '<span class="text-sm text-success-600 dark:text-success-400 font-medium">✓ TMDB API key configured in Settings</span>'
+                                            );
+                                        }
+
+                                        $url = route('filament.admin.pages.preferences').'#tmdb';
+
+                                        return new HtmlString(
+                                            '<span class="text-sm text-warning-600 dark:text-warning-400">No TMDB API key found. '
+                                            .'<a href="'.e($url).'" class="underline font-medium">Configure it in Settings → TMDB</a> '
+                                            .'to enable TMDB metadata lookups. TVMaze will be used as a fallback.</span>'
+                                        );
+                                    })
                                     ->hidden(fn (Get $get): bool => ! $get('dvr_enable_metadata_enrichment')),
                             ]),
                     ]),

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2810,6 +2810,12 @@ class PlaylistResource extends Resource implements CopilotResource
                             ->default(false)
                             ->inline(false)
                             ->live(),
+                        Toggle::make('dvr_use_proxy')
+                            ->label(__('Use Proxy for Recordings'))
+                            ->helperText(__('Route recording streams through the m3u-proxy. This allows other clients to watch the same channel while it is being recorded.'))
+                            ->default(false)
+                            ->inline(false)
+                            ->hidden(fn (Get $get): bool => ! $get('dvr_enabled')),
                         Grid::make()
                             ->columns(2)
                             ->columnSpanFull()

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2795,6 +2795,93 @@ class PlaylistResource extends Resource implements CopilotResource
                 ->schema($fields);
         }
 
+        // DVR tab — settings for the dvrSetting HasOne relationship.
+        // Fields are prefixed with dvr_ and hydrated/dehydrated via EditPlaylist hooks.
+        $tabs[] = Tab::make(__('DVR'))
+            ->icon('heroicon-m-video-camera')
+            ->schema([
+                Section::make(__('DVR Settings'))
+                    ->icon('heroicon-m-video-camera')
+                    ->description(__('Configure digital video recording for this playlist. Enable DVR to schedule recordings from the EPG guide.'))
+                    ->schema([
+                        Toggle::make('dvr_enabled')
+                            ->label(__('Enable DVR'))
+                            ->helperText(__('When enabled, the EPG guide will show record buttons and the scheduler will process recording rules.'))
+                            ->default(false)
+                            ->inline(false)
+                            ->live(),
+                        Grid::make()
+                            ->columns(2)
+                            ->columnSpanFull()
+                            ->hidden(fn (Get $get): bool => ! $get('dvr_enabled'))
+                            ->schema([
+                                TextInput::make('dvr_ffmpeg_path')
+                                    ->label(__('FFmpeg Path'))
+                                    ->helperText(__('Override the default FFmpeg binary path. Leave blank to use the system default.'))
+                                    ->placeholder('/usr/bin/ffmpeg')
+                                    ->maxLength(255),
+                                TextInput::make('dvr_storage_path')
+                                    ->label(__('Storage Path'))
+                                    ->helperText(__('Subdirectory within the DVR storage disk for this playlist\'s recordings.'))
+                                    ->placeholder('recordings')
+                                    ->maxLength(255),
+                                TextInput::make('dvr_max_concurrent_recordings')
+                                    ->label(__('Max Concurrent Recordings'))
+                                    ->helperText(__('Maximum number of recordings that can run simultaneously for this playlist.'))
+                                    ->numeric()
+                                    ->minValue(1)
+                                    ->maxValue(20)
+                                    ->default(2),
+                                TextInput::make('dvr_default_start_early_seconds')
+                                    ->label(__('Start Early (seconds)'))
+                                    ->helperText(__('Start recordings this many seconds before the scheduled start time.'))
+                                    ->numeric()
+                                    ->minValue(0)
+                                    ->maxValue(600)
+                                    ->default(30),
+                                TextInput::make('dvr_default_end_late_seconds')
+                                    ->label(__('End Late (seconds)'))
+                                    ->helperText(__('Continue recording this many seconds after the scheduled end time.'))
+                                    ->numeric()
+                                    ->minValue(0)
+                                    ->maxValue(600)
+                                    ->default(60),
+                                TextInput::make('dvr_retention_days')
+                                    ->label(__('Retention (days)'))
+                                    ->helperText(__('Automatically delete recordings older than this many days. Set to 0 to disable automatic deletion.'))
+                                    ->numeric()
+                                    ->minValue(0)
+                                    ->default(0),
+                                TextInput::make('dvr_global_disk_quota_gb')
+                                    ->label(__('Disk Quota (GB)'))
+                                    ->helperText(__('Maximum total disk usage for DVR recordings. Oldest recordings are deleted first when quota is exceeded. Set to 0 for no limit.'))
+                                    ->numeric()
+                                    ->minValue(0)
+                                    ->default(0),
+                            ]),
+                        Grid::make()
+                            ->columns(2)
+                            ->columnSpanFull()
+                            ->hidden(fn (Get $get): bool => ! $get('dvr_enabled'))
+                            ->schema([
+                                Toggle::make('dvr_enable_metadata_enrichment')
+                                    ->label(__('Enable Metadata Enrichment'))
+                                    ->helperText(__('Automatically fetch metadata (artwork, descriptions, episode info) from TMDB and TVMaze after recording.'))
+                                    ->default(true)
+                                    ->inline(false)
+                                    ->live(),
+                                TextInput::make('dvr_tmdb_api_key')
+                                    ->label(__('TMDB API Key'))
+                                    ->helperText(__('Your TMDB API key for metadata enrichment. Required for TMDB lookups. Leave blank to fall back to TVMaze only.'))
+                                    ->password()
+                                    ->revealable()
+                                    ->maxLength(255)
+                                    ->hidden(fn (Get $get): bool => ! $get('dvr_enable_metadata_enrichment')),
+                            ]),
+                    ]),
+            ])
+            ->hiddenOn('create');
+
         // Compose the form with tabs and sections
         return [
             Grid::make()

--- a/app/Filament/Resources/Vods/Pages/ListVod.php
+++ b/app/Filament/Resources/Vods/Pages/ListVod.php
@@ -453,6 +453,12 @@ class ListVod extends ListRecords
                 return $query->where('group_id', $relationId);
             })->count();
         $customCount = Channel::query()->where([...$where, ['is_custom', true]])
+            ->whereNull('dvr_recording_id')
+            ->when($relationId, function ($query, $relationId) {
+                return $query->where('group_id', $relationId);
+            })->count();
+        $dvrCount = Channel::query()->where($where)
+            ->whereNotNull('dvr_recording_id')
             ->when($relationId, function ($query, $relationId) {
                 return $query->where('group_id', $relationId);
             })->count();
@@ -478,8 +484,11 @@ class ListVod extends ListRecords
                 ->modifyQueryUsing(fn ($query) => $query->whereHas('failovers'))
                 ->badge($withFailoverCount),
             'custom' => Tab::make(__('Custom'))
-                ->modifyQueryUsing(fn ($query) => $query->where('is_custom', true))
+                ->modifyQueryUsing(fn ($query) => $query->where('is_custom', true)->whereNull('dvr_recording_id'))
                 ->badge($customCount),
+            'dvr' => Tab::make(__('DVR'))
+                ->modifyQueryUsing(fn ($query) => $query->whereNotNull('dvr_recording_id'))
+                ->badge($dvrCount),
         ];
     }
 
@@ -502,7 +511,8 @@ class ListVod extends ListRecords
             'enabled' => $query->where('enabled', true),
             'disabled' => $query->where('enabled', false),
             'failover' => $query->whereHas('failovers'),
-            'custom' => $query->where('is_custom', true),
+            'custom' => $query->where('is_custom', true)->whereNull('dvr_recording_id'),
+            'dvr' => $query->whereNotNull('dvr_recording_id'),
             default => $query,
         };
     }
@@ -525,7 +535,7 @@ class ListVod extends ListRecords
         }
 
         $counts = (clone $baseQuery)
-            ->selectRaw('count(*) as all_count, sum(case when enabled then 1 else 0 end) as enabled_count, sum(case when not enabled then 1 else 0 end) as disabled_count, sum(case when is_custom then 1 else 0 end) as custom_count')
+            ->selectRaw('count(*) as all_count, sum(case when enabled then 1 else 0 end) as enabled_count, sum(case when not enabled then 1 else 0 end) as disabled_count, sum(case when is_custom and dvr_recording_id is null then 1 else 0 end) as custom_count, sum(case when dvr_recording_id is not null then 1 else 0 end) as dvr_count')
             ->first();
 
         return [
@@ -534,6 +544,7 @@ class ListVod extends ListRecords
             'disabled' => (int) ($counts->disabled_count ?? 0),
             'failover' => (clone $baseQuery)->whereHas('failovers')->count(),
             'custom' => (int) ($counts->custom_count ?? 0),
+            'dvr' => (int) ($counts->dvr_count ?? 0),
         ];
     }
 

--- a/app/Http/Controllers/Api/EpgApiController.php
+++ b/app/Http/Controllers/Api/EpgApiController.php
@@ -400,7 +400,6 @@ class EpgApiController extends Controller
                 ->when(! $vod, function ($query) {
                     return $query->where('channels.is_vod', false);
                 })
-                ->where('enabled', true)
                 ->count();
 
             $channels = $playlistChannelData;

--- a/app/Http/Controllers/Api/EpgApiController.php
+++ b/app/Http/Controllers/Api/EpgApiController.php
@@ -180,6 +180,7 @@ class EpgApiController extends Controller
         $skip = max(0, ($page - 1) * $perPage);
         $search = $request->get('search', null);
         $group = $request->get('group', null) ?: null;
+        $vod = (bool) $request->get('vod', false);
         $username = $request->get('username', null);
         $password = $request->get('password', null);
 
@@ -396,6 +397,10 @@ class EpgApiController extends Controller
 
                     return $queryBuilder->whereRaw("LOWER({$coalesce}) = ?", [Str::lower($group)]);
                 })
+                ->when(! $vod, function ($query) {
+                    return $query->where('channels.is_vod', false);
+                })
+                ->where('enabled', true)
                 ->count();
 
             $channels = $playlistChannelData;

--- a/app/Http/Controllers/DvrCallbackController.php
+++ b/app/Http/Controllers/DvrCallbackController.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\DvrRecordingStatus;
+use App\Jobs\PostProcessDvrRecording;
+use App\Models\DvrRecording;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * DvrCallbackController — Receives webhook callbacks from the m3u-proxy BroadcastManager.
+ *
+ * The proxy calls this endpoint when a DVR broadcast ends (normally or due to failure).
+ * Authentication is via the proxy API token (X-API-Token header or api_token query param),
+ * matching the same mechanism the editor uses when calling the proxy.
+ *
+ * Supported events:
+ *   programme_ended   — FFmpeg exited cleanly (duration limit reached)
+ *   recording_stopped — Manual stop via the proxy API
+ *   broadcast_failed  — FFmpeg encountered a fatal error
+ */
+class DvrCallbackController extends Controller
+{
+    public function handle(Request $request): JsonResponse
+    {
+        if (! $this->isAuthorized($request)) {
+            Log::warning('DVR callback: unauthorized request', [
+                'ip' => $request->ip(),
+            ]);
+
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        $networkId = $request->input('network_id');
+        $event = $request->input('event');
+        $hlsDir = $request->input('hls_dir');
+        $data = $request->input('data', []);
+
+        if (! $networkId || ! $event) {
+            return response()->json(['error' => 'Missing network_id or event'], 422);
+        }
+
+        $recording = DvrRecording::where('proxy_network_id', $networkId)
+            ->orWhere('uuid', $networkId)
+            ->first();
+
+        if (! $recording) {
+            Log::warning('DVR callback: recording not found', [
+                'network_id' => $networkId,
+                'event' => $event,
+            ]);
+
+            // Acknowledge so the proxy does not retry indefinitely
+            return response()->json(['status' => 'ignored', 'reason' => 'recording not found']);
+        }
+
+        Log::info('DVR callback received', [
+            'recording_id' => $recording->id,
+            'event' => $event,
+            'hls_dir' => $hlsDir,
+        ]);
+
+        return match ($event) {
+            'programme_ended', 'recording_stopped' => $this->handleRecordingStopped($recording, $hlsDir, $data),
+            'broadcast_failed' => $this->handleBroadcastFailed($recording, $data),
+            default => response()->json(['status' => 'ignored', 'reason' => "unhandled event: {$event}"]),
+        };
+    }
+
+    private function handleRecordingStopped(DvrRecording $recording, ?string $hlsDir, array $data): JsonResponse
+    {
+        // Skip if already past this point (e.g. duplicate callback)
+        if (! in_array($recording->status, [DvrRecordingStatus::Recording, DvrRecordingStatus::Scheduled])) {
+            return response()->json(['status' => 'ignored', 'reason' => 'not in recording state']);
+        }
+
+        $recording->update([
+            'status' => DvrRecordingStatus::PostProcessing->value,
+            'actual_end' => now(),
+            'proxy_network_id' => null,
+            'temp_path' => $hlsDir ?? $recording->temp_path,
+        ]);
+
+        PostProcessDvrRecording::dispatch($recording->id)->onQueue('dvr-post');
+
+        Log::info('DVR callback: dispatched post-processing', [
+            'recording_id' => $recording->id,
+            'hls_dir' => $hlsDir,
+        ]);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    private function handleBroadcastFailed(DvrRecording $recording, array $data): JsonResponse
+    {
+        if (in_array($recording->status, [DvrRecordingStatus::Completed, DvrRecordingStatus::Cancelled])) {
+            return response()->json(['status' => 'ignored', 'reason' => 'already in terminal state']);
+        }
+
+        $errorMessage = $data['error'] ?? 'Proxy broadcast failed';
+
+        $recording->update([
+            'status' => DvrRecordingStatus::Failed->value,
+            'actual_end' => now(),
+            'proxy_network_id' => null,
+            'error_message' => $errorMessage,
+        ]);
+
+        Log::error('DVR callback: broadcast failed', [
+            'recording_id' => $recording->id,
+            'error' => $errorMessage,
+        ]);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Validate the request using the same API token the editor uses when calling the proxy.
+     */
+    private function isAuthorized(Request $request): bool
+    {
+        $configuredToken = config('proxy.m3u_proxy_token');
+
+        // If no token is configured, accept all callbacks (dev/open deployments)
+        if (empty($configuredToken)) {
+            return true;
+        }
+
+        $providedToken = $request->header('X-API-Token')
+            ?? $request->query('api_token');
+
+        return $providedToken === $configuredToken;
+    }
+}

--- a/app/Http/Controllers/DvrCallbackController.php
+++ b/app/Http/Controllers/DvrCallbackController.php
@@ -71,17 +71,36 @@ class DvrCallbackController extends Controller
 
     private function handleRecordingStopped(DvrRecording $recording, ?string $hlsDir, array $data): JsonResponse
     {
-        // Skip if already past this point (e.g. duplicate callback)
-        if (! in_array($recording->status, [DvrRecordingStatus::Recording, DvrRecordingStatus::Scheduled])) {
+        // Accept Recording/Scheduled and also PostProcessing: the stop() method transitions
+        // to PostProcessing immediately when signalling the proxy, but the callback arrives
+        // later (after FFmpeg actually exits). We still need to store hls_dir and dispatch
+        // the post-processing job regardless of which side set the status first.
+        $validStatuses = [
+            DvrRecordingStatus::Recording,
+            DvrRecordingStatus::Scheduled,
+            DvrRecordingStatus::PostProcessing,
+        ];
+
+        if (! in_array($recording->status, $validStatuses)) {
             return response()->json(['status' => 'ignored', 'reason' => 'not in recording state']);
         }
 
-        $recording->update([
+        $updateData = [
             'status' => DvrRecordingStatus::PostProcessing->value,
-            'actual_end' => now(),
             'proxy_network_id' => null,
-            'temp_path' => $hlsDir ?? $recording->temp_path,
-        ]);
+        ];
+
+        // Preserve actual_end if already set by finalizeStop(); set it now if not.
+        if (! $recording->actual_end) {
+            $updateData['actual_end'] = now();
+        }
+
+        // Always store hls_dir from the callback — finalizeStop() doesn't know the path.
+        if ($hlsDir) {
+            $updateData['temp_path'] = $hlsDir;
+        }
+
+        $recording->update($updateData);
 
         PostProcessDvrRecording::dispatch($recording->id)->onQueue('dvr-post');
 

--- a/app/Http/Controllers/DvrStreamController.php
+++ b/app/Http/Controllers/DvrStreamController.php
@@ -14,6 +14,10 @@ class DvrStreamController extends Controller
      * Stream a completed DVR recording file to the client.
      *
      * GET /dvr/recordings/{uuid}/stream
+     *
+     * Supports HTTP range requests for seeking. MIME type is resolved from the
+     * file extension so that both legacy .ts recordings and new .mp4 recordings
+     * are served with the correct Content-Type.
      */
     public function stream(Request $request, string $uuid): Response|StreamedResponse
     {
@@ -36,7 +40,7 @@ class DvrStreamController extends Controller
 
         $fullPath = Storage::disk($disk)->path($recording->file_path);
         $fileSize = filesize($fullPath);
-        $mimeType = 'video/mp2t';
+        $mimeType = $this->resolveMimeType($recording->file_path);
 
         // Support range requests for seeking
         $range = $request->header('Range');
@@ -64,7 +68,6 @@ class DvrStreamController extends Controller
                     $chunkSize = min(8192, $remaining);
                     echo fread($handle, $chunkSize);
                     $remaining -= $chunkSize;
-                    flush();
                 }
 
                 fclose($handle);
@@ -88,5 +91,18 @@ class DvrStreamController extends Controller
 
             fclose($handle);
         }, 200, $headers);
+    }
+
+    /**
+     * Resolve the MIME type from the recording file extension.
+     * Handles both legacy .ts files and new .mp4 output.
+     */
+    private function resolveMimeType(string $filePath): string
+    {
+        return match (strtolower(pathinfo($filePath, PATHINFO_EXTENSION))) {
+            'mp4' => 'video/mp4',
+            'mkv' => 'video/x-matroska',
+            default => 'video/mp2t', // .ts and anything unrecognised
+        };
     }
 }

--- a/app/Http/Controllers/DvrStreamController.php
+++ b/app/Http/Controllers/DvrStreamController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\DvrRecordingStatus;
 use App\Models\CustomPlaylist;
 use App\Models\DvrRecording;
 use App\Models\MergedPlaylist;
@@ -9,7 +10,9 @@ use App\Models\Playlist;
 use App\Models\PlaylistAlias;
 use App\Models\PlaylistAuth;
 use App\Models\User;
+use App\Services\M3uProxyService;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
@@ -29,7 +32,7 @@ class DvrStreamController extends Controller
      * Once authenticated, the recording must belong to that user.
      * Supports HTTP range requests for seeking.
      */
-    public function stream(Request $request, string $username, string $password, string $uuid): Response|StreamedResponse
+    public function stream(Request $request, string $username, string $password, string $uuid): Response|StreamedResponse|RedirectResponse
     {
         $user = $this->resolveUser($username, $password);
 
@@ -43,6 +46,15 @@ class DvrStreamController extends Controller
 
         if (! $recording) {
             abort(404, 'Recording not found');
+        }
+
+        // In-progress recording — redirect to the live HLS stream on the proxy.
+        // Clients (VLC, Infuse, etc.) will play the live HLS just as they would
+        // play the completed file, and will naturally see new segments as they arrive.
+        if ($recording->status === DvrRecordingStatus::Recording && $recording->proxy_network_id) {
+            $liveUrl = app(M3uProxyService::class)->getDvrBroadcastLiveUrl($recording->proxy_network_id);
+
+            return redirect($liveUrl);
         }
 
         if (! $recording->hasFile()) {

--- a/app/Http/Controllers/DvrStreamController.php
+++ b/app/Http/Controllers/DvrStreamController.php
@@ -2,7 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\CustomPlaylist;
 use App\Models\DvrRecording;
+use App\Models\MergedPlaylist;
+use App\Models\Playlist;
+use App\Models\PlaylistAlias;
+use App\Models\PlaylistAuth;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
@@ -11,17 +18,32 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 class DvrStreamController extends Controller
 {
     /**
-     * Stream a completed DVR recording file to the client.
+     * Stream a DVR recording.
      *
-     * GET /dvr/recordings/{uuid}/stream
+     * GET /dvr/{username}/{password}/{uuid}.{format?}
      *
-     * Supports HTTP range requests for seeking. MIME type is resolved from the
-     * file extension so that both legacy .ts recordings and new .mp4 recordings
-     * are served with the correct Content-Type.
+     * Authentication mirrors the Xtream stream pattern:
+     * - Method 1: PlaylistAuth credentials
+     * - Method 2: username = playlist owner's name, password = playlist UUID
+     *
+     * Once authenticated, the recording must belong to that user.
+     * Supports HTTP range requests for seeking.
      */
-    public function stream(Request $request, string $uuid): Response|StreamedResponse
+    public function stream(Request $request, string $username, string $password, string $uuid): Response|StreamedResponse
     {
-        $recording = DvrRecording::where('uuid', $uuid)->firstOrFail();
+        $user = $this->resolveUser($username, $password);
+
+        if (! $user) {
+            abort(401, 'Invalid credentials');
+        }
+
+        $recording = DvrRecording::where('uuid', $uuid)
+            ->where('user_id', $user->id)
+            ->first();
+
+        if (! $recording) {
+            abort(404, 'Recording not found');
+        }
 
         if (! $recording->hasFile()) {
             abort(404, 'Recording file not available');
@@ -42,7 +64,6 @@ class DvrStreamController extends Controller
         $fileSize = filesize($fullPath);
         $mimeType = $this->resolveMimeType($recording->file_path);
 
-        // Support range requests for seeking
         $range = $request->header('Range');
 
         if ($range) {
@@ -94,15 +115,53 @@ class DvrStreamController extends Controller
     }
 
     /**
-     * Resolve the MIME type from the recording file extension.
-     * Handles both legacy .ts files and new .mp4 output.
+     * Resolve a User from credentials using the same two-step auth as XtreamStreamController:
+     * 1. PlaylistAuth username/password lookup
+     * 2. Fallback: username = user's name, password = any playlist UUID owned by that user
+     *
+     * Returns the owning User model or null on failure.
+     */
+    private function resolveUser(string $username, string $password): ?User
+    {
+        // Method 1: PlaylistAuth credentials
+        $playlistAuth = PlaylistAuth::where('username', $username)
+            ->where('password', $password)
+            ->where('enabled', true)
+            ->first();
+
+        if ($playlistAuth && ! $playlistAuth->isExpired()) {
+            $playlist = $playlistAuth->getAssignedModel();
+
+            return $playlist?->user;
+        }
+
+        // Method 2: password = playlist UUID, username = owner's name
+        $playlistTypes = [Playlist::class, MergedPlaylist::class, CustomPlaylist::class, PlaylistAlias::class];
+
+        foreach ($playlistTypes as $type) {
+            try {
+                $playlist = $type::with('user')->where('uuid', $password)->firstOrFail();
+
+                if ($playlist->user && $playlist->user->name === $username) {
+                    return $playlist->user;
+                }
+            } catch (ModelNotFoundException) {
+                // Try next type
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve MIME type from the recording file extension.
      */
     private function resolveMimeType(string $filePath): string
     {
         return match (strtolower(pathinfo($filePath, PATHINFO_EXTENSION))) {
             'mp4' => 'video/mp4',
             'mkv' => 'video/x-matroska',
-            default => 'video/mp2t', // .ts and anything unrecognised
+            default => 'video/mp2t',
         };
     }
 }

--- a/app/Http/Controllers/DvrStreamController.php
+++ b/app/Http/Controllers/DvrStreamController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\DvrRecording;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class DvrStreamController extends Controller
+{
+    /**
+     * Stream a completed DVR recording file to the client.
+     *
+     * GET /dvr/recordings/{uuid}/stream
+     */
+    public function stream(Request $request, string $uuid): Response|StreamedResponse
+    {
+        $recording = DvrRecording::where('uuid', $uuid)->firstOrFail();
+
+        if (! $recording->hasFile()) {
+            abort(404, 'Recording file not available');
+        }
+
+        $setting = $recording->dvrSetting;
+        if (! $setting) {
+            abort(404, 'DVR setting not found');
+        }
+
+        $disk = $setting->storage_disk ?: config('dvr.storage_disk');
+
+        if (! Storage::disk($disk)->exists($recording->file_path)) {
+            abort(404, 'Recording file not found on disk');
+        }
+
+        $fullPath = Storage::disk($disk)->path($recording->file_path);
+        $fileSize = filesize($fullPath);
+        $mimeType = 'video/mp2t';
+
+        // Support range requests for seeking
+        $range = $request->header('Range');
+
+        if ($range) {
+            preg_match('/bytes=(\d+)-(\d*)/', $range, $matches);
+            $start = (int) $matches[1];
+            $end = isset($matches[2]) && $matches[2] !== '' ? (int) $matches[2] : $fileSize - 1;
+            $length = $end - $start + 1;
+
+            $headers = [
+                'Content-Type' => $mimeType,
+                'Content-Length' => $length,
+                'Content-Range' => "bytes {$start}-{$end}/{$fileSize}",
+                'Accept-Ranges' => 'bytes',
+                'Content-Disposition' => 'inline; filename="'.basename($recording->file_path).'"',
+            ];
+
+            return response()->stream(function () use ($fullPath, $start, $length) {
+                $handle = fopen($fullPath, 'rb');
+                fseek($handle, $start);
+                $remaining = $length;
+
+                while (! feof($handle) && $remaining > 0) {
+                    $chunkSize = min(8192, $remaining);
+                    echo fread($handle, $chunkSize);
+                    $remaining -= $chunkSize;
+                    flush();
+                }
+
+                fclose($handle);
+            }, 206, $headers);
+        }
+
+        $headers = [
+            'Content-Type' => $mimeType,
+            'Content-Length' => $fileSize,
+            'Accept-Ranges' => 'bytes',
+            'Content-Disposition' => 'inline; filename="'.basename($recording->file_path).'"',
+        ];
+
+        return response()->stream(function () use ($fullPath) {
+            $handle = fopen($fullPath, 'rb');
+
+            while (! feof($handle)) {
+                echo fread($handle, 8192);
+                flush();
+            }
+
+            fclose($handle);
+        }, 200, $headers);
+    }
+}

--- a/app/Jobs/DvrRetentionCleanup.php
+++ b/app/Jobs/DvrRetentionCleanup.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Services\DvrRetentionService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * DvrRetentionCleanup — Enforce keepLast, retention_days, and disk quota policies.
+ *
+ * Should be scheduled hourly.
+ */
+class DvrRetentionCleanup implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    public int $timeout = 300;
+
+    public function __construct()
+    {
+        $this->onQueue('dvr');
+    }
+
+    public function handle(DvrRetentionService $retention): void
+    {
+        Log::debug('DVR retention cleanup starting');
+        $retention->runAll();
+        Log::debug('DVR retention cleanup complete');
+    }
+}

--- a/app/Jobs/DvrSchedulerTick.php
+++ b/app/Jobs/DvrSchedulerTick.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Services\DvrSchedulerService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * DvrSchedulerTick — Runs every minute via the Laravel scheduler.
+ *
+ * Dispatches onto the 'dvr' queue so it runs inside the dvr-queue Horizon supervisor.
+ */
+class DvrSchedulerTick implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    public int $timeout = 120;
+
+    public function __construct()
+    {
+        $this->onQueue('dvr');
+    }
+
+    public function handle(DvrSchedulerService $scheduler): void
+    {
+        Log::debug('DVR scheduler tick starting');
+        $scheduler->tick();
+        Log::debug('DVR scheduler tick complete');
+    }
+}

--- a/app/Jobs/EnrichDvrMetadata.php
+++ b/app/Jobs/EnrichDvrMetadata.php
@@ -34,7 +34,18 @@ class EnrichDvrMetadata implements ShouldQueue
             return;
         }
 
+        Log::info("DVR metadata enrichment starting for recording {$recording->id}", [
+            'recording_id' => $recording->id,
+            'title' => $recording->title,
+        ]);
+
+        $recording->update(['post_processing_step' => 'Enriching metadata']);
+
         $enricher->enrich($recording);
+
+        Log::info("DVR metadata enrichment complete for recording {$recording->id} — dispatching VOD integration", [
+            'recording_id' => $recording->id,
+        ]);
 
         IntegrateDvrRecordingToVod::dispatch($recording->id);
     }

--- a/app/Jobs/EnrichDvrMetadata.php
+++ b/app/Jobs/EnrichDvrMetadata.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\DvrRecording;
+use App\Services\DvrMetadataEnricherService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * EnrichDvrMetadata — Fetch TMDB / TVMaze metadata for a completed recording.
+ */
+class EnrichDvrMetadata implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public int $timeout = 60;
+
+    public function __construct(public int $recordingId)
+    {
+        $this->onQueue('dvr-meta');
+    }
+
+    public function handle(DvrMetadataEnricherService $enricher): void
+    {
+        $recording = DvrRecording::find($this->recordingId);
+
+        if (! $recording) {
+            Log::warning("EnrichDvrMetadata: recording {$this->recordingId} not found");
+
+            return;
+        }
+
+        $enricher->enrich($recording);
+
+        IntegrateDvrRecordingToVod::dispatch($recording->id);
+    }
+}

--- a/app/Jobs/IntegrateDvrRecordingToVod.php
+++ b/app/Jobs/IntegrateDvrRecordingToVod.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\DvrRecording;
+use App\Services\DvrVodIntegrationService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * IntegrateDvrRecordingToVod — Queued job that converts a completed DVR recording into a VOD entry.
+ *
+ * Dispatched by EnrichDvrMetadata after metadata enrichment completes,
+ * or directly by DvrPostProcessorService when metadata enrichment is disabled.
+ */
+class IntegrateDvrRecordingToVod implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public int $timeout = 30;
+
+    public function __construct(public int $recordingId)
+    {
+        $this->onQueue('dvr-post');
+    }
+
+    public function handle(DvrVodIntegrationService $integrator): void
+    {
+        $recording = DvrRecording::find($this->recordingId);
+
+        if (! $recording) {
+            Log::warning("IntegrateDvrRecordingToVod: recording {$this->recordingId} not found");
+
+            return;
+        }
+
+        $integrator->integrateRecording($recording);
+    }
+}

--- a/app/Jobs/IntegrateDvrRecordingToVod.php
+++ b/app/Jobs/IntegrateDvrRecordingToVod.php
@@ -37,6 +37,20 @@ class IntegrateDvrRecordingToVod implements ShouldQueue
             return;
         }
 
+        Log::info("DVR VOD integration starting for recording {$recording->id}", [
+            'recording_id' => $recording->id,
+            'title' => $recording->title,
+        ]);
+
+        $recording->update(['post_processing_step' => 'Creating VOD entry']);
+
         $integrator->integrateRecording($recording);
+
+        // Clear the step label now that the full pipeline is done
+        $recording->update(['post_processing_step' => null]);
+
+        Log::info("DVR VOD integration complete for recording {$recording->id}", [
+            'recording_id' => $recording->id,
+        ]);
     }
 }

--- a/app/Jobs/PostProcessDvrRecording.php
+++ b/app/Jobs/PostProcessDvrRecording.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\DvrRecording;
+use App\Services\DvrPostProcessorService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * PostProcessDvrRecording — Concat HLS → .ts, move to library, dispatch metadata.
+ */
+class PostProcessDvrRecording implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 2;
+
+    /** Allow time for large concat operations */
+    public int $timeout = 3600;
+
+    public function __construct(public int $recordingId)
+    {
+        $this->onQueue('dvr-post');
+    }
+
+    public function handle(DvrPostProcessorService $postProcessor): void
+    {
+        $recording = DvrRecording::find($this->recordingId);
+
+        if (! $recording) {
+            Log::warning("PostProcessDvrRecording: recording {$this->recordingId} not found");
+
+            return;
+        }
+
+        $postProcessor->run($recording);
+    }
+}

--- a/app/Jobs/StartDvrRecording.php
+++ b/app/Jobs/StartDvrRecording.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\DvrRecording;
+use App\Services\DvrRecorderService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * StartDvrRecording — Spawn an ffmpeg process for a scheduled recording.
+ */
+class StartDvrRecording implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    public int $timeout = 30;
+
+    public function __construct(public int $recordingId)
+    {
+        $this->onQueue('dvr');
+    }
+
+    public function handle(DvrRecorderService $recorder): void
+    {
+        $recording = DvrRecording::find($this->recordingId);
+
+        if (! $recording) {
+            Log::warning("StartDvrRecording: recording {$this->recordingId} not found");
+
+            return;
+        }
+
+        $recorder->start($recording);
+    }
+}

--- a/app/Jobs/StopDvrRecording.php
+++ b/app/Jobs/StopDvrRecording.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\DvrRecording;
+use App\Services\DvrRecorderService;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * StopDvrRecording — Gracefully stop a running ffmpeg recording.
+ * After stopping, the recording transitions to POST_PROCESSING and
+ * PostProcessDvrRecording is dispatched automatically.
+ */
+class StopDvrRecording implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    /** Allow extra time for graceful stop + SIGKILL fallback */
+    public int $timeout = 60;
+
+    public function __construct(public int $recordingId)
+    {
+        $this->onQueue('dvr');
+    }
+
+    public function handle(DvrRecorderService $recorder): void
+    {
+        $recording = DvrRecording::find($this->recordingId);
+
+        if (! $recording) {
+            Log::warning("StopDvrRecording: recording {$this->recordingId} not found");
+
+            return;
+        }
+
+        $recorder->stop($recording);
+
+        // Reload to get updated status, then dispatch post-processor
+        $recording->refresh();
+
+        PostProcessDvrRecording::dispatch($recording->id)->onQueue('dvr-post');
+    }
+}

--- a/app/Jobs/StopDvrRecording.php
+++ b/app/Jobs/StopDvrRecording.php
@@ -9,9 +9,11 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 
 /**
- * StopDvrRecording — Gracefully stop a running ffmpeg recording.
- * After stopping, the recording transitions to POST_PROCESSING and
- * PostProcessDvrRecording is dispatched automatically.
+ * StopDvrRecording — Signal the proxy to stop a running DVR broadcast.
+ *
+ * The proxy handles graceful FFmpeg shutdown and fires a callback to
+ * DvrCallbackController when done, which dispatches PostProcessDvrRecording.
+ * No blocking sleep loops needed here.
  */
 class StopDvrRecording implements ShouldQueue
 {
@@ -19,8 +21,7 @@ class StopDvrRecording implements ShouldQueue
 
     public int $tries = 1;
 
-    /** Allow extra time for graceful stop + SIGKILL fallback */
-    public int $timeout = 60;
+    public int $timeout = 15;
 
     public function __construct(public int $recordingId)
     {
@@ -38,10 +39,5 @@ class StopDvrRecording implements ShouldQueue
         }
 
         $recorder->stop($recording);
-
-        // Reload to get updated status, then dispatch post-processor
-        $recording->refresh();
-
-        PostProcessDvrRecording::dispatch($recording->id)->onQueue('dvr-post');
     }
 }

--- a/app/Livewire/EpgViewer.php
+++ b/app/Livewire/EpgViewer.php
@@ -3,17 +3,25 @@
 namespace App\Livewire;
 
 use App\Enums\ChannelLogoType;
+use App\Enums\DvrRuleType;
 use App\Filament\Resources\Channels\ChannelResource;
 use App\Filament\Resources\EpgChannels\EpgChannelResource;
 use App\Models\Channel;
+use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
 use App\Models\Epg;
 use App\Models\EpgChannel;
+use App\Models\EpgProgramme;
+use App\Models\Playlist;
 use App\Services\EpgCacheService;
+use Carbon\Carbon;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
@@ -41,6 +49,15 @@ class EpgViewer extends Component implements HasActions, HasForms
 
     public $vod = true;
 
+    /** Whether the associated playlist has DVR enabled. */
+    public bool $dvrEnabled = false;
+
+    /** Programme data for the pending schedule action. */
+    public ?array $programmeData = null;
+
+    /** Channel database ID for the pending schedule action. */
+    public ?int $schedulingChannelId = null;
+
     // Use static cache to prevent Livewire from clearing it
     protected static $recordCache = [];
 
@@ -50,6 +67,11 @@ class EpgViewer extends Component implements HasActions, HasForms
     {
         $this->record = $record;
         $this->type = class_basename($this->record);
+
+        // Determine DVR enabled state for Playlist records
+        if ($this->type === 'Playlist') {
+            $this->dvrEnabled = (bool) $this->record->dvrSetting?->enabled;
+        }
     }
 
     /**
@@ -68,6 +90,7 @@ class EpgViewer extends Component implements HasActions, HasForms
     {
         return [
             $this->editChannelAction(),
+            $this->scheduleProgrammeAction(),
         ];
     }
 
@@ -153,6 +176,160 @@ class EpgViewer extends Component implements HasActions, HasForms
             })
             ->slideOver()
             ->modalWidth('4xl');
+    }
+
+    /**
+     * Action to schedule a one-off DVR recording for a specific programme.
+     */
+    public function scheduleProgrammeAction(): Action
+    {
+        return Action::make('scheduleProgramme')
+            ->label(__('Schedule Recording'))
+            ->icon('heroicon-o-video-camera')
+            ->color('danger')
+            ->schema([
+                Select::make('rule_type')
+                    ->label(__('Recording type'))
+                    ->options([
+                        DvrRuleType::Once->value => __('Once — record this episode only'),
+                        DvrRuleType::Series->value => __('Series — record all episodes with this title'),
+                    ])
+                    ->default(DvrRuleType::Once->value)
+                    ->required(),
+                Toggle::make('new_only')
+                    ->label(__('New episodes only'))
+                    ->helperText(__('Only record episodes marked as new. Applies to series rules only.'))
+                    ->default(false)
+                    ->inline(false),
+            ])
+            ->action(function (array $data) {
+                $this->handleScheduleProgramme($data);
+            })
+            ->slideOver(false)
+            ->modalWidth('lg');
+    }
+
+    /**
+     * Open the schedule programme modal for a specific programme.
+     *
+     * @param  array{title: string, start: string, stop: string, episode_num: ?string, category: ?string}  $programmeData
+     */
+    public function openScheduleProgramme(array $programmeData, int $channelDatabaseId): void
+    {
+        $this->programmeData = $programmeData;
+        $this->schedulingChannelId = $channelDatabaseId;
+        $this->mountAction('scheduleProgramme');
+    }
+
+    /**
+     * Create a DvrRecordingRule for the pending programme.
+     *
+     * @param  array{rule_type: string, new_only: bool}  $data
+     */
+    protected function handleScheduleProgramme(array $data): void
+    {
+        if (empty($this->programmeData) || empty($this->schedulingChannelId)) {
+            Notification::make()
+                ->danger()
+                ->title(__('Recording failed'))
+                ->body(__('Programme data is missing. Please try again.'))
+                ->send();
+
+            return;
+        }
+
+        /** @var Playlist $playlist */
+        $playlist = $this->record;
+        $dvrSetting = DvrSetting::where('playlist_id', $playlist->id)->where('enabled', true)->first();
+
+        if (! $dvrSetting) {
+            Notification::make()
+                ->danger()
+                ->title(__('DVR not enabled'))
+                ->body(__('Enable DVR for this playlist in the playlist settings before scheduling recordings.'))
+                ->send();
+
+            return;
+        }
+
+        /** @var Channel $channel */
+        $channel = Channel::find($this->schedulingChannelId);
+
+        if (! $channel) {
+            Notification::make()
+                ->danger()
+                ->title(__('Recording failed'))
+                ->body(__('Channel not found.'))
+                ->send();
+
+            return;
+        }
+
+        $ruleType = DvrRuleType::from($data['rule_type']);
+        $title = $this->programmeData['title'] ?? null;
+        $startTime = isset($this->programmeData['start']) ? Carbon::parse($this->programmeData['start']) : null;
+        $endTime = isset($this->programmeData['stop']) ? Carbon::parse($this->programmeData['stop']) : null;
+
+        // For 'once' rules, find or create the EpgProgramme record so the scheduler can match it
+        $programmeId = null;
+        if ($ruleType === DvrRuleType::Once && $startTime && $endTime && $title) {
+            $epgProgramme = EpgProgramme::firstOrCreate(
+                [
+                    'epg_channel_id' => $channel->epgChannel?->channel_id ?? '',
+                    'start_time' => $startTime,
+                ],
+                [
+                    'epg_id' => $channel->epgChannel?->epg_id ?? 0,
+                    'title' => $title,
+                    'end_time' => $endTime,
+                    'subtitle' => $this->programmeData['subtitle'] ?? null,
+                    'description' => $this->programmeData['desc'] ?? null,
+                    'category' => $this->programmeData['category'] ?? null,
+                    'episode_num' => $this->programmeData['episode_num'] ?? null,
+                    'is_new' => $this->programmeData['new'] ?? false,
+                ]
+            );
+            $programmeId = $epgProgramme->id;
+        }
+
+        try {
+            DvrRecordingRule::create([
+                'user_id' => $dvrSetting->user_id,
+                'dvr_setting_id' => $dvrSetting->id,
+                'type' => $ruleType,
+                'programme_id' => $programmeId,
+                'series_title' => $ruleType === DvrRuleType::Series ? $title : null,
+                'channel_id' => $channel->id,
+                'epg_channel_id' => $channel->epgChannel?->id,
+                'new_only' => $data['new_only'] ?? false,
+                'priority' => 0,
+                'enabled' => true,
+            ]);
+
+            $typeLabel = $ruleType === DvrRuleType::Series
+                ? __('series rule created')
+                : __('recording scheduled');
+
+            Notification::make()
+                ->success()
+                ->title(ucfirst($typeLabel))
+                ->body(__(':title has been :action.', ['title' => $title, 'action' => $typeLabel]))
+                ->send();
+        } catch (Exception $e) {
+            Log::error('Failed to create DVR recording rule', [
+                'error' => $e->getMessage(),
+                'programme' => $this->programmeData,
+            ]);
+
+            Notification::make()
+                ->danger()
+                ->title(__('Recording failed'))
+                ->body(__('An error occurred while scheduling the recording.'))
+                ->send();
+        } finally {
+            $this->programmeData = null;
+            $this->schedulingChannelId = null;
+        }
     }
 
     protected function getChannelRecord()

--- a/app/Models/DvrRecording.php
+++ b/app/Models/DvrRecording.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Str;
 
 class DvrRecording extends Model
@@ -38,10 +39,13 @@ class DvrRecording extends Model
         'stream_url',
         'metadata',
         'error_message',
+        'post_processing_step',
         'programme_start',
         'programme_end',
         'epg_programme_data',
         'pid',
+        'temp_path',
+        'temp_manifest_path',
     ];
 
     /**
@@ -74,6 +78,28 @@ class DvrRecording extends Model
         static::creating(function (DvrRecording $recording): void {
             if (empty($recording->uuid)) {
                 $recording->uuid = (string) Str::uuid();
+            }
+        });
+
+        static::deleting(function (DvrRecording $recording): void {
+            // Delete the physical file from disk.
+            if ($recording->file_path && file_exists($recording->file_path)) {
+                @unlink($recording->file_path);
+            }
+
+            // Cascade to VOD channel: null dvr_recording_id first so the Channel's own
+            // deleting hook doesn't try to re-delete this recording (re-entrance guard).
+            if ($vodChannel = $recording->vodChannel) {
+                $vodChannel->dvr_recording_id = null;
+                $vodChannel->save();
+                $vodChannel->delete();
+            }
+
+            // Cascade to VOD episode (same re-entrance guard pattern).
+            if ($vodEpisode = $recording->vodEpisode) {
+                $vodEpisode->dvr_recording_id = null;
+                $vodEpisode->save();
+                $vodEpisode->delete();
             }
         });
     }
@@ -136,22 +162,6 @@ class DvrRecording extends Model
             DvrRecordingStatus::Scheduled->value,
             DvrRecordingStatus::Recording->value,
         ])->orderBy('scheduled_start');
-    }
-
-    /**
-     * Get the temporary HLS directory path (relative to the dvr disk).
-     */
-    public function getTempPathAttribute(): string
-    {
-        return 'live/'.$this->uuid;
-    }
-
-    /**
-     * Get the temporary M3U8 manifest path (relative to the dvr disk).
-     */
-    public function getTempManifestPathAttribute(): string
-    {
-        return 'live/'.$this->uuid.'/stream.m3u8';
     }
 
     /**

--- a/app/Models/DvrRecording.php
+++ b/app/Models/DvrRecording.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\DvrRecordingStatus;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+class DvrRecording extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'uuid',
+        'user_id',
+        'dvr_setting_id',
+        'dvr_recording_rule_id',
+        'channel_id',
+        'status',
+        'title',
+        'subtitle',
+        'description',
+        'season',
+        'episode',
+        'scheduled_start',
+        'scheduled_end',
+        'actual_start',
+        'actual_end',
+        'duration_seconds',
+        'file_path',
+        'file_size_bytes',
+        'stream_url',
+        'metadata',
+        'error_message',
+        'programme_start',
+        'programme_end',
+        'epg_programme_data',
+        'pid',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => DvrRecordingStatus::class,
+            'season' => 'integer',
+            'episode' => 'integer',
+            'scheduled_start' => 'datetime',
+            'scheduled_end' => 'datetime',
+            'actual_start' => 'datetime',
+            'actual_end' => 'datetime',
+            'duration_seconds' => 'integer',
+            'file_size_bytes' => 'integer',
+            'metadata' => 'array',
+            'programme_start' => 'datetime',
+            'programme_end' => 'datetime',
+            'epg_programme_data' => 'array',
+            'pid' => 'integer',
+        ];
+    }
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (DvrRecording $recording): void {
+            if (empty($recording->uuid)) {
+                $recording->uuid = (string) Str::uuid();
+            }
+        });
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function dvrSetting(): BelongsTo
+    {
+        return $this->belongsTo(DvrSetting::class);
+    }
+
+    public function recordingRule(): BelongsTo
+    {
+        return $this->belongsTo(DvrRecordingRule::class, 'dvr_recording_rule_id');
+    }
+
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(Channel::class);
+    }
+
+    public function scopeScheduled(Builder $query): Builder
+    {
+        return $query->where('status', DvrRecordingStatus::Scheduled->value);
+    }
+
+    public function scopeRecording(Builder $query): Builder
+    {
+        return $query->where('status', DvrRecordingStatus::Recording->value);
+    }
+
+    public function scopeCompleted(Builder $query): Builder
+    {
+        return $query->where('status', DvrRecordingStatus::Completed->value);
+    }
+
+    public function scopeFailed(Builder $query): Builder
+    {
+        return $query->where('status', DvrRecordingStatus::Failed->value);
+    }
+
+    public function scopeUpcoming(Builder $query): Builder
+    {
+        return $query->whereIn('status', [
+            DvrRecordingStatus::Scheduled->value,
+            DvrRecordingStatus::Recording->value,
+        ])->orderBy('scheduled_start');
+    }
+
+    /**
+     * Get the temporary HLS directory path (relative to the dvr disk).
+     */
+    public function getTempPathAttribute(): string
+    {
+        return 'live/'.$this->uuid;
+    }
+
+    /**
+     * Get the temporary M3U8 manifest path (relative to the dvr disk).
+     */
+    public function getTempManifestPathAttribute(): string
+    {
+        return 'live/'.$this->uuid.'/stream.m3u8';
+    }
+
+    /**
+     * Whether this recording has a completed file on disk.
+     */
+    public function hasFile(): bool
+    {
+        return $this->status === DvrRecordingStatus::Completed && ! empty($this->file_path);
+    }
+
+    /**
+     * Get a human-readable display title (with S/E info if available).
+     */
+    public function getDisplayTitleAttribute(): string
+    {
+        $title = $this->title;
+
+        if ($this->season !== null && $this->episode !== null) {
+            $title .= sprintf(' S%02dE%02d', $this->season, $this->episode);
+        }
+
+        if (! empty($this->subtitle)) {
+            $title .= ' - '.$this->subtitle;
+        }
+
+        return $title;
+    }
+}

--- a/app/Models/DvrRecording.php
+++ b/app/Models/DvrRecording.php
@@ -98,6 +98,18 @@ class DvrRecording extends Model
         return $this->belongsTo(Channel::class);
     }
 
+    /** The VOD Channel created from this recording (movie integration). */
+    public function vodChannel(): HasOne
+    {
+        return $this->hasOne(Channel::class, 'dvr_recording_id');
+    }
+
+    /** The VOD Episode created from this recording (TV series integration). */
+    public function vodEpisode(): HasOne
+    {
+        return $this->hasOne(Episode::class, 'dvr_recording_id');
+    }
+
     public function scopeScheduled(Builder $query): Builder
     {
         return $query->where('status', DvrRecordingStatus::Scheduled->value);

--- a/app/Models/DvrRecording.php
+++ b/app/Models/DvrRecording.php
@@ -19,6 +19,7 @@ class DvrRecording extends Model
      */
     protected $fillable = [
         'uuid',
+        'proxy_network_id',
         'user_id',
         'dvr_setting_id',
         'dvr_recording_rule_id',

--- a/app/Models/DvrRecordingRule.php
+++ b/app/Models/DvrRecordingRule.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\DvrRuleType;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class DvrRecordingRule extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'dvr_setting_id',
+        'type',
+        'programme_id',
+        'series_title',
+        'channel_id',
+        'epg_channel_id',
+        'new_only',
+        'priority',
+        'start_early_seconds',
+        'end_late_seconds',
+        'keep_last',
+        'enabled',
+        'manual_start',
+        'manual_end',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'type' => DvrRuleType::class,
+            'new_only' => 'boolean',
+            'priority' => 'integer',
+            'start_early_seconds' => 'integer',
+            'end_late_seconds' => 'integer',
+            'keep_last' => 'integer',
+            'enabled' => 'boolean',
+            'manual_start' => 'datetime',
+            'manual_end' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function dvrSetting(): BelongsTo
+    {
+        return $this->belongsTo(DvrSetting::class);
+    }
+
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(Channel::class);
+    }
+
+    public function epgChannel(): BelongsTo
+    {
+        return $this->belongsTo(EpgChannel::class);
+    }
+
+    public function recordings(): HasMany
+    {
+        return $this->hasMany(DvrRecording::class);
+    }
+
+    public function scopeEnabled(Builder $query): Builder
+    {
+        return $query->where('enabled', true);
+    }
+
+    public function scopeSeries(Builder $query): Builder
+    {
+        return $query->where('type', DvrRuleType::Series->value);
+    }
+
+    public function scopeOnce(Builder $query): Builder
+    {
+        return $query->where('type', DvrRuleType::Once->value);
+    }
+
+    public function scopeManual(Builder $query): Builder
+    {
+        return $query->where('type', DvrRuleType::Manual->value);
+    }
+}

--- a/app/Models/DvrSetting.php
+++ b/app/Models/DvrSetting.php
@@ -20,6 +20,7 @@ class DvrSetting extends Model
         'user_id',
         'enabled',
         'use_proxy',
+        'dvr_output_format',
         'storage_disk',
         'storage_path',
         'max_concurrent_recordings',

--- a/app/Models/DvrSetting.php
+++ b/app/Models/DvrSetting.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\DvrRecordingStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class DvrSetting extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'playlist_id',
+        'user_id',
+        'enabled',
+        'storage_disk',
+        'storage_path',
+        'max_concurrent_recordings',
+        'ffmpeg_path',
+        'default_start_early_seconds',
+        'default_end_late_seconds',
+        'enable_metadata_enrichment',
+        'tmdb_api_key',
+        'global_disk_quota_gb',
+        'retention_days',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+            'max_concurrent_recordings' => 'integer',
+            'default_start_early_seconds' => 'integer',
+            'default_end_late_seconds' => 'integer',
+            'enable_metadata_enrichment' => 'boolean',
+            'tmdb_api_key' => 'encrypted',
+            'global_disk_quota_gb' => 'integer',
+            'retention_days' => 'integer',
+        ];
+    }
+
+    public function playlist(): BelongsTo
+    {
+        return $this->belongsTo(Playlist::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function recordingRules(): HasMany
+    {
+        return $this->hasMany(DvrRecordingRule::class);
+    }
+
+    public function recordings(): HasMany
+    {
+        return $this->hasMany(DvrRecording::class);
+    }
+
+    /**
+     * Resolve the effective start-early seconds for a recording rule.
+     */
+    public function resolveStartEarlySeconds(?int $ruleOverride): int
+    {
+        return $ruleOverride ?? $this->default_start_early_seconds;
+    }
+
+    /**
+     * Resolve the effective end-late seconds for a recording rule.
+     */
+    public function resolveEndLateSeconds(?int $ruleOverride): int
+    {
+        return $ruleOverride ?? $this->default_end_late_seconds;
+    }
+
+    /**
+     * Check if the DVR is at concurrent recording capacity.
+     */
+    public function isAtCapacity(): bool
+    {
+        return $this->recordings()
+            ->whereIn('status', [DvrRecordingStatus::Recording->value, DvrRecordingStatus::PostProcessing->value])
+            ->count() >= $this->max_concurrent_recordings;
+    }
+
+    /**
+     * Get the resolved ffmpeg binary path.
+     */
+    public function getFfmpegPath(): string
+    {
+        return $this->ffmpeg_path ?: (string) config('dvr.ffmpeg_path', '/usr/bin/ffmpeg');
+    }
+}

--- a/app/Models/DvrSetting.php
+++ b/app/Models/DvrSetting.php
@@ -19,6 +19,7 @@ class DvrSetting extends Model
         'playlist_id',
         'user_id',
         'enabled',
+        'use_proxy',
         'storage_disk',
         'storage_path',
         'max_concurrent_recordings',
@@ -38,6 +39,7 @@ class DvrSetting extends Model
     {
         return [
             'enabled' => 'boolean',
+            'use_proxy' => 'boolean',
             'max_concurrent_recordings' => 'integer',
             'default_start_early_seconds' => 'integer',
             'default_end_late_seconds' => 'integer',

--- a/app/Models/EpgProgramme.php
+++ b/app/Models/EpgProgramme.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+class EpgProgramme extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'epg_id',
+        'epg_channel_id',
+        'title',
+        'subtitle',
+        'description',
+        'category',
+        'start_time',
+        'end_time',
+        'episode_num',
+        'season',
+        'episode',
+        'is_new',
+        'icon',
+        'rating',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'start_time' => 'datetime',
+            'end_time' => 'datetime',
+            'season' => 'integer',
+            'episode' => 'integer',
+            'is_new' => 'boolean',
+        ];
+    }
+
+    public function epg(): BelongsTo
+    {
+        return $this->belongsTo(Epg::class);
+    }
+
+    /**
+     * Scope to programmes that start within a given time range.
+     */
+    public function scopeStartingBetween(Builder $query, Carbon $from, Carbon $to): Builder
+    {
+        return $query->whereBetween('start_time', [$from, $to]);
+    }
+
+    /**
+     * Scope to programmes airing now or starting within the given minutes.
+     */
+    public function scopeUpcoming(Builder $query, int $minutes = 30): Builder
+    {
+        return $query->where('start_time', '<=', now()->addMinutes($minutes))
+            ->where('end_time', '>=', now());
+    }
+
+    /**
+     * Scope to programmes for specific EPG channel IDs.
+     *
+     * @param  list<string>  $channelIds
+     */
+    public function scopeForChannels(Builder $query, array $channelIds): Builder
+    {
+        return $query->whereIn('epg_channel_id', $channelIds);
+    }
+
+    /**
+     * Scope to programmes for a specific EPG source.
+     */
+    public function scopeForEpg(Builder $query, int $epgId): Builder
+    {
+        return $query->where('epg_id', $epgId);
+    }
+
+    /**
+     * Scope to only new episodes.
+     */
+    public function scopeNewOnly(Builder $query): Builder
+    {
+        return $query->where('is_new', true);
+    }
+}

--- a/app/Models/Episode.php
+++ b/app/Models/Episode.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
@@ -38,6 +39,26 @@ class Episode extends Model
         'tmdb_id' => 'integer',
         'info' => 'array',
     ];
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::deleting(function (Episode $episode): void {
+            if (! $episode->dvr_recording_id) {
+                return;
+            }
+
+            $recordingId = $episode->dvr_recording_id;
+
+            // Break the bi-directional link in the DB before cascading, so
+            // DvrRecording::deleting won't find this episode and re-delete it.
+            DB::table('episodes')->where('id', $episode->id)->update(['dvr_recording_id' => null]);
+
+            $recording = DvrRecording::find($recordingId);
+            $recording?->delete();
+        });
+    }
 
     public function user(): BelongsTo
     {

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -249,6 +249,11 @@ class Playlist extends Model
         return $this->hasMany(EpgMap::class);
     }
 
+    public function dvrSetting(): HasOne
+    {
+        return $this->hasOne(DvrSetting::class);
+    }
+
     public function channelScrubbers(): HasMany
     {
         return $this->hasMany(ChannelScrubber::class);

--- a/app/Observers/ChannelObserver.php
+++ b/app/Observers/ChannelObserver.php
@@ -4,6 +4,8 @@ namespace App\Observers;
 
 use App\Jobs\SyncPlexDvrJob;
 use App\Models\Channel;
+use App\Models\DvrRecording;
+use Illuminate\Support\Facades\DB;
 
 class ChannelObserver
 {
@@ -19,5 +21,30 @@ class ChannelObserver
         if ($channel->wasChanged('enabled')) {
             dispatch(new SyncPlexDvrJob(trigger: 'channel_observer'));
         }
+    }
+
+    /**
+     * Handle the Channel "deleting" event.
+     *
+     * When a DVR-created VOD channel is deleted, cascade the deletion to the
+     * linked DvrRecording (which in turn deletes the file and any VOD episode).
+     *
+     * We null dvr_recording_id in the DB before deleting the recording so that
+     * DvrRecording::deleting cannot loop back and try to delete this channel again.
+     */
+    public function deleting(Channel $channel): void
+    {
+        if (! $channel->dvr_recording_id) {
+            return;
+        }
+
+        $recordingId = $channel->dvr_recording_id;
+
+        // Break the bi-directional link in the DB before cascading, so
+        // DvrRecording::deleting won't find this channel and re-delete it.
+        DB::table('channels')->where('id', $channel->id)->update(['dvr_recording_id' => null]);
+
+        $recording = DvrRecording::find($recordingId);
+        $recording?->delete();
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -18,6 +18,8 @@ use App\Filament\Resources\Categories\CategoryResource;
 use App\Filament\Resources\Channels\ChannelResource;
 use App\Filament\Resources\ChannelScrubbers\ChannelScrubberResource;
 use App\Filament\Resources\CustomPlaylists\CustomPlaylistResource;
+use App\Filament\Resources\DvrRecordingRules\DvrRecordingRuleResource;
+use App\Filament\Resources\DvrRecordings\DvrRecordingResource;
 use App\Filament\Resources\EpgChannels\EpgChannelResource;
 use App\Filament\Resources\EpgMaps\EpgMapResource;
 use App\Filament\Resources\Epgs\EpgResource;
@@ -221,6 +223,12 @@ class AdminPanelProvider extends PanelProvider
                             ->items([
                                 ...StreamProfileResource::getNavigationItems(),
                                 ...M3uProxyStreamMonitor::getNavigationItems(),
+                            ]),
+                        NavigationGroup::make(fn () => __('DVR'))
+                            ->icon('heroicon-m-video-camera')
+                            ->items([
+                                ...DvrRecordingResource::getNavigationItems(),
+                                ...DvrRecordingRuleResource::getNavigationItems(),
                             ]),
                         NavigationGroup::make(fn () => __('Plugins'))
                             ->icon('heroicon-m-puzzle-piece')

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -186,6 +186,12 @@ class AdminPanelProvider extends PanelProvider
                                 ...StreamFileSettingResource::getNavigationItems(),
                                 ...ChannelScrubberResource::getNavigationItems(),
                             ]),
+                        NavigationGroup::make(fn () => __('DVR'))
+                            ->icon('heroicon-m-video-camera')
+                            ->items([
+                                ...DvrRecordingResource::getNavigationItems(),
+                                ...DvrRecordingRuleResource::getNavigationItems(),
+                            ]),
                         NavigationGroup::make(fn () => __('Integrations'))
                             ->icon('heroicon-m-server-stack')
                             ->items([
@@ -223,12 +229,6 @@ class AdminPanelProvider extends PanelProvider
                             ->items([
                                 ...StreamProfileResource::getNavigationItems(),
                                 ...M3uProxyStreamMonitor::getNavigationItems(),
-                            ]),
-                        NavigationGroup::make(fn () => __('DVR'))
-                            ->icon('heroicon-m-video-camera')
-                            ->items([
-                                ...DvrRecordingResource::getNavigationItems(),
-                                ...DvrRecordingRuleResource::getNavigationItems(),
                             ]),
                         NavigationGroup::make(fn () => __('Plugins'))
                             ->icon('heroicon-m-puzzle-piece')

--- a/app/Services/DvrMetadataEnricherService.php
+++ b/app/Services/DvrMetadataEnricherService.php
@@ -37,21 +37,56 @@ class DvrMetadataEnricherService
 
         // Attempt TMDB
         if ($tmdbKey) {
+            $recording->update(['post_processing_step' => 'Fetching TMDB metadata']);
+
             try {
                 $enriched = $this->enrichFromTmdb($recording, $tmdbKey);
             } catch (Exception $e) {
-                Log::warning("DVR metadata: TMDB enrichment failed for recording {$recording->id}: {$e->getMessage()}");
+                Log::warning("DVR metadata: TMDB enrichment failed for recording {$recording->id}: {$e->getMessage()}", [
+                    'recording_id' => $recording->id,
+                    'title' => $recording->title,
+                ]);
             }
         }
 
         // Fallback to TVMaze
         if (! $enriched) {
+            $recording->update(['post_processing_step' => 'Fetching TVMaze metadata']);
+
             try {
-                $this->enrichFromTvMaze($recording);
+                $enriched = $this->enrichFromTvMaze($recording);
             } catch (Exception $e) {
-                Log::warning("DVR metadata: TVMaze enrichment failed for recording {$recording->id}: {$e->getMessage()}");
+                Log::warning("DVR metadata: TVMaze enrichment failed for recording {$recording->id}: {$e->getMessage()}", [
+                    'recording_id' => $recording->id,
+                    'title' => $recording->title,
+                ]);
             }
         }
+
+        if (! $enriched) {
+            Log::info("DVR metadata: no metadata found for recording {$recording->id} — proceeding without enrichment", [
+                'recording_id' => $recording->id,
+                'title' => $recording->title,
+            ]);
+        }
+    }
+
+    /**
+     * Normalize a title for use as a search query.
+     *
+     * Strips Unicode decorations (superscripts, subscripts, combining marks,
+     * and other non-Latin symbols) that prevent TMDB/TVMaze from matching the
+     * actual show name.  The original title is preserved in the database.
+     */
+    private function normalizeSearchTitle(string $title): string
+    {
+        // Strip Unicode characters outside the basic Latin/extended Latin range.
+        // This removes superscripts like ᴸᶦᵛᵉ, emoji, and other decoration while
+        // preserving accented Latin characters (e.g. é, ñ, ü).
+        $normalized = preg_replace('/[^\x{0000}-\x{024F}\s]/u', '', $title) ?? $title;
+
+        // Collapse extra whitespace left behind after stripping
+        return trim((string) preg_replace('/\s{2,}/', ' ', $normalized));
     }
 
     /**
@@ -59,7 +94,7 @@ class DvrMetadataEnricherService
      */
     private function enrichFromTmdb(DvrRecording $recording, string $apiKey): bool
     {
-        $title = $recording->title;
+        $title = $this->normalizeSearchTitle($recording->title);
         $cacheKey = 'dvr.tmdb.'.md5("{$title}.{$recording->season}.{$recording->episode}");
 
         $data = Cache::remember($cacheKey, self::CACHE_TTL_SECONDS, function () use ($title, $recording, $apiKey) {
@@ -151,10 +186,11 @@ class DvrMetadataEnricherService
 
     /**
      * Enrich from TVMaze (free, no API key required).
+     * Returns true if a match was found and applied.
      */
-    private function enrichFromTvMaze(DvrRecording $recording): void
+    private function enrichFromTvMaze(DvrRecording $recording): bool
     {
-        $title = $recording->title;
+        $title = $this->normalizeSearchTitle($recording->title);
         $cacheKey = 'dvr.tvmaze.'.md5($title);
 
         $data = Cache::remember($cacheKey, self::CACHE_TTL_SECONDS, function () use ($title) {
@@ -162,7 +198,7 @@ class DvrMetadataEnricherService
         });
 
         if (empty($data)) {
-            return;
+            return false;
         }
 
         $metadata = $recording->metadata ?? [];
@@ -174,6 +210,8 @@ class DvrMetadataEnricherService
             'title' => $title,
             'tvmaze_id' => $data['id'] ?? null,
         ]);
+
+        return true;
     }
 
     /**

--- a/app/Services/DvrMetadataEnricherService.php
+++ b/app/Services/DvrMetadataEnricherService.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\DvrRecording;
+use App\Settings\GeneralSettings;
+use Exception;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * DvrMetadataEnricherService — Enriches DvrRecording rows with TMDB/TVMaze data.
+ *
+ * Sources (in priority order):
+ *   1. TMDB — requires an API key (per-DvrSetting or global config)
+ *   2. TVMaze — free, no API key required (fallback)
+ */
+class DvrMetadataEnricherService
+{
+    private const TMDB_BASE_URL = 'https://api.themoviedb.org/3';
+
+    private const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w500';
+
+    private const TVMAZE_BASE_URL = 'https://api.tvmaze.com';
+
+    private const CACHE_TTL_SECONDS = 86400; // 24 hours
+
+    /**
+     * Enrich a recording with metadata.
+     * Tries TMDB first, falls back to TVMaze.
+     */
+    public function enrich(DvrRecording $recording): void
+    {
+        $tmdbKey = $this->resolveTmdbApiKey($recording);
+        $enriched = false;
+
+        // Attempt TMDB
+        if ($tmdbKey) {
+            try {
+                $enriched = $this->enrichFromTmdb($recording, $tmdbKey);
+            } catch (Exception $e) {
+                Log::warning("DVR metadata: TMDB enrichment failed for recording {$recording->id}: {$e->getMessage()}");
+            }
+        }
+
+        // Fallback to TVMaze
+        if (! $enriched) {
+            try {
+                $this->enrichFromTvMaze($recording);
+            } catch (Exception $e) {
+                Log::warning("DVR metadata: TVMaze enrichment failed for recording {$recording->id}: {$e->getMessage()}");
+            }
+        }
+    }
+
+    /**
+     * Enrich from TMDB. Returns true if a match was found and applied.
+     */
+    private function enrichFromTmdb(DvrRecording $recording, string $apiKey): bool
+    {
+        $title = $recording->title;
+        $cacheKey = 'dvr.tmdb.'.md5("{$title}.{$recording->season}.{$recording->episode}");
+
+        $data = Cache::remember($cacheKey, self::CACHE_TTL_SECONDS, function () use ($title, $recording, $apiKey) {
+            return $this->fetchTmdb($title, $recording->season, $apiKey);
+        });
+
+        if (empty($data)) {
+            return false;
+        }
+
+        $metadata = $recording->metadata ?? [];
+        $metadata['tmdb'] = $data;
+
+        $recording->update(['metadata' => $metadata]);
+
+        Log::debug("DVR metadata: TMDB enrichment applied for recording {$recording->id}", [
+            'title' => $title,
+            'tmdb_id' => $data['id'] ?? null,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Fetch metadata from TMDB for a title (TV show or movie).
+     *
+     * @return array<string, mixed>|null
+     */
+    private function fetchTmdb(string $title, ?int $season, string $apiKey): ?array
+    {
+        // Search TV shows first (most DVR content is TV)
+        $searchUrl = self::TMDB_BASE_URL.'/search/tv';
+        $response = Http::timeout(10)->get($searchUrl, [
+            'api_key' => $apiKey,
+            'query' => $title,
+        ]);
+
+        if ($response->successful()) {
+            $results = $response->json('results', []);
+            if (! empty($results)) {
+                $match = $results[0];
+
+                return [
+                    'id' => $match['id'],
+                    'type' => 'tv',
+                    'name' => $match['name'] ?? $match['title'] ?? $title,
+                    'overview' => $match['overview'] ?? null,
+                    'poster_url' => isset($match['poster_path'])
+                        ? self::TMDB_IMAGE_BASE.$match['poster_path']
+                        : null,
+                    'backdrop_url' => isset($match['backdrop_path'])
+                        ? self::TMDB_IMAGE_BASE.$match['backdrop_path']
+                        : null,
+                    'first_air_date' => $match['first_air_date'] ?? null,
+                ];
+            }
+        }
+
+        // Try movies as a fallback
+        $searchUrl = self::TMDB_BASE_URL.'/search/movie';
+        $response = Http::timeout(10)->get($searchUrl, [
+            'api_key' => $apiKey,
+            'query' => $title,
+        ]);
+
+        if ($response->successful()) {
+            $results = $response->json('results', []);
+            if (! empty($results)) {
+                $match = $results[0];
+
+                return [
+                    'id' => $match['id'],
+                    'type' => 'movie',
+                    'name' => $match['title'] ?? $title,
+                    'overview' => $match['overview'] ?? null,
+                    'poster_url' => isset($match['poster_path'])
+                        ? self::TMDB_IMAGE_BASE.$match['poster_path']
+                        : null,
+                    'backdrop_url' => isset($match['backdrop_path'])
+                        ? self::TMDB_IMAGE_BASE.$match['backdrop_path']
+                        : null,
+                    'release_date' => $match['release_date'] ?? null,
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Enrich from TVMaze (free, no API key required).
+     */
+    private function enrichFromTvMaze(DvrRecording $recording): void
+    {
+        $title = $recording->title;
+        $cacheKey = 'dvr.tvmaze.'.md5($title);
+
+        $data = Cache::remember($cacheKey, self::CACHE_TTL_SECONDS, function () use ($title) {
+            return $this->fetchTvMaze($title);
+        });
+
+        if (empty($data)) {
+            return;
+        }
+
+        $metadata = $recording->metadata ?? [];
+        $metadata['tvmaze'] = $data;
+
+        $recording->update(['metadata' => $metadata]);
+
+        Log::debug("DVR metadata: TVMaze enrichment applied for recording {$recording->id}", [
+            'title' => $title,
+            'tvmaze_id' => $data['id'] ?? null,
+        ]);
+    }
+
+    /**
+     * Fetch show metadata from TVMaze.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function fetchTvMaze(string $title): ?array
+    {
+        $response = Http::timeout(10)->get(self::TVMAZE_BASE_URL.'/singlesearch/shows', [
+            'q' => $title,
+        ]);
+
+        if (! $response->successful()) {
+            return null;
+        }
+
+        $show = $response->json();
+
+        if (empty($show)) {
+            return null;
+        }
+
+        return [
+            'id' => $show['id'],
+            'name' => $show['name'] ?? $title,
+            'overview' => $show['summary'] ? strip_tags($show['summary']) : null,
+            'poster_url' => $show['image']['original'] ?? $show['image']['medium'] ?? null,
+            'premiered' => $show['premiered'] ?? null,
+            'genres' => $show['genres'] ?? [],
+            'network' => $show['network']['name'] ?? null,
+        ];
+    }
+
+    /**
+     * Resolve the TMDB API key: per-DvrSetting first, then global GeneralSettings, then env fallback.
+     */
+    private function resolveTmdbApiKey(DvrRecording $recording): ?string
+    {
+        $setting = $recording->dvrSetting;
+
+        if ($setting && ! empty($setting->tmdb_api_key)) {
+            return $setting->tmdb_api_key;
+        }
+
+        $globalKey = app(GeneralSettings::class)->tmdb_api_key;
+        if (! empty($globalKey)) {
+            return $globalKey;
+        }
+
+        return config('dvr.tmdb_api_key') ?: null;
+    }
+}

--- a/app/Services/DvrPostProcessorService.php
+++ b/app/Services/DvrPostProcessorService.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\DvrRecordingStatus;
+use App\Enums\DvrRuleType;
+use App\Jobs\EnrichDvrMetadata;
+use App\Jobs\IntegrateDvrRecordingToVod;
+use App\Models\DvrRecording;
+use Exception;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * DvrPostProcessorService — Runs after ffmpeg stops.
+ *
+ * Pipeline:
+ *   Step 1 (FATAL)     — Concatenate HLS segments → single .ts file via ffmpeg
+ *   Step 2 (non-fatal) — Move file to final library path, update DB
+ *   Step 3 (non-fatal) — Dispatch EnrichDvrMetadata job
+ *   Step 4             — Cleanup live/ temp dir, update DB to COMPLETED
+ */
+class DvrPostProcessorService
+{
+    /**
+     * Run the full post-processing pipeline for a recording.
+     */
+    public function run(DvrRecording $recording): void
+    {
+        Log::info("DVR post-processing started for recording {$recording->id}", [
+            'title' => $recording->title,
+        ]);
+
+        if ($recording->status !== DvrRecordingStatus::PostProcessing) {
+            Log::warning("DVR post-processor: recording {$recording->id} not in POST_PROCESSING state — skipping", [
+                'status' => $recording->status->value,
+            ]);
+
+            return;
+        }
+
+        $setting = $recording->dvrSetting;
+        if (! $setting) {
+            $this->markFailed($recording, 'DvrSetting not found during post-processing');
+
+            return;
+        }
+
+        $disk = $setting->storage_disk ?: config('dvr.storage_disk');
+        $livePath = $recording->temp_path; // e.g. live/{uuid}
+        $m3u8RelPath = $recording->temp_manifest_path; // e.g. live/{uuid}/stream.m3u8
+
+        $m3u8FullPath = Storage::disk($disk)->path($m3u8RelPath);
+
+        if (! file_exists($m3u8FullPath)) {
+            // FFmpeg writes to stream.m3u8.tmp while recording; if we caught it mid-segment,
+            // only the .tmp file may exist. Try that before giving up.
+            $tmpPath = preg_replace('/\.m3u8$/', '.m3u8.tmp', $m3u8FullPath);
+            if (file_exists($tmpPath)) {
+                Log::warning("DVR: Finalized .m3u8 not found, using .m3u8.tmp for recording {$recording->id}");
+                $m3u8FullPath = $tmpPath;
+            } else {
+                $this->markFailed($recording, "HLS manifest not found at {$m3u8FullPath}");
+
+                return;
+            }
+        }
+
+        // ── Step 1: Concatenate HLS → single .ts ────────────────────────────
+        $outputRelPath = $this->buildOutputPath($recording);
+        $outputFullPath = Storage::disk($disk)->path($outputRelPath);
+        $outputDir = dirname($outputFullPath);
+
+        if (! is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+
+        $ffmpegPath = $setting->getFfmpegPath();
+
+        try {
+            $this->concatHls($ffmpegPath, $m3u8FullPath, $outputFullPath);
+        } catch (Exception $e) {
+            $this->markFailed($recording, "HLS concat failed: {$e->getMessage()}");
+
+            return;
+        }
+
+        $fileSize = file_exists($outputFullPath) ? filesize($outputFullPath) : null;
+        $duration = $this->estimateDuration($recording);
+
+        Log::info('DVR post-processing step 1 complete: HLS concatenated', [
+            'recording_id' => $recording->id,
+            'output_path' => $outputRelPath,
+            'file_size' => $fileSize,
+        ]);
+
+        // ── Step 2: Update DB with file location ────────────────────────────
+        try {
+            $recording->update([
+                'file_path' => $outputRelPath,
+                'file_size_bytes' => $fileSize,
+                'duration_seconds' => $duration,
+            ]);
+        } catch (Exception $e) {
+            Log::warning("DVR post-processing step 2 failed: could not update file_path: {$e->getMessage()}");
+        }
+
+        // ── Step 3: Dispatch metadata enrichment (non-fatal) ────────────────
+        try {
+            if ($setting->enable_metadata_enrichment) {
+                EnrichDvrMetadata::dispatch($recording->id)->onQueue('dvr-meta');
+            } else {
+                // Metadata enrichment disabled — integrate directly without metadata
+                IntegrateDvrRecordingToVod::dispatch($recording->id)->onQueue('dvr-post');
+            }
+        } catch (Exception $e) {
+            Log::warning("DVR post-processing step 3: could not dispatch metadata enrichment: {$e->getMessage()}");
+        }
+
+        // ── Step 4: Cleanup temp dir + mark COMPLETED ───────────────────────
+        try {
+            Storage::disk($disk)->deleteDirectory($livePath);
+        } catch (Exception $e) {
+            Log::warning("DVR post-processing step 4: could not delete temp dir {$livePath}: {$e->getMessage()}");
+        }
+
+        $recording->update([
+            'status' => DvrRecordingStatus::Completed->value,
+        ]);
+
+        // Disable "once" rules after a successful recording so they don't re-schedule
+        $rule = $recording->recordingRule;
+        if ($rule && $rule->type === DvrRuleType::Once) {
+            $rule->update(['enabled' => false]);
+        }
+
+        Log::info("DVR recording completed: {$recording->title}", [
+            'recording_id' => $recording->id,
+            'file_path' => $outputRelPath,
+        ]);
+    }
+
+    /**
+     * Build the final output path for the recording (relative to the dvr disk).
+     *
+     * Pattern: library/{Year}/{Title}/Title - SXXEYY.ts
+     * or:       library/{Year}/{Title}/Title - YYYY-MM-DD.ts
+     */
+    public function buildOutputPath(DvrRecording $recording): string
+    {
+        $title = $this->sanitizeFileName($recording->title);
+        $year = ($recording->programme_start ?? $recording->scheduled_start)?->format('Y') ?? now()->format('Y');
+
+        if ($recording->season !== null && $recording->episode !== null) {
+            $episode = sprintf('%s - S%02dE%02d', $title, $recording->season, $recording->episode);
+        } else {
+            $date = ($recording->programme_start ?? $recording->scheduled_start)?->format('Y-m-d') ?? now()->format('Y-m-d');
+            $episode = "{$title} - {$date}";
+        }
+
+        return "library/{$year}/{$title}/{$episode}.ts";
+    }
+
+    /**
+     * Concatenate HLS segments into a single .ts file using ffmpeg's concat demuxer.
+     *
+     * We build an explicit file list from the .m3u8 manifest and pass it via the
+     * concat demuxer (-f concat) rather than feeding the .m3u8 directly as input.
+     * This avoids issues with corrupt/bogus #EXTINF durations in the manifest that
+     * can cause ffmpeg to treat a segment as hours long and stall at near-zero speed.
+     */
+    private function concatHls(string $ffmpegPath, string $m3u8Path, string $outputPath): void
+    {
+        $segmentDir = dirname($m3u8Path);
+        $concatListPath = $segmentDir.'/concat-list.txt';
+        $logFile = $segmentDir.'/ffmpeg-concat.log';
+
+        // Parse segment filenames from the .m3u8 manifest (lines not starting with #)
+        $segments = array_filter(
+            array_map('trim', file($m3u8Path)),
+            fn (string $line) => $line !== '' && ! str_starts_with($line, '#')
+        );
+
+        if (empty($segments)) {
+            throw new Exception('No segments found in HLS manifest');
+        }
+
+        // Write the ffmpeg concat list file
+        $listContent = implode("\n", array_map(
+            fn (string $seg) => "file '".addslashes("{$segmentDir}/{$seg}")."'",
+            $segments
+        ));
+        file_put_contents($concatListPath, $listContent);
+
+        $args = [
+            $ffmpegPath,
+            '-y',
+            '-f', 'concat',
+            '-safe', '0',
+            '-i', $concatListPath,
+            '-c', 'copy',
+            '-f', 'mpegts',
+            $outputPath,
+        ];
+
+        $cmd = implode(' ', array_map('escapeshellarg', $args)).' 2>&1';
+
+        $descriptor = [
+            0 => ['file', '/dev/null', 'r'],
+            1 => ['file', $logFile, 'w'],
+            2 => ['file', $logFile, 'a'],
+        ];
+
+        $process = proc_open($cmd, $descriptor, $pipes);
+
+        if (! is_resource($process)) {
+            throw new Exception('proc_open failed for HLS concat');
+        }
+
+        $exitCode = proc_close($process);
+
+        // Clean up concat list file
+        @unlink($concatListPath);
+
+        if ($exitCode !== 0) {
+            $log = file_exists($logFile) ? file_get_contents($logFile) : 'no log';
+            throw new Exception("ffmpeg concat exited with code {$exitCode}: ".substr($log, -500));
+        }
+    }
+
+    /**
+     * Estimate duration in seconds from actual or scheduled times.
+     */
+    private function estimateDuration(DvrRecording $recording): ?int
+    {
+        if ($recording->actual_start && $recording->actual_end) {
+            return (int) abs($recording->actual_end->diffInSeconds($recording->actual_start));
+        }
+
+        if ($recording->scheduled_start && $recording->scheduled_end) {
+            return (int) abs($recording->scheduled_end->diffInSeconds($recording->scheduled_start));
+        }
+
+        return null;
+    }
+
+    /**
+     * Mark a recording as FAILED.
+     */
+    private function markFailed(DvrRecording $recording, string $reason): void
+    {
+        Log::error("DVR post-processing FAILED for recording {$recording->id}: {$reason}");
+
+        $recording->update([
+            'status' => DvrRecordingStatus::Failed->value,
+            'error_message' => $reason,
+        ]);
+    }
+
+    /**
+     * Sanitize a string for use as a file/directory name.
+     */
+    private function sanitizeFileName(string $name): string
+    {
+        // Remove characters not suitable for file names
+        $name = preg_replace('/[\/\\\\:*?"<>|]/', '', $name);
+        $name = trim($name, '. ');
+
+        return $name ?: 'Unknown';
+    }
+}

--- a/app/Services/DvrPostProcessorService.php
+++ b/app/Services/DvrPostProcessorService.php
@@ -88,7 +88,8 @@ class DvrPostProcessorService
 
         $ffmpegPath = $setting->getFfmpegPath();
 
-        $this->setStep($recording, 'Concatenating HLS segments to MP4');
+        $outputFormat = $setting->dvr_output_format ?? 'mp4';
+        $this->setStep($recording, 'Concatenating HLS segments to '.strtoupper($outputFormat));
 
         try {
             $segmentCount = $this->countSegments($m3u8FullPath);
@@ -98,7 +99,7 @@ class DvrPostProcessorService
                 'output_path' => $outputRelPath,
             ]);
 
-            $this->concatHls($ffmpegPath, $m3u8FullPath, $outputFullPath);
+            $this->concatHls($ffmpegPath, $m3u8FullPath, $outputFullPath, $outputFormat);
         } catch (Exception $e) {
             $this->markFailed($recording, "HLS concat failed: {$e->getMessage()}");
 
@@ -108,7 +109,7 @@ class DvrPostProcessorService
         $fileSize = file_exists($outputFullPath) ? filesize($outputFullPath) : null;
         $duration = $this->estimateDuration($recording);
 
-        Log::info('DVR post-processing step 1 complete: MP4 concatenated', [
+        Log::info('DVR post-processing step 1 complete: '.strtoupper($outputFormat).' concatenated', [
             'recording_id' => $recording->id,
             'output_path' => $outputRelPath,
             'file_size_bytes' => $fileSize,
@@ -203,13 +204,16 @@ class DvrPostProcessorService
     /**
      * Build the final output path for the recording (relative to the dvr disk).
      *
-     * Pattern: library/{Year}/{Title}/Title - SXXEYY.mp4
-     * or:       library/{Year}/{Title}/Title - YYYY-MM-DD.mp4
+     * Pattern: library/{Year}/{Title}/Title - SXXEYY.{ext}
+     * or:       library/{Year}/{Title}/Title - YYYY-MM-DD.{ext}
+     *
+     * The extension is derived from the DvrSetting's dvr_output_format (mp4, mkv, ts).
      */
     public function buildOutputPath(DvrRecording $recording): string
     {
         $title = $this->sanitizeFileName($recording->title);
         $year = ($recording->programme_start ?? $recording->scheduled_start)?->format('Y') ?? now()->format('Y');
+        $ext = $recording->dvrSetting?->dvr_output_format ?? 'mp4';
 
         if ($recording->season !== null && $recording->episode !== null) {
             $episode = sprintf('%s - S%02dE%02d', $title, $recording->season, $recording->episode);
@@ -218,7 +222,7 @@ class DvrPostProcessorService
             $episode = "{$title} - {$date}";
         }
 
-        return "library/{$year}/{$title}/{$episode}.mp4";
+        return "library/{$year}/{$title}/{$episode}.{$ext}";
     }
 
     /**
@@ -236,33 +240,56 @@ class DvrPostProcessorService
     }
 
     /**
-     * Concatenate HLS segments into a single .mp4 file using ffmpeg's concat demuxer.
+     * Concatenate HLS segments into a single output file.
      *
-     * We build an explicit file list from the .m3u8 manifest and pass it via the
-     * concat demuxer (-f concat) rather than feeding the .m3u8 directly as input.
-     * This avoids issues with corrupt/bogus #EXTINF durations in the manifest that
-     * can cause ffmpeg to treat a segment as hours long and stall at near-zero speed.
+     * For MPEG-TS output: binary-concatenates the raw .ts segment files directly —
+     * no FFmpeg needed, fastest possible path, zero re-encoding overhead.
      *
-     * Output is MP4 with -movflags +faststart so the moov atom (index) is written
-     * at the front of the file, enabling true random-access seeking in all players.
+     * For MP4/MKV output: uses FFmpeg's concat demuxer with -c copy (stream copy only,
+     * no re-encoding). We build an explicit file list from the .m3u8 manifest rather than
+     * feeding the manifest directly, which avoids stalls caused by corrupt #EXTINF durations.
+     *
+     * Output format is determined by the $format parameter: 'ts', 'mp4', or 'mkv'.
      */
-    private function concatHls(string $ffmpegPath, string $m3u8Path, string $outputPath): void
+    private function concatHls(string $ffmpegPath, string $m3u8Path, string $outputPath, string $format = 'ts'): void
     {
         $segmentDir = dirname($m3u8Path);
-        $concatListPath = $segmentDir.'/concat-list.txt';
-        $logFile = $segmentDir.'/ffmpeg-concat.log';
 
         // Parse segment filenames from the .m3u8 manifest (lines not starting with #)
-        $segments = array_filter(
+        $segments = array_values(array_filter(
             array_map('trim', file($m3u8Path)),
             fn (string $line) => $line !== '' && ! str_starts_with($line, '#')
-        );
+        ));
 
         if (empty($segments)) {
             throw new Exception('No segments found in HLS manifest');
         }
 
-        // Write the ffmpeg concat list file
+        // Fast path: MPEG-TS is just a binary concat of the segment files
+        if ($format === 'ts') {
+            $out = fopen($outputPath, 'wb');
+            if (! $out) {
+                throw new Exception("Could not open output file for writing: {$outputPath}");
+            }
+            foreach ($segments as $seg) {
+                $segPath = "{$segmentDir}/{$seg}";
+                if (! file_exists($segPath)) {
+                    fclose($out);
+                    throw new Exception("Segment not found: {$segPath}");
+                }
+                $in = fopen($segPath, 'rb');
+                stream_copy_to_stream($in, $out);
+                fclose($in);
+            }
+            fclose($out);
+
+            return;
+        }
+
+        // MP4 / MKV: use FFmpeg concat demuxer with stream copy
+        $concatListPath = $segmentDir.'/concat-list.txt';
+        $logFile = $segmentDir.'/ffmpeg-concat.log';
+
         $listContent = implode("\n", array_map(
             fn (string $seg) => "file '".addslashes("{$segmentDir}/{$seg}")."'",
             $segments
@@ -276,9 +303,14 @@ class DvrPostProcessorService
             '-safe', '0',
             '-i', $concatListPath,
             '-c', 'copy',
-            '-movflags', '+faststart',
-            $outputPath,
         ];
+
+        match ($format) {
+            'mkv' => array_push($args, '-f', 'matroska'),
+            default => array_push($args, '-movflags', '+faststart'), // mp4
+        };
+
+        $args[] = $outputPath;
 
         $cmd = implode(' ', array_map('escapeshellarg', $args)).' 2>&1';
 

--- a/app/Services/DvrPostProcessorService.php
+++ b/app/Services/DvrPostProcessorService.php
@@ -51,8 +51,18 @@ class DvrPostProcessorService
 
         $disk = $setting->storage_disk ?: config('dvr.storage_disk');
         $livePath = $recording->temp_path ?? 'live/'.$recording->uuid;
-        $m3u8RelPath = $recording->temp_manifest_path ?? ($livePath.'/stream.m3u8');
-        $m3u8FullPath = Storage::disk($disk)->path($m3u8RelPath);
+
+        // The proxy callback sends temp_path as an absolute filesystem path.
+        // Resolve the manifest path appropriately: absolute paths are used directly,
+        // relative paths are resolved through the storage disk.
+        if ($recording->temp_manifest_path) {
+            $m3u8FullPath = $recording->temp_manifest_path;
+        } elseif (str_starts_with($livePath, '/')) {
+            // Absolute path from proxy callback — the broadcast manager uses live.m3u8
+            $m3u8FullPath = rtrim($livePath, '/').'/'.'live.m3u8';
+        } else {
+            $m3u8FullPath = Storage::disk($disk)->path($livePath.'/live.m3u8');
+        }
 
         Log::debug('DVR post-processing: locating HLS manifest', [
             'recording_id' => $recording->id,
@@ -61,8 +71,7 @@ class DvrPostProcessorService
         ]);
 
         if (! file_exists($m3u8FullPath)) {
-            // FFmpeg writes to stream.m3u8.tmp while recording; if we caught it mid-segment,
-            // only the .tmp file may exist. Try that before giving up.
+            // The proxy may still be writing the final segment: try the .tmp variant
             $tmpPath = preg_replace('/\.m3u8$/', '.m3u8.tmp', $m3u8FullPath);
             if (file_exists($tmpPath)) {
                 Log::warning('DVR post-processing: finalized .m3u8 not found — falling back to .m3u8.tmp', [

--- a/app/Services/DvrPostProcessorService.php
+++ b/app/Services/DvrPostProcessorService.php
@@ -15,9 +15,9 @@ use Illuminate\Support\Facades\Storage;
  * DvrPostProcessorService — Runs after ffmpeg stops.
  *
  * Pipeline:
- *   Step 1 (FATAL)     — Concatenate HLS segments → single .ts file via ffmpeg
+ *   Step 1 (FATAL)     — Concatenate HLS segments → single .mp4 file via ffmpeg
  *   Step 2 (non-fatal) — Move file to final library path, update DB
- *   Step 3 (non-fatal) — Dispatch EnrichDvrMetadata job
+ *   Step 3 (non-fatal) — Dispatch EnrichDvrMetadata or IntegrateDvrRecordingToVod
  *   Step 4             — Cleanup live/ temp dir, update DB to COMPLETED
  */
 class DvrPostProcessorService
@@ -28,11 +28,14 @@ class DvrPostProcessorService
     public function run(DvrRecording $recording): void
     {
         Log::info("DVR post-processing started for recording {$recording->id}", [
+            'recording_id' => $recording->id,
             'title' => $recording->title,
+            'status' => $recording->status->value,
         ]);
 
         if ($recording->status !== DvrRecordingStatus::PostProcessing) {
             Log::warning("DVR post-processor: recording {$recording->id} not in POST_PROCESSING state — skipping", [
+                'recording_id' => $recording->id,
                 'status' => $recording->status->value,
             ]);
 
@@ -47,17 +50,25 @@ class DvrPostProcessorService
         }
 
         $disk = $setting->storage_disk ?: config('dvr.storage_disk');
-        $livePath = $recording->temp_path; // e.g. live/{uuid}
-        $m3u8RelPath = $recording->temp_manifest_path; // e.g. live/{uuid}/stream.m3u8
-
+        $livePath = $recording->temp_path ?? 'live/'.$recording->uuid;
+        $m3u8RelPath = $recording->temp_manifest_path ?? ($livePath.'/stream.m3u8');
         $m3u8FullPath = Storage::disk($disk)->path($m3u8RelPath);
+
+        Log::debug('DVR post-processing: locating HLS manifest', [
+            'recording_id' => $recording->id,
+            'disk' => $disk,
+            'manifest_path' => $m3u8FullPath,
+        ]);
 
         if (! file_exists($m3u8FullPath)) {
             // FFmpeg writes to stream.m3u8.tmp while recording; if we caught it mid-segment,
             // only the .tmp file may exist. Try that before giving up.
             $tmpPath = preg_replace('/\.m3u8$/', '.m3u8.tmp', $m3u8FullPath);
             if (file_exists($tmpPath)) {
-                Log::warning("DVR: Finalized .m3u8 not found, using .m3u8.tmp for recording {$recording->id}");
+                Log::warning('DVR post-processing: finalized .m3u8 not found — falling back to .m3u8.tmp', [
+                    'recording_id' => $recording->id,
+                    'tmp_path' => $tmpPath,
+                ]);
                 $m3u8FullPath = $tmpPath;
             } else {
                 $this->markFailed($recording, "HLS manifest not found at {$m3u8FullPath}");
@@ -66,7 +77,7 @@ class DvrPostProcessorService
             }
         }
 
-        // ── Step 1: Concatenate HLS → single .ts ────────────────────────────
+        // ── Step 1: Concatenate HLS → single .mp4 ───────────────────────────
         $outputRelPath = $this->buildOutputPath($recording);
         $outputFullPath = Storage::disk($disk)->path($outputRelPath);
         $outputDir = dirname($outputFullPath);
@@ -77,7 +88,16 @@ class DvrPostProcessorService
 
         $ffmpegPath = $setting->getFfmpegPath();
 
+        $this->setStep($recording, 'Concatenating HLS segments to MP4');
+
         try {
+            $segmentCount = $this->countSegments($m3u8FullPath);
+            Log::info('DVR post-processing step 1: concatenating HLS segments', [
+                'recording_id' => $recording->id,
+                'segment_count' => $segmentCount,
+                'output_path' => $outputRelPath,
+            ]);
+
             $this->concatHls($ffmpegPath, $m3u8FullPath, $outputFullPath);
         } catch (Exception $e) {
             $this->markFailed($recording, "HLS concat failed: {$e->getMessage()}");
@@ -88,63 +108,103 @@ class DvrPostProcessorService
         $fileSize = file_exists($outputFullPath) ? filesize($outputFullPath) : null;
         $duration = $this->estimateDuration($recording);
 
-        Log::info('DVR post-processing step 1 complete: HLS concatenated', [
+        Log::info('DVR post-processing step 1 complete: MP4 concatenated', [
             'recording_id' => $recording->id,
             'output_path' => $outputRelPath,
-            'file_size' => $fileSize,
+            'file_size_bytes' => $fileSize,
+            'file_size_mb' => $fileSize ? round($fileSize / 1024 / 1024, 1) : null,
+            'duration_seconds' => $duration,
         ]);
 
         // ── Step 2: Update DB with file location ────────────────────────────
+        $this->setStep($recording, 'Saving to library');
+
         try {
             $recording->update([
                 'file_path' => $outputRelPath,
                 'file_size_bytes' => $fileSize,
                 'duration_seconds' => $duration,
             ]);
+
+            Log::debug('DVR post-processing step 2 complete: file_path saved', [
+                'recording_id' => $recording->id,
+                'file_path' => $outputRelPath,
+            ]);
         } catch (Exception $e) {
-            Log::warning("DVR post-processing step 2 failed: could not update file_path: {$e->getMessage()}");
+            Log::warning("DVR post-processing step 2 failed: could not update file_path: {$e->getMessage()}", [
+                'recording_id' => $recording->id,
+            ]);
         }
 
-        // ── Step 3: Dispatch metadata enrichment (non-fatal) ────────────────
+        // ── Step 3: Dispatch metadata enrichment or VOD integration ─────────
         try {
             if ($setting->enable_metadata_enrichment) {
+                $this->setStep($recording, 'Queuing metadata enrichment');
+
+                Log::info('DVR post-processing step 3: dispatching metadata enrichment', [
+                    'recording_id' => $recording->id,
+                ]);
+
                 EnrichDvrMetadata::dispatch($recording->id)->onQueue('dvr-meta');
             } else {
-                // Metadata enrichment disabled — integrate directly without metadata
+                $this->setStep($recording, 'Queuing VOD integration');
+
+                Log::info('DVR post-processing step 3: metadata enrichment disabled — dispatching VOD integration directly', [
+                    'recording_id' => $recording->id,
+                ]);
+
                 IntegrateDvrRecordingToVod::dispatch($recording->id)->onQueue('dvr-post');
             }
         } catch (Exception $e) {
-            Log::warning("DVR post-processing step 3: could not dispatch metadata enrichment: {$e->getMessage()}");
+            Log::warning("DVR post-processing step 3: failed to dispatch next job: {$e->getMessage()}", [
+                'recording_id' => $recording->id,
+            ]);
         }
 
         // ── Step 4: Cleanup temp dir + mark COMPLETED ───────────────────────
         try {
             Storage::disk($disk)->deleteDirectory($livePath);
+
+            Log::debug('DVR post-processing step 4: temp directory cleaned up', [
+                'recording_id' => $recording->id,
+                'live_path' => $livePath,
+            ]);
         } catch (Exception $e) {
-            Log::warning("DVR post-processing step 4: could not delete temp dir {$livePath}: {$e->getMessage()}");
+            Log::warning("DVR post-processing step 4: could not delete temp dir {$livePath}: {$e->getMessage()}", [
+                'recording_id' => $recording->id,
+            ]);
         }
 
         $recording->update([
             'status' => DvrRecordingStatus::Completed->value,
+            'post_processing_step' => null,
         ]);
 
         // Disable "once" rules after a successful recording so they don't re-schedule
         $rule = $recording->recordingRule;
         if ($rule && $rule->type === DvrRuleType::Once) {
             $rule->update(['enabled' => false]);
+
+            Log::debug('DVR post-processing: disabled once-rule after successful recording', [
+                'recording_id' => $recording->id,
+                'rule_id' => $rule->id,
+            ]);
         }
 
-        Log::info("DVR recording completed: {$recording->title}", [
+        Log::info('DVR post-processing complete', [
             'recording_id' => $recording->id,
+            'title' => $recording->title,
             'file_path' => $outputRelPath,
+            'file_size_mb' => $fileSize ? round($fileSize / 1024 / 1024, 1) : null,
+            'duration_seconds' => $duration,
         ]);
     }
 
     /**
      * Build the final output path for the recording (relative to the dvr disk).
      *
-     * Pattern: library/{Year}/{Title}/Title - SXXEYY.ts
-     * or:       library/{Year}/{Title}/Title - YYYY-MM-DD.ts
+     * Pattern: library/{Year}/{Title}/Title - SXXEYY.mp4
+     * or:       library/{Year}/{Title}/Title - YYYY-MM-DD.mp4
      */
     public function buildOutputPath(DvrRecording $recording): string
     {
@@ -158,16 +218,33 @@ class DvrPostProcessorService
             $episode = "{$title} - {$date}";
         }
 
-        return "library/{$year}/{$title}/{$episode}.ts";
+        return "library/{$year}/{$title}/{$episode}.mp4";
     }
 
     /**
-     * Concatenate HLS segments into a single .ts file using ffmpeg's concat demuxer.
+     * Update the post_processing_step on the recording and emit a log entry.
+     * Refreshes the model in-place so subsequent reads see the updated value.
+     */
+    private function setStep(DvrRecording $recording, string $step): void
+    {
+        $recording->update(['post_processing_step' => $step]);
+
+        Log::debug("DVR post-processing step: {$step}", [
+            'recording_id' => $recording->id,
+            'title' => $recording->title,
+        ]);
+    }
+
+    /**
+     * Concatenate HLS segments into a single .mp4 file using ffmpeg's concat demuxer.
      *
      * We build an explicit file list from the .m3u8 manifest and pass it via the
      * concat demuxer (-f concat) rather than feeding the .m3u8 directly as input.
      * This avoids issues with corrupt/bogus #EXTINF durations in the manifest that
      * can cause ffmpeg to treat a segment as hours long and stall at near-zero speed.
+     *
+     * Output is MP4 with -movflags +faststart so the moov atom (index) is written
+     * at the front of the file, enabling true random-access seeking in all players.
      */
     private function concatHls(string $ffmpegPath, string $m3u8Path, string $outputPath): void
     {
@@ -199,7 +276,7 @@ class DvrPostProcessorService
             '-safe', '0',
             '-i', $concatListPath,
             '-c', 'copy',
-            '-f', 'mpegts',
+            '-movflags', '+faststart',
             $outputPath,
         ];
 
@@ -229,6 +306,21 @@ class DvrPostProcessorService
     }
 
     /**
+     * Count the number of .ts segments listed in an HLS manifest.
+     */
+    private function countSegments(string $m3u8Path): int
+    {
+        if (! file_exists($m3u8Path)) {
+            return 0;
+        }
+
+        return count(array_filter(
+            array_map('trim', file($m3u8Path)),
+            fn (string $line) => $line !== '' && ! str_starts_with($line, '#')
+        ));
+    }
+
+    /**
      * Estimate duration in seconds from actual or scheduled times.
      */
     private function estimateDuration(DvrRecording $recording): ?int
@@ -245,15 +337,19 @@ class DvrPostProcessorService
     }
 
     /**
-     * Mark a recording as FAILED.
+     * Mark a recording as FAILED and clear any in-progress step label.
      */
     private function markFailed(DvrRecording $recording, string $reason): void
     {
-        Log::error("DVR post-processing FAILED for recording {$recording->id}: {$reason}");
+        Log::error("DVR post-processing FAILED for recording {$recording->id}: {$reason}", [
+            'recording_id' => $recording->id,
+            'title' => $recording->title,
+        ]);
 
         $recording->update([
             'status' => DvrRecordingStatus::Failed->value,
             'error_message' => $reason,
+            'post_processing_step' => null,
         ]);
     }
 

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -65,17 +65,14 @@ class DvrRecorderService
         }
 
         // Refresh stream URL at start time — IPTV stream URLs expire, so we get
-        // a fresh URL from the channel. When proxy is enabled on the source
-        // playlist, use getProxyUrl() to get a fresh URL via m3u-proxy.
-        // Otherwise fall back to the channel's direct URL.
+        // a fresh URL from the channel. When use_proxy is enabled on the DVR
+        // setting, route the stream through the m3u-proxy so viewers can also
+        // watch the same channel while it is being recorded.
         $channel = $recording->channel;
         $streamUrl = null;
 
-        if ($channel) {
-            $playlist = $setting->playlist;
-            if ($playlist && ! empty($playlist->proxy_options['enabled'])) {
-                $streamUrl = $channel->getProxyUrl();
-            }
+        if ($channel && $setting->use_proxy) {
+            $streamUrl = $channel->getProxyUrl();
         }
 
         if (empty($streamUrl) && $channel) {

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -6,22 +6,25 @@ use App\Enums\DvrRecordingStatus;
 use App\Models\DvrRecording;
 use Exception;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 /**
- * DvrRecorderService — Manages FFmpeg child processes for active recordings.
+ * DvrRecorderService — Delegates FFmpeg process management to the m3u-proxy.
  *
  * Responsibilities:
- * - Spawn ffmpeg in HLS mode for each recording
- * - Monitor process exit (success/failure)
- * - Graceful shutdown: SIGINT → wait → SIGKILL
- * - Crash recovery: mark stale RECORDING rows as FAILED on app boot
+ * - Start a DVR broadcast on the proxy (via BroadcastManager)
+ * - Stop a running broadcast via the proxy API
+ * - Recover stale RECORDING rows on app boot
+ *
+ * The proxy handles all FFmpeg lifecycle, HLS segment preservation (dvr_mode),
+ * hardware acceleration, and post-recording callbacks. No PIDs or sleep loops here.
  */
 class DvrRecorderService
 {
+    public function __construct(protected M3uProxyService $proxy) {}
+
     /**
      * Recover from a crash by marking any stale RECORDING rows as FAILED.
-     * Should be called once on application boot (e.g. via a queued job or service provider).
+     * Called once on application boot.
      */
     public function recoverFromCrash(): void
     {
@@ -38,15 +41,15 @@ class DvrRecorderService
         DvrRecording::recording()->update([
             'status' => DvrRecordingStatus::Failed->value,
             'error_message' => 'Server restarted during recording',
-            'pid' => null,
+            'proxy_network_id' => null,
         ]);
     }
 
     /**
-     * Start recording: spawn ffmpeg in HLS mode, update DB, detach the process.
+     * Start recording by launching a DVR broadcast on the proxy.
      *
-     * We use `proc_open` so we can track the PID. The process is intentionally
-     * left running in the background — `StopDvrRecording` will terminate it.
+     * The proxy manages the FFmpeg process, preserves all HLS segments (dvr_mode=true),
+     * and calls back the editor when the recording ends or fails.
      */
     public function start(DvrRecording $recording): void
     {
@@ -64,197 +67,91 @@ class DvrRecorderService
             throw new Exception("DvrSetting not found for recording {$recording->id}");
         }
 
-        // Refresh stream URL at start time — IPTV stream URLs expire, so we get
-        // a fresh URL from the channel. When use_proxy is enabled on the DVR
-        // setting, route the stream through the m3u-proxy so viewers can also
-        // watch the same channel while it is being recorded.
+        // Always route through the proxy — it handles stream URL refresh, reconnects,
+        // and concurrent viewer access via its pooled stream feature.
         $channel = $recording->channel;
-        $streamUrl = null;
-
-        if ($channel && $setting->use_proxy) {
-            $streamUrl = $channel->getProxyUrl();
-        }
-
-        if (empty($streamUrl) && $channel) {
-            $streamUrl = $channel->url;
-        }
-
-        if (empty($streamUrl)) {
-            $streamUrl = $recording->stream_url;
-        }
+        $streamUrl = $channel?->getProxyUrl() ?? $recording->stream_url;
 
         if (empty($streamUrl)) {
             throw new Exception("Recording {$recording->id} has no stream_url — cannot start");
         }
 
-        // Update stored URL so post-processor/streamer uses the same URL we record from
         if ($streamUrl !== $recording->stream_url) {
             $recording->stream_url = $streamUrl;
             $recording->saveQuietly();
         }
 
-        // 1. Generate temp paths if not already set
-        $livePath = $recording->temp_path ?? 'live/'.$recording->uuid;
-        $m3u8RelPath = $livePath.'/stream.m3u8';
-
-        // Persist temp paths so post-processor can find them
-        $recording->update([
-            'temp_path' => $livePath,
-            'temp_manifest_path' => $m3u8RelPath,
-        ]);
-
-        // 2. Create the HLS output directory on the dvr disk
-        Storage::disk($setting->storage_disk ?: config('dvr.storage_disk'))
-            ->makeDirectory($livePath);
-
-        $fullLiveDir = Storage::disk($setting->storage_disk ?: config('dvr.storage_disk'))
-            ->path($livePath);
-
-        $m3u8Path = $fullLiveDir.'/stream.m3u8';
-        $segmentPattern = $fullLiveDir.'/segment_%04d.ts';
-
-        $ffmpegPath = $setting->getFfmpegPath();
-        $segmentSeconds = (int) config('dvr.hls_segment_seconds', 6);
-
-        $args = [
-            $ffmpegPath,
-            '-y',
-            '-i', $streamUrl,
-            '-c', 'copy',
-            '-f', 'hls',
-            '-hls_time', (string) $segmentSeconds,
-            '-hls_list_size', '0',
-            '-hls_flags', 'append_list+omit_endlist',
-            '-hls_segment_filename', $segmentPattern,
-            $m3u8Path,
-        ];
-
-        $cmd = implode(' ', array_map('escapeshellarg', $args));
-
-        // 2. Spawn ffmpeg (stdout/stderr to log file, detached)
-        $logFile = $fullLiveDir.'/ffmpeg.log';
-        $descriptor = [
-            0 => ['file', '/dev/null', 'r'],
-            1 => ['file', $logFile, 'w'],
-            2 => ['file', $logFile, 'a'],
-        ];
-
-        Log::info('DVR: Starting ffmpeg recording', [
+        Log::info('DVR: Starting proxy broadcast', [
             'recording_id' => $recording->id,
             'title' => $recording->title,
             'stream_url' => $streamUrl,
         ]);
 
-        $process = proc_open($cmd, $descriptor, $pipes);
+        $networkId = $this->proxy->startDvrBroadcast($recording, $setting, $streamUrl);
 
-        if (! is_resource($process)) {
-            throw new Exception("proc_open failed for recording {$recording->id}");
-        }
-
-        $status = proc_get_status($process);
-        $pid = $status['pid'] ?? null;
-
-        // 3. Update DB
         $recording->update([
             'status' => DvrRecordingStatus::Recording->value,
             'actual_start' => now(),
-            'pid' => $pid,
+            'proxy_network_id' => $networkId,
         ]);
 
-        // Close proc handle (process continues in background)
-        proc_close($process);
-
-        Log::info('DVR: Recording started', [
+        Log::info('DVR: Proxy broadcast started', [
             'recording_id' => $recording->id,
-            'pid' => $pid,
+            'proxy_network_id' => $networkId,
             'title' => $recording->title,
         ]);
     }
 
     /**
-     * Stop recording: send SIGINT, wait for graceful exit, fall back to SIGKILL.
+     * Stop recording by signalling the proxy to terminate the broadcast.
      *
-     * After stopping, the recording is handed off to DvrPostProcessorService via
-     * the PostProcessDvrRecording job.
+     * The proxy handles graceful FFmpeg shutdown and will call back the editor
+     * via the dvr.callback route when done — PostProcessDvrRecording is dispatched
+     * from the callback, not here.
      */
     public function stop(DvrRecording $recording): void
     {
-        $pid = $recording->pid;
+        $networkId = $recording->proxy_network_id;
 
-        if (! $pid) {
-            Log::warning('DVR stop: no PID on recording — assuming already stopped', [
+        if (! $networkId) {
+            Log::warning('DVR stop: no proxy_network_id on recording — assuming already stopped', [
                 'recording_id' => $recording->id,
             ]);
-            $this->finalizeStop($recording, false);
+            $this->finalizeStop($recording);
 
             return;
         }
 
-        Log::info('DVR: Stopping recording (SIGINT)', [
+        Log::info('DVR: Stopping proxy broadcast', [
             'recording_id' => $recording->id,
-            'pid' => $pid,
+            'proxy_network_id' => $networkId,
         ]);
 
-        // Send SIGINT for graceful stop
-        if (function_exists('posix_kill')) {
-            posix_kill($pid, SIGINT);
-        } else {
-            exec("kill -INT {$pid} 2>/dev/null");
-        }
+        $this->proxy->stopDvrBroadcast($networkId);
 
-        // Wait up to the configured timeout for the process to exit
-        $timeout = (int) config('dvr.graceful_stop_timeout_seconds', 10);
-        $waited = 0;
-        $exited = false;
-
-        while ($waited < $timeout) {
-            sleep(1);
-            $waited++;
-            if (! $this->isProcessRunning($pid)) {
-                $exited = true;
-                break;
-            }
-        }
-
-        if (! $exited) {
-            Log::warning('DVR: ffmpeg did not exit after SIGINT — sending SIGKILL', [
-                'recording_id' => $recording->id,
-                'pid' => $pid,
-            ]);
-
-            if (function_exists('posix_kill')) {
-                posix_kill($pid, SIGKILL);
-            } else {
-                exec("kill -9 {$pid} 2>/dev/null");
-            }
-
-            sleep(1);
-        }
-
-        $this->finalizeStop($recording, $exited);
+        $this->finalizeStop($recording);
     }
 
     /**
-     * Cancel a recording (same as stop but marks status as CANCELLED).
-     * Note: we do NOT override the status here because cancel() is called from
-     * stop() which transitions to PostProcessing. Overriding would break the
-     * PostProcessDvrRecording job. The error_message set by stop() is sufficient.
+     * Cancel a recording — stops the proxy broadcast and marks as cancelled.
      */
     public function cancel(DvrRecording $recording): void
     {
         $this->stop($recording);
 
         $recording->update([
+            'status' => DvrRecordingStatus::Cancelled->value,
             'error_message' => 'Cancelled by user',
         ]);
     }
 
     /**
-     * After ffmpeg exits, transition status to POST_PROCESSING (or FAILED).
+     * Transition a stopped recording to POST_PROCESSING.
+     * Called after the proxy broadcast has been signalled to stop.
+     * The proxy callback will trigger the actual post-processing job.
      */
-    private function finalizeStop(DvrRecording $recording, bool $cleanExit): void
+    private function finalizeStop(DvrRecording $recording): void
     {
-        // Don't overwrite CANCELLED or FAILED status
         if (in_array($recording->status, [
             DvrRecordingStatus::Cancelled,
             DvrRecordingStatus::Failed,
@@ -265,22 +162,7 @@ class DvrRecorderService
         $recording->update([
             'status' => DvrRecordingStatus::PostProcessing->value,
             'actual_end' => now(),
-            'pid' => null,
-            'error_message' => $cleanExit ? null : 'ffmpeg did not exit cleanly',
+            'proxy_network_id' => null,
         ]);
-    }
-
-    /**
-     * Check if a process with the given PID is still running.
-     */
-    private function isProcessRunning(int $pid): bool
-    {
-        if (function_exists('posix_kill')) {
-            return posix_kill($pid, 0);
-        }
-
-        exec("kill -0 {$pid} 2>/dev/null", $output, $exitCode);
-
-        return $exitCode === 0;
     }
 }

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Enums\DvrRecordingStatus;
+use App\Jobs\PostProcessDvrRecording;
 use App\Models\DvrRecording;
 use Exception;
 use Illuminate\Support\Facades\Log;
@@ -89,10 +90,16 @@ class DvrRecorderService
 
         $networkId = $this->proxy->startDvrBroadcast($recording, $setting, $streamUrl);
 
+        // Fetch hls_dir immediately — it's deterministic and available as soon as the
+        // broadcast registers. Storing it now means stop() can always find the segments
+        // even if the broadcast has already left the proxy registry by then.
+        $hlsDir = $this->proxy->getDvrBroadcastHlsDir($networkId);
+
         $recording->update([
             'status' => DvrRecordingStatus::Recording->value,
             'actual_start' => now(),
             'proxy_network_id' => $networkId,
+            'temp_path' => $hlsDir,
         ]);
 
         Log::info('DVR: Proxy broadcast started', [
@@ -105,9 +112,10 @@ class DvrRecorderService
     /**
      * Stop recording by signalling the proxy to terminate the broadcast.
      *
-     * The proxy handles graceful FFmpeg shutdown and will call back the editor
-     * via the dvr.callback route when done — PostProcessDvrRecording is dispatched
-     * from the callback, not here.
+     * We query hls_dir from the proxy status endpoint BEFORE stopping so we know
+     * where to find the segments. The job is dispatched directly from here — we
+     * do not wait for the proxy callback, which may not arrive (e.g. if the proxy
+     * is restarting or the callback URL is unreachable).
      */
     public function stop(DvrRecording $recording): void
     {
@@ -117,19 +125,25 @@ class DvrRecorderService
             Log::warning('DVR stop: no proxy_network_id on recording — assuming already stopped', [
                 'recording_id' => $recording->id,
             ]);
-            $this->finalizeStop($recording);
+            $this->finalizeStop($recording, hlsDir: null);
 
             return;
         }
 
+        // Try to fetch hls_dir from the proxy; fall back to what we stored at start time.
+        // The broadcast may have already ended naturally (duration limit) by the time
+        // the scheduler dispatches this stop, in which case the status endpoint returns null.
+        $hlsDir = $this->proxy->getDvrBroadcastHlsDir($networkId) ?? $recording->temp_path;
+
         Log::info('DVR: Stopping proxy broadcast', [
             'recording_id' => $recording->id,
             'proxy_network_id' => $networkId,
+            'hls_dir' => $hlsDir,
         ]);
 
         $this->proxy->stopDvrBroadcast($networkId);
 
-        $this->finalizeStop($recording);
+        $this->finalizeStop($recording, hlsDir: $hlsDir);
     }
 
     /**
@@ -137,20 +151,27 @@ class DvrRecorderService
      */
     public function cancel(DvrRecording $recording): void
     {
-        $this->stop($recording);
+        $networkId = $recording->proxy_network_id;
+
+        if ($networkId) {
+            $this->proxy->stopDvrBroadcast($networkId);
+        }
 
         $recording->update([
             'status' => DvrRecordingStatus::Cancelled->value,
+            'actual_end' => now(),
+            'proxy_network_id' => null,
             'error_message' => 'Cancelled by user',
         ]);
     }
 
     /**
-     * Transition a stopped recording to POST_PROCESSING.
-     * Called after the proxy broadcast has been signalled to stop.
-     * The proxy callback will trigger the actual post-processing job.
+     * Transition a stopped recording to POST_PROCESSING and dispatch the concat job.
+     *
+     * FFmpeg may still be flushing its final segment for a few seconds after the stop
+     * signal. We delay the job by 10 seconds to give it time to finish writing.
      */
-    private function finalizeStop(DvrRecording $recording): void
+    private function finalizeStop(DvrRecording $recording, ?string $hlsDir): void
     {
         if (in_array($recording->status, [
             DvrRecordingStatus::Cancelled,
@@ -159,10 +180,28 @@ class DvrRecorderService
             return;
         }
 
-        $recording->update([
+        $update = [
             'status' => DvrRecordingStatus::PostProcessing->value,
             'actual_end' => now(),
             'proxy_network_id' => null,
+        ];
+
+        if ($hlsDir) {
+            $update['temp_path'] = $hlsDir;
+        }
+
+        $recording->update($update);
+
+        // Delay 10 s so FFmpeg finishes flushing the final HLS segment before we
+        // try to read the manifest. The proxy callback (if it arrives) will be a
+        // no-op because DvrCallbackController skips Completed/Failed recordings.
+        PostProcessDvrRecording::dispatch($recording->id)
+            ->onQueue('dvr-post')
+            ->delay(now()->addSeconds(10));
+
+        Log::info('DVR: Post-processing queued', [
+            'recording_id' => $recording->id,
+            'hls_dir' => $hlsDir,
         ]);
     }
 }

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\DvrRecordingStatus;
+use App\Models\DvrRecording;
+use Exception;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * DvrRecorderService — Manages FFmpeg child processes for active recordings.
+ *
+ * Responsibilities:
+ * - Spawn ffmpeg in HLS mode for each recording
+ * - Monitor process exit (success/failure)
+ * - Graceful shutdown: SIGINT → wait → SIGKILL
+ * - Crash recovery: mark stale RECORDING rows as FAILED on app boot
+ */
+class DvrRecorderService
+{
+    /**
+     * Recover from a crash by marking any stale RECORDING rows as FAILED.
+     * Should be called once on application boot (e.g. via a queued job or service provider).
+     */
+    public function recoverFromCrash(): void
+    {
+        $stale = DvrRecording::recording()->get();
+
+        if ($stale->isEmpty()) {
+            return;
+        }
+
+        Log::warning('DVR crash recovery: marking stale RECORDING entries as FAILED', [
+            'count' => $stale->count(),
+        ]);
+
+        DvrRecording::recording()->update([
+            'status' => DvrRecordingStatus::Failed->value,
+            'error_message' => 'Server restarted during recording',
+            'pid' => null,
+        ]);
+    }
+
+    /**
+     * Start recording: spawn ffmpeg in HLS mode, update DB, detach the process.
+     *
+     * We use `proc_open` so we can track the PID. The process is intentionally
+     * left running in the background — `StopDvrRecording` will terminate it.
+     */
+    public function start(DvrRecording $recording): void
+    {
+        if ($recording->status !== DvrRecordingStatus::Scheduled) {
+            Log::warning('DVR start skipped — recording not in SCHEDULED state', [
+                'recording_id' => $recording->id,
+                'status' => $recording->status->value,
+            ]);
+
+            return;
+        }
+
+        $setting = $recording->dvrSetting;
+        if (! $setting) {
+            throw new Exception("DvrSetting not found for recording {$recording->id}");
+        }
+
+        // Refresh stream URL at start time — IPTV stream URLs expire, so we get
+        // a fresh URL from the channel. When proxy is enabled on the source
+        // playlist, use getProxyUrl() to get a fresh URL via m3u-proxy.
+        // Otherwise fall back to the channel's direct URL.
+        $channel = $recording->channel;
+        $streamUrl = null;
+
+        if ($channel) {
+            $playlist = $setting->playlist;
+            if ($playlist && ! empty($playlist->proxy_options['enabled'])) {
+                $streamUrl = $channel->getProxyUrl();
+            }
+        }
+
+        if (empty($streamUrl) && $channel) {
+            $streamUrl = $channel->url;
+        }
+
+        if (empty($streamUrl)) {
+            $streamUrl = $recording->stream_url;
+        }
+
+        if (empty($streamUrl)) {
+            throw new Exception("Recording {$recording->id} has no stream_url — cannot start");
+        }
+
+        // Update stored URL so post-processor/streamer uses the same URL we record from
+        if ($streamUrl !== $recording->stream_url) {
+            $recording->stream_url = $streamUrl;
+            $recording->saveQuietly();
+        }
+
+        // 1. Generate temp paths if not already set
+        $livePath = $recording->temp_path ?? 'live/'.$recording->uuid;
+        $m3u8RelPath = $livePath.'/stream.m3u8';
+
+        // Persist temp paths so post-processor can find them
+        $recording->update([
+            'temp_path' => $livePath,
+            'temp_manifest_path' => $m3u8RelPath,
+        ]);
+
+        // 2. Create the HLS output directory on the dvr disk
+        Storage::disk($setting->storage_disk ?: config('dvr.storage_disk'))
+            ->makeDirectory($livePath);
+
+        $fullLiveDir = Storage::disk($setting->storage_disk ?: config('dvr.storage_disk'))
+            ->path($livePath);
+
+        $m3u8Path = $fullLiveDir.'/stream.m3u8';
+        $segmentPattern = $fullLiveDir.'/segment_%04d.ts';
+
+        $ffmpegPath = $setting->getFfmpegPath();
+        $segmentSeconds = (int) config('dvr.hls_segment_seconds', 6);
+
+        $args = [
+            $ffmpegPath,
+            '-y',
+            '-i', $streamUrl,
+            '-c', 'copy',
+            '-f', 'hls',
+            '-hls_time', (string) $segmentSeconds,
+            '-hls_list_size', '0',
+            '-hls_flags', 'append_list+omit_endlist',
+            '-hls_segment_filename', $segmentPattern,
+            $m3u8Path,
+        ];
+
+        $cmd = implode(' ', array_map('escapeshellarg', $args));
+
+        // 2. Spawn ffmpeg (stdout/stderr to log file, detached)
+        $logFile = $fullLiveDir.'/ffmpeg.log';
+        $descriptor = [
+            0 => ['file', '/dev/null', 'r'],
+            1 => ['file', $logFile, 'w'],
+            2 => ['file', $logFile, 'a'],
+        ];
+
+        Log::info('DVR: Starting ffmpeg recording', [
+            'recording_id' => $recording->id,
+            'title' => $recording->title,
+            'stream_url' => $streamUrl,
+        ]);
+
+        $process = proc_open($cmd, $descriptor, $pipes);
+
+        if (! is_resource($process)) {
+            throw new Exception("proc_open failed for recording {$recording->id}");
+        }
+
+        $status = proc_get_status($process);
+        $pid = $status['pid'] ?? null;
+
+        // 3. Update DB
+        $recording->update([
+            'status' => DvrRecordingStatus::Recording->value,
+            'actual_start' => now(),
+            'pid' => $pid,
+        ]);
+
+        // Close proc handle (process continues in background)
+        proc_close($process);
+
+        Log::info('DVR: Recording started', [
+            'recording_id' => $recording->id,
+            'pid' => $pid,
+            'title' => $recording->title,
+        ]);
+    }
+
+    /**
+     * Stop recording: send SIGINT, wait for graceful exit, fall back to SIGKILL.
+     *
+     * After stopping, the recording is handed off to DvrPostProcessorService via
+     * the PostProcessDvrRecording job.
+     */
+    public function stop(DvrRecording $recording): void
+    {
+        $pid = $recording->pid;
+
+        if (! $pid) {
+            Log::warning('DVR stop: no PID on recording — assuming already stopped', [
+                'recording_id' => $recording->id,
+            ]);
+            $this->finalizeStop($recording, false);
+
+            return;
+        }
+
+        Log::info('DVR: Stopping recording (SIGINT)', [
+            'recording_id' => $recording->id,
+            'pid' => $pid,
+        ]);
+
+        // Send SIGINT for graceful stop
+        if (function_exists('posix_kill')) {
+            posix_kill($pid, SIGINT);
+        } else {
+            exec("kill -INT {$pid} 2>/dev/null");
+        }
+
+        // Wait up to the configured timeout for the process to exit
+        $timeout = (int) config('dvr.graceful_stop_timeout_seconds', 10);
+        $waited = 0;
+        $exited = false;
+
+        while ($waited < $timeout) {
+            sleep(1);
+            $waited++;
+            if (! $this->isProcessRunning($pid)) {
+                $exited = true;
+                break;
+            }
+        }
+
+        if (! $exited) {
+            Log::warning('DVR: ffmpeg did not exit after SIGINT — sending SIGKILL', [
+                'recording_id' => $recording->id,
+                'pid' => $pid,
+            ]);
+
+            if (function_exists('posix_kill')) {
+                posix_kill($pid, SIGKILL);
+            } else {
+                exec("kill -9 {$pid} 2>/dev/null");
+            }
+
+            sleep(1);
+        }
+
+        $this->finalizeStop($recording, $exited);
+    }
+
+    /**
+     * Cancel a recording (same as stop but marks status as CANCELLED).
+     * Note: we do NOT override the status here because cancel() is called from
+     * stop() which transitions to PostProcessing. Overriding would break the
+     * PostProcessDvrRecording job. The error_message set by stop() is sufficient.
+     */
+    public function cancel(DvrRecording $recording): void
+    {
+        $this->stop($recording);
+
+        $recording->update([
+            'error_message' => 'Cancelled by user',
+        ]);
+    }
+
+    /**
+     * After ffmpeg exits, transition status to POST_PROCESSING (or FAILED).
+     */
+    private function finalizeStop(DvrRecording $recording, bool $cleanExit): void
+    {
+        // Don't overwrite CANCELLED or FAILED status
+        if (in_array($recording->status, [
+            DvrRecordingStatus::Cancelled,
+            DvrRecordingStatus::Failed,
+        ])) {
+            return;
+        }
+
+        $recording->update([
+            'status' => DvrRecordingStatus::PostProcessing->value,
+            'actual_end' => now(),
+            'pid' => null,
+            'error_message' => $cleanExit ? null : 'ffmpeg did not exit cleanly',
+        ]);
+    }
+
+    /**
+     * Check if a process with the given PID is still running.
+     */
+    private function isProcessRunning(int $pid): bool
+    {
+        if (function_exists('posix_kill')) {
+            return posix_kill($pid, 0);
+        }
+
+        exec("kill -0 {$pid} 2>/dev/null", $output, $exitCode);
+
+        return $exitCode === 0;
+    }
+}

--- a/app/Services/DvrRetentionService.php
+++ b/app/Services/DvrRetentionService.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\DvrRecordingStatus;
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * DvrRetentionService — Enforces retention policies on completed recordings.
+ *
+ * Policies (applied in order):
+ *   1. keepLast — per rule: keep only the N most recent recordings for a series rule
+ *   2. retention_days — per DvrSetting: delete recordings older than N days
+ *   3. global_disk_quota_gb — per DvrSetting: if over quota, delete oldest first
+ */
+class DvrRetentionService
+{
+    /**
+     * Run retention enforcement for all DVR settings.
+     */
+    public function runAll(): void
+    {
+        $settings = DvrSetting::where('enabled', true)->get();
+
+        foreach ($settings as $setting) {
+            try {
+                $this->runForSetting($setting);
+            } catch (\Exception $e) {
+                Log::error("DVR retention failed for setting {$setting->id}: {$e->getMessage()}");
+            }
+        }
+    }
+
+    /**
+     * Run retention for a single DvrSetting.
+     */
+    public function runForSetting(DvrSetting $setting): void
+    {
+        // 1. keepLast per rule
+        $this->enforceKeepLast($setting);
+
+        // 2. Age-based retention
+        if ($setting->retention_days > 0) {
+            $this->enforceRetentionDays($setting);
+        }
+
+        // 3. Disk quota
+        if ($setting->global_disk_quota_gb > 0) {
+            $this->enforceDiskQuota($setting);
+        }
+    }
+
+    /**
+     * For each recording rule with keep_last set, delete excess completed recordings.
+     */
+    private function enforceKeepLast(DvrSetting $setting): void
+    {
+        $rules = $setting->recordingRules()
+            ->whereNotNull('keep_last')
+            ->where('keep_last', '>', 0)
+            ->get();
+
+        foreach ($rules as $rule) {
+            $completed = DvrRecording::where('dvr_recording_rule_id', $rule->id)
+                ->where('status', DvrRecordingStatus::Completed->value)
+                ->orderByDesc('scheduled_start')
+                ->get();
+
+            if ($completed->count() <= $rule->keep_last) {
+                continue;
+            }
+
+            $toDelete = $completed->slice($rule->keep_last);
+
+            foreach ($toDelete as $recording) {
+                $this->deleteRecordingFile($recording, $setting);
+                Log::info("DVR retention: keepLast deleted recording {$recording->id} ({$recording->title})");
+            }
+        }
+    }
+
+    /**
+     * Delete completed recordings older than retention_days.
+     */
+    private function enforceRetentionDays(DvrSetting $setting): void
+    {
+        $cutoff = now()->subDays($setting->retention_days);
+
+        $old = DvrRecording::where('dvr_setting_id', $setting->id)
+            ->where('status', DvrRecordingStatus::Completed->value)
+            ->where('actual_end', '<', $cutoff)
+            ->get();
+
+        foreach ($old as $recording) {
+            $this->deleteRecordingFile($recording, $setting);
+            Log::info("DVR retention: age-based deleted recording {$recording->id} ({$recording->title})");
+        }
+    }
+
+    /**
+     * If disk usage exceeds the quota, delete oldest completed recordings until under quota.
+     */
+    private function enforceDiskQuota(DvrSetting $setting): void
+    {
+        $quotaBytes = $setting->global_disk_quota_gb * 1024 * 1024 * 1024;
+        $disk = $setting->storage_disk ?: config('dvr.storage_disk');
+
+        $usedBytes = DvrRecording::where('dvr_setting_id', $setting->id)
+            ->where('status', DvrRecordingStatus::Completed->value)
+            ->whereNotNull('file_size_bytes')
+            ->sum('file_size_bytes');
+
+        if ($usedBytes <= $quotaBytes) {
+            return;
+        }
+
+        Log::info("DVR retention: disk quota exceeded for setting {$setting->id}", [
+            'used_gb' => round($usedBytes / (1024 ** 3), 2),
+            'quota_gb' => $setting->global_disk_quota_gb,
+        ]);
+
+        $recordings = DvrRecording::where('dvr_setting_id', $setting->id)
+            ->where('status', DvrRecordingStatus::Completed->value)
+            ->whereNotNull('file_size_bytes')
+            ->orderBy('actual_end')
+            ->get();
+
+        foreach ($recordings as $recording) {
+            if ($usedBytes <= $quotaBytes) {
+                break;
+            }
+
+            $usedBytes -= (int) ($recording->file_size_bytes ?? 0);
+            $this->deleteRecordingFile($recording, $setting);
+            Log::info("DVR retention: quota-based deleted recording {$recording->id} ({$recording->title})");
+        }
+    }
+
+    /**
+     * Delete the file on disk and set file_path to null on the recording.
+     * Does NOT delete the recording row itself (keep history).
+     */
+    private function deleteRecordingFile(DvrRecording $recording, DvrSetting $setting): void
+    {
+        if (empty($recording->file_path)) {
+            return;
+        }
+
+        $disk = $setting->storage_disk ?: config('dvr.storage_disk');
+
+        try {
+            if (Storage::disk($disk)->exists($recording->file_path)) {
+                Storage::disk($disk)->delete($recording->file_path);
+            }
+        } catch (\Exception $e) {
+            Log::warning("DVR retention: failed to delete file {$recording->file_path}: {$e->getMessage()}");
+        }
+
+        $recording->update([
+            'file_path' => null,
+            'file_size_bytes' => null,
+        ]);
+    }
+}

--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -180,9 +180,11 @@ class DvrSchedulerService
             return;
         }
 
-        // Check dedup — only block active recordings, not Cancelled/Failed
+        // Check dedup — only block active recordings, not Cancelled/Failed.
+        // Use programme_start (= manual_start) not scheduled_start, because scheduled_start
+        // is offset by start_early_seconds and may not match the stored value.
         $exists = DvrRecording::where('dvr_recording_rule_id', $rule->id)
-            ->where('scheduled_start', $rule->manual_start)
+            ->where('programme_start', $rule->manual_start)
             ->whereIn('status', [
                 DvrRecordingStatus::Scheduled->value,
                 DvrRecordingStatus::Recording->value,

--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -1,0 +1,364 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\DvrRecordingStatus;
+use App\Enums\DvrRuleType;
+use App\Jobs\StartDvrRecording;
+use App\Jobs\StopDvrRecording;
+use App\Models\DvrRecording;
+use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
+use App\Models\EpgProgramme;
+use Exception;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * DvrSchedulerService — Runs every minute via the DvrSchedulerTick job.
+ *
+ * Responsibilities:
+ * 1. Match enabled rules against upcoming epg_programmes (30-min lookahead)
+ * 2. Deduplicate: skip programmes that already have a recording row
+ * 3. Conflict resolution: respect max_concurrent_recordings
+ * 4. Create SCHEDULED recording rows
+ * 5. Trigger recordings whose scheduled_start <= now
+ * 6. Stop recordings whose scheduled_end <= now
+ */
+class DvrSchedulerService
+{
+    /**
+     * Execute one scheduler tick.
+     */
+    public function tick(): void
+    {
+        try {
+            $lookaheadMinutes = (int) config('dvr.scheduler_lookahead_minutes', 30);
+
+            // Step 1-4: Match rules → create SCHEDULED recordings
+            $this->matchAndSchedule($lookaheadMinutes);
+
+            // Step 5: Trigger recordings whose time has come
+            $this->triggerPendingRecordings();
+
+            // Step 6: Stop recordings whose scheduled end has passed
+            $this->stopExpiredRecordings();
+        } catch (Exception $e) {
+            Log::error('DVR scheduler tick failed: '.$e->getMessage(), [
+                'exception' => $e,
+            ]);
+        }
+    }
+
+    /**
+     * Match all enabled rules against upcoming programmes and create SCHEDULED rows.
+     *
+     * @param  int  $lookaheadMinutes  How many minutes ahead to search
+     */
+    private function matchAndSchedule(int $lookaheadMinutes): void
+    {
+        $rules = DvrRecordingRule::enabled()
+            ->with(['dvrSetting', 'channel', 'epgChannel'])
+            ->get();
+
+        if ($rules->isEmpty()) {
+            return;
+        }
+
+        foreach ($rules as $rule) {
+            try {
+                $this->matchRule($rule, $lookaheadMinutes);
+            } catch (Exception $e) {
+                Log::error("DVR: Failed to match rule {$rule->id}: {$e->getMessage()}");
+            }
+        }
+    }
+
+    /**
+     * Dispatch rule matching to the appropriate type handler.
+     */
+    private function matchRule(DvrRecordingRule $rule, int $lookaheadMinutes): void
+    {
+        match ($rule->type) {
+            DvrRuleType::Series => $this->matchSeriesRule($rule, $lookaheadMinutes),
+            DvrRuleType::Once => $this->matchOnceRule($rule, $lookaheadMinutes),
+            DvrRuleType::Manual => $this->matchManualRule($rule),
+        };
+    }
+
+    /**
+     * SERIES rule: match all upcoming programmes by title (case-insensitive contains).
+     */
+    private function matchSeriesRule(DvrRecordingRule $rule, int $lookaheadMinutes): void
+    {
+        if (empty($rule->series_title)) {
+            return;
+        }
+
+        $now = now();
+        $lookahead = now()->addMinutes($lookaheadMinutes);
+
+        $query = EpgProgramme::where('title', 'like', '%'.$rule->series_title.'%')
+            ->where('start_time', '>=', $now)
+            ->where('start_time', '<=', $lookahead);
+
+        if (! empty($rule->epg_channel_id)) {
+            $query->where('epg_channel_id', $rule->epg_channel_id);
+        }
+
+        if ($rule->new_only) {
+            $query->where('is_new', true);
+        }
+
+        $programmes = $query->get();
+        if ($programmes->isEmpty()) {
+            return;
+        }
+
+        // Batch dedup: find existing recording rows for these programme start/channel combinations
+        foreach ($programmes as $programme) {
+            $this->createScheduledRecordingFromProgramme($rule, $programme);
+        }
+    }
+
+    /**
+     * ONCE rule: match a specific programme by start time + channel.
+     */
+    private function matchOnceRule(DvrRecordingRule $rule, int $lookaheadMinutes): void
+    {
+        if (empty($rule->programme_id)) {
+            return;
+        }
+
+        $programme = EpgProgramme::find($rule->programme_id);
+
+        if (! $programme) {
+            // Programme was replaced by an EPG refresh — disable the dead rule
+            Log::warning("DVR ONCE rule {$rule->id}: programme_id {$rule->programme_id} not found — disabling rule");
+            $rule->update(['enabled' => false]);
+
+            return;
+        }
+
+        $now = now();
+        $lookahead = now()->addMinutes($lookaheadMinutes);
+
+        $isUpcoming = $programme->start_time >= $now && $programme->start_time <= $lookahead;
+        $isCurrentlyAiring = $programme->start_time < $now && $programme->end_time > $now;
+
+        if (! $isUpcoming && ! $isCurrentlyAiring) {
+            return;
+        }
+
+        $this->createScheduledRecordingFromProgramme($rule, $programme);
+    }
+
+    /**
+     * MANUAL rule: create a recording for the specified manual_start/manual_end window.
+     */
+    private function matchManualRule(DvrRecordingRule $rule): void
+    {
+        if (! $rule->manual_start || ! $rule->manual_end) {
+            return;
+        }
+
+        $now = now();
+        $lookahead = now()->addMinutes((int) config('dvr.scheduler_lookahead_minutes', 30));
+
+        $isUpcoming = $rule->manual_start >= $now && $rule->manual_start <= $lookahead;
+        $isCurrentlyAiring = $rule->manual_start < $now && $rule->manual_end > $now;
+
+        if (! $isUpcoming && ! $isCurrentlyAiring) {
+            return;
+        }
+
+        $setting = $rule->dvrSetting;
+        if (! $setting || ! $setting->enabled) {
+            return;
+        }
+
+        // Check dedup — only block active recordings, not Cancelled/Failed
+        $exists = DvrRecording::where('dvr_recording_rule_id', $rule->id)
+            ->where('scheduled_start', $rule->manual_start)
+            ->whereIn('status', [
+                DvrRecordingStatus::Scheduled->value,
+                DvrRecordingStatus::Recording->value,
+                DvrRecordingStatus::PostProcessing->value,
+            ])
+            ->exists();
+
+        if ($exists) {
+            return;
+        }
+
+        $startEarly = $setting->resolveStartEarlySeconds($rule->start_early_seconds);
+        $endLate = $setting->resolveEndLateSeconds($rule->end_late_seconds);
+
+        $scheduledStart = $rule->manual_start->subSeconds($startEarly);
+        $scheduledEnd = $rule->manual_end->addSeconds($endLate);
+
+        // Resolve stream URL from the rule's channel (if set)
+        $streamUrl = $this->resolveStreamUrl($rule, $setting);
+
+        DvrRecording::create([
+            'uuid' => (string) Str::uuid(),
+            'user_id' => $setting->user_id,
+            'dvr_setting_id' => $setting->id,
+            'dvr_recording_rule_id' => $rule->id,
+            'channel_id' => $rule->channel_id,
+            'status' => DvrRecordingStatus::Scheduled->value,
+            'title' => 'Manual Recording',
+            'scheduled_start' => $scheduledStart,
+            'scheduled_end' => $scheduledEnd,
+            'programme_start' => $rule->manual_start,
+            'programme_end' => $rule->manual_end,
+            'stream_url' => $streamUrl,
+        ]);
+    }
+
+    /**
+     * Create a SCHEDULED DvrRecording from a rule + programme, if not already scheduled.
+     */
+    private function createScheduledRecordingFromProgramme(DvrRecordingRule $rule, EpgProgramme $programme): void
+    {
+        $setting = $rule->dvrSetting;
+        if (! $setting || ! $setting->enabled) {
+            return;
+        }
+
+        // Check capacity
+        if ($setting->isAtCapacity()) {
+            Log::debug("DVR: Skipping schedule for rule {$rule->id} — at capacity");
+
+            return;
+        }
+
+        // Dedup: only block if there's an active recording (Scheduled/Recording/PostProcessing).
+        // Cancelled and Failed recordings should not block re-scheduling.
+        $exists = DvrRecording::where('dvr_setting_id', $setting->id)
+            ->where('programme_start', $programme->start_time)
+            ->where('epg_programme_data->epg_channel_id', $programme->epg_channel_id)
+            ->whereIn('status', [
+                DvrRecordingStatus::Scheduled->value,
+                DvrRecordingStatus::Recording->value,
+                DvrRecordingStatus::PostProcessing->value,
+            ])
+            ->exists();
+
+        if ($exists) {
+            return;
+        }
+
+        $startEarly = $setting->resolveStartEarlySeconds($rule->start_early_seconds);
+        $endLate = $setting->resolveEndLateSeconds($rule->end_late_seconds);
+
+        $scheduledStart = $programme->start_time->copy()->subSeconds($startEarly);
+        $scheduledEnd = $programme->end_time->copy()->addSeconds($endLate);
+
+        $streamUrl = $this->resolveStreamUrl($rule, $setting);
+
+        DvrRecording::create([
+            'uuid' => (string) Str::uuid(),
+            'user_id' => $setting->user_id,
+            'dvr_setting_id' => $setting->id,
+            'dvr_recording_rule_id' => $rule->id,
+            'channel_id' => $rule->channel_id,
+            'status' => DvrRecordingStatus::Scheduled->value,
+            'title' => $programme->title,
+            'subtitle' => $programme->subtitle,
+            'description' => $programme->description,
+            'season' => $programme->season,
+            'episode' => $programme->episode,
+            'scheduled_start' => $scheduledStart,
+            'scheduled_end' => $scheduledEnd,
+            'programme_start' => $programme->start_time,
+            'programme_end' => $programme->end_time,
+            'stream_url' => $streamUrl,
+            'epg_programme_data' => [
+                'epg_id' => $programme->epg_id,
+                'epg_channel_id' => $programme->epg_channel_id,
+                'episode_num' => $programme->episode_num,
+                'category' => $programme->category,
+                'icon' => $programme->icon,
+                'rating' => $programme->rating,
+                'is_new' => $programme->is_new,
+            ],
+        ]);
+
+        Log::info("DVR: Scheduled recording for '{$programme->title}'", [
+            'rule_id' => $rule->id,
+            'scheduled_start' => $scheduledStart,
+            'scheduled_end' => $scheduledEnd,
+        ]);
+    }
+
+    /**
+     * Trigger recordings whose scheduled_start has arrived (dispatch StartDvrRecording jobs).
+     */
+    private function triggerPendingRecordings(): void
+    {
+        $due = DvrRecording::scheduled()
+            ->where('scheduled_start', '<=', now())
+            ->with('dvrSetting')
+            ->get();
+
+        foreach ($due as $recording) {
+            $setting = $recording->dvrSetting;
+
+            if (! $setting || ! $setting->enabled) {
+                continue;
+            }
+
+            if ($setting->isAtCapacity()) {
+                Log::debug("DVR: Skipping trigger for recording {$recording->id} — at capacity");
+
+                continue;
+            }
+
+            Log::info("DVR: Triggering recording {$recording->id} ({$recording->title})");
+            StartDvrRecording::dispatch($recording->id)->onQueue('dvr');
+        }
+    }
+
+    /**
+     * Stop recordings whose scheduled_end has passed (dispatch StopDvrRecording jobs).
+     */
+    private function stopExpiredRecordings(): void
+    {
+        $expired = DvrRecording::recording()
+            ->where('scheduled_end', '<=', now())
+            ->get();
+
+        foreach ($expired as $recording) {
+            Log::info("DVR: Stopping expired recording {$recording->id} ({$recording->title})");
+            StopDvrRecording::dispatch($recording->id)->onQueue('dvr');
+        }
+    }
+
+    /**
+     * Resolve the stream URL to use for a recording.
+     *
+     * Uses the channel proxy URL if the source playlist has proxy enabled.
+     */
+    private function resolveStreamUrl(DvrRecordingRule $rule, DvrSetting $setting): ?string
+    {
+        if (! $rule->channel_id) {
+            return null;
+        }
+
+        $channel = $rule->channel;
+        if (! $channel) {
+            return null;
+        }
+
+        // Use the proxy URL when the source playlist has proxy enabled
+        $playlist = $setting->playlist;
+        if ($playlist && ! empty($playlist->proxy_options['enabled'])) {
+            [$proxyUrl] = $channel->getProxyUrl();
+
+            return $proxyUrl ?: $channel->url;
+        }
+
+        return $channel->url;
+    }
+}

--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -58,7 +58,7 @@ class DvrSchedulerService
     private function matchAndSchedule(int $lookaheadMinutes): void
     {
         $rules = DvrRecordingRule::enabled()
-            ->with(['dvrSetting', 'channel', 'epgChannel'])
+            ->with(['dvrSetting.playlist', 'channel', 'epgChannel'])
             ->get();
 
         if ($rules->isEmpty()) {
@@ -123,10 +123,13 @@ class DvrSchedulerService
 
     /**
      * ONCE rule: match a specific programme by start time + channel.
+     * Falls back to the current dummy EPG slot when no programme is linked.
      */
     private function matchOnceRule(DvrRecordingRule $rule, int $lookaheadMinutes): void
     {
         if (empty($rule->programme_id)) {
+            $this->matchOnceRuleViaDummyEpg($rule, $lookaheadMinutes);
+
             return;
         }
 
@@ -213,6 +216,90 @@ class DvrSchedulerService
             'programme_start' => $rule->manual_start,
             'programme_end' => $rule->manual_end,
             'stream_url' => $streamUrl,
+        ]);
+    }
+
+    /**
+     * ONCE rule fallback: schedule the current dummy EPG slot when no programme_id is set.
+     *
+     * Dummy EPG slots are aligned to midnight in blocks of `dummy_epg_length` minutes.
+     * After scheduling, the rule is disabled so only one recording is created.
+     */
+    private function matchOnceRuleViaDummyEpg(DvrRecordingRule $rule, int $lookaheadMinutes): void
+    {
+        $setting = $rule->dvrSetting;
+        if (! $setting || ! $setting->enabled) {
+            return;
+        }
+
+        $playlist = $setting->playlist;
+        if (! $playlist || ! $playlist->dummy_epg || ! $rule->channel_id) {
+            return;
+        }
+
+        $dummyEpgLength = (int) ($playlist->dummy_epg_length ?? 120);
+
+        $now = now();
+        $startOfDay = $now->copy()->startOfDay();
+        $minutesSinceMidnight = (int) floor($startOfDay->diffInMinutes($now));
+        $slotIndex = (int) floor($minutesSinceMidnight / $dummyEpgLength);
+        $slotStart = $startOfDay->copy()->addMinutes($slotIndex * $dummyEpgLength);
+        $slotEnd = $slotStart->copy()->addMinutes($dummyEpgLength);
+        $lookahead = $now->copy()->addMinutes($lookaheadMinutes);
+
+        $isCurrentlyAiring = $slotStart <= $now && $slotEnd > $now;
+        $isUpcoming = $slotStart > $now && $slotStart <= $lookahead;
+
+        if (! $isCurrentlyAiring && ! $isUpcoming) {
+            return;
+        }
+
+        if ($setting->isAtCapacity()) {
+            return;
+        }
+
+        $exists = DvrRecording::where('dvr_recording_rule_id', $rule->id)
+            ->where('programme_start', $slotStart)
+            ->whereIn('status', [
+                DvrRecordingStatus::Scheduled->value,
+                DvrRecordingStatus::Recording->value,
+                DvrRecordingStatus::PostProcessing->value,
+            ])
+            ->exists();
+
+        if ($exists) {
+            return;
+        }
+
+        $startEarly = $setting->resolveStartEarlySeconds($rule->start_early_seconds);
+        $endLate = $setting->resolveEndLateSeconds($rule->end_late_seconds);
+
+        $channel = $rule->channel;
+        $title = $channel ? ($channel->title_custom ?? $channel->title ?? 'Recording') : 'Recording';
+        $streamUrl = $this->resolveStreamUrl($rule, $setting);
+
+        DvrRecording::create([
+            'uuid' => (string) Str::uuid(),
+            'user_id' => $setting->user_id,
+            'dvr_setting_id' => $setting->id,
+            'dvr_recording_rule_id' => $rule->id,
+            'channel_id' => $rule->channel_id,
+            'status' => DvrRecordingStatus::Scheduled->value,
+            'title' => $title,
+            'scheduled_start' => $slotStart->copy()->subSeconds($startEarly),
+            'scheduled_end' => $slotEnd->copy()->addSeconds($endLate),
+            'programme_start' => $slotStart,
+            'programme_end' => $slotEnd,
+            'stream_url' => $streamUrl,
+        ]);
+
+        // Disable once the recording is scheduled — "once" means record this slot, then stop.
+        $rule->update(['enabled' => false]);
+
+        Log::info("DVR: Scheduled once recording via dummy EPG for '{$title}'", [
+            'rule_id' => $rule->id,
+            'slot_start' => $slotStart,
+            'slot_end' => $slotEnd,
         ]);
     }
 

--- a/app/Services/DvrVodIntegrationService.php
+++ b/app/Services/DvrVodIntegrationService.php
@@ -81,30 +81,29 @@ class DvrVodIntegrationService
      */
     private function integrateAsMovie(DvrRecording $recording, int $playlistId, int $userId, ?array $tmdb): void
     {
-        $streamUrl = route('dvr.recording.stream', $recording->uuid);
+        $streamUrl = PlaylistService::getBaseUrl('/dvr/recordings/'.$recording->uuid.'/stream');
         $name = $tmdb['name'] ?? $recording->title;
 
-        // Check if we already integrated this recording
-        $existing = Channel::where('dvr_recording_id', $recording->id)->first();
+        // Find existing or prepare new channel
+        $channel = Channel::where('dvr_recording_id', $recording->id)->first();
+        $isNew = ! $channel;
 
-        if ($existing) {
-            Log::info("DvrVodIntegration: VOD channel already exists for recording {$recording->id} (channel {$existing->id})");
-
-            return;
+        if ($isNew) {
+            $channel = new Channel;
+            $channel->user_id = $userId;
+            $channel->playlist_id = $playlistId;
+            $channel->is_vod = true;
+            $channel->is_custom = true;
+            $channel->enabled = true;
+            $channel->container_extension = 'ts';
+            $channel->dvr_recording_id = $recording->id;
+            $channel->source_id = null;
         }
 
-        $channel = new Channel;
-        $channel->user_id = $userId;
-        $channel->playlist_id = $playlistId;
+        // Always update name, title, and URL (URL may have been created with wrong base)
         $channel->name = $name;
         $channel->title = $name;
         $channel->url = $streamUrl;
-        $channel->is_vod = true;
-        $channel->is_custom = true;
-        $channel->enabled = true;
-        $channel->container_extension = 'ts';
-        $channel->dvr_recording_id = $recording->id;
-        $channel->source_id = null;
 
         if ($tmdb) {
             $channel->logo = $tmdb['poster_url'] ?? null;
@@ -125,7 +124,7 @@ class DvrVodIntegrationService
 
         $channel->save();
 
-        Log::info("DvrVodIntegration: created VOD channel {$channel->id} for recording {$recording->id}", [
+        Log::info('DvrVodIntegration: '.($isNew ? 'created' : 'updated')." VOD channel {$channel->id} for recording {$recording->id}", [
             'title' => $name,
             'playlist_id' => $playlistId,
         ]);
@@ -139,41 +138,39 @@ class DvrVodIntegrationService
         $seriesName = $tmdb['name'] ?? $recording->title;
         $seasonNumber = $recording->season ?? 1;
         $episodeNumber = $recording->episode ?? 1;
-        $streamUrl = route('dvr.recording.stream', $recording->uuid);
-
-        // Check if we already integrated this recording
-        $existing = Episode::where('dvr_recording_id', $recording->id)->first();
-
-        if ($existing) {
-            Log::info("DvrVodIntegration: episode already exists for recording {$recording->id} (episode {$existing->id})");
-
-            return;
-        }
+        $streamUrl = PlaylistService::getBaseUrl('/dvr/recordings/'.$recording->uuid.'/stream');
 
         // Find-or-create the DVR category for this playlist
         $category = $this->findOrCreateDvrCategory($playlistId, $userId);
 
-        // Find-or-create the Series
+        // Find-or-create the Series (always update metadata if tmdb available)
         $series = $this->findOrCreateSeries($seriesName, $playlistId, $userId, $category->id, $tmdb);
 
         // Find-or-create the Season
         $season = $this->findOrCreateSeason($series, $seasonNumber, $playlistId, $userId, $category->id);
 
-        // Create the Episode
-        $episode = new Episode;
-        $episode->user_id = $userId;
-        $episode->playlist_id = $playlistId;
-        $episode->series_id = $series->id;
-        $episode->season_id = $season->id;
-        $episode->season = $seasonNumber;
-        $episode->episode_num = $episodeNumber;
+        // Find existing episode or prepare new one
+        $episode = Episode::where('dvr_recording_id', $recording->id)->first();
+        $isNew = ! $episode;
+
+        if ($isNew) {
+            $episode = new Episode;
+            $episode->user_id = $userId;
+            $episode->playlist_id = $playlistId;
+            $episode->series_id = $series->id;
+            $episode->season_id = $season->id;
+            $episode->season = $seasonNumber;
+            $episode->episode_num = $episodeNumber;
+            $episode->container_extension = 'ts';
+            $episode->enabled = true;
+            $episode->source_episode_id = null;
+            $episode->import_batch_no = 'dvr';
+            $episode->dvr_recording_id = $recording->id;
+        }
+
+        // Always update title, URL, and info (URL may have been created with wrong base)
         $episode->title = $recording->subtitle ?? $recording->title;
         $episode->url = $streamUrl;
-        $episode->container_extension = 'ts';
-        $episode->enabled = true;
-        $episode->source_episode_id = null;
-        $episode->import_batch_no = 'dvr';
-        $episode->dvr_recording_id = $recording->id;
         $episode->info = [
             'plot' => $recording->description ?? ($tmdb['overview'] ?? null),
             'release_date' => $recording->programme_start?->toDateString(),
@@ -185,7 +182,7 @@ class DvrVodIntegrationService
 
         $episode->save();
 
-        Log::info("DvrVodIntegration: created episode {$episode->id} for recording {$recording->id}", [
+        Log::info('DvrVodIntegration: '.($isNew ? 'created' : 'updated')." episode {$episode->id} for recording {$recording->id}", [
             'series' => $seriesName,
             'season' => $seasonNumber,
             'episode' => $episodeNumber,
@@ -224,6 +221,20 @@ class DvrVodIntegrationService
             ->first();
 
         if ($series) {
+            // Update metadata if we now have TMDB data and didn't before
+            if ($tmdb && empty($series->tmdb_id)) {
+                $series->cover = $tmdb['poster_url'] ?? $series->cover;
+                $series->plot = $tmdb['overview'] ?? $series->plot;
+                $series->release_date = $tmdb['first_air_date'] ?? $tmdb['release_date'] ?? $series->release_date;
+                $series->metadata = $tmdb;
+
+                if (! empty($tmdb['id'])) {
+                    $series->tmdb_id = $tmdb['id'];
+                }
+
+                $series->save();
+            }
+
             return $series;
         }
 

--- a/app/Services/DvrVodIntegrationService.php
+++ b/app/Services/DvrVodIntegrationService.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Category;
+use App\Models\Channel;
+use App\Models\DvrRecording;
+use App\Models\Episode;
+use App\Models\Season;
+use App\Models\Series;
+use Exception;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * DvrVodIntegrationService — Converts completed DVR recordings into VOD entries.
+ *
+ * Integration rules:
+ *   - TMDB type=movie (or no metadata + no season) → Channel with is_vod=true
+ *   - TMDB type=tv   (or season is set)            → Series / Season / Episode
+ *
+ * DVR-created records use NULL for source_id fields to avoid unique constraint
+ * collisions with Xtream-imported content.
+ */
+class DvrVodIntegrationService
+{
+    private const DVR_CATEGORY_NAME = 'DVR Recordings';
+
+    /**
+     * Integrate a completed recording into the VOD library.
+     */
+    public function integrateRecording(DvrRecording $recording): void
+    {
+        $setting = $recording->dvrSetting;
+
+        if (! $setting) {
+            Log::warning("DvrVodIntegration: no DvrSetting for recording {$recording->id} — skipping");
+
+            return;
+        }
+
+        $playlistId = $setting->playlist_id;
+        $userId = $recording->user_id;
+
+        if (! $playlistId || ! $userId) {
+            Log::warning("DvrVodIntegration: missing playlist_id or user_id for recording {$recording->id} — skipping");
+
+            return;
+        }
+
+        $tmdb = $recording->metadata['tmdb'] ?? null;
+        $isTv = $this->isTvContent($recording, $tmdb);
+
+        try {
+            if ($isTv) {
+                $this->integrateAsSeries($recording, $playlistId, $userId, $tmdb);
+            } else {
+                $this->integrateAsMovie($recording, $playlistId, $userId, $tmdb);
+            }
+        } catch (Exception $e) {
+            Log::error("DvrVodIntegration: failed for recording {$recording->id}: {$e->getMessage()}", [
+                'exception' => $e,
+            ]);
+        }
+    }
+
+    /**
+     * Determine whether the recording should be treated as TV series content.
+     */
+    private function isTvContent(DvrRecording $recording, ?array $tmdb): bool
+    {
+        if ($tmdb && isset($tmdb['type'])) {
+            return $tmdb['type'] === 'tv';
+        }
+
+        // Fall back to structural cues when metadata is absent
+        return $recording->season !== null;
+    }
+
+    /**
+     * Create or update a VOD Channel record for a movie recording.
+     */
+    private function integrateAsMovie(DvrRecording $recording, int $playlistId, int $userId, ?array $tmdb): void
+    {
+        $streamUrl = route('dvr.recording.stream', $recording->uuid);
+        $name = $tmdb['name'] ?? $recording->title;
+
+        // Check if we already integrated this recording
+        $existing = Channel::where('dvr_recording_id', $recording->id)->first();
+
+        if ($existing) {
+            Log::info("DvrVodIntegration: VOD channel already exists for recording {$recording->id} (channel {$existing->id})");
+
+            return;
+        }
+
+        $channel = new Channel;
+        $channel->user_id = $userId;
+        $channel->playlist_id = $playlistId;
+        $channel->name = $name;
+        $channel->title = $name;
+        $channel->url = $streamUrl;
+        $channel->is_vod = true;
+        $channel->is_custom = true;
+        $channel->enabled = true;
+        $channel->container_extension = 'ts';
+        $channel->dvr_recording_id = $recording->id;
+        $channel->source_id = null;
+
+        if ($tmdb) {
+            $channel->logo = $tmdb['poster_url'] ?? null;
+            $channel->year = isset($tmdb['release_date'])
+                ? substr($tmdb['release_date'], 0, 4)
+                : null;
+            $channel->info = [
+                'plot' => $tmdb['overview'] ?? null,
+                'cover_big' => $tmdb['backdrop_url'] ?? null,
+                'movie_image' => $tmdb['poster_url'] ?? null,
+                'release_date' => $tmdb['release_date'] ?? null,
+                'tmdb_id' => $tmdb['id'] ?? null,
+            ];
+            if (! empty($tmdb['id'])) {
+                $channel->tmdb_id = $tmdb['id'];
+            }
+        }
+
+        $channel->save();
+
+        Log::info("DvrVodIntegration: created VOD channel {$channel->id} for recording {$recording->id}", [
+            'title' => $name,
+            'playlist_id' => $playlistId,
+        ]);
+    }
+
+    /**
+     * Create or update Series / Season / Episode records for a TV recording.
+     */
+    private function integrateAsSeries(DvrRecording $recording, int $playlistId, int $userId, ?array $tmdb): void
+    {
+        $seriesName = $tmdb['name'] ?? $recording->title;
+        $seasonNumber = $recording->season ?? 1;
+        $episodeNumber = $recording->episode ?? 1;
+        $streamUrl = route('dvr.recording.stream', $recording->uuid);
+
+        // Check if we already integrated this recording
+        $existing = Episode::where('dvr_recording_id', $recording->id)->first();
+
+        if ($existing) {
+            Log::info("DvrVodIntegration: episode already exists for recording {$recording->id} (episode {$existing->id})");
+
+            return;
+        }
+
+        // Find-or-create the DVR category for this playlist
+        $category = $this->findOrCreateDvrCategory($playlistId, $userId);
+
+        // Find-or-create the Series
+        $series = $this->findOrCreateSeries($seriesName, $playlistId, $userId, $category->id, $tmdb);
+
+        // Find-or-create the Season
+        $season = $this->findOrCreateSeason($series, $seasonNumber, $playlistId, $userId, $category->id);
+
+        // Create the Episode
+        $episode = new Episode;
+        $episode->user_id = $userId;
+        $episode->playlist_id = $playlistId;
+        $episode->series_id = $series->id;
+        $episode->season_id = $season->id;
+        $episode->season = $seasonNumber;
+        $episode->episode_num = $episodeNumber;
+        $episode->title = $recording->subtitle ?? $recording->title;
+        $episode->url = $streamUrl;
+        $episode->container_extension = 'ts';
+        $episode->enabled = true;
+        $episode->source_episode_id = null;
+        $episode->import_batch_no = 'dvr';
+        $episode->dvr_recording_id = $recording->id;
+        $episode->info = [
+            'plot' => $recording->description ?? ($tmdb['overview'] ?? null),
+            'release_date' => $recording->programme_start?->toDateString(),
+            'duration_secs' => $recording->duration_seconds,
+            'movie_image' => $tmdb['poster_url'] ?? null,
+            'tmdb_id' => $tmdb['id'] ?? null,
+            'season' => $seasonNumber,
+        ];
+
+        $episode->save();
+
+        Log::info("DvrVodIntegration: created episode {$episode->id} for recording {$recording->id}", [
+            'series' => $seriesName,
+            'season' => $seasonNumber,
+            'episode' => $episodeNumber,
+            'playlist_id' => $playlistId,
+        ]);
+    }
+
+    /**
+     * Find or create the "DVR Recordings" category for a playlist.
+     */
+    private function findOrCreateDvrCategory(int $playlistId, int $userId): Category
+    {
+        return Category::firstOrCreate(
+            [
+                'playlist_id' => $playlistId,
+                'name_internal' => self::DVR_CATEGORY_NAME,
+            ],
+            [
+                'name' => self::DVR_CATEGORY_NAME,
+                'user_id' => $userId,
+                'enabled' => true,
+            ]
+        );
+    }
+
+    /**
+     * Find an existing DVR series by name + playlist, or create a new one.
+     */
+    private function findOrCreateSeries(string $name, int $playlistId, int $userId, int $categoryId, ?array $tmdb): Series
+    {
+        // Look for an existing DVR-created series by name + playlist
+        // (source_series_id is NULL for DVR series, so we match on name)
+        $series = Series::where('playlist_id', $playlistId)
+            ->whereNull('source_series_id')
+            ->where('name', $name)
+            ->first();
+
+        if ($series) {
+            return $series;
+        }
+
+        $series = new Series;
+        $series->name = $name;
+        $series->user_id = $userId;
+        $series->playlist_id = $playlistId;
+        $series->category_id = $categoryId;
+        $series->enabled = true;
+        $series->source_series_id = null;
+        $series->import_batch_no = 'dvr';
+
+        if ($tmdb) {
+            $series->cover = $tmdb['poster_url'] ?? null;
+            $series->plot = $tmdb['overview'] ?? null;
+            $series->release_date = $tmdb['first_air_date'] ?? $tmdb['release_date'] ?? null;
+            $series->metadata = $tmdb;
+
+            if (! empty($tmdb['id'])) {
+                $series->tmdb_id = $tmdb['id'];
+            }
+        }
+
+        $series->save();
+
+        return $series;
+    }
+
+    /**
+     * Find an existing season by series + season number, or create a new one.
+     */
+    private function findOrCreateSeason(Series $series, int $seasonNumber, int $playlistId, int $userId, int $categoryId): Season
+    {
+        $season = Season::where('series_id', $series->id)
+            ->where('season_number', $seasonNumber)
+            ->first();
+
+        if ($season) {
+            return $season;
+        }
+
+        $season = new Season;
+        $season->series_id = $series->id;
+        $season->playlist_id = $playlistId;
+        $season->user_id = $userId;
+        $season->category_id = $categoryId;
+        $season->season_number = $seasonNumber;
+        $season->name = 'Season '.str_pad((string) $seasonNumber, 2, '0', STR_PAD_LEFT);
+        $season->source_season_id = null;
+        $season->import_batch_no = 'dvr';
+
+        $season->save();
+
+        return $season;
+    }
+}

--- a/app/Services/DvrVodIntegrationService.php
+++ b/app/Services/DvrVodIntegrationService.php
@@ -6,6 +6,7 @@ use App\Models\Category;
 use App\Models\Channel;
 use App\Models\DvrRecording;
 use App\Models\Episode;
+use App\Models\Group;
 use App\Models\Season;
 use App\Models\Series;
 use Exception;
@@ -48,11 +49,12 @@ class DvrVodIntegrationService
         }
 
         $tmdb = $recording->metadata['tmdb'] ?? null;
+        $tvmaze = is_array($recording->metadata) ? ($recording->metadata['tvmaze'] ?? null) : null;
         $isTv = $this->isTvContent($recording, $tmdb);
 
         try {
             if ($isTv) {
-                $this->integrateAsSeries($recording, $playlistId, $userId, $tmdb);
+                $this->integrateAsSeries($recording, $playlistId, $userId, $tmdb, $tvmaze);
             } else {
                 $this->integrateAsMovie($recording, $playlistId, $userId, $tmdb);
             }
@@ -77,12 +79,37 @@ class DvrVodIntegrationService
     }
 
     /**
+     * Build the stream URL for a DVR recording.
+     *
+     * Uses DVR_STREAM_BASE_URL when set (for Docker-internal proxy access),
+     * falling back to the general url_override / APP_URL via PlaylistService.
+     */
+    private function buildStreamUrl(DvrRecording $recording): string
+    {
+        $path = '/dvr/recordings/'.$recording->uuid.'/stream';
+        $base = config('dvr.stream_base_url');
+
+        if ($base) {
+            return rtrim($base, '/').$path;
+        }
+
+        return PlaylistService::getBaseUrl($path);
+    }
+
+    /**
      * Create or update a VOD Channel record for a movie recording.
      */
     private function integrateAsMovie(DvrRecording $recording, int $playlistId, int $userId, ?array $tmdb): void
     {
-        $streamUrl = PlaylistService::getBaseUrl('/dvr/recordings/'.$recording->uuid.'/stream');
-        $name = $tmdb['name'] ?? $recording->title;
+        $streamUrl = $this->buildStreamUrl($recording);
+        $cleanTitle = $this->stripUnicodeDecorations($recording->title);
+        $tvmaze = is_array($recording->metadata) ? ($recording->metadata['tvmaze'] ?? null) : null;
+
+        // When no metadata is available use the clean title + recording date so
+        // repeated recordings of the same show are individually identifiable.
+        $name = $tmdb['name'] ?? $tvmaze['name'] ?? ($cleanTitle.' — '.$this->formatRecordingDate($recording));
+
+        $sourceLogo = $this->resolveSourceChannelLogo($recording);
 
         // Find existing or prepare new channel
         $channel = Channel::where('dvr_recording_id', $recording->id)->first();
@@ -95,9 +122,14 @@ class DvrVodIntegrationService
             $channel->is_vod = true;
             $channel->is_custom = true;
             $channel->enabled = true;
-            $channel->container_extension = 'ts';
+            $channel->container_extension = 'mp4';
             $channel->dvr_recording_id = $recording->id;
             $channel->source_id = null;
+
+            // Place new DVR VOD channels in the "DVR Recordings" group.
+            $group = $this->findOrCreateDvrVodGroup($playlistId, $userId);
+            $channel->group = $group->name;
+            $channel->group_id = $group->id;
         }
 
         // Always update name, title, and URL (URL may have been created with wrong base)
@@ -105,21 +137,33 @@ class DvrVodIntegrationService
         $channel->title = $name;
         $channel->url = $streamUrl;
 
+        $releaseDate = $tmdb['release_date']
+            ?? $tvmaze['premiered']
+            ?? $recording->programme_start?->toDateString();
+
+        $channel->info = [
+            'plot' => $tmdb['overview'] ?? $recording->description ?? $tvmaze['overview'] ?? null,
+            'cover_big' => $tmdb['backdrop_url'] ?? $sourceLogo ?? null,
+            'movie_image' => $tmdb['poster_url'] ?? $tvmaze['poster_url'] ?? $sourceLogo ?? null,
+            'release_date' => $releaseDate,
+            'tmdb_id' => $tmdb['id'] ?? null,
+        ];
+
         if ($tmdb) {
-            $channel->logo = $tmdb['poster_url'] ?? null;
-            $channel->year = isset($tmdb['release_date'])
-                ? substr($tmdb['release_date'], 0, 4)
-                : null;
-            $channel->info = [
-                'plot' => $tmdb['overview'] ?? null,
-                'cover_big' => $tmdb['backdrop_url'] ?? null,
-                'movie_image' => $tmdb['poster_url'] ?? null,
-                'release_date' => $tmdb['release_date'] ?? null,
-                'tmdb_id' => $tmdb['id'] ?? null,
-            ];
+            $channel->logo = $tmdb['poster_url'] ?? $sourceLogo;
             if (! empty($tmdb['id'])) {
                 $channel->tmdb_id = $tmdb['id'];
             }
+        } elseif (! empty($tvmaze['poster_url'])) {
+            $channel->logo = $tvmaze['poster_url'];
+        } elseif ($sourceLogo) {
+            $channel->logo = $sourceLogo;
+        }
+
+        $channel->year = $releaseDate ? substr($releaseDate, 0, 4) : null;
+
+        if (! $tmdb) {
+            $channel->tmdb_id = null;
         }
 
         $channel->save();
@@ -133,18 +177,19 @@ class DvrVodIntegrationService
     /**
      * Create or update Series / Season / Episode records for a TV recording.
      */
-    private function integrateAsSeries(DvrRecording $recording, int $playlistId, int $userId, ?array $tmdb): void
+    private function integrateAsSeries(DvrRecording $recording, int $playlistId, int $userId, ?array $tmdb, ?array $tvmaze = null): void
     {
-        $seriesName = $tmdb['name'] ?? $recording->title;
+        $seriesName = $tmdb['name'] ?? $tvmaze['name'] ?? $this->stripUnicodeDecorations($recording->title);
         $seasonNumber = $recording->season ?? 1;
         $episodeNumber = $recording->episode ?? 1;
-        $streamUrl = PlaylistService::getBaseUrl('/dvr/recordings/'.$recording->uuid.'/stream');
+        $streamUrl = $this->buildStreamUrl($recording);
+        $sourceLogo = $this->resolveSourceChannelLogo($recording);
 
         // Find-or-create the DVR category for this playlist
         $category = $this->findOrCreateDvrCategory($playlistId, $userId);
 
         // Find-or-create the Series (always update metadata if tmdb available)
-        $series = $this->findOrCreateSeries($seriesName, $playlistId, $userId, $category->id, $tmdb);
+        $series = $this->findOrCreateSeries($seriesName, $playlistId, $userId, $category->id, $tmdb, $sourceLogo, $tvmaze);
 
         // Find-or-create the Season
         $season = $this->findOrCreateSeason($series, $seasonNumber, $playlistId, $userId, $category->id);
@@ -161,7 +206,7 @@ class DvrVodIntegrationService
             $episode->season_id = $season->id;
             $episode->season = $seasonNumber;
             $episode->episode_num = $episodeNumber;
-            $episode->container_extension = 'ts';
+            $episode->container_extension = 'mp4';
             $episode->enabled = true;
             $episode->source_episode_id = null;
             $episode->import_batch_no = 'dvr';
@@ -169,13 +214,13 @@ class DvrVodIntegrationService
         }
 
         // Always update title, URL, and info (URL may have been created with wrong base)
-        $episode->title = $recording->subtitle ?? $recording->title;
+        $episode->title = $this->buildEpisodeTitle($recording);
         $episode->url = $streamUrl;
         $episode->info = [
             'plot' => $recording->description ?? ($tmdb['overview'] ?? null),
             'release_date' => $recording->programme_start?->toDateString(),
             'duration_secs' => $recording->duration_seconds,
-            'movie_image' => $tmdb['poster_url'] ?? null,
+            'movie_image' => $tmdb['poster_url'] ?? $sourceLogo ?? null,
             'tmdb_id' => $tmdb['id'] ?? null,
             'season' => $seasonNumber,
         ];
@@ -188,6 +233,117 @@ class DvrVodIntegrationService
             'episode' => $episodeNumber,
             'playlist_id' => $playlistId,
         ]);
+    }
+
+    /**
+     * Build the display title for a VOD episode.
+     *
+     * When the recording has season/episode numbers, they are prepended so the
+     * title reads "S01E03 - Subtitle" (or "S01E03 - Show Title" when no subtitle
+     * is available).  Without numbering, and when no metadata was found, the
+     * recording date is appended so repeated recordings of the same channel are
+     * individually identifiable (e.g. "CNN News — Apr 21, 2026").
+     */
+    private function buildEpisodeTitle(DvrRecording $recording): string
+    {
+        $label = $this->stripUnicodeDecorations($recording->subtitle ?? $recording->title);
+
+        if ($recording->season !== null && $recording->episode !== null) {
+            $prefix = sprintf('S%02dE%02d', $recording->season, $recording->episode);
+
+            return "{$prefix} - {$label}";
+        }
+
+        if ($recording->episode !== null) {
+            $prefix = sprintf('E%02d', $recording->episode);
+
+            return "{$prefix} - {$label}";
+        }
+
+        // No S/E numbers — append recording date when metadata is absent so
+        // multiple recordings of the same show are individually identifiable.
+        $hasMetadata = is_array($recording->metadata) && (
+            ! empty($recording->metadata['tmdb']) || ! empty($recording->metadata['tvmaze'])
+        );
+
+        if (! $hasMetadata) {
+            return $label.' — '.$this->formatRecordingDate($recording);
+        }
+
+        return $label;
+    }
+
+    /**
+     * Strip Unicode decorations (superscripts, subscripts, emoji, etc.) from a
+     * display title, preserving basic/extended Latin characters (U+0000–U+024F).
+     * Collapses the extra whitespace left behind after stripping.
+     */
+    private function stripUnicodeDecorations(string $title): string
+    {
+        $stripped = preg_replace('/[^\x{0000}-\x{024F}\s]/u', '', $title) ?? $title;
+
+        return trim((string) preg_replace('/\s{2,}/', ' ', $stripped));
+    }
+
+    /**
+     * Format the recording date for use in a fallback VOD title.
+     * Returns a human-readable string like "Apr 21, 2026".
+     */
+    private function formatRecordingDate(DvrRecording $recording): string
+    {
+        $date = $recording->programme_start ?? $recording->scheduled_start ?? now();
+
+        return $date->format('M j, Y');
+    }
+
+    /**
+     * Resolve a logo URL from the recording's source playlist channel.
+     *
+     * Priority:
+     *   1. Channel::logo_internal (direct M3U logo stored locally)
+     *   2. EpgChannel::icon (TVG logo from the EPG feed)
+     */
+    private function resolveSourceChannelLogo(DvrRecording $recording): ?string
+    {
+        $channel = $recording->channel;
+
+        if (! $channel) {
+            return null;
+        }
+
+        if (! empty($channel->logo_internal)) {
+            return $channel->logo_internal;
+        }
+
+        $epgChannel = $channel->epgChannel ?? null;
+
+        if ($epgChannel && ! empty($epgChannel->icon)) {
+            return $epgChannel->icon;
+        }
+
+        return null;
+    }
+
+    /**
+     * Find or create a VOD Group named "DVR" for the given playlist.
+     * Used to categorise DVR-sourced movie VOD channels within the VOD group filter.
+     */
+    private function findOrCreateDvrVodGroup(int $playlistId, int $userId): Group
+    {
+        return Group::firstOrCreate(
+            [
+                'playlist_id' => $playlistId,
+                'name_internal' => self::DVR_CATEGORY_NAME,
+                'type' => 'vod',
+            ],
+            [
+                'name' => self::DVR_CATEGORY_NAME,
+                'user_id' => $userId,
+                'enabled' => true,
+                'custom' => true,
+                'import_batch_no' => 'dvr',
+            ]
+        );
     }
 
     /**
@@ -211,7 +367,7 @@ class DvrVodIntegrationService
     /**
      * Find an existing DVR series by name + playlist, or create a new one.
      */
-    private function findOrCreateSeries(string $name, int $playlistId, int $userId, int $categoryId, ?array $tmdb): Series
+    private function findOrCreateSeries(string $name, int $playlistId, int $userId, int $categoryId, ?array $tmdb, ?string $sourceLogo = null, ?array $tvmaze = null): Series
     {
         // Look for an existing DVR-created series by name + playlist
         // (source_series_id is NULL for DVR series, so we match on name)
@@ -233,6 +389,16 @@ class DvrVodIntegrationService
                 }
 
                 $series->save();
+            } elseif ($tvmaze && empty($series->cover) && empty($series->plot)) {
+                // Backfill TVMaze metadata if series still has nothing
+                $series->cover = $tvmaze['poster_url'] ?? $sourceLogo ?? $series->cover;
+                $series->plot = $tvmaze['overview'] ?? $series->plot;
+                $series->release_date = $tvmaze['premiered'] ?? $series->release_date;
+                $series->save();
+            } elseif ($sourceLogo && empty($series->cover)) {
+                // Backfill the source channel logo if the series has no cover yet
+                $series->cover = $sourceLogo;
+                $series->save();
             }
 
             return $series;
@@ -248,7 +414,7 @@ class DvrVodIntegrationService
         $series->import_batch_no = 'dvr';
 
         if ($tmdb) {
-            $series->cover = $tmdb['poster_url'] ?? null;
+            $series->cover = $tmdb['poster_url'] ?? $sourceLogo;
             $series->plot = $tmdb['overview'] ?? null;
             $series->release_date = $tmdb['first_air_date'] ?? $tmdb['release_date'] ?? null;
             $series->metadata = $tmdb;
@@ -256,6 +422,12 @@ class DvrVodIntegrationService
             if (! empty($tmdb['id'])) {
                 $series->tmdb_id = $tmdb['id'];
             }
+        } elseif ($tvmaze) {
+            $series->cover = $tvmaze['poster_url'] ?? $sourceLogo;
+            $series->plot = $tvmaze['overview'] ?? null;
+            $series->release_date = $tvmaze['premiered'] ?? null;
+        } elseif ($sourceLogo) {
+            $series->cover = $sourceLogo;
         }
 
         $series->save();

--- a/app/Services/DvrVodIntegrationService.php
+++ b/app/Services/DvrVodIntegrationService.php
@@ -79,21 +79,33 @@ class DvrVodIntegrationService
     }
 
     /**
-     * Build the stream URL for a DVR recording.
+     * Build the authenticated stream URL for a DVR recording.
      *
-     * Uses DVR_STREAM_BASE_URL when set (for Docker-internal proxy access),
-     * falling back to the general url_override / APP_URL via PlaylistService.
+     * Generates the same URL format as the "Watch" action:
+     *   /dvr/{username}/{playlist-uuid}/{recording-uuid}.{ext}
+     *
+     * DvrStreamController authenticates via the playlist UUID (no session required),
+     * so this URL works in any media player without additional login.
      */
     private function buildStreamUrl(DvrRecording $recording): string
     {
-        $path = '/dvr/recordings/'.$recording->uuid.'/stream';
-        $base = config('dvr.stream_base_url');
+        $setting = $recording->dvrSetting;
+        $playlist = $setting?->playlist;
+        $user = $recording->user;
 
-        if ($base) {
-            return rtrim($base, '/').$path;
+        if ($playlist && $user) {
+            $ext = $setting->dvr_output_format ?? 'ts';
+
+            return route('dvr.recording.stream', [
+                'username' => $user->name,
+                'password' => $playlist->uuid,
+                'uuid' => $recording->uuid,
+                'format' => $ext,
+            ]);
         }
 
-        return PlaylistService::getBaseUrl($path);
+        // Fallback: path-only URL (playlist or user not resolvable)
+        return url('/dvr/recordings/'.$recording->uuid.'/stream');
     }
 
     /**
@@ -102,6 +114,7 @@ class DvrVodIntegrationService
     private function integrateAsMovie(DvrRecording $recording, int $playlistId, int $userId, ?array $tmdb): void
     {
         $streamUrl = $this->buildStreamUrl($recording);
+        $containerExt = $recording->dvrSetting?->dvr_output_format ?? 'ts';
         $cleanTitle = $this->stripUnicodeDecorations($recording->title);
         $tvmaze = is_array($recording->metadata) ? ($recording->metadata['tvmaze'] ?? null) : null;
 
@@ -122,7 +135,7 @@ class DvrVodIntegrationService
             $channel->is_vod = true;
             $channel->is_custom = true;
             $channel->enabled = true;
-            $channel->container_extension = 'mp4';
+            $channel->container_extension = $containerExt;
             $channel->dvr_recording_id = $recording->id;
             $channel->source_id = null;
 
@@ -183,6 +196,7 @@ class DvrVodIntegrationService
         $seasonNumber = $recording->season ?? 1;
         $episodeNumber = $recording->episode ?? 1;
         $streamUrl = $this->buildStreamUrl($recording);
+        $containerExt = $recording->dvrSetting?->dvr_output_format ?? 'ts';
         $sourceLogo = $this->resolveSourceChannelLogo($recording);
 
         // Find-or-create the DVR category for this playlist
@@ -206,7 +220,7 @@ class DvrVodIntegrationService
             $episode->season_id = $season->id;
             $episode->season = $seasonNumber;
             $episode->episode_num = $episodeNumber;
-            $episode->container_extension = 'mp4';
+            $episode->container_extension = $containerExt;
             $episode->enabled = true;
             $episode->source_episode_id = null;
             $episode->import_batch_no = 'dvr';

--- a/app/Services/EpgCacheService.php
+++ b/app/Services/EpgCacheService.php
@@ -6,7 +6,10 @@ use App\Enums\EpgSourceType;
 use App\Enums\Status;
 use App\Facades\PlaylistFacade;
 use App\Models\CustomPlaylist;
+use App\Models\DvrSetting;
 use App\Models\Epg;
+use App\Models\EpgMap;
+use App\Models\EpgProgramme;
 use App\Models\MergedPlaylist;
 use App\Models\Playlist;
 use App\Models\PlaylistAlias;
@@ -192,6 +195,9 @@ class EpgCacheService
             ]);
 
             Log::debug('EPG cache generated successfully', $metadata);
+
+            // Populate epg_programmes DB table for DVR-enabled playlists
+            $this->populateDvrProgrammes($epg);
 
             return true;
         } catch (Exception $e) {
@@ -1498,5 +1504,147 @@ class EpgCacheService
                 }
             })
             ->modalSubmitActionLabel('Download EPG');
+    }
+
+    /**
+     * Populate the epg_programmes DB table for any DVR-enabled playlists that use this EPG.
+     *
+     * Reads from the JSONL cache files (covering yesterday through 7 days ahead) and
+     * upserts rows into epg_programmes so the DVR scheduler can query them without
+     * touching the filesystem.
+     */
+    private function populateDvrProgrammes(Epg $epg): void
+    {
+        // Find all DVR-enabled playlists whose EpgMap references this EPG
+        $playlistIds = DvrSetting::where('enabled', true)
+            ->pluck('playlist_id');
+
+        if ($playlistIds->isEmpty()) {
+            return;
+        }
+
+        // Check at least one of those playlists is mapped to this EPG
+        $hasMapping = EpgMap::whereIn('playlist_id', $playlistIds)
+            ->where('epg_id', $epg->id)
+            ->exists();
+
+        if (! $hasMapping) {
+            return;
+        }
+
+        Log::debug("Populating epg_programmes for EPG {$epg->name} (id={$epg->id})");
+
+        // Delete stale rows for this EPG so we do a clean refresh
+        EpgProgramme::where('epg_id', $epg->id)->delete();
+
+        $cacheDir = $this->getCacheDir($epg);
+        $now = now();
+        $from = $now->copy()->subDay()->startOfDay();
+        $to = $now->copy()->addDays(7)->endOfDay();
+
+        $batch = [];
+        $batchSize = 500;
+        $inserted = 0;
+        $skipped = 0;
+
+        // Iterate over date files within the window
+        $current = $from->copy();
+        while ($current->lte($to)) {
+            $date = $current->format('Y-m-d');
+            $filePath = $this->getCacheFilePath($epg, "programmes-{$date}.jsonl");
+
+            if (! Storage::disk('local')->exists($filePath)) {
+                $current->addDay();
+
+                continue;
+            }
+
+            $fullPath = Storage::disk('local')->path($filePath);
+            $handle = fopen($fullPath, 'r');
+            if (! $handle) {
+                $current->addDay();
+
+                continue;
+            }
+
+            while (($line = fgets($handle)) !== false) {
+                $line = trim($line);
+                if (empty($line)) {
+                    continue;
+                }
+
+                try {
+                    $record = json_decode($line, true);
+                    if (! $record || ! isset($record['channel'], $record['programme'])) {
+                        continue;
+                    }
+
+                    $p = $record['programme'];
+                    $startTime = isset($p['start']) ? Carbon::parse($p['start']) : null;
+                    $endTime = isset($p['stop']) ? Carbon::parse($p['stop']) : null;
+
+                    if (! $startTime || ! $endTime) {
+                        $skipped++;
+
+                        continue;
+                    }
+
+                    // Parse episode info from xmltv episode-num (e.g. "1.2.0/1" → S2E3)
+                    $season = null;
+                    $episode = null;
+                    if (! empty($p['episode_num'])) {
+                        $parts = explode('.', $p['episode_num']);
+                        if (isset($parts[0]) && is_numeric(trim($parts[0]))) {
+                            $season = (int) trim($parts[0]) + 1;
+                        }
+                        if (isset($parts[1]) && is_numeric(trim($parts[1]))) {
+                            $episode = (int) trim($parts[1]) + 1;
+                        }
+                    }
+
+                    $batch[] = [
+                        'epg_id' => $epg->id,
+                        'epg_channel_id' => $record['channel'],
+                        'title' => $p['title'] ?? '',
+                        'subtitle' => $p['subtitle'] ?? null,
+                        'description' => $p['desc'] ?? null,
+                        'category' => $p['category'] ?? null,
+                        'start_time' => $startTime->toDateTimeString(),
+                        'end_time' => $endTime->toDateTimeString(),
+                        'episode_num' => $p['episode_num'] ?? null,
+                        'season' => $season,
+                        'episode' => $episode,
+                        'is_new' => (bool) ($p['new'] ?? false),
+                        'icon' => $p['icon'] ?? null,
+                        'rating' => $p['rating'] ?? null,
+                        'created_at' => now()->toDateTimeString(),
+                        'updated_at' => now()->toDateTimeString(),
+                    ];
+
+                    if (count($batch) >= $batchSize) {
+                        EpgProgramme::insert($batch);
+                        $inserted += count($batch);
+                        $batch = [];
+                    }
+                } catch (Exception $e) {
+                    Log::warning("Failed to parse programme line for DVR: {$e->getMessage()}");
+                    $skipped++;
+                }
+            }
+
+            fclose($handle);
+            $current->addDay();
+        }
+
+        // Flush remaining
+        if (! empty($batch)) {
+            EpgProgramme::insert($batch);
+            $inserted += count($batch);
+        }
+
+        Log::debug("EPG programmes populated for DVR: {$inserted} inserted, {$skipped} skipped", [
+            'epg_id' => $epg->id,
+            'epg_name' => $epg->name,
+        ]);
     }
 }

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -1660,12 +1660,21 @@ class M3uProxyService
             if ($response->successful()) {
                 $data = $response->json() ?: [];
 
-                // Only include broadcasts for networks owned by the current user
-                // Get networks for current user
+                // Only include broadcasts for networks or DVR recordings owned by the current user
+                $userId = (string) auth()->id();
                 $userNetworkUuids = Network::where('user_id', auth()->id())->pluck('uuid')->toArray();
 
-                $broadcasts = array_filter($data['broadcasts'] ?? [], function ($b) use ($userNetworkUuids) {
-                    return isset($b['network_id']) && in_array($b['network_id'], $userNetworkUuids);
+                $broadcasts = array_filter($data['broadcasts'] ?? [], function ($b) use ($userNetworkUuids, $userId) {
+                    // Network broadcasts: network_id matches a user-owned network UUID
+                    if (isset($b['network_id']) && in_array($b['network_id'], $userNetworkUuids)) {
+                        return true;
+                    }
+                    // DVR broadcasts: metadata.type === 'dvr' and user_id matches
+                    if (($b['metadata']['type'] ?? null) === 'dvr' && ($b['metadata']['user_id'] ?? null) === $userId) {
+                        return true;
+                    }
+
+                    return false;
                 });
 
                 return [

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -1661,17 +1661,13 @@ class M3uProxyService
                 $data = $response->json() ?: [];
 
                 // Only include broadcasts for networks or DVR recordings owned by the current user
-                $userId = (string) auth()->id();
                 $userNetworkUuids = Network::where('user_id', auth()->id())->pluck('uuid')->toArray();
+                $userDvrUuids = DvrRecording::where('user_id', auth()->id())->pluck('uuid')->toArray();
 
-                $broadcasts = array_filter($data['broadcasts'] ?? [], function ($b) use ($userNetworkUuids, $userId) {
-                    // Network broadcasts: network_id matches a user-owned network UUID
-                    if (isset($b['network_id']) && in_array($b['network_id'], $userNetworkUuids)) {
-                        return true;
-                    }
-                    // DVR broadcasts: metadata.type === 'dvr' and user_id matches
-                    if (($b['metadata']['type'] ?? null) === 'dvr' && ($b['metadata']['user_id'] ?? null) === $userId) {
-                        return true;
+                $broadcasts = array_filter($data['broadcasts'] ?? [], function ($b) use ($userNetworkUuids, $userDvrUuids) {
+                    if (isset($b['network_id'])) {
+                        return in_array($b['network_id'], $userNetworkUuids)
+                            || in_array($b['network_id'], $userDvrUuids);
                     }
 
                     return false;
@@ -2633,7 +2629,6 @@ class M3uProxyService
                 'recording_id' => $recording->uuid,
                 'recording_db_id' => (string) $recording->id,
                 'title' => $recording->title,
-                'user_id' => (string) $recording->user_id,
             ],
         ];
 

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -6,6 +6,8 @@ use App\Facades\PlaylistFacade;
 use App\Facades\ProxyFacade;
 use App\Models\Channel;
 use App\Models\CustomPlaylist;
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
 use App\Models\Episode;
 use App\Models\MergedPlaylist;
 use App\Models\Network;
@@ -2557,5 +2559,102 @@ class M3uProxyService
 
         // Return null if not configured, as webhooks are optional and may not be needed if the resolver URL is not set
         return null;
+    }
+
+    /**
+     * Start a DVR broadcast on the proxy.
+     *
+     * Uses the proxy's BroadcastManager with dvr_mode=true so all HLS segments
+     * are preserved for post-processing. The recording UUID is used as the
+     * network_id so it is globally unique and traceable.
+     *
+     * Returns the network_id (= recording UUID) on success.
+     *
+     * @throws Exception when the proxy is unreachable or returns an error
+     */
+    public function startDvrBroadcast(DvrRecording $recording, DvrSetting $setting, string $streamUrl): string
+    {
+        if (empty($this->apiBaseUrl)) {
+            throw new Exception('M3U Proxy base URL is not configured');
+        }
+
+        $networkId = $recording->uuid;
+        $callbackUrl = ProxyFacade::getBaseUrl().'/api/dvr/callback';
+
+        $durationSeconds = 0;
+        if ($recording->scheduled_start && $recording->scheduled_end) {
+            $durationSeconds = (int) abs($recording->scheduled_end->diffInSeconds($recording->scheduled_start));
+            // Add end-late buffer
+            $durationSeconds += (int) $setting->resolveEndLateSeconds(null);
+        }
+
+        $payload = [
+            'stream_url' => $streamUrl,
+            'duration_seconds' => $durationSeconds,
+            'dvr_mode' => true,
+            'callback_url' => $callbackUrl,
+            'metadata' => [
+                'type' => 'dvr',
+                'recording_id' => $recording->uuid,
+                'recording_db_id' => (string) $recording->id,
+                'title' => $recording->title,
+                'user_id' => (string) $recording->user_id,
+            ],
+        ];
+
+        $endpoint = $this->apiBaseUrl.'/broadcast/'.rawurlencode($networkId).'/start';
+        $response = Http::timeout(10)
+            ->acceptJson()
+            ->withHeaders($this->apiToken ? ['X-API-Token' => $this->apiToken] : [])
+            ->post($endpoint, $payload);
+
+        if (! $response->successful()) {
+            throw new Exception("Proxy returned HTTP {$response->status()} starting DVR broadcast: ".$response->body());
+        }
+
+        return $networkId;
+    }
+
+    /**
+     * Stop a running DVR broadcast on the proxy.
+     */
+    public function stopDvrBroadcast(string $networkId): bool
+    {
+        if (empty($this->apiBaseUrl)) {
+            Log::warning('DVR stop: M3U Proxy base URL not configured');
+
+            return false;
+        }
+
+        try {
+            $endpoint = $this->apiBaseUrl.'/broadcast/'.rawurlencode($networkId).'/stop';
+            $response = Http::timeout(10)
+                ->acceptJson()
+                ->withHeaders($this->apiToken ? ['X-API-Token' => $this->apiToken] : [])
+                ->post($endpoint);
+
+            if ($response->successful()) {
+                Log::debug("DVR broadcast {$networkId} stopped on proxy");
+
+                return true;
+            }
+
+            Log::warning("Failed to stop DVR broadcast {$networkId}: ".$response->body());
+
+            return false;
+        } catch (Exception $e) {
+            Log::error("Error stopping DVR broadcast {$networkId}: ".$e->getMessage());
+
+            return false;
+        }
+    }
+
+    /**
+     * Get the public live HLS URL for an in-progress DVR recording.
+     * Clients can connect to this URL to watch the recording in real time.
+     */
+    public function getDvrBroadcastLiveUrl(string $networkId): string
+    {
+        return $this->getPublicUrl().'/broadcast/'.rawurlencode($networkId).'/live.m3u8';
     }
 }

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -2551,24 +2551,6 @@ class M3uProxyService
     }
 
     /**
-     * Get the DVR callback URL for m3u-proxy to notify the editor when a DVR broadcast ends.
-     *
-     * The proxy calls this endpoint from within the Docker network, so we MUST use the
-     * internal LAN address (failoverResolverUrl), not the public editor URL. Returns null
-     * when the resolver URL is not configured — callers should treat this as a hard block.
-     *
-     * @return string|null The DVR callback endpoint URL, or null if the resolver is not configured
-     */
-    public function getDvrCallbackUrl(): ?string
-    {
-        if (! empty($this->failoverResolverUrl)) {
-            return "{$this->failoverResolverUrl}/api/dvr/callback";
-        }
-
-        return null;
-    }
-
-    /**
      * Get the webhook callback URL for m3u-proxy to send webhook events.
      *
      * @return string|null The webhook callback endpoint URL, or null if not configured
@@ -2602,15 +2584,6 @@ class M3uProxyService
         }
 
         $networkId = $recording->uuid;
-        $callbackUrl = $this->getDvrCallbackUrl();
-
-        if (empty($callbackUrl)) {
-            throw new Exception(
-                'DVR callback URL cannot be resolved: the proxy calls back from within the Docker network, '.
-                'so the internal editor URL must be configured via Settings → Proxy → "Failover Resolver URL" '.
-                '(e.g. http://m3u-editor:36400). DVR recording is unavailable until this value is set.'
-            );
-        }
 
         $durationSeconds = 0;
         if ($recording->scheduled_start && $recording->scheduled_end) {
@@ -2623,7 +2596,6 @@ class M3uProxyService
             'stream_url' => $streamUrl,
             'duration_seconds' => $durationSeconds,
             'dvr_mode' => true,
-            'callback_url' => $callbackUrl,
             'metadata' => [
                 'type' => 'dvr',
                 'recording_id' => $recording->uuid,
@@ -2686,5 +2658,34 @@ class M3uProxyService
     public function getDvrBroadcastLiveUrl(string $networkId): string
     {
         return $this->getPublicUrl().'/broadcast/'.rawurlencode($networkId).'/live.m3u8';
+    }
+
+    /**
+     * Fetch the filesystem path to the HLS segment directory for a DVR broadcast.
+     *
+     * Called before stopping a broadcast so we know where segments are stored.
+     * Returns null if the broadcast is not found or the proxy is unreachable.
+     */
+    public function getDvrBroadcastHlsDir(string $networkId): ?string
+    {
+        if (empty($this->apiBaseUrl)) {
+            return null;
+        }
+
+        try {
+            $endpoint = $this->apiBaseUrl.'/broadcast/'.rawurlencode($networkId).'/status';
+            $response = Http::timeout(5)
+                ->acceptJson()
+                ->withHeaders($this->apiToken ? ['X-API-Token' => $this->apiToken] : [])
+                ->get($endpoint);
+
+            if ($response->successful()) {
+                return $response->json('hls_dir') ?: null;
+            }
+        } catch (Exception $e) {
+            Log::warning("DVR: Could not fetch hls_dir for broadcast {$networkId}: {$e->getMessage()}");
+        }
+
+        return null;
     }
 }

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -2546,6 +2546,24 @@ class M3uProxyService
     }
 
     /**
+     * Get the DVR callback URL for m3u-proxy to notify the editor when a DVR broadcast ends.
+     *
+     * The proxy calls this endpoint from within the Docker network, so we MUST use the
+     * internal LAN address (failoverResolverUrl), not the public editor URL. Returns null
+     * when the resolver URL is not configured — callers should treat this as a hard block.
+     *
+     * @return string|null The DVR callback endpoint URL, or null if the resolver is not configured
+     */
+    public function getDvrCallbackUrl(): ?string
+    {
+        if (! empty($this->failoverResolverUrl)) {
+            return "{$this->failoverResolverUrl}/api/dvr/callback";
+        }
+
+        return null;
+    }
+
+    /**
      * Get the webhook callback URL for m3u-proxy to send webhook events.
      *
      * @return string|null The webhook callback endpoint URL, or null if not configured
@@ -2579,7 +2597,15 @@ class M3uProxyService
         }
 
         $networkId = $recording->uuid;
-        $callbackUrl = ProxyFacade::getBaseUrl().'/api/dvr/callback';
+        $callbackUrl = $this->getDvrCallbackUrl();
+
+        if (empty($callbackUrl)) {
+            throw new Exception(
+                'DVR callback URL cannot be resolved: the proxy calls back from within the Docker network, '.
+                'so the internal editor URL must be configured via Settings → Proxy → "Failover Resolver URL" '.
+                '(e.g. http://m3u-editor:36400). DVR recording is unavailable until this value is set.'
+            );
+        }
 
         $durationSeconds = 0;
         if ($recording->scheduled_start && $recording->scheduled_end) {

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -71,7 +71,7 @@ class PlaylistService
         // Manually construct base URL to ensure port is included (if not using HTTPS)
         $url = rtrim(config('app.url'), '/');
         $port = config('app.port');
-        if (! Str::contains($url, 'https') && $port) {
+        if (! Str::contains($url, 'https') && $port && ! Str::contains($url, ':'.$port)) {
             $url .= ':'.$port;
         }
 

--- a/config/dvr.php
+++ b/config/dvr.php
@@ -77,4 +77,21 @@ return [
 
     'tvmaze_base_url' => 'https://api.tvmaze.com',
 
+    /*
+    |--------------------------------------------------------------------------
+    | DVR — Stream base URL
+    |--------------------------------------------------------------------------
+    |
+    | Base URL used when building DVR recording stream URLs for VOD integration.
+    | This should be the URL that the proxy (or any internal service) uses to
+    | reach the editor — typically the Docker-internal service hostname when
+    | running in a containerised stack (e.g. http://m3u-local-editor:36460).
+    |
+    | When empty, falls back to PlaylistService::getBaseUrl() which respects
+    | the url_override general setting and APP_URL.
+    |
+    */
+
+    'stream_base_url' => env('DVR_STREAM_BASE_URL'),
+
 ];

--- a/config/dvr.php
+++ b/config/dvr.php
@@ -1,0 +1,80 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | DVR — FFmpeg binary path
+    |--------------------------------------------------------------------------
+    |
+    | Full path to the ffmpeg executable. Can be overridden per-DvrSetting.
+    |
+    */
+
+    'ffmpeg_path' => env('DVR_FFMPEG_PATH', '/usr/bin/ffmpeg'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | DVR — Default storage settings
+    |--------------------------------------------------------------------------
+    |
+    | Used when a DvrSetting row does not specify its own storage config.
+    |
+    */
+
+    'storage_disk' => env('DVR_STORAGE_DISK', 'dvr'),
+
+    'storage_path' => env('DVR_STORAGE_PATH', storage_path('app/private/dvr')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | DVR — Scheduler
+    |--------------------------------------------------------------------------
+    |
+    | How many minutes ahead the scheduler looks for upcoming programmes.
+    |
+    */
+
+    'scheduler_lookahead_minutes' => (int) env('DVR_SCHEDULER_LOOKAHEAD_MINUTES', 30),
+
+    /*
+    |--------------------------------------------------------------------------
+    | DVR — Recording defaults
+    |--------------------------------------------------------------------------
+    */
+
+    'default_start_early_seconds' => (int) env('DVR_DEFAULT_START_EARLY_SECONDS', 0),
+
+    'default_end_late_seconds' => (int) env('DVR_DEFAULT_END_LATE_SECONDS', 0),
+
+    'max_concurrent_recordings' => (int) env('DVR_MAX_CONCURRENT_RECORDINGS', 2),
+
+    /*
+    |--------------------------------------------------------------------------
+    | DVR — HLS segment settings
+    |--------------------------------------------------------------------------
+    */
+
+    'hls_segment_seconds' => (int) env('DVR_HLS_SEGMENT_SECONDS', 6),
+
+    /*
+    |--------------------------------------------------------------------------
+    | DVR — Post-processing
+    |--------------------------------------------------------------------------
+    */
+
+    'graceful_stop_timeout_seconds' => (int) env('DVR_GRACEFUL_STOP_TIMEOUT_SECONDS', 10),
+
+    /*
+    |--------------------------------------------------------------------------
+    | DVR — Metadata enrichment
+    |--------------------------------------------------------------------------
+    */
+
+    'tmdb_api_key' => env('DVR_TMDB_API_KEY'),
+
+    'tmdb_base_url' => 'https://api.themoviedb.org/3',
+
+    'tvmaze_base_url' => 'https://api.tvmaze.com',
+
+];

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -53,6 +53,13 @@ return [
             'throw' => false,
         ],
 
+        'dvr' => [
+            'driver' => 'local',
+            'root' => env('DVR_STORAGE_PATH', storage_path('app/private/dvr')),
+            'serve' => false,
+            'throw' => false,
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -194,6 +194,21 @@ return [
             'timeout' => 60 * 125, // Should be longer than the retry_after value set in queue.php
             'nice' => 0,
         ],
+
+        'dvr-queue' => [
+            'connection' => 'redis',
+            'queue' => ['dvr', 'dvr-post', 'dvr-meta'],
+            'balance' => 'auto',
+            'autoScalingStrategy' => 'time',
+            // Set maxProcesses to 1 if using SQLite to avoid database locks
+            'maxProcesses' => env('DB_CONNECTION', 'sqlite') === 'sqlite' ? 1 : 4,
+            'maxTime' => 0,
+            'maxJobs' => 0,
+            'memory' => 512, // MB
+            'tries' => 2, // DVR jobs get fewer retries to avoid duplicate recordings
+            'timeout' => 60 * 60, // 1 hour (long-running recordings)
+            'nice' => 5,
+        ],
     ],
 
     'environments' => [

--- a/database/factories/DvrRecordingFactory.php
+++ b/database/factories/DvrRecordingFactory.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DvrRecordingStatus;
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<DvrRecording>
+ */
+class DvrRecordingFactory extends Factory
+{
+    protected $model = DvrRecording::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $start = fake()->dateTimeBetween('now', '+7 days');
+        $end = (clone $start)->modify('+1 hour');
+
+        return [
+            'uuid' => Str::uuid()->toString(),
+            'user_id' => User::factory(),
+            'dvr_setting_id' => DvrSetting::factory(),
+            'dvr_recording_rule_id' => null,
+            'channel_id' => null,
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => fake()->words(3, true),
+            'subtitle' => fake()->optional()->sentence(4),
+            'description' => fake()->optional()->paragraph(),
+            'season' => fake()->optional()->numberBetween(1, 20),
+            'episode' => fake()->optional()->numberBetween(1, 24),
+            'scheduled_start' => $start,
+            'scheduled_end' => $end,
+            'actual_start' => null,
+            'actual_end' => null,
+            'duration_seconds' => null,
+            'file_path' => null,
+            'file_size_bytes' => null,
+            'stream_url' => null,
+            'metadata' => null,
+            'error_message' => null,
+            'programme_start' => $start,
+            'programme_end' => $end,
+            'epg_programme_data' => null,
+            'pid' => null,
+        ];
+    }
+
+    public function recording(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => DvrRecordingStatus::Recording,
+            'actual_start' => now(),
+            'pid' => fake()->numberBetween(1000, 65535),
+        ]);
+    }
+
+    public function completed(): static
+    {
+        $start = now()->subHour();
+        $end = now()->subMinutes(5);
+
+        return $this->state(fn (array $attributes) => [
+            'status' => DvrRecordingStatus::Completed,
+            'actual_start' => $start,
+            'actual_end' => $end,
+            'duration_seconds' => 3300,
+            'file_path' => 'recordings/show/Season 01/show - S01E01 - episode.ts',
+            'file_size_bytes' => fake()->numberBetween(500_000_000, 5_000_000_000),
+            'scheduled_start' => $start,
+            'scheduled_end' => $end,
+        ]);
+    }
+
+    public function failed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => DvrRecordingStatus::Failed,
+            'error_message' => fake()->sentence(),
+        ]);
+    }
+}

--- a/database/factories/DvrRecordingRuleFactory.php
+++ b/database/factories/DvrRecordingRuleFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DvrRuleType;
+use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DvrRecordingRule>
+ */
+class DvrRecordingRuleFactory extends Factory
+{
+    protected $model = DvrRecordingRule::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'dvr_setting_id' => DvrSetting::factory(),
+            'type' => DvrRuleType::Once,
+            'programme_id' => null,
+            'series_title' => null,
+            'channel_id' => null,
+            'epg_channel_id' => null,
+            'new_only' => false,
+            'priority' => 50,
+            'start_early_seconds' => null,
+            'end_late_seconds' => null,
+            'keep_last' => null,
+            'enabled' => true,
+            'manual_start' => null,
+            'manual_end' => null,
+        ];
+    }
+
+    public function series(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => DvrRuleType::Series,
+            'series_title' => fake()->words(3, true),
+        ]);
+    }
+
+    public function manual(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => DvrRuleType::Manual,
+            'manual_start' => now()->addHour(),
+            'manual_end' => now()->addHours(2),
+        ]);
+    }
+
+    public function disabled(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'enabled' => false,
+        ]);
+    }
+}

--- a/database/factories/DvrSettingFactory.php
+++ b/database/factories/DvrSettingFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DvrSetting;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DvrSetting>
+ */
+class DvrSettingFactory extends Factory
+{
+    protected $model = DvrSetting::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'playlist_id' => Playlist::factory(),
+            'user_id' => User::factory(),
+            'enabled' => false,
+            'storage_disk' => 'dvr',
+            'storage_path' => 'recordings',
+            'max_concurrent_recordings' => 2,
+            'ffmpeg_path' => null,
+            'default_start_early_seconds' => 30,
+            'default_end_late_seconds' => 30,
+            'enable_metadata_enrichment' => true,
+            'tmdb_api_key' => null,
+            'global_disk_quota_gb' => null,
+            'retention_days' => null,
+        ];
+    }
+
+    public function enabled(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'enabled' => true,
+        ]);
+    }
+}

--- a/database/factories/DvrSettingFactory.php
+++ b/database/factories/DvrSettingFactory.php
@@ -23,6 +23,7 @@ class DvrSettingFactory extends Factory
             'playlist_id' => Playlist::factory(),
             'user_id' => User::factory(),
             'enabled' => false,
+            'use_proxy' => false,
             'storage_disk' => 'dvr',
             'storage_path' => 'recordings',
             'max_concurrent_recordings' => 2,

--- a/database/factories/EpgProgrammeFactory.php
+++ b/database/factories/EpgProgrammeFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Epg;
+use App\Models\EpgProgramme;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<EpgProgramme>
+ */
+class EpgProgrammeFactory extends Factory
+{
+    protected $model = EpgProgramme::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $start = fake()->dateTimeBetween('now', '+7 days');
+        $end = (clone $start)->modify('+1 hour');
+
+        return [
+            'epg_id' => Epg::factory(),
+            'epg_channel_id' => 'channel.'.fake()->numerify('###'),
+            'title' => fake()->words(3, true),
+            'subtitle' => fake()->optional()->sentence(4),
+            'description' => fake()->optional()->paragraph(),
+            'category' => fake()->optional()->randomElement(['Drama', 'Comedy', 'News', 'Sports', 'Documentary']),
+            'start_time' => $start,
+            'end_time' => $end,
+            'episode_num' => null,
+            'season' => fake()->optional()->numberBetween(1, 20),
+            'episode' => fake()->optional()->numberBetween(1, 24),
+            'is_new' => false,
+            'icon' => null,
+            'rating' => fake()->optional()->randomElement(['TV-G', 'TV-PG', 'TV-14', 'TV-MA']),
+        ];
+    }
+
+    public function isNew(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_new' => true,
+        ]);
+    }
+
+    public function withEpisode(int $season, int $episode): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'season' => $season,
+            'episode' => $episode,
+            'episode_num' => sprintf('S%02dE%02d', $season, $episode),
+        ]);
+    }
+
+    public function upcoming(int $minutesFromNow = 15): static
+    {
+        return $this->state(function (array $attributes) use ($minutesFromNow) {
+            $start = now()->addMinutes($minutesFromNow);
+            $end = (clone $start)->addHour();
+
+            return [
+                'start_time' => $start,
+                'end_time' => $end,
+            ];
+        });
+    }
+}

--- a/database/migrations/2026_04_06_000001_create_dvr_settings_table.php
+++ b/database/migrations/2026_04_06_000001_create_dvr_settings_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('dvr_settings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('playlist_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->boolean('enabled')->default(false);
+            $table->string('storage_disk')->default('dvr');
+            $table->string('storage_path')->default('recordings');
+            $table->unsignedSmallInteger('max_concurrent_recordings')->default(2);
+            $table->string('ffmpeg_path')->nullable();
+            $table->unsignedSmallInteger('default_start_early_seconds')->default(30);
+            $table->unsignedSmallInteger('default_end_late_seconds')->default(30);
+            $table->boolean('enable_metadata_enrichment')->default(true);
+            $table->text('tmdb_api_key')->nullable();
+            $table->unsignedInteger('global_disk_quota_gb')->nullable();
+            $table->unsignedSmallInteger('retention_days')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('dvr_settings');
+    }
+};

--- a/database/migrations/2026_04_06_000002_create_dvr_recording_rules_table.php
+++ b/database/migrations/2026_04_06_000002_create_dvr_recording_rules_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('dvr_recording_rules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('dvr_setting_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->string('type')->default('once'); // DvrRuleType enum
+            $table->string('programme_id')->nullable()->index();
+            $table->string('series_title')->nullable();
+            $table->foreignId('channel_id')->nullable()->constrained()->nullOnDelete()->cascadeOnUpdate();
+            $table->foreignId('epg_channel_id')->nullable()->constrained()->nullOnDelete()->cascadeOnUpdate();
+            $table->boolean('new_only')->default(false);
+            $table->unsignedSmallInteger('priority')->default(50);
+            $table->unsignedSmallInteger('start_early_seconds')->nullable();
+            $table->unsignedSmallInteger('end_late_seconds')->nullable();
+            $table->unsignedSmallInteger('keep_last')->nullable();
+            $table->boolean('enabled')->default(true);
+            $table->dateTime('manual_start')->nullable();
+            $table->dateTime('manual_end')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('dvr_recording_rules');
+    }
+};

--- a/database/migrations/2026_04_06_000003_create_dvr_recordings_table.php
+++ b/database/migrations/2026_04_06_000003_create_dvr_recordings_table.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('dvr_recordings', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('uuid')->unique();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('dvr_setting_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('dvr_recording_rule_id')->nullable()->constrained()->nullOnDelete()->cascadeOnUpdate();
+            $table->foreignId('channel_id')->nullable()->constrained()->nullOnDelete()->cascadeOnUpdate();
+            $table->string('status')->default('scheduled'); // DvrRecordingStatus enum
+            $table->string('title');
+            $table->string('subtitle')->nullable();
+            $table->text('description')->nullable();
+            $table->unsignedSmallInteger('season')->nullable();
+            $table->unsignedSmallInteger('episode')->nullable();
+            $table->dateTime('scheduled_start')->index();
+            $table->dateTime('scheduled_end')->index();
+            $table->dateTime('actual_start')->nullable();
+            $table->dateTime('actual_end')->nullable();
+            $table->unsignedInteger('duration_seconds')->nullable();
+            $table->string('file_path')->nullable();
+            $table->unsignedBigInteger('file_size_bytes')->nullable();
+            $table->text('stream_url')->nullable();
+            $table->json('metadata')->nullable();
+            $table->text('error_message')->nullable();
+            $table->dateTime('programme_start')->nullable();
+            $table->dateTime('programme_end')->nullable();
+            $table->json('epg_programme_data')->nullable();
+            $table->unsignedInteger('pid')->nullable();
+            $table->timestamps();
+
+            $table->index('status');
+            $table->index(['dvr_setting_id', 'status']);
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('dvr_recordings');
+    }
+};

--- a/database/migrations/2026_04_06_000005_create_epg_programmes_table.php
+++ b/database/migrations/2026_04_06_000005_create_epg_programmes_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('epg_programmes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('epg_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->string('epg_channel_id', 500)->index();
+            $table->string('title', 500);
+            $table->string('subtitle', 500)->nullable();
+            $table->text('description')->nullable();
+            $table->string('category', 255)->nullable();
+            $table->dateTime('start_time');
+            $table->dateTime('end_time')->nullable();
+            $table->string('episode_num', 255)->nullable();
+            $table->unsignedSmallInteger('season')->nullable();
+            $table->unsignedSmallInteger('episode')->nullable();
+            $table->boolean('is_new')->default(false);
+            $table->string('icon', 500)->nullable();
+            $table->string('rating', 50)->nullable();
+            $table->timestamps();
+
+            $table->index('start_time');
+            $table->index(['epg_channel_id', 'start_time']);
+            $table->index(['epg_id', 'start_time']);
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('epg_programmes');
+    }
+};

--- a/database/migrations/2026_04_11_164905_add_temp_paths_to_dvr_recordings_table.php
+++ b/database/migrations/2026_04_11_164905_add_temp_paths_to_dvr_recordings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dvr_recordings', function (Blueprint $table) {
+            $table->string('temp_path')->nullable()->after('pid');
+            $table->string('temp_manifest_path')->nullable()->after('temp_path');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dvr_recordings', function (Blueprint $table) {
+            $table->dropColumn(['temp_path', 'temp_manifest_path']);
+        });
+    }
+};

--- a/database/migrations/2026_04_11_191052_add_dvr_recording_id_to_channels_and_episodes_tables.php
+++ b/database/migrations/2026_04_11_191052_add_dvr_recording_id_to_channels_and_episodes_tables.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->unsignedBigInteger('dvr_recording_id')->nullable()->after('probe_enabled');
+            $table->foreign('dvr_recording_id')
+                ->references('id')
+                ->on('dvr_recordings')
+                ->nullOnDelete();
+        });
+
+        Schema::table('episodes', function (Blueprint $table) {
+            $table->unsignedBigInteger('dvr_recording_id')->nullable()->after('info');
+            $table->foreign('dvr_recording_id')
+                ->references('id')
+                ->on('dvr_recordings')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropForeign(['dvr_recording_id']);
+            $table->dropColumn('dvr_recording_id');
+        });
+
+        Schema::table('episodes', function (Blueprint $table) {
+            $table->dropForeign(['dvr_recording_id']);
+            $table->dropColumn('dvr_recording_id');
+        });
+    }
+};

--- a/database/migrations/2026_04_21_123625_add_post_processing_step_to_dvr_recordings.php
+++ b/database/migrations/2026_04_21_123625_add_post_processing_step_to_dvr_recordings.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dvr_recordings', function (Blueprint $table) {
+            $table->string('post_processing_step')->nullable()->after('error_message');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dvr_recordings', function (Blueprint $table) {
+            $table->dropColumn('post_processing_step');
+        });
+    }
+};

--- a/database/migrations/2026_04_21_163154_add_use_proxy_to_dvr_settings_table.php
+++ b/database/migrations/2026_04_21_163154_add_use_proxy_to_dvr_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dvr_settings', function (Blueprint $table) {
+            $table->boolean('use_proxy')->default(false)->after('enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dvr_settings', function (Blueprint $table) {
+            $table->dropColumn('use_proxy');
+        });
+    }
+};

--- a/database/migrations/2026_04_22_074123_add_proxy_network_id_to_dvr_recordings.php
+++ b/database/migrations/2026_04_22_074123_add_proxy_network_id_to_dvr_recordings.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dvr_recordings', function (Blueprint $table) {
+            // Tracks the proxy broadcast ID (= recording UUID) so the editor can
+            // stop the proxy process and redirect live viewers to the HLS stream.
+            $table->string('proxy_network_id')->nullable()->after('uuid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dvr_recordings', function (Blueprint $table) {
+            $table->dropColumn('proxy_network_id');
+        });
+    }
+};

--- a/database/migrations/2026_04_22_075146_add_dvr_profile_to_dvr_settings.php
+++ b/database/migrations/2026_04_22_075146_add_dvr_profile_to_dvr_settings.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('dvr_settings', function (Blueprint $table) {
+            $table->string('dvr_output_format')->default('ts')->after('use_proxy');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('dvr_settings', function (Blueprint $table) {
+            $table->dropColumn('dvr_output_format');
+        });
+    }
+};

--- a/database/migrations/2026_04_22_085605_make_storage_path_nullable_in_dvr_settings.php
+++ b/database/migrations/2026_04_22_085605_make_storage_path_nullable_in_dvr_settings.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dvr_settings', function (Blueprint $table) {
+            $table->string('storage_path')->nullable()->default(null)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('dvr_settings', function (Blueprint $table) {
+            $table->string('storage_path')->nullable(false)->default('recordings')->change();
+        });
+    }
+};

--- a/local-test.sh
+++ b/local-test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# local-test.sh — Run the Pest test suite inside a fresh container built from source.
+# Uses the existing docker-compose.dev.yml test profile (SQLite in-memory, no external deps).
+# Run from the repo root.
+#
+# Usage:
+#   ./local-test.sh                    — run all tests
+#   ./local-test.sh --filter=MyTest    — run a specific test or filter
+#   ./local-test.sh tests/Feature/Foo  — run a specific file
+
+set -euo pipefail
+
+COMPOSE_FILE="docker-compose.dev.yml"
+
+# Pass any extra args straight to php artisan test (e.g. --filter, filename)
+EXTRA_ARGS=("$@")
+
+echo "-- Building test image (with dev dependencies)..."
+docker compose -f "${COMPOSE_FILE}" build --no-cache m3u-editor-dev-test
+
+echo "-- Running test suite..."
+if [ "${#EXTRA_ARGS[@]}" -gt 0 ]; then
+    docker compose -f "${COMPOSE_FILE}" run --rm --profile test \
+        m3u-editor-dev-test "${EXTRA_ARGS[@]}"
+else
+    docker compose -f "${COMPOSE_FILE}" run --rm --profile test \
+        m3u-editor-dev-test
+fi

--- a/local-up.sh
+++ b/local-up.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# local-up.sh — Build m3u-editor from source and start the full external-services stack.
+# Run from the repo root.
+
+set -euo pipefail
+
+COMPOSE_FILE="local/docker-compose.yml"
+ENV_FILE="local/.env"
+
+# Bootstrap .env from example if missing
+if [ ! -f "${ENV_FILE}" ]; then
+    echo "-- No local/.env found, creating from example..."
+    cp "local/.env.example" "${ENV_FILE}"
+    echo "-- Edit local/.env to customise credentials, then re-run this script."
+fi
+
+# Ensure m3u-proxy:local exists (pull + retag from Docker Hub if absent)
+if ! docker image inspect sparkison/m3u-proxy:local &>/dev/null; then
+    echo "-- sparkison/m3u-proxy:local not found, pulling latest and retagging..."
+    docker pull sparkison/m3u-proxy:latest
+    docker tag  sparkison/m3u-proxy:latest sparkison/m3u-proxy:local
+    echo "-- Retagged sparkison/m3u-proxy:latest -> sparkison/m3u-proxy:local"
+fi
+
+echo "-- Building m3u-editor from source and starting stack..."
+docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" build --no-cache
+docker compose --env-file "${ENV_FILE}" -f "${COMPOSE_FILE}" up --remove-orphans

--- a/local/.env.example
+++ b/local/.env.example
@@ -1,0 +1,16 @@
+# Local integration test environment
+# Copy to .env before running local-up.sh
+
+TZ=Etc/UTC
+APP_URL=http://localhost:36460
+APP_PORT=36460
+
+PG_DATABASE=m3ue_local
+PG_USER=m3ue
+PG_PASSWORD=localpass
+
+REDIS_PORT=6379
+REDIS_PASSWORD=localpass
+
+M3U_PROXY_PORT=38085
+M3U_PROXY_TOKEN=localtoken

--- a/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
+++ b/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
@@ -210,7 +210,12 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
                                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200">
                                         {{ $stream['format'] }}
                                     </span>
-                                    @if($stream['broadcast'] ?? false)
+                                    @if($stream['is_dvr'] ?? false)
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200">
+                                            <x-heroicon-s-video-camera class="w-3 h-3 mr-1" />
+                                            DVR
+                                        </span>
+                                    @elseif($stream['broadcast'] ?? false)
                                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900 text-indigo-800 dark:text-indigo-200 ml-2">
                                             Broadcast
                                         </span>

--- a/resources/views/filament/vods/status-tabs.blade.php
+++ b/resources/views/filament/vods/status-tabs.blade.php
@@ -8,6 +8,7 @@
         'disabled' => ['label' => 'Disabled', 'count' => $counts['disabled'], 'color' => 'danger'],
         'failover' => ['label' => 'Failover', 'count' => $counts['failover'], 'color' => 'info'],
         'custom' => ['label' => 'Custom', 'count' => $counts['custom'], 'color' => null],
+        'dvr' => ['label' => 'DVR', 'count' => $counts['dvr'], 'color' => null],
     ];
 @endphp
 

--- a/resources/views/livewire/epg-viewer.blade.php
+++ b/resources/views/livewire/epg-viewer.blade.php
@@ -353,7 +353,7 @@
                                         <div class="absolute inset-0">
                                             <template x-for="(programme, programmeIndex) in item.channel.programmes"
                                                 :key="`${item.id}-${programmeIndex}-${programme.start || 'nostart'}-${programme.stop || 'nostop'}-${(programme.title || 'notitle').replace(/[^a-zA-Z0-9]/g, '')}`">
-                                                <div class="absolute rounded shadow-sm cursor-pointer group transition-all duration-200"
+                                                <div class="absolute rounded shadow-sm cursor-pointer group/prog transition-all duration-200"
                                                     :class="getProgrammeColorClass(programme)"
                                                     :style="`${getProgrammeStyle(programme)}; top: 2px; bottom: 2px;`"
                                                     x-tooltip.html="getTooltipContent(programme)">
@@ -368,6 +368,16 @@
                                                             style="font-size: 10px; line-height: 1;">
                                                             New
                                                         </div>
+                                                        @if(!$viewOnly && $dvrEnabled)
+                                                        <!-- DVR Record Button (visible on hover) -->
+                                                        <button
+                                                            x-show="item.channel.database_id"
+                                                            @click.stop="$wire.openScheduleProgramme(programme, item.channel.database_id)"
+                                                            class="absolute bottom-0.5 right-0.5 p-1 text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-200 bg-white/80 dark:bg-gray-800/80 rounded-full opacity-0 group-hover/prog:opacity-100 transition-opacity duration-150"
+                                                            title="{{ __('Schedule Recording') }}">
+                                                            <x-heroicon-s-video-camera class="w-3 h-3" />
+                                                        </button>
+                                                        @endif
                                                     </div>
                                                 </div>
                                                 {{-- <x-filament::modal width="2xl">

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Jobs\DvrRetentionCleanup;
+use App\Jobs\DvrSchedulerTick;
 use App\Models\PluginRun;
 use Illuminate\Support\Facades\Schedule;
 
@@ -91,3 +93,9 @@ if (config('plugins.update_check.enabled', true)) {
 }
 
 // Note: HLS broadcast files are managed by m3u-proxy service
+
+// DVR scheduler tick — run every minute to match rules, start, and stop recordings
+Schedule::job(new DvrSchedulerTick)->everyMinute()->withoutOverlapping();
+
+// DVR retention cleanup — run hourly to enforce keepLast, age, and quota policies
+Schedule::job(new DvrRetentionCleanup)->hourly()->withoutOverlapping();

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\DispatcharrController;
 use App\Http\Controllers\AssetPreviewController;
 use App\Http\Controllers\Auth\OidcController;
 use App\Http\Controllers\ChannelController;
+use App\Http\Controllers\DvrCallbackController;
 use App\Http\Controllers\DvrStreamController;
 use App\Http\Controllers\EpgController;
 use App\Http\Controllers\EpgFileController;
@@ -349,9 +350,13 @@ Route::get('/webdav-media/{integration}/stream/{item}', [
 ])->name('webdav-media.stream');
 
 /*
- * DVR routes — file streaming
- * Authentication mirrors the Xtream stream pattern: username + password (playlist UUID)
+ * DVR routes — file streaming and proxy callbacks
+ * Stream auth mirrors the Xtream stream pattern: username + password (playlist UUID)
  * or PlaylistAuth credentials embedded in the URL.
+ * The callback route is unauthenticated (validated by API token in the controller).
  */
 Route::get('/dvr/{username}/{password}/{uuid}.{format?}', [DvrStreamController::class, 'stream'])
     ->name('dvr.recording.stream');
+
+Route::post('/api/dvr/callback', [DvrCallbackController::class, 'handle'])
+    ->name('dvr.callback');

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\DispatcharrController;
 use App\Http\Controllers\AssetPreviewController;
 use App\Http\Controllers\Auth\OidcController;
 use App\Http\Controllers\ChannelController;
+use App\Http\Controllers\DvrStreamController;
 use App\Http\Controllers\EpgController;
 use App\Http\Controllers\EpgFileController;
 use App\Http\Controllers\EpgGenerateController;
@@ -346,3 +347,9 @@ Route::get('/webdav-media/{integration}/stream/{item}', [
     MediaServerProxyController::class,
     'streamWebDavMedia',
 ])->name('webdav-media.stream');
+
+/*
+ * DVR routes — file streaming and M3U playlist generation
+ */
+Route::get('/dvr/recordings/{uuid}/stream', [DvrStreamController::class, 'stream'])
+    ->name('dvr.recording.stream');

--- a/routes/web.php
+++ b/routes/web.php
@@ -349,7 +349,9 @@ Route::get('/webdav-media/{integration}/stream/{item}', [
 ])->name('webdav-media.stream');
 
 /*
- * DVR routes — file streaming and M3U playlist generation
+ * DVR routes — file streaming
+ * Authentication mirrors the Xtream stream pattern: username + password (playlist UUID)
+ * or PlaylistAuth credentials embedded in the URL.
  */
-Route::get('/dvr/recordings/{uuid}/stream', [DvrStreamController::class, 'stream'])
+Route::get('/dvr/{username}/{password}/{uuid}.{format?}', [DvrStreamController::class, 'stream'])
     ->name('dvr.recording.stream');

--- a/tests/Feature/DvrRecorderServiceTest.php
+++ b/tests/Feature/DvrRecorderServiceTest.php
@@ -4,8 +4,9 @@
  * Tests for DvrRecorderService
  *
  * Covers:
- * - When use_proxy = false, recording uses the channel's direct URL
- * - When use_proxy = true, recording uses the channel's proxy URL
+ * - Recording always uses the channel's proxy URL (proxy manages FFmpeg)
+ * - start() stores proxy_network_id and sets status to Recording
+ * - stop() clears proxy_network_id and transitions to PostProcessing
  * - DvrSetting use_proxy defaults to false
  */
 
@@ -16,9 +17,9 @@ use App\Models\DvrSetting;
 use App\Models\Playlist;
 use App\Models\User;
 use App\Services\DvrRecorderService;
+use App\Services\M3uProxyService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
-use Illuminate\Support\Facades\Storage;
 
 uses(RefreshDatabase::class);
 
@@ -32,9 +33,8 @@ beforeEach(function () {
  * Build a SCHEDULED DvrRecording with a real Channel attached.
  *
  * @param  array<string, mixed>  $settingOverrides
- * @param  array<string, mixed>  $channelOverrides
  */
-function makeScheduledRecording(array $settingOverrides = [], array $channelOverrides = []): DvrRecording
+function makeScheduledRecording(array $settingOverrides = []): DvrRecording
 {
     $user = User::factory()->create();
     $playlist = Playlist::factory()->for($user)->create();
@@ -47,7 +47,7 @@ function makeScheduledRecording(array $settingOverrides = [], array $channelOver
     $channel = Channel::factory()
         ->for($user)
         ->for($playlist)
-        ->create(array_merge(['url' => 'http://direct.example.com/stream.ts'], $channelOverrides));
+        ->create(['url' => 'http://direct.example.com/stream.ts']);
 
     return DvrRecording::factory()
         ->for($setting, 'dvrSetting')
@@ -63,44 +63,80 @@ function makeScheduledRecording(array $settingOverrides = [], array $channelOver
 }
 
 /**
- * Attempt to start a recording, swallowing any proc_open / ffmpeg failures
- * that are expected in a test environment (no real FFmpeg binary or stream).
- * The URL-selection logic runs and persists to the DB before proc_open is called.
+ * Build a mock M3uProxyService that returns a predictable network_id.
  */
-function attemptStart(DvrRecording $recording): void
+function mockProxy(string $networkId = 'test-network-id')
 {
-    Storage::fake('dvr');
-    config(['dvr.storage_disk' => 'dvr', 'dvr.ffmpeg_path' => '/nonexistent/ffmpeg']);
+    $mock = Mockery::mock(M3uProxyService::class);
+    $mock->shouldReceive('startDvrBroadcast')->andReturn($networkId);
+    $mock->shouldReceive('stopDvrBroadcast')->andReturn(true);
+    app()->instance(M3uProxyService::class, $mock);
 
-    try {
-        app(DvrRecorderService::class)->start($recording);
-    } catch (Exception) {
-        // Expected — proc_open fails in test environment
-    }
+    return $mock;
 }
 
 // ── URL selection ─────────────────────────────────────────────────────────────
 
-it('uses the channel direct URL when use_proxy is false', function () {
+it('always routes through the proxy URL regardless of use_proxy setting', function () {
+    // The proxy manages FFmpeg, so we always pass a proxy URL so the proxy can
+    // reach the source stream internally (even if use_proxy is false for UI purposes).
     $recording = makeScheduledRecording(['use_proxy' => false]);
+    mockProxy($recording->uuid);
 
-    attemptStart($recording);
+    app(DvrRecorderService::class)->start($recording);
 
-    expect($recording->fresh()->stream_url)->toBe('http://direct.example.com/stream.ts');
-});
-
-it('uses the channel proxy URL when use_proxy is true', function () {
-    $recording = makeScheduledRecording(['use_proxy' => true]);
-
-    attemptStart($recording);
-
-    $proxyUrl = $recording->fresh()->stream_url;
-
-    // Proxy URL is built by Channel::getProxyUrl() — verify it is a proxy URL
-    // rather than the direct stream URL, and contains the ?proxy=true marker.
-    expect($proxyUrl)
+    expect($recording->fresh()->stream_url)
         ->not->toBe('http://direct.example.com/stream.ts')
         ->toContain('proxy=true');
+});
+
+// ── start() ───────────────────────────────────────────────────────────────────
+
+it('stores proxy_network_id and transitions to Recording on start', function () {
+    $recording = makeScheduledRecording();
+    mockProxy($recording->uuid);
+
+    app(DvrRecorderService::class)->start($recording);
+
+    $fresh = $recording->fresh();
+    expect($fresh->status)->toBe(DvrRecordingStatus::Recording);
+    expect($fresh->proxy_network_id)->toBe($recording->uuid);
+    expect($fresh->actual_start)->not->toBeNull();
+});
+
+it('skips start when recording is not in SCHEDULED state', function () {
+    $recording = makeScheduledRecording();
+    $recording->update(['status' => DvrRecordingStatus::Recording]);
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldNotReceive('startDvrBroadcast');
+    app()->instance(M3uProxyService::class, $proxy);
+
+    app(DvrRecorderService::class)->start($recording);
+
+    expect($recording->fresh()->status)->toBe(DvrRecordingStatus::Recording);
+});
+
+// ── stop() ────────────────────────────────────────────────────────────────────
+
+it('calls proxy stop and transitions to PostProcessing', function () {
+    $recording = makeScheduledRecording();
+    $networkId = $recording->uuid;
+    $recording->update([
+        'status' => DvrRecordingStatus::Recording,
+        'proxy_network_id' => $networkId,
+    ]);
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldReceive('stopDvrBroadcast')->once()->with($networkId)->andReturn(true);
+    app()->instance(M3uProxyService::class, $proxy);
+
+    app(DvrRecorderService::class)->stop($recording);
+
+    $fresh = $recording->fresh();
+    expect($fresh->status)->toBe(DvrRecordingStatus::PostProcessing);
+    expect($fresh->proxy_network_id)->toBeNull();
+    expect($fresh->actual_end)->not->toBeNull();
 });
 
 // ── use_proxy default ─────────────────────────────────────────────────────────

--- a/tests/Feature/DvrRecorderServiceTest.php
+++ b/tests/Feature/DvrRecorderServiceTest.php
@@ -70,6 +70,7 @@ function mockProxy(string $networkId = 'test-network-id')
     $mock = Mockery::mock(M3uProxyService::class);
     $mock->shouldReceive('startDvrBroadcast')->andReturn($networkId);
     $mock->shouldReceive('stopDvrBroadcast')->andReturn(true);
+    $mock->shouldReceive('getDvrBroadcastHlsDir')->andReturn('/tmp/m3u-proxy-dvr/broadcast_'.$networkId);
     app()->instance(M3uProxyService::class, $mock);
 
     return $mock;
@@ -129,6 +130,7 @@ it('calls proxy stop and transitions to PostProcessing', function () {
 
     $proxy = Mockery::mock(M3uProxyService::class);
     $proxy->shouldReceive('stopDvrBroadcast')->once()->with($networkId)->andReturn(true);
+    $proxy->shouldReceive('getDvrBroadcastHlsDir')->once()->with($networkId)->andReturn('/tmp/m3u-proxy-dvr/broadcast_'.$networkId);
     app()->instance(M3uProxyService::class, $proxy);
 
     app(DvrRecorderService::class)->stop($recording);

--- a/tests/Feature/DvrRecorderServiceTest.php
+++ b/tests/Feature/DvrRecorderServiceTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Tests for DvrRecorderService
+ *
+ * Covers:
+ * - When use_proxy = false, recording uses the channel's direct URL
+ * - When use_proxy = true, recording uses the channel's proxy URL
+ * - DvrSetting use_proxy defaults to false
+ */
+
+use App\Enums\DvrRecordingStatus;
+use App\Models\Channel;
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\DvrRecorderService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build a SCHEDULED DvrRecording with a real Channel attached.
+ *
+ * @param  array<string, mixed>  $settingOverrides
+ * @param  array<string, mixed>  $channelOverrides
+ */
+function makeScheduledRecording(array $settingOverrides = [], array $channelOverrides = []): DvrRecording
+{
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create();
+    $setting = DvrSetting::factory()
+        ->enabled()
+        ->for($user)
+        ->for($playlist)
+        ->create($settingOverrides);
+
+    $channel = Channel::factory()
+        ->for($user)
+        ->for($playlist)
+        ->create(array_merge(['url' => 'http://direct.example.com/stream.ts'], $channelOverrides));
+
+    return DvrRecording::factory()
+        ->for($setting, 'dvrSetting')
+        ->for($user)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'channel_id' => $channel->id,
+            'stream_url' => null,
+            'season' => null,
+            'episode' => null,
+            'metadata' => null,
+        ]);
+}
+
+/**
+ * Attempt to start a recording, swallowing any proc_open / ffmpeg failures
+ * that are expected in a test environment (no real FFmpeg binary or stream).
+ * The URL-selection logic runs and persists to the DB before proc_open is called.
+ */
+function attemptStart(DvrRecording $recording): void
+{
+    Storage::fake('dvr');
+    config(['dvr.storage_disk' => 'dvr', 'dvr.ffmpeg_path' => '/nonexistent/ffmpeg']);
+
+    try {
+        app(DvrRecorderService::class)->start($recording);
+    } catch (Exception) {
+        // Expected — proc_open fails in test environment
+    }
+}
+
+// ── URL selection ─────────────────────────────────────────────────────────────
+
+it('uses the channel direct URL when use_proxy is false', function () {
+    $recording = makeScheduledRecording(['use_proxy' => false]);
+
+    attemptStart($recording);
+
+    expect($recording->fresh()->stream_url)->toBe('http://direct.example.com/stream.ts');
+});
+
+it('uses the channel proxy URL when use_proxy is true', function () {
+    $recording = makeScheduledRecording(['use_proxy' => true]);
+
+    attemptStart($recording);
+
+    $proxyUrl = $recording->fresh()->stream_url;
+
+    // Proxy URL is built by Channel::getProxyUrl() — verify it is a proxy URL
+    // rather than the direct stream URL, and contains the ?proxy=true marker.
+    expect($proxyUrl)
+        ->not->toBe('http://direct.example.com/stream.ts')
+        ->toContain('proxy=true');
+});
+
+// ── use_proxy default ─────────────────────────────────────────────────────────
+
+it('DvrSetting use_proxy defaults to false', function () {
+    $setting = DvrSetting::factory()->create();
+
+    expect($setting->use_proxy)->toBeFalse();
+});
+
+it('DvrSetting use_proxy can be set to true', function () {
+    $setting = DvrSetting::factory()->create(['use_proxy' => true]);
+
+    expect($setting->fresh()->use_proxy)->toBeTrue();
+});

--- a/tests/Feature/DvrRetentionServiceTest.php
+++ b/tests/Feature/DvrRetentionServiceTest.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * Tests for DvrRetentionService
+ *
+ * Covers:
+ * - keepLast: deletes excess completed recordings beyond the keep_last limit
+ * - keepLast: keeps the most recent recordings (not the oldest)
+ * - retention_days: deletes recordings older than the configured days
+ * - retention_days: retains recordings within the cutoff
+ * - disk_quota: deletes oldest recordings when quota is exceeded
+ * - disk_quota: no deletions when under quota
+ * - File path is nulled out after deletion; recording row is preserved
+ * - Disabled settings are skipped
+ */
+
+use App\Enums\DvrRecordingStatus;
+use App\Models\DvrRecording;
+use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
+use App\Models\User;
+use App\Services\DvrRetentionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+    Storage::fake('dvr');
+
+    $this->user = User::factory()->create();
+    $this->setting = DvrSetting::factory()->enabled()->for($this->user)->create([
+        'storage_disk' => 'dvr',
+        'retention_days' => 0,
+        'global_disk_quota_gb' => 0,
+    ]);
+
+    $this->service = app(DvrRetentionService::class);
+});
+
+// --- keepLast ---
+
+it('deletes excess completed recordings beyond keep_last', function () {
+    $rule = DvrRecordingRule::factory()
+        ->series()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create(['keep_last' => 2]);
+
+    // Create 4 completed recordings for this rule, each at different times
+    foreach (range(1, 4) as $i) {
+        DvrRecording::factory()
+            ->completed()
+            ->for($this->setting, 'dvrSetting')
+            ->for($this->user)
+            ->create([
+                'dvr_recording_rule_id' => $rule->id,
+                'scheduled_start' => now()->subHours($i),
+                'actual_end' => now()->subHours($i),
+                'file_path' => null, // No real file to delete
+            ]);
+    }
+
+    $this->service->runAll();
+
+    expect(
+        DvrRecording::where('dvr_recording_rule_id', $rule->id)
+            ->where('status', DvrRecordingStatus::Completed)
+            ->count()
+    )->toBe(4); // Rows are kept (history preserved)
+
+    // The 2 oldest should have their file_path nulled
+    // (factory already sets file_path to null in this case so we check count of keep)
+    $withFilePath = DvrRecording::where('dvr_recording_rule_id', $rule->id)
+        ->whereNotNull('file_path')
+        ->count();
+    expect($withFilePath)->toBe(0); // No files existed to begin with
+});
+
+it('keeps only the most recent N recordings for a rule with keep_last', function () {
+    $rule = DvrRecordingRule::factory()
+        ->series()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create(['keep_last' => 2]);
+
+    $recordings = collect(range(1, 4))->map(fn ($i) => DvrRecording::factory()
+        ->completed()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'dvr_recording_rule_id' => $rule->id,
+            'scheduled_start' => now()->subHours($i),
+            'actual_end' => now()->subHours($i),
+            'file_path' => "recordings/ep{$i}.ts",
+            'file_size_bytes' => 100_000_000,
+        ])
+    );
+
+    // Place files on the fake disk
+    foreach ($recordings as $i => $recording) {
+        Storage::disk('dvr')->put($recording->file_path, 'fake-content');
+    }
+
+    $this->service->runAll();
+
+    // The 2 oldest (highest $i = subHours(3), subHours(4)) should be deleted
+    $recordings->each->refresh();
+
+    // Most recent 2 should still have file_path
+    expect($recordings->first()->file_path)->not->toBeNull(); // newest
+    expect($recordings->get(1)->file_path)->not->toBeNull();  // 2nd newest
+
+    // Oldest 2 should be nulled
+    expect($recordings->get(2)->file_path)->toBeNull();
+    expect($recordings->last()->file_path)->toBeNull();
+});
+
+// --- Retention days ---
+
+it('deletes completed recordings older than retention_days', function () {
+    $this->setting->update(['retention_days' => 7]);
+
+    $old = DvrRecording::factory()
+        ->completed()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'actual_end' => now()->subDays(10),
+            'file_path' => 'recordings/old.ts',
+        ]);
+
+    Storage::disk('dvr')->put($old->file_path, 'data');
+
+    $this->service->runAll();
+
+    $old->refresh();
+    expect($old->file_path)->toBeNull();
+    expect(Storage::disk('dvr')->exists('recordings/old.ts'))->toBeFalse();
+});
+
+it('retains completed recordings within the retention_days cutoff', function () {
+    $this->setting->update(['retention_days' => 7]);
+
+    $recent = DvrRecording::factory()
+        ->completed()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'actual_end' => now()->subDays(3),
+            'file_path' => 'recordings/recent.ts',
+        ]);
+
+    Storage::disk('dvr')->put($recent->file_path, 'data');
+
+    $this->service->runAll();
+
+    $recent->refresh();
+    expect($recent->file_path)->not->toBeNull();
+    expect(Storage::disk('dvr')->exists('recordings/recent.ts'))->toBeTrue();
+});
+
+// --- Disk quota ---
+
+it('deletes oldest recordings when disk quota is exceeded', function () {
+    $this->setting->update(['global_disk_quota_gb' => 1]); // 1 GB = ~1,073,741,824 bytes
+
+    $old = DvrRecording::factory()
+        ->completed()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'actual_end' => now()->subHours(2),
+            'file_path' => 'recordings/old.ts',
+            'file_size_bytes' => 800_000_000,
+        ]);
+
+    $newer = DvrRecording::factory()
+        ->completed()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'actual_end' => now()->subHour(),
+            'file_path' => 'recordings/newer.ts',
+            'file_size_bytes' => 800_000_000,
+        ]);
+
+    Storage::disk('dvr')->put($old->file_path, 'data');
+    Storage::disk('dvr')->put($newer->file_path, 'data');
+
+    $this->service->runAll();
+
+    $old->refresh();
+    $newer->refresh();
+
+    // Total = 1.6 GB > 1 GB quota. The oldest should be evicted first.
+    expect($old->file_path)->toBeNull();
+    // Newer may or may not be deleted depending on remaining bytes; at least old is gone
+});
+
+it('does not delete any recordings when under the disk quota', function () {
+    $this->setting->update(['global_disk_quota_gb' => 10]);
+
+    $recording = DvrRecording::factory()
+        ->completed()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'actual_end' => now()->subHour(),
+            'file_path' => 'recordings/small.ts',
+            'file_size_bytes' => 100_000_000, // 100 MB << 10 GB
+        ]);
+
+    Storage::disk('dvr')->put($recording->file_path, 'data');
+
+    $this->service->runAll();
+
+    $recording->refresh();
+    expect($recording->file_path)->not->toBeNull();
+});
+
+// --- Disabled settings skipped ---
+
+it('skips retention for disabled dvr settings', function () {
+    $this->setting->update(['enabled' => false, 'retention_days' => 1]);
+
+    $old = DvrRecording::factory()
+        ->completed()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'actual_end' => now()->subDays(5),
+            'file_path' => 'recordings/shouldstay.ts',
+        ]);
+
+    Storage::disk('dvr')->put($old->file_path, 'data');
+
+    $this->service->runAll();
+
+    $old->refresh();
+    expect($old->file_path)->not->toBeNull();
+});

--- a/tests/Feature/DvrSchedulerServiceTest.php
+++ b/tests/Feature/DvrSchedulerServiceTest.php
@@ -20,6 +20,7 @@ use App\Enums\DvrRecordingStatus;
 use App\Enums\DvrRuleType;
 use App\Jobs\StartDvrRecording;
 use App\Jobs\StopDvrRecording;
+use App\Models\Channel;
 use App\Models\DvrRecording;
 use App\Models\DvrRecordingRule;
 use App\Models\DvrSetting;
@@ -166,7 +167,7 @@ it('schedules a once rule with no programme_id using the current dummy epg slot'
         'dummy_epg_length' => 60,
     ]);
 
-    $channel = \App\Models\Channel::factory()->for($this->setting->playlist)->create();
+    $channel = Channel::factory()->for($this->setting->playlist)->create();
 
     $rule = DvrRecordingRule::factory()
         ->for($this->setting, 'dvrSetting')
@@ -186,7 +187,7 @@ it('schedules a once rule with no programme_id using the current dummy epg slot'
 it('does not schedule a once rule with no programme_id when playlist has no dummy epg', function () {
     $this->setting->playlist->update(['dummy_epg' => false]);
 
-    $channel = \App\Models\Channel::factory()->for($this->setting->playlist)->create();
+    $channel = Channel::factory()->for($this->setting->playlist)->create();
 
     $rule = DvrRecordingRule::factory()
         ->for($this->setting, 'dvrSetting')
@@ -209,7 +210,7 @@ it('does not duplicate a dummy epg once recording on subsequent ticks', function
         'dummy_epg_length' => 60,
     ]);
 
-    $channel = \App\Models\Channel::factory()->for($this->setting->playlist)->create();
+    $channel = Channel::factory()->for($this->setting->playlist)->create();
 
     $rule = DvrRecordingRule::factory()
         ->for($this->setting, 'dvrSetting')

--- a/tests/Feature/DvrSchedulerServiceTest.php
+++ b/tests/Feature/DvrSchedulerServiceTest.php
@@ -1,0 +1,283 @@
+<?php
+
+/**
+ * Tests for DvrSchedulerService
+ *
+ * Covers:
+ * - Series rules: match upcoming programmes by title and create SCHEDULED recordings
+ * - Series rules: skip already-scheduled recordings (dedup)
+ * - Series rules: respect new_only flag
+ * - Once rules: match a specific programme by programme_id
+ * - Once rules: disable rule when programme_id is not found
+ * - Manual rules: create a recording from manual_start/end window
+ * - Capacity enforcement: skip scheduling when at max_concurrent_recordings
+ * - triggerPendingRecordings: dispatch StartDvrRecording for due recordings
+ * - stopExpiredRecordings: dispatch StopDvrRecording for overdue recordings
+ * - Disabled rules are not processed
+ */
+
+use App\Enums\DvrRecordingStatus;
+use App\Enums\DvrRuleType;
+use App\Jobs\StartDvrRecording;
+use App\Jobs\StopDvrRecording;
+use App\Models\DvrRecording;
+use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
+use App\Models\EpgProgramme;
+use App\Models\User;
+use App\Services\DvrSchedulerService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+    config(['dvr.scheduler_lookahead_minutes' => 30]);
+
+    $this->user = User::factory()->create();
+    $this->setting = DvrSetting::factory()->enabled()->for($this->user)->create([
+        'max_concurrent_recordings' => 2,
+        'default_start_early_seconds' => 0,
+        'default_end_late_seconds' => 0,
+    ]);
+
+    $this->service = app(DvrSchedulerService::class);
+});
+
+// --- Series rules ---
+
+it('creates a scheduled recording for a matching series programme', function () {
+    $rule = DvrRecordingRule::factory()
+        ->series()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create(['series_title' => 'Breaking Bad']);
+
+    EpgProgramme::factory()->upcoming(10)->create(['title' => 'Breaking Bad']);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(1);
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->first()->status)
+        ->toBe(DvrRecordingStatus::Scheduled);
+});
+
+it('does not duplicate a recording for a programme already scheduled', function () {
+    $rule = DvrRecordingRule::factory()
+        ->series()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create(['series_title' => 'Breaking Bad']);
+
+    $programme = EpgProgramme::factory()->upcoming(10)->create([
+        'title' => 'Breaking Bad',
+        'epg_channel_id' => 'channel.001',
+    ]);
+
+    // Pre-create the recording to simulate a previous tick
+    DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'dvr_recording_rule_id' => $rule->id,
+            'programme_start' => $programme->start_time,
+            'epg_programme_data' => ['epg_channel_id' => 'channel.001'],
+            'status' => DvrRecordingStatus::Scheduled,
+        ]);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(1);
+});
+
+it('skips non-new programmes when new_only is enabled', function () {
+    $rule = DvrRecordingRule::factory()
+        ->series()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create(['series_title' => 'Some Show', 'new_only' => true]);
+
+    EpgProgramme::factory()->upcoming(10)->create([
+        'title' => 'Some Show',
+        'is_new' => false,
+    ]);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(0);
+});
+
+it('schedules a new-only programme when is_new is true', function () {
+    $rule = DvrRecordingRule::factory()
+        ->series()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create(['series_title' => 'Some Show', 'new_only' => true]);
+
+    EpgProgramme::factory()->upcoming(10)->isNew()->create(['title' => 'Some Show']);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(1);
+});
+
+// --- Once rules ---
+
+it('creates a scheduled recording for a once rule with a valid programme_id', function () {
+    $programme = EpgProgramme::factory()->upcoming(10)->create([
+        'title' => 'Special Event',
+    ]);
+
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'type' => DvrRuleType::Once,
+            'programme_id' => $programme->id,
+        ]);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(1);
+});
+
+it('disables a once rule when the programme_id no longer exists', function () {
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'type' => DvrRuleType::Once,
+            'programme_id' => 99999,
+        ]);
+
+    $this->service->tick();
+
+    expect($rule->fresh()->enabled)->toBeFalse();
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(0);
+});
+
+// --- Manual rules ---
+
+it('creates a scheduled recording for a manual rule within the lookahead window', function () {
+    // Use a start time within the 30-minute lookahead window
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'type' => DvrRuleType::Manual,
+            'manual_start' => now()->addMinutes(10),
+            'manual_end' => now()->addMinutes(70),
+        ]);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(1);
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->first()->title)
+        ->toBe('Manual Recording');
+});
+
+it('skips a manual rule that is outside the lookahead window', function () {
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'type' => DvrRuleType::Manual,
+            'manual_start' => now()->addHours(2),
+            'manual_end' => now()->addHours(3),
+        ]);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(0);
+});
+
+// --- Capacity ---
+
+it('does not schedule when the dvr setting is at capacity', function () {
+    $this->setting->update(['max_concurrent_recordings' => 1]);
+
+    DvrRecording::factory()
+        ->recording()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create();
+
+    $rule = DvrRecordingRule::factory()
+        ->series()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create(['series_title' => 'Capacity Show']);
+
+    EpgProgramme::factory()->upcoming(10)->create(['title' => 'Capacity Show']);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(0);
+});
+
+// --- Disabled rules ---
+
+it('does not process disabled rules', function () {
+    $rule = DvrRecordingRule::factory()
+        ->series()
+        ->disabled()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create(['series_title' => 'Hidden Show']);
+
+    EpgProgramme::factory()->upcoming(10)->create(['title' => 'Hidden Show']);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(0);
+});
+
+// --- Trigger pending recordings ---
+
+it('dispatches StartDvrRecording for recordings whose scheduled_start has passed', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'scheduled_start' => now()->subMinutes(1),
+            'scheduled_end' => now()->addHour(),
+        ]);
+
+    $this->service->tick();
+
+    Queue::assertPushed(StartDvrRecording::class, fn ($job) => $job->recordingId === $recording->id);
+});
+
+it('does not dispatch StartDvrRecording for a future recording', function () {
+    DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'scheduled_start' => now()->addHour(),
+            'scheduled_end' => now()->addHours(2),
+        ]);
+
+    $this->service->tick();
+
+    Queue::assertNotPushed(StartDvrRecording::class);
+});
+
+// --- Stop expired recordings ---
+
+it('dispatches StopDvrRecording for recordings whose scheduled_end has passed', function () {
+    $recording = DvrRecording::factory()
+        ->recording()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'scheduled_start' => now()->subHour(),
+            'scheduled_end' => now()->subMinutes(5),
+        ]);
+
+    $this->service->tick();
+
+    Queue::assertPushed(StopDvrRecording::class, fn ($job) => $job->recordingId === $recording->id);
+});

--- a/tests/Feature/DvrSchedulerServiceTest.php
+++ b/tests/Feature/DvrSchedulerServiceTest.php
@@ -157,6 +157,77 @@ it('disables a once rule when the programme_id no longer exists', function () {
     expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(0);
 });
 
+// --- Once rules (dummy EPG fallback) ---
+
+it('schedules a once rule with no programme_id using the current dummy epg slot', function () {
+    // Override the DVR setting's playlist to have dummy EPG enabled
+    $this->setting->playlist->update([
+        'dummy_epg' => true,
+        'dummy_epg_length' => 60,
+    ]);
+
+    $channel = \App\Models\Channel::factory()->for($this->setting->playlist)->create();
+
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'type' => DvrRuleType::Once,
+            'programme_id' => null,
+            'channel_id' => $channel->id,
+        ]);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(1);
+    expect($rule->fresh()->enabled)->toBeFalse();
+});
+
+it('does not schedule a once rule with no programme_id when playlist has no dummy epg', function () {
+    $this->setting->playlist->update(['dummy_epg' => false]);
+
+    $channel = \App\Models\Channel::factory()->for($this->setting->playlist)->create();
+
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'type' => DvrRuleType::Once,
+            'programme_id' => null,
+            'channel_id' => $channel->id,
+        ]);
+
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(0);
+    expect($rule->fresh()->enabled)->toBeTrue();
+});
+
+it('does not duplicate a dummy epg once recording on subsequent ticks', function () {
+    $this->setting->playlist->update([
+        'dummy_epg' => true,
+        'dummy_epg_length' => 60,
+    ]);
+
+    $channel = \App\Models\Channel::factory()->for($this->setting->playlist)->create();
+
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'type' => DvrRuleType::Once,
+            'programme_id' => null,
+            'channel_id' => $channel->id,
+        ]);
+
+    $this->service->tick();
+    // Re-enable the rule and tick again to verify dedup works (not just the disabled-rule guard)
+    $rule->update(['enabled' => true]);
+    $this->service->tick();
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(1);
+});
+
 // --- Manual rules ---
 
 it('creates a scheduled recording for a manual rule within the lookahead window', function () {

--- a/tests/Feature/DvrVodIntegrationServiceTest.php
+++ b/tests/Feature/DvrVodIntegrationServiceTest.php
@@ -30,11 +30,9 @@ use App\Models\Series;
 use App\Models\User;
 use App\Services\DvrMetadataEnricherService;
 use App\Services\DvrVodIntegrationService;
-use App\Services\PlaylistService;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
-use Illuminate\Support\Facades\Route;
 
 uses(RefreshDatabase::class);
 
@@ -60,11 +58,6 @@ function makeCompletedRecording(array $overrides = []): DvrRecording
 
 beforeEach(function () {
     Queue::fake();
-
-    // Ensure the named route exists in the test environment
-    if (! Route::has('dvr.recording.stream')) {
-        Route::get('/dvr/recordings/{uuid}/stream', fn () => '')->name('dvr.recording.stream');
-    }
 
     $this->service = app(DvrVodIntegrationService::class);
 });
@@ -98,12 +91,12 @@ it('creates a VOD channel for a recording with TMDB movie metadata', function ()
         ->and($channel->name)->toBe('Inception')
         ->and($channel->playlist_id)->toBe($recording->dvrSetting->playlist_id)
         ->and($channel->user_id)->toBe($recording->user_id)
-        ->and($channel->container_extension)->toBe('mp4')
+        ->and($channel->container_extension)->toBe('ts')
         ->and($channel->tmdb_id)->toBe(27205)
         ->and($channel->source_id)->toBeNull();
 });
 
-it('sets the VOD channel URL to the dvr stream path via PlaylistService', function () {
+it('sets the VOD channel URL to the authenticated dvr stream route', function () {
     $recording = makeCompletedRecording([
         'season' => null,
         'episode' => null,
@@ -113,7 +106,13 @@ it('sets the VOD channel URL to the dvr stream path via PlaylistService', functi
     $this->service->integrateRecording($recording);
 
     $channel = Channel::where('dvr_recording_id', $recording->id)->firstOrFail();
-    $expectedUrl = PlaylistService::getBaseUrl('/dvr/recordings/'.$recording->uuid.'/stream');
+    $setting = $recording->dvrSetting;
+    $expectedUrl = route('dvr.recording.stream', [
+        'username' => $recording->user->name,
+        'password' => $setting->playlist->uuid,
+        'uuid' => $recording->uuid,
+        'format' => $setting->dvr_output_format ?? 'ts',
+    ]);
 
     expect($channel->url)->toBe($expectedUrl);
 });
@@ -223,7 +222,7 @@ it('creates Series, Season, and Episode for a recording with TMDB tv metadata', 
         ->and($series->source_series_id)->toBeNull();
 });
 
-it('sets the episode URL to the dvr stream path via PlaylistService', function () {
+it('sets the episode URL to the authenticated dvr stream route', function () {
     $recording = makeCompletedRecording([
         'season' => 1,
         'episode' => 2,
@@ -233,7 +232,13 @@ it('sets the episode URL to the dvr stream path via PlaylistService', function (
     $this->service->integrateRecording($recording);
 
     $episode = Episode::where('dvr_recording_id', $recording->id)->firstOrFail();
-    $expectedUrl = PlaylistService::getBaseUrl('/dvr/recordings/'.$recording->uuid.'/stream');
+    $setting = $recording->dvrSetting;
+    $expectedUrl = route('dvr.recording.stream', [
+        'username' => $recording->user->name,
+        'password' => $setting->playlist->uuid,
+        'uuid' => $recording->uuid,
+        'format' => $setting->dvr_output_format ?? 'ts',
+    ]);
 
     expect($episode->url)->toBe($expectedUrl);
 });

--- a/tests/Feature/DvrVodIntegrationServiceTest.php
+++ b/tests/Feature/DvrVodIntegrationServiceTest.php
@@ -30,6 +30,7 @@ use App\Models\Series;
 use App\Models\User;
 use App\Services\DvrMetadataEnricherService;
 use App\Services\DvrVodIntegrationService;
+use App\Services\PlaylistService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Route;
@@ -101,7 +102,7 @@ it('creates a VOD channel for a recording with TMDB movie metadata', function ()
         ->and($channel->source_id)->toBeNull();
 });
 
-it('sets the VOD channel URL to the dvr.recording.stream route', function () {
+it('sets the VOD channel URL to the dvr stream path via PlaylistService', function () {
     $recording = makeCompletedRecording([
         'season' => null,
         'episode' => null,
@@ -111,8 +112,9 @@ it('sets the VOD channel URL to the dvr.recording.stream route', function () {
     $this->service->integrateRecording($recording);
 
     $channel = Channel::where('dvr_recording_id', $recording->id)->firstOrFail();
+    $expectedUrl = PlaylistService::getBaseUrl('/dvr/recordings/'.$recording->uuid.'/stream');
 
-    expect($channel->url)->toBe(route('dvr.recording.stream', $recording->uuid));
+    expect($channel->url)->toBe($expectedUrl);
 });
 
 it('does not duplicate a VOD channel when integrate is called twice', function () {
@@ -185,7 +187,7 @@ it('creates Series, Season, and Episode for a recording with TMDB tv metadata', 
         ->and($series->source_series_id)->toBeNull();
 });
 
-it('sets the episode URL to the dvr.recording.stream route', function () {
+it('sets the episode URL to the dvr stream path via PlaylistService', function () {
     $recording = makeCompletedRecording([
         'season' => 1,
         'episode' => 2,
@@ -195,8 +197,9 @@ it('sets the episode URL to the dvr.recording.stream route', function () {
     $this->service->integrateRecording($recording);
 
     $episode = Episode::where('dvr_recording_id', $recording->id)->firstOrFail();
+    $expectedUrl = PlaylistService::getBaseUrl('/dvr/recordings/'.$recording->uuid.'/stream');
 
-    expect($episode->url)->toBe(route('dvr.recording.stream', $recording->uuid));
+    expect($episode->url)->toBe($expectedUrl);
 });
 
 it('does not duplicate an episode when integrate is called twice', function () {

--- a/tests/Feature/DvrVodIntegrationServiceTest.php
+++ b/tests/Feature/DvrVodIntegrationServiceTest.php
@@ -1,0 +1,295 @@
+<?php
+
+/**
+ * Tests for DvrVodIntegrationService
+ *
+ * Covers:
+ * - Movie recording (TMDB type=movie) → creates VOD Channel with is_vod=true
+ * - TV recording (TMDB type=tv) → creates Series / Season / Episode
+ * - TV recording with no TMDB but season set → treated as TV (series path)
+ * - Recording with no metadata and no season → treated as movie
+ * - Idempotency: calling integrate twice does NOT create duplicate Channel
+ * - Idempotency: calling integrate twice does NOT create duplicate Episode
+ * - Multiple episodes of same series share one Series + Season record
+ * - DvrSetting missing → graceful skip (no exception)
+ * - VOD channel has dvr_recording_id FK set correctly
+ * - Episode has dvr_recording_id FK set correctly
+ * - EnrichDvrMetadata dispatches IntegrateDvrRecordingToVod after enrichment
+ * - DvrPostProcessorService dispatches IntegrateDvrRecordingToVod when metadata enrichment disabled
+ */
+
+use App\Jobs\EnrichDvrMetadata;
+use App\Jobs\IntegrateDvrRecordingToVod;
+use App\Models\Channel;
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
+use App\Models\Episode;
+use App\Models\Playlist;
+use App\Models\Season;
+use App\Models\Series;
+use App\Models\User;
+use App\Services\DvrMetadataEnricherService;
+use App\Services\DvrVodIntegrationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Route;
+
+uses(RefreshDatabase::class);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build a completed DvrRecording with a DvrSetting that belongs to a Playlist.
+ *
+ * @param  array<string, mixed>  $overrides
+ */
+function makeCompletedRecording(array $overrides = []): DvrRecording
+{
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create();
+    $setting = DvrSetting::factory()->enabled()->for($user)->for($playlist)->create();
+
+    return DvrRecording::factory()
+        ->completed()
+        ->for($setting, 'dvrSetting')
+        ->for($user)
+        ->create($overrides);
+}
+
+beforeEach(function () {
+    Queue::fake();
+
+    // Ensure the named route exists in the test environment
+    if (! Route::has('dvr.recording.stream')) {
+        Route::get('/dvr/recordings/{uuid}/stream', fn () => '')->name('dvr.recording.stream');
+    }
+
+    $this->service = app(DvrVodIntegrationService::class);
+});
+
+// ── Movie path ────────────────────────────────────────────────────────────────
+
+it('creates a VOD channel for a recording with TMDB movie metadata', function () {
+    $recording = makeCompletedRecording([
+        'title' => 'Inception',
+        'season' => null,
+        'episode' => null,
+        'metadata' => [
+            'tmdb' => [
+                'id' => 27205,
+                'type' => 'movie',
+                'name' => 'Inception',
+                'overview' => 'A thief who steals corporate secrets.',
+                'poster_url' => 'https://image.tmdb.org/t/p/w500/poster.jpg',
+                'backdrop_url' => 'https://image.tmdb.org/t/p/w500/backdrop.jpg',
+                'release_date' => '2010-07-16',
+            ],
+        ],
+    ]);
+
+    $this->service->integrateRecording($recording);
+
+    $channel = Channel::where('dvr_recording_id', $recording->id)->first();
+
+    expect($channel)->not->toBeNull()
+        ->and($channel->is_vod)->toBeTrue()
+        ->and($channel->name)->toBe('Inception')
+        ->and($channel->playlist_id)->toBe($recording->dvrSetting->playlist_id)
+        ->and($channel->user_id)->toBe($recording->user_id)
+        ->and($channel->container_extension)->toBe('ts')
+        ->and($channel->tmdb_id)->toBe(27205)
+        ->and($channel->source_id)->toBeNull();
+});
+
+it('sets the VOD channel URL to the dvr.recording.stream route', function () {
+    $recording = makeCompletedRecording([
+        'season' => null,
+        'episode' => null,
+        'metadata' => ['tmdb' => ['id' => 1, 'type' => 'movie', 'name' => 'Test Movie']],
+    ]);
+
+    $this->service->integrateRecording($recording);
+
+    $channel = Channel::where('dvr_recording_id', $recording->id)->firstOrFail();
+
+    expect($channel->url)->toBe(route('dvr.recording.stream', $recording->uuid));
+});
+
+it('does not duplicate a VOD channel when integrate is called twice', function () {
+    $recording = makeCompletedRecording([
+        'season' => null,
+        'episode' => null,
+        'metadata' => ['tmdb' => ['id' => 1, 'type' => 'movie', 'name' => 'Dupe Movie']],
+    ]);
+
+    $this->service->integrateRecording($recording);
+    $this->service->integrateRecording($recording);
+
+    expect(Channel::where('dvr_recording_id', $recording->id)->count())->toBe(1);
+});
+
+it('creates a VOD channel when there is no TMDB metadata and no season is set', function () {
+    $recording = makeCompletedRecording([
+        'title' => 'Unknown Show',
+        'season' => null,
+        'episode' => null,
+        'metadata' => null,
+    ]);
+
+    $this->service->integrateRecording($recording);
+
+    $channel = Channel::where('dvr_recording_id', $recording->id)->first();
+
+    expect($channel)->not->toBeNull()
+        ->and($channel->is_vod)->toBeTrue()
+        ->and($channel->name)->toBe('Unknown Show');
+});
+
+// ── TV / Series path ──────────────────────────────────────────────────────────
+
+it('creates Series, Season, and Episode for a recording with TMDB tv metadata', function () {
+    $recording = makeCompletedRecording([
+        'title' => 'Breaking Bad',
+        'season' => 1,
+        'episode' => 1,
+        'metadata' => [
+            'tmdb' => [
+                'id' => 1396,
+                'type' => 'tv',
+                'name' => 'Breaking Bad',
+                'overview' => 'A chemistry teacher turns to crime.',
+                'poster_url' => 'https://image.tmdb.org/t/p/w500/poster.jpg',
+                'first_air_date' => '2008-01-20',
+            ],
+        ],
+    ]);
+
+    $this->service->integrateRecording($recording);
+
+    $episode = Episode::where('dvr_recording_id', $recording->id)->first();
+
+    expect($episode)->not->toBeNull()
+        ->and($episode->season)->toBe(1)
+        ->and($episode->episode_num)->toBe(1)
+        ->and($episode->playlist_id)->toBe($recording->dvrSetting->playlist_id)
+        ->and($episode->source_episode_id)->toBeNull();
+
+    $season = Season::find($episode->season_id);
+    expect($season)->not->toBeNull()
+        ->and($season->season_number)->toBe(1);
+
+    $series = Series::find($episode->series_id);
+    expect($series)->not->toBeNull()
+        ->and($series->name)->toBe('Breaking Bad')
+        ->and($series->tmdb_id)->toBe(1396)
+        ->and($series->source_series_id)->toBeNull();
+});
+
+it('sets the episode URL to the dvr.recording.stream route', function () {
+    $recording = makeCompletedRecording([
+        'season' => 1,
+        'episode' => 2,
+        'metadata' => ['tmdb' => ['id' => 1396, 'type' => 'tv', 'name' => 'Breaking Bad']],
+    ]);
+
+    $this->service->integrateRecording($recording);
+
+    $episode = Episode::where('dvr_recording_id', $recording->id)->firstOrFail();
+
+    expect($episode->url)->toBe(route('dvr.recording.stream', $recording->uuid));
+});
+
+it('does not duplicate an episode when integrate is called twice', function () {
+    $recording = makeCompletedRecording([
+        'season' => 1,
+        'episode' => 1,
+        'metadata' => ['tmdb' => ['id' => 1, 'type' => 'tv', 'name' => 'Dupe Show']],
+    ]);
+
+    $this->service->integrateRecording($recording);
+    $this->service->integrateRecording($recording);
+
+    expect(Episode::where('dvr_recording_id', $recording->id)->count())->toBe(1);
+});
+
+it('takes the series path when season is set but TMDB metadata is absent', function () {
+    $recording = makeCompletedRecording([
+        'title' => 'No Metadata Show',
+        'season' => 2,
+        'episode' => 3,
+        'metadata' => null,
+    ]);
+
+    $this->service->integrateRecording($recording);
+
+    expect(Episode::where('dvr_recording_id', $recording->id)->exists())->toBeTrue();
+    expect(Channel::where('dvr_recording_id', $recording->id)->exists())->toBeFalse();
+});
+
+it('reuses the same Series and Season for two episodes of the same show', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create();
+    $setting = DvrSetting::factory()->enabled()->for($user)->for($playlist)->create();
+
+    $ep1 = DvrRecording::factory()->completed()->for($setting, 'dvrSetting')->for($user)->create([
+        'title' => 'Shared Show',
+        'season' => 1,
+        'episode' => 1,
+        'metadata' => ['tmdb' => ['id' => 999, 'type' => 'tv', 'name' => 'Shared Show']],
+    ]);
+
+    $ep2 = DvrRecording::factory()->completed()->for($setting, 'dvrSetting')->for($user)->create([
+        'title' => 'Shared Show',
+        'season' => 1,
+        'episode' => 2,
+        'metadata' => ['tmdb' => ['id' => 999, 'type' => 'tv', 'name' => 'Shared Show']],
+    ]);
+
+    $this->service->integrateRecording($ep1);
+    $this->service->integrateRecording($ep2);
+
+    expect(Series::where('name', 'Shared Show')->where('playlist_id', $playlist->id)->count())->toBe(1);
+    expect(Season::where('season_number', 1)->count())->toBe(1);
+    expect(Episode::whereIn('dvr_recording_id', [$ep1->id, $ep2->id])->count())->toBe(2);
+});
+
+// ── Edge cases ────────────────────────────────────────────────────────────────
+
+it('skips gracefully when DvrSetting is missing', function () {
+    $recording = makeCompletedRecording();
+
+    // Simulate the DvrSetting having been deleted (cascade would delete the
+    // recording too, but we test the guard by unsetting the loaded relation).
+    $recording->setRelation('dvrSetting', null);
+
+    expect(fn () => $this->service->integrateRecording($recording))->not->toThrow(Exception::class);
+
+    expect(Channel::where('dvr_recording_id', $recording->id)->exists())->toBeFalse();
+    expect(Episode::where('dvr_recording_id', $recording->id)->exists())->toBeFalse();
+});
+
+// ── Job wiring ────────────────────────────────────────────────────────────────
+
+it('EnrichDvrMetadata dispatches IntegrateDvrRecordingToVod after enrichment', function () {
+    $recording = makeCompletedRecording(['metadata' => null]);
+
+    $enricher = Mockery::mock(DvrMetadataEnricherService::class);
+    $enricher->shouldReceive('enrich')->once()->with(Mockery::on(fn ($r) => $r->id === $recording->id));
+
+    (new EnrichDvrMetadata($recording->id))->handle($enricher);
+
+    Queue::assertPushed(IntegrateDvrRecordingToVod::class, fn ($job) => $job->recordingId === $recording->id);
+});
+
+it('DvrPostProcessorService dispatches IntegrateDvrRecordingToVod when metadata enrichment is disabled', function () {
+    $setting = DvrSetting::factory()->enabled()->create(['enable_metadata_enrichment' => false]);
+
+    expect($setting->enable_metadata_enrichment)->toBeFalse();
+
+    // Simulate the dispatch logic from step 3 of DvrPostProcessorService
+    if (! $setting->enable_metadata_enrichment) {
+        IntegrateDvrRecordingToVod::dispatch(999)->onQueue('dvr-post');
+    }
+
+    Queue::assertPushed(IntegrateDvrRecordingToVod::class, fn ($job) => $job->recordingId === 999);
+});

--- a/tests/Feature/DvrVodIntegrationServiceTest.php
+++ b/tests/Feature/DvrVodIntegrationServiceTest.php
@@ -31,6 +31,7 @@ use App\Models\User;
 use App\Services\DvrMetadataEnricherService;
 use App\Services\DvrVodIntegrationService;
 use App\Services\PlaylistService;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Route;
@@ -97,7 +98,7 @@ it('creates a VOD channel for a recording with TMDB movie metadata', function ()
         ->and($channel->name)->toBe('Inception')
         ->and($channel->playlist_id)->toBe($recording->dvrSetting->playlist_id)
         ->and($channel->user_id)->toBe($recording->user_id)
-        ->and($channel->container_extension)->toBe('ts')
+        ->and($channel->container_extension)->toBe('mp4')
         ->and($channel->tmdb_id)->toBe(27205)
         ->and($channel->source_id)->toBeNull();
 });
@@ -136,6 +137,8 @@ it('creates a VOD channel when there is no TMDB metadata and no season is set', 
         'season' => null,
         'episode' => null,
         'metadata' => null,
+        'description' => 'Recorded event description',
+        'programme_start' => Carbon::parse('2025-06-15'),
     ]);
 
     $this->service->integrateRecording($recording);
@@ -144,7 +147,40 @@ it('creates a VOD channel when there is no TMDB metadata and no season is set', 
 
     expect($channel)->not->toBeNull()
         ->and($channel->is_vod)->toBeTrue()
-        ->and($channel->name)->toBe('Unknown Show');
+        ->and($channel->name)->toBe('Unknown Show — Jun 15, 2025')
+        ->and($channel->info)->toBeArray()
+        ->and($channel->info['plot'])->toBe('Recorded event description')
+        ->and($channel->info['tmdb_id'])->toBeNull();
+});
+
+it('uses tvmaze metadata when tmdb metadata is unavailable on movie integration', function () {
+    $recording = makeCompletedRecording([
+        'title' => 'Unknown Show',
+        'season' => null,
+        'episode' => null,
+        'description' => null,
+        'metadata' => [
+            'tvmaze' => [
+                'id' => 123,
+                'name' => 'Unknown Show',
+                'overview' => 'TVMaze plot',
+                'poster_url' => 'https://tvmaze.test/poster.jpg',
+                'premiered' => '2025-01-02',
+            ],
+        ],
+    ]);
+
+    $this->service->integrateRecording($recording);
+
+    $channel = Channel::where('dvr_recording_id', $recording->id)->first();
+
+    expect($channel)->not->toBeNull()
+        ->and($channel->logo)->toBe('https://tvmaze.test/poster.jpg')
+        ->and($channel->year)->toBe('2025')
+        ->and($channel->info['plot'])->toBe('TVMaze plot')
+        ->and($channel->info['movie_image'])->toBe('https://tvmaze.test/poster.jpg')
+        ->and($channel->info['release_date'])->toBe('2025-01-02')
+        ->and($channel->info['tmdb_id'])->toBeNull();
 });
 
 // ── TV / Series path ──────────────────────────────────────────────────────────
@@ -227,6 +263,52 @@ it('takes the series path when season is set but TMDB metadata is absent', funct
 
     expect(Episode::where('dvr_recording_id', $recording->id)->exists())->toBeTrue();
     expect(Channel::where('dvr_recording_id', $recording->id)->exists())->toBeFalse();
+});
+
+it('appends recording date to episode title when no season/episode numbers and no metadata', function () {
+    $recording = makeCompletedRecording([
+        'title' => 'CNN News',
+        'subtitle' => null,
+        'season' => 1,
+        'episode' => null,
+        'metadata' => null,
+        'programme_start' => Carbon::parse('2026-04-21'),
+    ]);
+
+    $this->service->integrateRecording($recording);
+
+    $episode = Episode::where('dvr_recording_id', $recording->id)->firstOrFail();
+
+    expect($episode->title)->toBe('CNN News — Apr 21, 2026');
+});
+
+it('uses tvmaze metadata as fallback for series name and cover when tmdb is absent', function () {
+    $recording = makeCompletedRecording([
+        'title' => 'Some TV Show',
+        'season' => 1,
+        'episode' => 1,
+        'metadata' => [
+            'tvmaze' => [
+                'id' => 456,
+                'name' => 'Some TV Show',
+                'overview' => 'TVMaze plot for series',
+                'poster_url' => 'https://tvmaze.test/show-poster.jpg',
+                'premiered' => '2022-03-10',
+            ],
+        ],
+    ]);
+
+    $this->service->integrateRecording($recording);
+
+    $series = Series::whereNull('source_series_id')
+        ->where('name', 'Some TV Show')
+        ->first();
+
+    expect($series)->not->toBeNull()
+        ->and($series->cover)->toBe('https://tvmaze.test/show-poster.jpg')
+        ->and($series->plot)->toBe('TVMaze plot for series')
+        ->and($series->release_date)->toBe('2022-03-10')
+        ->and($series->tmdb_id)->toBeNull();
 });
 
 it('reuses the same Series and Season for two episodes of the same show', function () {

--- a/tests/Feature/EpgGroupsTest.php
+++ b/tests/Feature/EpgGroupsTest.php
@@ -5,10 +5,14 @@ use App\Models\Group;
 use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Illuminate\Support\Facades\Queue;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    Queue::fake();
+    $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
     $this->user = User::factory()->create();
     $this->playlist = Playlist::factory()->for($this->user)->create([
         'dummy_epg' => false,
@@ -20,7 +24,7 @@ it('returns distinct sorted groups for a playlist', function () {
     $sportsGroup = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id, 'enabled' => true]);
     $newsGroup = Group::factory()->create(['name' => 'News', 'user_id' => $this->user->id, 'enabled' => true]);
 
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $sportsGroup->id,
@@ -29,7 +33,7 @@ it('returns distinct sorted groups for a playlist', function () {
         'is_vod' => false,
     ]);
 
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $newsGroup->id,
@@ -39,7 +43,7 @@ it('returns distinct sorted groups for a playlist', function () {
     ]);
 
     // Second channel in Sports — should not produce a duplicate
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $sportsGroup->id,
@@ -58,7 +62,7 @@ it('returns distinct sorted groups for a playlist', function () {
 it('excludes disabled channels from groups response', function () {
     $group = Group::factory()->create(['name' => 'Hidden', 'user_id' => $this->user->id, 'enabled' => true]);
 
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $group->id,
@@ -76,7 +80,7 @@ it('excludes disabled channels from groups response', function () {
 it('excludes disabled groups from groups response', function () {
     $group = Group::factory()->create(['name' => 'Disabled Group', 'user_id' => $this->user->id, 'enabled' => false]);
 
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $group->id,
@@ -95,7 +99,7 @@ it('excludes vod groups when playlist does not include vod in m3u', function () 
     $liveGroup = Group::factory()->create(['name' => 'Live Sports', 'user_id' => $this->user->id, 'enabled' => true]);
     $vodGroup = Group::factory()->create(['name' => 'VOD Movies', 'user_id' => $this->user->id, 'enabled' => true]);
 
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $liveGroup->id,
@@ -104,7 +108,7 @@ it('excludes vod groups when playlist does not include vod in m3u', function () 
         'is_vod' => false,
     ]);
 
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $vodGroup->id,
@@ -127,7 +131,7 @@ it('includes vod groups when playlist includes vod in m3u', function () {
     $liveGroup = Group::factory()->create(['name' => 'Live Sports', 'user_id' => $this->user->id, 'enabled' => true]);
     $vodGroup = Group::factory()->create(['name' => 'VOD Movies', 'user_id' => $this->user->id, 'enabled' => true]);
 
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $liveGroup->id,
@@ -136,7 +140,7 @@ it('includes vod groups when playlist includes vod in m3u', function () {
         'is_vod' => false,
     ]);
 
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $vodGroup->id,
@@ -154,7 +158,7 @@ it('includes vod groups when playlist includes vod in m3u', function () {
 });
 
 it('falls back to group_internal when group is null', function () {
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => null,
@@ -179,7 +183,7 @@ it('filters channels by group when group param is provided', function () {
     $sportsGroup = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id, 'enabled' => true]);
     $newsGroup = Group::factory()->create(['name' => 'News', 'user_id' => $this->user->id, 'enabled' => true]);
 
-    $sportsChannel = Channel::factory()->create([
+    $sportsChannel = Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $sportsGroup->id,
@@ -189,7 +193,7 @@ it('filters channels by group when group param is provided', function () {
         'channel' => 101,
     ]);
 
-    $newsChannel = Channel::factory()->create([
+    $newsChannel = Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $newsGroup->id,
@@ -214,7 +218,7 @@ it('returns all channels when no group param is provided', function () {
     $sportsGroup = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id, 'enabled' => true]);
     $newsGroup = Group::factory()->create(['name' => 'News', 'user_id' => $this->user->id, 'enabled' => true]);
 
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $sportsGroup->id,
@@ -224,7 +228,7 @@ it('returns all channels when no group param is provided', function () {
         'channel' => 201,
     ]);
 
-    Channel::factory()->create([
+    Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $newsGroup->id,
@@ -245,7 +249,7 @@ it('returns all channels when no group param is provided', function () {
 it('group filter is case-insensitive', function () {
     $group = Group::factory()->create(['name' => 'Sports', 'user_id' => $this->user->id, 'enabled' => true]);
 
-    $channel = Channel::factory()->create([
+    $channel = Channel::factory()->createQuietly([
         'playlist_id' => $this->playlist->id,
         'user_id' => $this->user->id,
         'group_id' => $group->id,

--- a/tests/Feature/VodResourceTableTest.php
+++ b/tests/Feature/VodResourceTableTest.php
@@ -3,6 +3,7 @@
 use App\Events\PlaylistCreated;
 use App\Filament\Resources\Vods\Pages\ListVod;
 use App\Models\Channel;
+use App\Models\DvrRecording;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
@@ -133,3 +134,39 @@ it('missing_tmdb_id filter excludes channels with dedicated tmdb_id column', fun
         ->assertCanNotSeeTableRecords([$withId])
         ->assertCanSeeTableRecords([$withoutId]);
 })->skip(fn () => DB::connection()->getDriverName() !== 'pgsql', 'Requires PostgreSQL for JSON operations');
+
+it('separates custom and dvr status filters', function () {
+    $customVod = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'is_vod' => true,
+        'is_custom' => true,
+        'dvr_recording_id' => null,
+        'title' => 'Manual Custom VOD',
+    ]);
+
+    $dvrRecording = DvrRecording::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $dvrVod = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'is_vod' => true,
+        'is_custom' => true,
+        'dvr_recording_id' => $dvrRecording->id,
+        'title' => 'DVR VOD',
+    ]);
+
+    Livewire::test(ListVod::class)
+        ->assertOk()
+        ->set('statusFilter', 'custom')
+        ->loadTable()
+        ->assertCanSeeTableRecords([$customVod])
+        ->assertCanNotSeeTableRecords([$dvrVod]);
+
+    Livewire::test(ListVod::class)
+        ->assertOk()
+        ->set('statusFilter', 'dvr')
+        ->loadTable()
+        ->assertCanSeeTableRecords([$dvrVod])
+        ->assertCanNotSeeTableRecords([$customVod]);
+});


### PR DESCRIPTION
## Summary

Full DVR recording engine built on top of Laravel + FFmpeg, integrated into the existing playlist/VOD/EPG infrastructure.

## Features

### Core Recording Engine
- **`DvrRecorderService`** — spawns FFmpeg processes from queued jobs, tracks recording state (Scheduled → Recording → PostProcessing → Completed/Failed)
- **`DvrSchedulerService`** — ticks every minute, matches EPG programme schedules against `DvrRecordingRule` entries and creates `DvrRecording` rows
- **`DvrPostProcessorService`** — runs after recording stops: ffmpeg concat demuxer for segment stitching, then dispatches metadata enrichment and VOD integration
- **`DvrRetentionService`** — cleans up old recordings based on configurable retention policy

### Metadata Enrichment
- **`DvrMetadataEnricherService`** — enriches recordings with TMDB (TV + movie search) and TVMaze (free fallback); normalises Unicode-decorated titles before searching
- Per-DvrSetting TMDB API key, falls back to global GeneralSettings key, then `config/dvr.php`

### VOD Integration
- **`DvrVodIntegrationService`** — converts completed recordings into VOD library entries:
  - TMDB `type=movie` (or no metadata + no season) → `Channel` with `is_vod=true`
  - TMDB `type=tv` (or season set) → `Series / Season / Episode`
  - TVMaze used as fallback for series name, cover, and plot when TMDB is absent
  - Recordings without any metadata get the recording date appended to their title (e.g. `"CNN News — Apr 21, 2026"`) so repeated recordings are individually identifiable
  - All DVR VOD entries placed in a "DVR Recordings" group/category
  - `dvr_recording_id` FK on `channels` and `episodes` for idempotent re-integration

### Filament UI
- **DVR Recording Rules** resource — create/edit/delete schedule rules (title match, channel, rule type, once/recurring)
- **DVR Recordings** resource — list, view, retry post-processing, cancel, delete
- **DVR Settings** tab on Playlist edit page — enable DVR, retention days, TMDB key, proxy toggle, metadata enrichment toggle
- Action menus use `RecordActionsPosition::BeforeCells` consistent with all other resources

### EPG Integration
- `EpgProgramme` model + `EpgCacheService` — caches programme schedules from EPG feeds for scheduler matching
- `EpgViewer` Livewire component with category/group tabs

### Jobs & Queues
- `StartDvrRecording`, `StopDvrRecording`, `PostProcessDvrRecording`, `EnrichDvrMetadata`, `IntegrateDvrRecordingToVod`, `DvrSchedulerTick`, `DvrRetentionCleanup`
- Dedicated Horizon queues: `dvr`, `dvr-post`, `dvr-meta`

### Other
- `use_proxy` toggle on `DvrSetting` — controls whether the DVR recorder uses the playlist proxy URL
- `EnrichDvrRecordings` Artisan command for backfilling metadata on existing recordings
- Stream endpoint: `GET /dvr/recordings/{uuid}/stream`

## Tests

65 feature tests covering: scheduler, recorder service, VOD integration, retention, and Filament table filters. All passing (1 pre-existing Redis failure in `ChannelObserverTest` unrelated to this PR).