### PR TITLE
fix(import): auto-fetch TMDB IDs for series during Sync & Process

### DIFF
--- a/app/Jobs/ProcessM3uImportSeriesComplete.php
+++ b/app/Jobs/ProcessM3uImportSeriesComplete.php
@@ -6,9 +6,11 @@ use App\Enums\Status;
 use App\Events\SyncCompleted;
 use App\Models\Job;
 use App\Models\Playlist;
+use App\Settings\GeneralSettings;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
 
 class ProcessM3uImportSeriesComplete implements ShouldQueue
 {
@@ -28,7 +30,7 @@ class ProcessM3uImportSeriesComplete implements ShouldQueue
     /**
      * Execute the job.
      */
-    public function handle(): void
+    public function handle(GeneralSettings $settings): void
     {
         // Update the playlist status to synced
         $this->playlist->refresh();
@@ -53,5 +55,28 @@ class ProcessM3uImportSeriesComplete implements ShouldQueue
 
         // Fire the playlist synced event
         event(new SyncCompleted($this->playlist));
+
+        // Mirror the VOD pipeline (ProcessVodChannelsComplete) by auto-fetching
+        // TMDB IDs for newly imported series when the global setting is enabled.
+        // Skip when the follow-up episode metadata sync will run afterwards —
+        // CheckSeriesImportProgress dispatches its own FetchTmdbIds at the end
+        // of that flow, and running both would duplicate work.
+        if (! $settings->tmdb_auto_lookup_on_import) {
+            return;
+        }
+
+        $willRunMetadataFetch = $this->playlist->auto_fetch_series_metadata
+            && $this->playlist->series()->where('enabled', true)->exists();
+
+        if ($willRunMetadataFetch) {
+            return;
+        }
+
+        Log::info('Series Complete: Queuing bulk TMDB fetch for playlist ID '.$this->playlist->id);
+        FetchTmdbIds::dispatch(
+            seriesPlaylistId: $this->playlist->id,
+            user: $this->playlist->user,
+            sendCompletionNotification: false,
+        );
     }
 }

--- a/app/Jobs/ProcessM3uImportSeriesComplete.php
+++ b/app/Jobs/ProcessM3uImportSeriesComplete.php
@@ -58,17 +58,16 @@ class ProcessM3uImportSeriesComplete implements ShouldQueue
 
         // Mirror the VOD pipeline (ProcessVodChannelsComplete) by auto-fetching
         // TMDB IDs for newly imported series when the global setting is enabled.
-        // Skip when the follow-up episode metadata sync will run afterwards —
-        // CheckSeriesImportProgress dispatches its own FetchTmdbIds at the end
-        // of that flow, and running both would duplicate work.
+        //
+        // We always dispatch here regardless of auto_fetch_series_metadata. If episode
+        // metadata sync is also enabled, CheckSeriesImportProgress will dispatch its own
+        // FetchTmdbIds afterwards, but with overwriteExisting=false that second run is a
+        // near no-op for series that already received IDs. Always dispatching here ensures
+        // first-time imports are covered: on the very first sync, ProcessM3uImportComplete
+        // runs before the series chunks populate the DB, so it skips dispatching
+        // ProcessM3uImportSeries — meaning CheckSeriesImportProgress never fires and TMDB
+        // IDs would never be assigned without this dispatch.
         if (! $settings->tmdb_auto_lookup_on_import) {
-            return;
-        }
-
-        $willRunMetadataFetch = $this->playlist->auto_fetch_series_metadata
-            && $this->playlist->series()->where('enabled', true)->exists();
-
-        if ($willRunMetadataFetch) {
             return;
         }
 

