### PR TITLE
fix: single-item Fetch TMDB/TVDB IDs silently returns no result (#1054)

### DIFF
--- a/app/Filament/Resources/Series/SeriesResource.php
+++ b/app/Filament/Resources/Series/SeriesResource.php
@@ -294,12 +294,25 @@ class SeriesResource extends Resource implements CopilotResource
                     ->modalDescription(__('Fetch TMDB, TVDB, and IMDB IDs for this series from The Movie Database.'))
                     ->modalSubmitActionLabel(__('Fetch IDs now'))
                     ->action(function ($record) {
+                        $settings = app(GeneralSettings::class);
+                        if (empty($settings->tmdb_api_key)) {
+                            Notification::make()
+                                ->danger()
+                                ->title(__('TMDB API Key Required'))
+                                ->body(__('Please configure your TMDB API key in Settings > TMDB before using this feature.'))
+                                ->duration(10000)
+                                ->send();
+
+                            return;
+                        }
+
                         app('Illuminate\Contracts\Bus\Dispatcher')
                             ->dispatch(new FetchTmdbIds(
-                                seriesIds: [$record->id]
+                                seriesIds: [$record->id],
+                                overwriteExisting: true,
+                                user: auth()->user(),
                             ));
-                    })
-                    ->after(function () {
+
                         Notification::make()
                             ->success()
                             ->title(__('TMDB Search Started'))

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -478,12 +478,25 @@ class VodResource extends Resource implements CopilotResource
                     ->modalDescription(__('Fetch TMDB, TVDB, and IMDB IDs for this series from The Movie Database.'))
                     ->modalSubmitActionLabel(__('Fetch IDs now'))
                     ->action(function ($record) {
+                        $settings = app(GeneralSettings::class);
+                        if (empty($settings->tmdb_api_key)) {
+                            Notification::make()
+                                ->danger()
+                                ->title(__('TMDB API Key Required'))
+                                ->body(__('Please configure your TMDB API key in Settings > TMDB before using this feature.'))
+                                ->duration(10000)
+                                ->send();
+
+                            return;
+                        }
+
                         app('Illuminate\Contracts\Bus\Dispatcher')
                             ->dispatch(new FetchTmdbIds(
-                                vodChannelIds: [$record->id]
+                                vodChannelIds: [$record->id],
+                                overwriteExisting: true,
+                                user: auth()->user(),
                             ));
-                    })
-                    ->after(function () {
+
                         Notification::make()
                             ->success()
                             ->title(__('TMDB Search Started'))

--- a/app/Jobs/FetchTmdbIds.php
+++ b/app/Jobs/FetchTmdbIds.php
@@ -295,7 +295,7 @@ class FetchTmdbIds implements ShouldQueue
         } elseif (! empty($this->vodChannelIds)) {
             // Legacy: direct ID array support
             $query->whereIn('id', $this->vodChannelIds)
-                ->where('user_id', $this->user?->id);
+                ->when($this->user, fn ($q) => $q->where('user_id', $this->user->id));
         } else {
             return null; // No criteria specified
         }
@@ -332,7 +332,7 @@ class FetchTmdbIds implements ShouldQueue
         } elseif (! empty($this->seriesIds)) {
             // Legacy: direct ID array support
             $query->whereIn('id', $this->seriesIds)
-                ->where('user_id', $this->user?->id);
+                ->when($this->user, fn ($q) => $q->where('user_id', $this->user->id));
         } else {
             return null; // No criteria specified
         }

--- a/tests/Feature/FetchTmdbIdsTest.php
+++ b/tests/Feature/FetchTmdbIdsTest.php
@@ -1241,6 +1241,145 @@ it('excludes series that were attempted but had no match from query when overwri
     $job->handle($tmdb);
 });
 
+it('processes legacy VOD channel IDs when dispatched without a user (import pipeline)', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/search/movie*' => Http::response([
+            'results' => [
+                [
+                    'id' => 603,
+                    'title' => 'The Matrix',
+                    'release_date' => '1999-03-30',
+                    'popularity' => 85.5,
+                ],
+            ],
+        ], 200),
+        'https://api.themoviedb.org/3/movie/603/external_ids*' => Http::response([
+            'imdb_id' => 'tt0133093',
+        ], 200),
+        'https://api.themoviedb.org/3/movie/603*' => Http::response([
+            'id' => 603,
+            'title' => 'The Matrix',
+            'overview' => 'A computer hacker learns about the true nature of reality.',
+            'poster_path' => '/matrix.jpg',
+        ], 200),
+    ]);
+
+    $channel = Channel::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'is_vod' => true,
+        'title' => 'The Matrix',
+        'year' => 1999,
+        'info' => [],
+    ]);
+
+    $job = new TestableFetchTmdbIds(
+        vodChannelIds: [$channel->id],
+        seriesIds: null,
+        overwriteExisting: false,
+        user: null,
+    );
+
+    $job->handle(app(TmdbService::class));
+
+    $channel->refresh();
+
+    expect($channel->info['tmdb_id'])->toBe(603);
+});
+
+it('processes legacy series IDs when dispatched without a user (import pipeline)', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/search/tv*' => Http::response([
+            'results' => [
+                [
+                    'id' => 4592,
+                    'name' => 'ALF',
+                    'first_air_date' => '1986-09-22',
+                    'popularity' => 45.2,
+                ],
+            ],
+        ], 200),
+        'https://api.themoviedb.org/3/tv/4592/external_ids*' => Http::response([
+            'tvdb_id' => 78020,
+            'imdb_id' => 'tt0090390',
+        ], 200),
+        'https://api.themoviedb.org/3/tv/4592*' => Http::response([
+            'id' => 4592,
+            'name' => 'ALF',
+            'overview' => 'An alien lifestyle.',
+            'poster_path' => '/alf.jpg',
+        ], 200),
+    ]);
+
+    $series = Series::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'name' => 'ALF',
+        'release_date' => '1986-09-22',
+        'metadata' => [],
+    ]);
+
+    $job = new TestableFetchTmdbIds(
+        vodChannelIds: null,
+        seriesIds: [$series->id],
+        overwriteExisting: false,
+        user: null,
+    );
+
+    $job->handle(app(TmdbService::class));
+
+    $series->refresh();
+
+    expect($series->metadata['tmdb_id'])->toBe(4592);
+});
+
+it('retries a previously-attempted series when overwriteExisting is true (single-item action)', function () {
+    Http::fake([
+        'https://api.themoviedb.org/3/search/tv*' => Http::response([
+            'results' => [
+                [
+                    'id' => 4592,
+                    'name' => 'ALF',
+                    'first_air_date' => '1986-09-22',
+                    'popularity' => 45.2,
+                ],
+            ],
+        ], 200),
+        'https://api.themoviedb.org/3/tv/4592/external_ids*' => Http::response([
+            'tvdb_id' => 78020,
+            'imdb_id' => 'tt0090390',
+        ], 200),
+        'https://api.themoviedb.org/3/tv/4592*' => Http::response([
+            'id' => 4592,
+            'name' => 'ALF',
+            'overview' => 'An alien lifestyle.',
+            'poster_path' => '/alf.jpg',
+        ], 200),
+    ]);
+
+    $series = Series::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'name' => 'ALF',
+        'release_date' => '1986-09-22',
+        'metadata' => [],
+        'last_metadata_fetch' => now(),
+    ]);
+
+    $job = new TestableFetchTmdbIds(
+        vodChannelIds: null,
+        seriesIds: [$series->id],
+        overwriteExisting: true,
+        user: $this->user,
+    );
+
+    $job->handle(app(TmdbService::class));
+
+    $series->refresh();
+
+    expect($series->metadata['tmdb_id'])->toBe(4592);
+});
+
 class TestableFetchTmdbIds extends FetchTmdbIds
 {
     protected function sendCompletionNotification(): void {}


### PR DESCRIPTION
## Summary

Fixes #1054 — clicking the 3-dot "Fetch TMDB/TVDB IDs" action on a single Series or VOD row returns no result, while the bulk action with overwrite works for the same record.

Two things are compounding:

- `FetchTmdbIds::buildVodQuery` / `buildSeriesQuery` apply `->where('user_id', $this->user?->id)` on the legacy IDs branch. When the single-item action dispatches without a user, this becomes `WHERE user_id IS NULL` and filters every row out. The sibling playlist-id branches were already switched to `->when($this->user, …)` in 952a000c but the legacy IDs branch was missed.
- The single-item Filament actions also don't pass `user` or `overwriteExisting`. So even once the query is fixed, a record with `last_metadata_fetch` set but no ID is skipped by the per-item guards at `FetchTmdbIds.php:478` (VOD) / `:784` (series) — which is surprising when the user has explicitly clicked "fetch this one".

## Changes

- `app/Jobs/FetchTmdbIds.php` — use `->when($this->user, …)` on the legacy IDs branches, matching the sibling branches. This also benefits the import pipeline callers in `Models/Series.php` and `Models/Channel.php` which dispatch without a user.
- `app/Filament/Resources/Series/SeriesResource.php` and `app/Filament/Resources/Vods/VodResource.php` single-item actions — pass `user: auth()->user()` and `overwriteExisting: true`, and add the TMDB API key guard that the bulk actions already have.
- `tests/Feature/FetchTmdbIdsTest.php` — three regression tests covering the null-user dispatch path (VOD + series) and the retry-after-failed-attempt case.

## Test plan

- [x] 3-dot action on a series with `last_metadata_fetch` set returns "1 processed" instead of silently completing with 0
- [x] 3-dot action on a VOD with `last_metadata_fetch` set behaves the same
- [x] Bulk actions still honor the `overwrite_existing` toggle exactly as before
- [x] TMDB API key missing → 3-dot action shows the "TMDB API Key Required" notification (matching bulk)