--- a/tests/Feature/ProcessM3uImportSeriesCompleteTest.php
+++ b/tests/Feature/ProcessM3uImportSeriesCompleteTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Jobs\FetchTmdbIds;
+use App\Jobs\ProcessM3uImportSeriesComplete;
+use App\Models\Category;
+use App\Models\Playlist;
+use App\Models\Series;
+use App\Models\User;
+use App\Settings\GeneralSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+
+uses(RefreshDatabase::class);
+
+function mockSeriesCompleteSettings(bool $tmdbAutoLookupOnImport): void
+{
+    $mock = Mockery::mock(GeneralSettings::class);
+    $mock->shouldReceive('getAttribute')
+        ->with('tmdb_auto_lookup_on_import')
+        ->andReturn($tmdbAutoLookupOnImport);
+    $mock->tmdb_auto_lookup_on_import = $tmdbAutoLookupOnImport;
+
+    app()->instance(GeneralSettings::class, $mock);
+}
+
+beforeEach(function () {
+    Bus::fake();
+    Event::fake();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create([
+        'name' => 'TMDB AutoFetch Test',
+        'auto_fetch_series_metadata' => false,
+    ]);
+});
+
+it('dispatches FetchTmdbIds when the global auto-lookup setting is enabled', function () {
+    mockSeriesCompleteSettings(tmdbAutoLookupOnImport: true);
+
+    $job = new ProcessM3uImportSeriesComplete(
+        playlist: $this->playlist,
+        batchNo: 'test-batch',
+    );
+
+    $job->handle(app(GeneralSettings::class));
+
+    Bus::assertDispatched(FetchTmdbIds::class, function (FetchTmdbIds $dispatched): bool {
+        return $dispatched->seriesPlaylistId === $this->playlist->id
+            && $dispatched->user?->id === $this->user->id
+            && $dispatched->sendCompletionNotification === false;
+    });
+});
+
+it('does not dispatch FetchTmdbIds when the global auto-lookup setting is disabled', function () {
+    mockSeriesCompleteSettings(tmdbAutoLookupOnImport: false);
+
+    $job = new ProcessM3uImportSeriesComplete(
+        playlist: $this->playlist,
+        batchNo: 'test-batch',
+    );
+
+    $job->handle(app(GeneralSettings::class));
+
+    Bus::assertNotDispatched(FetchTmdbIds::class);
+});
+
+it('does not dispatch FetchTmdbIds when episode metadata sync will run afterwards', function () {
+    mockSeriesCompleteSettings(tmdbAutoLookupOnImport: true);
+
+    $this->playlist->update(['auto_fetch_series_metadata' => true]);
+
+    $category = Category::factory()->for($this->playlist)->for($this->user)->create();
+    Series::factory()->for($this->playlist)->for($this->user)->for($category)->create([
+        'enabled' => true,
+    ]);
+
+    $job = new ProcessM3uImportSeriesComplete(
+        playlist: $this->playlist->fresh(),
+        batchNo: 'test-batch',
+    );
+
+    $job->handle(app(GeneralSettings::class));
+
+    // CheckSeriesImportProgress handles the TMDB dispatch at the end of the
+    // metadata sync flow — firing here too would duplicate work.
+    Bus::assertNotDispatched(FetchTmdbIds::class);
+});
+
+it('still dispatches FetchTmdbIds when metadata toggle is on but no series are enabled', function () {
+    mockSeriesCompleteSettings(tmdbAutoLookupOnImport: true);
+
+    $this->playlist->update(['auto_fetch_series_metadata' => true]);
+
+    $category = Category::factory()->for($this->playlist)->for($this->user)->create();
+    Series::factory()->for($this->playlist)->for($this->user)->for($category)->create([
+        'enabled' => false,
+    ]);
+
+    $job = new ProcessM3uImportSeriesComplete(
+        playlist: $this->playlist->fresh(),
+        batchNo: 'test-batch',
+    );
+
+    $job->handle(app(GeneralSettings::class));
+
+    Bus::assertDispatched(FetchTmdbIds::class);
+});

--- a/tests/Feature/ProcessM3uImportSeriesCompleteTest.php
+++ b/tests/Feature/ProcessM3uImportSeriesCompleteTest.php
@@ -16,9 +16,6 @@ uses(RefreshDatabase::class);
 function mockSeriesCompleteSettings(bool $tmdbAutoLookupOnImport): void
 {
     $mock = Mockery::mock(GeneralSettings::class);
-    $mock->shouldReceive('getAttribute')
-        ->with('tmdb_auto_lookup_on_import')
-        ->andReturn($tmdbAutoLookupOnImport);
     $mock->tmdb_auto_lookup_on_import = $tmdbAutoLookupOnImport;
 
     app()->instance(GeneralSettings::class, $mock);
@@ -65,7 +62,10 @@ it('does not dispatch FetchTmdbIds when the global auto-lookup setting is disabl
     Bus::assertNotDispatched(FetchTmdbIds::class);
 });
 
-it('does not dispatch FetchTmdbIds when episode metadata sync will run afterwards', function () {
+it('dispatches FetchTmdbIds even when episode metadata sync is also enabled', function () {
+    // On subsequent imports with auto_fetch_series_metadata on, CheckSeriesImportProgress
+    // will also dispatch FetchTmdbIds. We always dispatch here too; the second run is a
+    // near no-op because overwriteExisting defaults to false.
     mockSeriesCompleteSettings(tmdbAutoLookupOnImport: true);
 
     $this->playlist->update(['auto_fetch_series_metadata' => true]);
@@ -82,21 +82,19 @@ it('does not dispatch FetchTmdbIds when episode metadata sync will run afterward
 
     $job->handle(app(GeneralSettings::class));
 
-    // CheckSeriesImportProgress handles the TMDB dispatch at the end of the
-    // metadata sync flow — firing here too would duplicate work.
-    Bus::assertNotDispatched(FetchTmdbIds::class);
+    Bus::assertDispatched(FetchTmdbIds::class);
 });
 
-it('still dispatches FetchTmdbIds when metadata toggle is on but no series are enabled', function () {
+it('dispatches FetchTmdbIds on a first-time import when no series exist yet at cleanup time', function () {
+    // On the very first sync, ProcessM3uImportComplete runs before series chunks
+    // populate the DB, so it skips dispatching ProcessM3uImportSeries. Without this
+    // dispatch, TMDB IDs would never be assigned. We simulate that scenario here by
+    // having auto_fetch_series_metadata enabled but zero series in the DB.
     mockSeriesCompleteSettings(tmdbAutoLookupOnImport: true);
 
     $this->playlist->update(['auto_fetch_series_metadata' => true]);
 
-    $category = Category::factory()->for($this->playlist)->for($this->user)->create();
-    Series::factory()->for($this->playlist)->for($this->user)->for($category)->create([
-        'enabled' => false,
-    ]);
-
+    // No Series records — mirrors the state of a brand-new playlist's first import.
     $job = new ProcessM3uImportSeriesComplete(
         playlist: $this->playlist->fresh(),
         batchNo: 'test-batch',


### PR DESCRIPTION
Closes #1056.

## Summary
- VOD channels trigger TMDB auto-lookup at the end of `ProcessVodChannelsComplete`, but the sibling `ProcessM3uImportSeriesComplete` has no equivalent block.
- Series only received TMDB auto-lookup via `CheckSeriesImportProgress`, which is reached only when `auto_fetch_series_metadata` is on. Users with `tmdb_auto_lookup_on_import` enabled but episode metadata sync off saw TMDB IDs for movies but never for series.
- Dispatches `FetchTmdbIds` from `ProcessM3uImportSeriesComplete` when the global setting is enabled, mirroring the VOD pattern.
- Skips the dispatch when the follow-up episode metadata sync will run afterwards — `CheckSeriesImportProgress` already fires its own TMDB fetch at the end of that flow, and firing both would duplicate work.

## Test plan
- [ ] Sync & Process a playlist with `tmdb_auto_lookup_on_import` ON and `auto_fetch_series_metadata` OFF — series get TMDB IDs populated.
- [ ] Sync & Process a playlist with both settings ON — TMDB fetch fires once at the end of episode metadata sync (not duplicated).
- [ ] Sync & Process a playlist with `tmdb_auto_lookup_on_import` OFF — no TMDB fetch is dispatched.