### PR TITLE
feat: add sports stream file settings, sync paths, and sports nfo support

### DIFF
--- a/app/Filament/Resources/StreamFileSettings/StreamFileSettingResource.php
+++ b/app/Filament/Resources/StreamFileSettings/StreamFileSettingResource.php
@@ -83,6 +83,7 @@ class StreamFileSettingResource extends Resource implements CopilotResource
                     ->options([
                         'series' => 'Series',
                         'vod' => 'VOD',
+                        'sports' => 'Sports (Kodi / SportsDB)',
                     ])
                     ->required()
                     ->live()
@@ -91,6 +92,17 @@ class StreamFileSettingResource extends Resource implements CopilotResource
                         if ($state === 'series') {
                             $set('path_structure', ['category', 'series', 'season']);
                             $set('folder_metadata', []);
+                        } elseif ($state === 'sports') {
+                            $set('path_structure', ['league', 'season']);
+                            $set('folder_metadata', []);
+                            $set('filename_metadata', []);
+                            $set('sports_league_source', 'group');
+                            $set('sports_season_source', 'title_year');
+                            $set('sports_episode_strategy', 'sequential_per_season');
+                            $set('sports_repeat_league_in_filename', true);
+                            $set('sports_include_event_title', true);
+
+                            return;
                         } else {
                             $set('path_structure', ['group', 'title']);
                             $set('folder_metadata', ['year', 'tmdb_id']);
@@ -216,6 +228,35 @@ class StreamFileSettingResource extends Resource implements CopilotResource
                             return $preview;
                         }
 
+                        if ($type === 'sports') {
+                            $path = $get('location') ?? '';
+                            $pathStructure = $get('path_structure') ?? [];
+                            $repeatLeague = (bool) ($get('sports_repeat_league_in_filename') ?? true);
+                            $includeEventTitle = (bool) ($get('sports_include_event_title') ?? true);
+
+                            $league = 'Formula 1';
+                            $seasonYear = 2026;
+                            $eventTitle = 'GP Japan - Qualifying';
+                            $episodeCode = "S{$seasonYear}E01";
+
+                            $preview = 'Preview: '.$path;
+
+                            if (in_array('league', $pathStructure, true)) {
+                                $preview .= '/'.$league;
+                            }
+
+                            if (in_array('season', $pathStructure, true)) {
+                                $preview .= "/Season {$seasonYear}";
+                            }
+
+                            $filename = $repeatLeague ? "{$league} {$episodeCode}" : $episodeCode;
+                            if ($includeEventTitle) {
+                                $filename .= " {$eventTitle}";
+                            }
+
+                            return $preview.'/'.PlaylistService::makeFilesystemSafe($filename).'.strm';
+                        }
+
                         // Default to series preview
                         $series = PlaylistService::getEpisodeExample();
 
@@ -301,14 +342,16 @@ class StreamFileSettingResource extends Resource implements CopilotResource
                     ->live()
                     ->multiple()
                     ->grouped()
-                    ->options(fn ($get) => $get('type') === 'series'
-                        ? ['category' => 'Category', 'series' => 'Series', 'season' => 'Season']
-                        : ['group' => 'Group', 'title' => 'Title']
-                    )
-                    ->default(fn ($get) => $get('type') === 'series'
-                        ? ['category', 'series', 'season']
-                        : ['group', 'title']
-                    )
+                    ->options(fn ($get) => match ($get('type')) {
+                        'series' => ['category' => 'Category', 'series' => 'Series', 'season' => 'Season'],
+                        'sports' => ['league' => 'League', 'season' => 'Season'],
+                        default => ['group' => 'Group', 'title' => 'Title'],
+                    })
+                    ->default(fn ($get) => match ($get('type')) {
+                        'series' => ['category', 'series', 'season'],
+                        'sports' => ['league', 'season'],
+                        default => ['group', 'title'],
+                    })
                     ->afterStateUpdated(function ($state, Set $set, Get $get): void {
                         if ($get('type') !== 'vod') {
                             return;
@@ -347,6 +390,7 @@ class StreamFileSettingResource extends Resource implements CopilotResource
                                     'tmdb_id' => 'TMDB ID',
                                     'category' => 'Category',
                                 ],
+                                $get('type') === 'sports' => [],
                                 $get('type') === 'vod' && in_array('title', $get('path_structure') ?? []) => [
                                     'year' => 'Year',
                                     'group' => 'Group',
@@ -384,6 +428,56 @@ class StreamFileSettingResource extends Resource implements CopilotResource
                             ->hidden(fn (Get $get): bool => $get('type') !== 'series' || ! in_array('tmdb_id', $get('filename_metadata') ?? [])),
                     ])
                     ->hidden(fn ($get) => ! $get('enabled')),
+
+                Fieldset::make(__('Sports Schema'))
+                    ->columnSpanFull()
+                    ->columns(2)
+                    ->schema([
+                        Select::make('sports_league_source')
+                            ->label(__('League source'))
+                            ->options([
+                                'group' => 'Group',
+                                'category' => 'Category',
+                                'series_name' => 'Series name',
+                                'vod_title' => 'VOD title',
+                                'static' => 'Static value',
+                            ])
+                            ->default('group')
+                            ->native(false)
+                            ->live(),
+                        TextInput::make('sports_static_league')
+                            ->label(__('Static league value'))
+                            ->placeholder('Formula 1')
+                            ->visible(fn (Get $get): bool => $get('sports_league_source') === 'static'),
+                        Select::make('sports_season_source')
+                            ->label(__('Season year source'))
+                            ->options([
+                                'title_year' => 'Parse year from title',
+                                'release_date' => 'Release/Air date year',
+                                'current_year' => 'Current year',
+                            ])
+                            ->default('title_year')
+                            ->native(false),
+                        ToggleButtons::make('sports_episode_strategy')
+                            ->label(__('Episode numbering strategy'))
+                            ->inline()
+                            ->grouped()
+                            ->options([
+                                'sequential_per_season' => 'Sequential per season',
+                                'date_code' => 'Date code',
+                                'from_episode_field' => 'Episode field',
+                            ])
+                            ->default('sequential_per_season'),
+                        Toggle::make('sports_repeat_league_in_filename')
+                            ->label(__('Repeat league in filename'))
+                            ->default(true)
+                            ->inline(false),
+                        Toggle::make('sports_include_event_title')
+                            ->label(__('Include event title in filename'))
+                            ->default(true)
+                            ->inline(false),
+                    ])
+                    ->visible(fn (Get $get): bool => $get('enabled') && $get('type') === 'sports'),
 
                 Fieldset::make(__('Filename Cleansing'))
                     ->columnSpanFull()
@@ -497,6 +591,7 @@ class StreamFileSettingResource extends Resource implements CopilotResource
                     ->colors([
                         'primary' => 'series',
                         'success' => 'vod',
+                        'warning' => 'sports',
                     ])
                     ->sortable(),
                 TextColumn::make('location')
@@ -527,6 +622,7 @@ class StreamFileSettingResource extends Resource implements CopilotResource
                     ->options([
                         'series' => 'Series',
                         'vod' => 'VOD',
+                        'sports' => 'Sports',
                     ]),
             ])
             ->recordActions([

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -10,6 +10,7 @@ use App\Models\StrmFileMapping;
 use App\Models\User;
 use App\Services\NfoService;
 use App\Services\PlaylistService;
+use App\Services\SportsPathBuilder;
 use App\Settings\GeneralSettings;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -401,6 +402,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
         }
 
         $playlist = $series->playlist;
+        $sportsPathBuilder = app(SportsPathBuilder::class);
         try {
             // Resolve settings with priority chain: Series > Category > Global Profile > Legacy Settings
             $sync_settings = $this->resolveSeriesSyncSettings($series, $settings);
@@ -475,6 +477,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
             $replaceChar = $sync_settings['replace_char'] ?? 'space';
             $cleanSpecialChars = $sync_settings['clean_special_chars'] ?? false;
             $tmdbIdFormat = $sync_settings['tmdb_id_format'] ?? 'square';
+            $isSportsSchema = ($sync_settings['type'] ?? null) === 'sports';
 
             // Get filename metadata settings early so folder/episode naming can respect TMDB target settings
             $filenameMetadata = $sync_settings['filename_metadata'] ?? [];
@@ -499,77 +502,93 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 return trim($name);
             };
 
-            // See if the category is enabled, if not, skip, else create the folder
-            if (in_array('category', $pathStructure)) {
-                // Create the category folder
-                // Remove any special characters from the category name
-                $category = $series->category;
-                $catName = $category?->name ?? $category?->name_internal ?? 'Uncategorized';
-                // Apply name filtering
-                $catName = $applyNameFilter($catName);
-                $cleanName = $cleanSpecialChars
-                    ? PlaylistService::makeFilesystemSafe($catName, $replaceChar)
-                    : PlaylistService::makeFilesystemSafe($catName);
-                $path .= '/'.$cleanName;
-            }
+            $category = $series->category;
+            if ($isSportsSchema) {
+                $leagueName = $applyNameFilter($sportsPathBuilder->resolveLeagueForSeries($series, $sync_settings));
 
-            // See if the series is enabled, if not, skip, else create the folder
-            if (in_array('series', $pathStructure)) {
-                // Create the series folder with Trash Guides format support
-                // Remove any special characters from the series name
-                $seriesName = $applyNameFilter($series->name);
-                $seriesFolder = $seriesName;
-
-                // Add year to folder name if available
-                if (! empty($series->release_date)) {
-                    $year = substr($series->release_date, 0, 4);
-                    if (strpos($seriesFolder, "({$year})") === false) {
-                        $seriesFolder .= " ({$year})";
-                    }
+                if (in_array('league', $pathStructure, true)) {
+                    $cleanLeagueName = $cleanSpecialChars
+                        ? PlaylistService::makeFilesystemSafe($leagueName, $replaceChar)
+                        : PlaylistService::makeFilesystemSafe($leagueName);
+                    $path .= '/'.$cleanLeagueName;
                 }
 
-                // Add TVDB/TMDB/IMDB ID to folder name for Trash Guides compatibility.
-                // TMDB is only included in series folder names when explicitly enabled via tmdb_id_apply_to.
-                // Check dedicated columns first, then fall back to metadata JSON for legacy support
-                $ids = $series->getMovieDbIds();
-                $tvdbId = $ids['tvdb'] ?? null;
-                $tmdbId = $ids['tmdb'] ?? null;
-                $imdbId = $ids['imdb'] ?? null;
-
-                // Ensure IDs are scalar values (not arrays)
-                $tvdbId = is_scalar($tvdbId) ? $tvdbId : null;
-                $tmdbId = is_scalar($tmdbId) ? $tmdbId : null;
-                $imdbId = is_scalar($imdbId) ? $imdbId : null;
-
-                // Determine bracket style based on settings
-                $bracket = $tmdbIdFormat === 'curly' ? ['{', '}'] : ['[', ']'];
-
-                // When applying TMDB ID to the series folder and the series has no IDs,
-                // fall back to the first episode's TMDB ID
-                if ($applyTmdbToSeriesFolder && empty($tvdbId) && empty($tmdbId) && empty($imdbId)) {
-                    $firstEpisode = $episodes->first();
-                    if ($firstEpisode) {
-                        $epInfo = $firstEpisode->info ?? [];
-                        $fallbackTmdb = $firstEpisode->tmdb_id ?? $epInfo['tmdb_id'] ?? $epInfo['tmdb'] ?? null;
-                        $tmdbId = \is_scalar($fallbackTmdb) ? $fallbackTmdb : null;
-                    }
+                $sportsSeasonYear = $sportsPathBuilder->resolveSeasonYearForEpisode($episodes->first(), $series, $sync_settings);
+                if (in_array('season', $pathStructure, true)) {
+                    $path .= '/Season '.$sportsSeasonYear;
+                }
+            } else {
+                // See if the category is enabled, if not, skip, else create the folder
+                if (in_array('category', $pathStructure)) {
+                    // Create the category folder
+                    // Remove any special characters from the category name
+                    $catName = $category?->name ?? $category?->name_internal ?? 'Uncategorized';
+                    // Apply name filtering
+                    $catName = $applyNameFilter($catName);
+                    $cleanName = $cleanSpecialChars
+                        ? PlaylistService::makeFilesystemSafe($catName, $replaceChar)
+                        : PlaylistService::makeFilesystemSafe($catName);
+                    $path .= '/'.$cleanName;
                 }
 
-                // Add TMDB/TVDB/IMDB ID to series folder name if enabled and available (TMDB only if tmdb_id_apply_to includes series)
-                if ($applyTmdbToSeriesFolder) {
-                    if (! empty($tmdbId)) {
-                        $seriesFolder .= " {$bracket[0]}tmdb-{$tmdbId}{$bracket[1]}";
-                    } elseif (! empty($tvdbId)) {
-                        $seriesFolder .= " {$bracket[0]}tvdb-{$tvdbId}{$bracket[1]}";
-                    } elseif (! empty($imdbId)) {
-                        $seriesFolder .= " {$bracket[0]}imdb-{$imdbId}{$bracket[1]}";
-                    }
-                }
+                // See if the series is enabled, if not, skip, else create the folder
+                if (in_array('series', $pathStructure)) {
+                    // Create the series folder with Trash Guides format support
+                    // Remove any special characters from the series name
+                    $seriesName = $applyNameFilter($series->name);
+                    $seriesFolder = $seriesName;
 
-                $cleanName = $cleanSpecialChars
-                    ? PlaylistService::makeFilesystemSafe($seriesFolder, $replaceChar)
-                    : PlaylistService::makeFilesystemSafe($seriesFolder);
-                $path .= '/'.$cleanName;
+                    // Add year to folder name if available
+                    if (! empty($series->release_date)) {
+                        $year = substr($series->release_date, 0, 4);
+                        if (strpos($seriesFolder, "({$year})") === false) {
+                            $seriesFolder .= " ({$year})";
+                        }
+                    }
+
+                    // Add TVDB/TMDB/IMDB ID to folder name for Trash Guides compatibility.
+                    // TMDB is only included in series folder names when explicitly enabled via tmdb_id_apply_to.
+                    // Check dedicated columns first, then fall back to metadata JSON for legacy support
+                    $ids = $series->getMovieDbIds();
+                    $tvdbId = $ids['tvdb'] ?? null;
+                    $tmdbId = $ids['tmdb'] ?? null;
+                    $imdbId = $ids['imdb'] ?? null;
+
+                    // Ensure IDs are scalar values (not arrays)
+                    $tvdbId = is_scalar($tvdbId) ? $tvdbId : null;
+                    $tmdbId = is_scalar($tmdbId) ? $tmdbId : null;
+                    $imdbId = is_scalar($imdbId) ? $imdbId : null;
+
+                    // Determine bracket style based on settings
+                    $bracket = $tmdbIdFormat === 'curly' ? ['{', '}'] : ['[', ']'];
+
+                    // When applying TMDB ID to the series folder and the series has no IDs,
+                    // fall back to the first episode's TMDB ID
+                    if ($applyTmdbToSeriesFolder && empty($tvdbId) && empty($tmdbId) && empty($imdbId)) {
+                        $firstEpisode = $episodes->first();
+                        if ($firstEpisode) {
+                            $epInfo = $firstEpisode->info ?? [];
+                            $fallbackTmdb = $firstEpisode->tmdb_id ?? $epInfo['tmdb_id'] ?? $epInfo['tmdb'] ?? null;
+                            $tmdbId = \is_scalar($fallbackTmdb) ? $fallbackTmdb : null;
+                        }
+                    }
+
+                    // Add TMDB/TVDB/IMDB ID to series folder name if enabled and available (TMDB only if tmdb_id_apply_to includes series)
+                    if ($applyTmdbToSeriesFolder) {
+                        if (! empty($tmdbId)) {
+                            $seriesFolder .= " {$bracket[0]}tmdb-{$tmdbId}{$bracket[1]}";
+                        } elseif (! empty($tvdbId)) {
+                            $seriesFolder .= " {$bracket[0]}tvdb-{$tvdbId}{$bracket[1]}";
+                        } elseif (! empty($imdbId)) {
+                            $seriesFolder .= " {$bracket[0]}imdb-{$imdbId}{$bracket[1]}";
+                        }
+                    }
+
+                    $cleanName = $cleanSpecialChars
+                        ? PlaylistService::makeFilesystemSafe($seriesFolder, $replaceChar)
+                        : PlaylistService::makeFilesystemSafe($seriesFolder);
+                    $path .= '/'.$cleanName;
+                }
             }
 
             // Track the series folder path for tvshow.nfo generation
@@ -580,11 +599,10 @@ class SyncSeriesStrmFiles implements ShouldQueue
 
             // NFO generation setting - instantiate service once if needed
             $generateNfo = $sync_settings['generate_nfo'] ?? false;
-            $nfoService = null;
+            $nfoService = $generateNfo ? app(NfoService::class) : null;
 
             // Early NFO generation for series-level tvshow.nfo
-            if ($generateNfo) {
-                $nfoService = app(NfoService::class);
+            if ($nfoService && ! $isSportsSchema) {
                 // Generate tvshow.nfo for the series if NFO generation is enabled
                 // This should be at the series folder level (or base path if no series folder)
                 // Pass name filter settings for consistent title filtering
@@ -596,6 +614,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
             $seriesMetadata = $series->metadata ?? [];
             $playlistUser = $playlist?->user;
             $playlistUuid = $playlist?->uuid;
+            $sportsEpisodeCounters = [];
 
             if (! $playlistUser || ! $playlistUuid) {
                 Log::warning('STRM Sync: Series has no associated playlist user, skipping episode URL generation', [
@@ -608,6 +627,96 @@ class SyncSeriesStrmFiles implements ShouldQueue
 
             // Loop through each episode
             foreach ($episodes as $ep) {
+                if ($isSportsSchema) {
+                    $sportsLeagueName = $applyNameFilter($sportsPathBuilder->resolveLeagueForSeries($series, $sync_settings));
+                    $sportsSeasonYear = $sportsPathBuilder->resolveSeasonYearForEpisode($ep, $series, $sync_settings);
+                    $sportsEventDate = $sportsPathBuilder->resolveEventDateForEpisode($ep);
+
+                    $counterKey = mb_strtolower(trim($sportsLeagueName)).':'.$sportsSeasonYear;
+                    $sportsEpisodeCounters[$counterKey] = ($sportsEpisodeCounters[$counterKey] ?? 0) + 1;
+
+                    $episodeCode = $sportsPathBuilder->buildEpisodeCode(
+                        $sportsSeasonYear,
+                        $sportsEpisodeCounters[$counterKey],
+                        $sync_settings['sports_episode_strategy'] ?? 'sequential_per_season',
+                        $sportsEventDate,
+                        $ep->episode_num,
+                    );
+
+                    $eventTitle = $applyNameFilter((string) ($ep->title ?? 'Event'));
+                    $fileName = ($sync_settings['sports_repeat_league_in_filename'] ?? true)
+                        ? "{$sportsLeagueName} {$episodeCode}"
+                        : $episodeCode;
+
+                    if (($sync_settings['sports_include_event_title'] ?? true) && $eventTitle !== '') {
+                        $fileName .= ' '.$eventTitle;
+                    }
+
+                    $fileName = $cleanSpecialChars
+                        ? PlaylistService::makeFilesystemSafe($fileName, $replaceChar)
+                        : PlaylistService::makeFilesystemSafe($fileName);
+
+                    if ($removeConsecutiveChars && $replaceChar !== 'remove') {
+                        $char = $replaceChar === 'space' ? ' ' : ($replaceChar === 'dash' ? '-' : ($replaceChar === 'underscore' ? '_' : '.'));
+                        $fileName = preg_replace('/'.preg_quote($char, '/').'{2,}/', $char, $fileName);
+                    }
+
+                    $fileName = "{$fileName}.strm";
+                    $filePath = $path.'/'.$fileName;
+
+                    $useOriginalUrl = ($sync_settings['url_type'] ?? 'proxy') === 'original';
+                    if ($useOriginalUrl) {
+                        $url = $ep->url;
+                    } else {
+                        $containerExtension = $ep->container_extension ?? 'mp4';
+                        $url = rtrim("/series/{$playlistUser->name}/{$playlistUuid}/".$ep->id.'.'.$containerExtension, '.');
+                        $url = PlaylistService::getBaseUrl($url);
+                    }
+
+                    $pathOptions = [
+                        'path_structure' => $pathStructure,
+                        'sports_league_source' => $sync_settings['sports_league_source'] ?? 'series_name',
+                        'sports_season_source' => $sync_settings['sports_season_source'] ?? 'title_year',
+                        'sports_episode_strategy' => $sync_settings['sports_episode_strategy'] ?? 'sequential_per_season',
+                        'sports_repeat_league_in_filename' => $sync_settings['sports_repeat_league_in_filename'] ?? true,
+                        'sports_include_event_title' => $sync_settings['sports_include_event_title'] ?? true,
+                        'clean_special_chars' => $cleanSpecialChars,
+                        'replace_char' => $replaceChar,
+                        'remove_consecutive_chars' => $removeConsecutiveChars,
+                        'name_filter_enabled' => $nameFilterEnabled,
+                        'name_filter_patterns' => $nameFilterPatterns,
+                    ];
+
+                    $episodeMapping = StrmFileMapping::syncFileWithCache(
+                        $ep,
+                        $syncLocation,
+                        $filePath,
+                        $url,
+                        $pathOptions,
+                        $mappingCache
+                    );
+
+                    if ($nfoService) {
+                        $leagueFolderPath = $path;
+                        if (in_array('season', $pathStructure, true)) {
+                            $leagueFolderPath = dirname($path);
+                        }
+
+                        $nfoService->generateSportsLeagueNfo($sportsLeagueName, $sportsSeasonYear, $leagueFolderPath);
+                        $nfoService->generateSportsEventNfoFromEpisode(
+                            $ep,
+                            $series,
+                            $filePath,
+                            $sportsLeagueName,
+                            $sportsSeasonYear,
+                            $sportsEpisodeCounters[$counterKey],
+                            $episodeMapping,
+                        );
+                    }
+
+                    continue;
+                }
+
                 // Setup episode prefix
                 $season = $ep->season;
                 $num = str_pad($ep->episode_num, 2, '0', STR_PAD_LEFT);

--- a/app/Jobs/SyncVodStrmFiles.php
+++ b/app/Jobs/SyncVodStrmFiles.php
@@ -10,6 +10,7 @@ use App\Models\StrmFileMapping;
 use App\Models\User;
 use App\Services\NfoService;
 use App\Services\PlaylistService;
+use App\Services\SportsPathBuilder;
 use App\Settings\GeneralSettings;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -31,6 +32,11 @@ class SyncVodStrmFiles implements ShouldQueue
      * Track sync locations that were processed for deferred cleanup
      */
     protected array $processedSyncLocations = [];
+
+    /**
+     * Sequence counters for sports filenames keyed by league + season.
+     */
+    protected array $sportsEpisodeCounters = [];
 
     /**
      * Batch size for processing VOD STRM files.
@@ -227,6 +233,8 @@ class SyncVodStrmFiles implements ShouldQueue
         // Get the default sync location for bulk mapping cache
         $defaultSyncLocation = $globalStreamFileSetting?->location ?? $settings->vod_stream_file_sync_location ?? '';
 
+        $sportsPathBuilder = app(SportsPathBuilder::class);
+
         // PERFORMANCE OPTIMIZATION: Bulk load all existing mappings for these channels
         // This reduces N queries (one per channel) to 1 query for all channels
         $syncLocation = rtrim($defaultSyncLocation, '/');
@@ -289,6 +297,7 @@ class SyncVodStrmFiles implements ShouldQueue
             $folderMetadata = $sync_settings['folder_metadata'] ?? [];
             $tmdbIdFormat = $sync_settings['tmdb_id_format'] ?? 'square';
             $removeConsecutiveChars = $sync_settings['remove_consecutive_chars'] ?? false;
+            $isSportsSchema = ($sync_settings['type'] ?? null) === 'sports';
 
             // Get name filtering settings
             $nameFilterEnabled = $sync_settings['name_filter_enabled'] ?? false;
@@ -305,6 +314,111 @@ class SyncVodStrmFiles implements ShouldQueue
 
                 return trim($name);
             };
+
+            if ($isSportsSchema) {
+                $leagueName = $applyNameFilter($sportsPathBuilder->resolveLeagueForChannel($channel, $sync_settings));
+                $seasonYear = $sportsPathBuilder->resolveSeasonYearForChannel($channel, $sync_settings);
+                $eventDate = $sportsPathBuilder->resolveEventDateForChannel($channel);
+                $counterKey = mb_strtolower(trim($leagueName)).':'.$seasonYear;
+                $this->sportsEpisodeCounters[$counterKey] = ($this->sportsEpisodeCounters[$counterKey] ?? 0) + 1;
+
+                $episodeCode = $sportsPathBuilder->buildEpisodeCode(
+                    $seasonYear,
+                    $this->sportsEpisodeCounters[$counterKey],
+                    $sync_settings['sports_episode_strategy'] ?? 'sequential_per_season',
+                    $eventDate,
+                );
+
+                $path = $syncLocation;
+                $pathStructure = $sync_settings['path_structure'] ?? ['league', 'season'];
+
+                if (in_array('league', $pathStructure, true)) {
+                    $leagueFolder = $cleanSpecialChars
+                        ? PlaylistService::makeFilesystemSafe($leagueName, $replaceChar)
+                        : PlaylistService::makeFilesystemSafe($leagueName);
+                    $path .= '/'.$leagueFolder;
+                }
+
+                if (in_array('season', $pathStructure, true)) {
+                    $path .= '/Season '.$seasonYear;
+                }
+
+                $eventTitle = $applyNameFilter((string) ($channel->title_custom ?? $channel->title ?? 'Event'));
+                $fileName = ($sync_settings['sports_repeat_league_in_filename'] ?? true)
+                    ? "{$leagueName} {$episodeCode}"
+                    : $episodeCode;
+
+                if (($sync_settings['sports_include_event_title'] ?? true) && $eventTitle !== '') {
+                    $fileName .= ' '.$eventTitle;
+                }
+
+                $fileName = $cleanSpecialChars
+                    ? PlaylistService::makeFilesystemSafe($fileName, $replaceChar)
+                    : PlaylistService::makeFilesystemSafe($fileName);
+
+                if ($removeConsecutiveChars && $replaceChar !== 'remove') {
+                    $char = $replaceChar === 'space' ? ' ' : ($replaceChar === 'dash' ? '-' : ($replaceChar === 'underscore' ? '_' : '.'));
+                    $fileName = preg_replace('/'.preg_quote($char, '/').'{2,}/', $char, $fileName);
+                }
+
+                $filePath = $path.'/'.$fileName.'.strm';
+
+                $useOriginalUrl = ($sync_settings['url_type'] ?? 'proxy') === 'original';
+                if ($useOriginalUrl) {
+                    $url = $channel->url_custom ?? $channel->url;
+                } else {
+                    $playlist = $this->playlist ?? $channel->getEffectivePlaylist();
+                    $extension = $channel->container_extension ?? 'mkv';
+                    $url = rtrim("/movie/{$playlist->user->name}/{$playlist->uuid}/".$channel->id.'.'.$extension, '.');
+                    $url = PlaylistService::getBaseUrl($url);
+                }
+
+                $pathOptions = [
+                    'path_structure' => $pathStructure,
+                    'sports_league_source' => $sync_settings['sports_league_source'] ?? 'group',
+                    'sports_season_source' => $sync_settings['sports_season_source'] ?? 'title_year',
+                    'sports_episode_strategy' => $sync_settings['sports_episode_strategy'] ?? 'sequential_per_season',
+                    'sports_repeat_league_in_filename' => $sync_settings['sports_repeat_league_in_filename'] ?? true,
+                    'sports_include_event_title' => $sync_settings['sports_include_event_title'] ?? true,
+                    'clean_special_chars' => $cleanSpecialChars,
+                    'replace_char' => $replaceChar,
+                    'remove_consecutive_chars' => $removeConsecutiveChars,
+                    'name_filter_enabled' => $nameFilterEnabled,
+                    'name_filter_patterns' => $nameFilterPatterns,
+                ];
+
+                $channelMapping = StrmFileMapping::syncFileWithCache(
+                    $channel,
+                    $syncLocation,
+                    $filePath,
+                    $url,
+                    $pathOptions,
+                    $mappingCache
+                );
+
+                if ($nfoService) {
+                    $leagueFolderPath = $path;
+                    if (in_array('season', $pathStructure, true)) {
+                        $leagueFolderPath = dirname($path);
+                    }
+
+                    $nfoService->generateSportsLeagueNfo($leagueName, $seasonYear, $leagueFolderPath);
+                    $nfoService->generateSportsEventNfoFromChannel(
+                        $channel,
+                        $filePath,
+                        $leagueName,
+                        $seasonYear,
+                        $this->sportsEpisodeCounters[$counterKey],
+                        $channelMapping,
+                    );
+                }
+
+                if (! in_array($syncLocation, $this->processedSyncLocations, true)) {
+                    $this->processedSyncLocations[] = $syncLocation;
+                }
+
+                continue;
+            }
 
             // Create the group folder if enabled
             $groupModel = $channel->relationLoaded('group')

--- a/app/Models/StreamFileSetting.php
+++ b/app/Models/StreamFileSetting.php
@@ -24,6 +24,8 @@ class StreamFileSetting extends Model
         'generate_nfo' => 'boolean',
         'refresh_media_server' => 'boolean',
         'refresh_delay_seconds' => 'integer',
+        'sports_repeat_league_in_filename' => 'boolean',
+        'sports_include_event_title' => 'boolean',
     ];
 
     public function user(): BelongsTo
@@ -58,12 +60,17 @@ class StreamFileSetting extends Model
 
     public function scopeForSeries(Builder $query): Builder
     {
-        return $query->where('type', 'series');
+        return $query->whereIn('type', ['series', 'sports']);
     }
 
     public function scopeForVod(Builder $query): Builder
     {
-        return $query->where('type', 'vod');
+        return $query->whereIn('type', ['vod', 'sports']);
+    }
+
+    public function scopeForSports(Builder $query): Builder
+    {
+        return $query->where('type', 'sports');
     }
 
     /**
@@ -72,6 +79,7 @@ class StreamFileSetting extends Model
     public function toSyncSettings(): array
     {
         return [
+            'type' => $this->type,
             'enabled' => $this->enabled,
             'url_type' => $this->url_type ?? 'proxy',
             'sync_location' => $this->location,
@@ -80,6 +88,12 @@ class StreamFileSetting extends Model
             'folder_metadata' => $this->folder_metadata ?? [],
             'tmdb_id_format' => $this->tmdb_id_format,
             'tmdb_id_apply_to' => $this->tmdb_id_apply_to ?? 'episodes',
+            'sports_league_source' => $this->sports_league_source ?? 'group',
+            'sports_static_league' => $this->sports_static_league,
+            'sports_season_source' => $this->sports_season_source ?? 'title_year',
+            'sports_episode_strategy' => $this->sports_episode_strategy ?? 'sequential_per_season',
+            'sports_repeat_league_in_filename' => $this->sports_repeat_league_in_filename ?? true,
+            'sports_include_event_title' => $this->sports_include_event_title ?? true,
             'clean_special_chars' => $this->clean_special_chars,
             'remove_consecutive_chars' => $this->remove_consecutive_chars,
             'replace_char' => $this->replace_char,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -75,6 +75,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravel\Ai\AiManager;
 use Livewire\Livewire;
+use PDO;
 use SocialiteProviders\Manager\SocialiteWasCalled;
 use SocialiteProviders\OIDC\OIDCExtendSocialite;
 use Spatie\Tags\Tag;
@@ -335,16 +336,32 @@ class AppServiceProvider extends ServiceProvider
      */
     private function configureSqliteOpenFlags(): void
     {
-        $openFlagsAttr = defined('Pdo\\Sqlite::ATTR_OPEN_FLAGS')
-            ? constant('Pdo\\Sqlite::ATTR_OPEN_FLAGS')
-            : PDO::SQLITE_ATTR_OPEN_FLAGS;
+        $openFlagsAttr = null;
+        if (defined('Pdo\\Sqlite::ATTR_OPEN_FLAGS')) {
+            $openFlagsAttr = constant('Pdo\\Sqlite::ATTR_OPEN_FLAGS');
+        } elseif (defined('PDO::SQLITE_ATTR_OPEN_FLAGS')) {
+            $openFlagsAttr = constant('PDO::SQLITE_ATTR_OPEN_FLAGS');
+        }
 
-        $openMode = (defined('Pdo\\Sqlite::OPEN_READWRITE')
-            ? constant('Pdo\\Sqlite::OPEN_READWRITE')
-            : PDO::SQLITE_OPEN_READWRITE)
-            | (defined('Pdo\\Sqlite::OPEN_CREATE')
-                ? constant('Pdo\\Sqlite::OPEN_CREATE')
-                : PDO::SQLITE_OPEN_CREATE);
+        $openReadWrite = null;
+        if (defined('Pdo\\Sqlite::OPEN_READWRITE')) {
+            $openReadWrite = constant('Pdo\\Sqlite::OPEN_READWRITE');
+        } elseif (defined('PDO::SQLITE_OPEN_READWRITE')) {
+            $openReadWrite = constant('PDO::SQLITE_OPEN_READWRITE');
+        }
+
+        $openCreate = null;
+        if (defined('Pdo\\Sqlite::OPEN_CREATE')) {
+            $openCreate = constant('Pdo\\Sqlite::OPEN_CREATE');
+        } elseif (defined('PDO::SQLITE_OPEN_CREATE')) {
+            $openCreate = constant('PDO::SQLITE_OPEN_CREATE');
+        }
+
+        if ($openFlagsAttr === null || $openReadWrite === null || $openCreate === null) {
+            return;
+        }
+
+        $openMode = $openReadWrite | $openCreate;
 
         foreach (['sqlite', 'jobs'] as $connection) {
             $options = config("database.connections.{$connection}.options", []);

--- a/app/Services/NfoService.php
+++ b/app/Services/NfoService.php
@@ -10,6 +10,112 @@ use Illuminate\Support\Facades\Log;
 
 class NfoService
 {
+    public function generateSportsLeagueNfo(string $league, int $seasonYear, string $path, ?StrmFileMapping $mapping = null): bool
+    {
+        try {
+            $xml = $this->startXml('tvshow');
+            $xml .= $this->xmlElement('title', $league);
+            $xml .= $this->xmlElement('originaltitle', $league);
+            $xml .= $this->xmlElement('sorttitle', $league);
+            $xml .= $this->xmlElement('genre', 'Sport');
+            $xml .= $this->xmlElement('studio', $league);
+            $xml .= $this->xmlElement('year', $seasonYear);
+            $xml .= $this->xmlElement('premiered', sprintf('%d-01-01', $seasonYear));
+            $xml .= $this->endXml('tvshow');
+
+            $filePath = rtrim($path, '/').'/tvshow.nfo';
+
+            return $this->writeFileWithHash($filePath, $xml, $mapping);
+        } catch (\Throwable $e) {
+            Log::error("NfoService: Error generating sports league NFO for {$league}: {$e->getMessage()}");
+
+            return false;
+        }
+    }
+
+    public function generateSportsEventNfoFromChannel(Channel $channel, string $filePath, string $league, int $seasonYear, int $episodeNumber, ?StrmFileMapping $mapping = null): bool
+    {
+        try {
+            $info = $channel->info ?? [];
+            $title = (string) ($channel->title_custom ?? $channel->title ?? 'Event');
+            $aired = $info['air_date'] ?? $info['releasedate'] ?? $info['release_date'] ?? null;
+
+            $xml = $this->startXml('episodedetails');
+            $xml .= $this->xmlElement('title', $title);
+            $xml .= $this->xmlElement('showtitle', $league);
+            $xml .= $this->xmlElement('genre', 'Sport');
+            $xml .= $this->xmlElement('studio', $league);
+            $xml .= $this->xmlElement('season', $seasonYear);
+            $xml .= $this->xmlElement('episode', $episodeNumber);
+
+            if (is_string($aired) && $aired !== '') {
+                $xml .= $this->xmlElement('aired', $aired);
+                $xml .= $this->xmlElement('premiered', $aired);
+            }
+
+            if (! empty($info['plot']) && is_string($info['plot'])) {
+                $xml .= $this->xmlElement('plot', $info['plot']);
+            }
+
+            if (! empty($info['thumb']) && is_string($info['thumb'])) {
+                $xml .= $this->xmlElement('thumb', $info['thumb']);
+            }
+
+            $xml .= $this->endXml('episodedetails');
+
+            $nfoPath = preg_replace('/\.strm$/i', '.nfo', $filePath);
+
+            return $this->writeFileWithHash($nfoPath, $xml, $mapping);
+        } catch (\Throwable $e) {
+            Log::error("NfoService: Error generating sports event NFO for {$channel->title}: {$e->getMessage()}");
+
+            return false;
+        }
+    }
+
+    public function generateSportsEventNfoFromEpisode(Episode $episode, Series $series, string $filePath, string $league, int $seasonYear, int $episodeNumber, ?StrmFileMapping $mapping = null): bool
+    {
+        try {
+            $info = $episode->info ?? [];
+            $title = (string) ($episode->title ?? 'Event');
+            $aired = $info['air_date'] ?? $info['releasedate'] ?? null;
+
+            $xml = $this->startXml('episodedetails');
+            $xml .= $this->xmlElement('title', $title);
+            $xml .= $this->xmlElement('showtitle', $league);
+            $xml .= $this->xmlElement('genre', 'Sport');
+            $xml .= $this->xmlElement('studio', $league);
+            $xml .= $this->xmlElement('season', $seasonYear);
+            $xml .= $this->xmlElement('episode', $episodeNumber);
+
+            if (is_string($aired) && $aired !== '') {
+                $xml .= $this->xmlElement('aired', $aired);
+                $xml .= $this->xmlElement('premiered', $aired);
+            }
+
+            if (! empty($info['plot']) && is_string($info['plot'])) {
+                $xml .= $this->xmlElement('plot', $info['plot']);
+            }
+
+            if (! empty($info['still_path']) && is_string($info['still_path'])) {
+                $thumbUrl = str_starts_with($info['still_path'], 'http')
+                    ? $info['still_path']
+                    : 'https://image.tmdb.org/t/p/original'.$info['still_path'];
+                $xml .= $this->xmlElement('thumb', $thumbUrl);
+            }
+
+            $xml .= $this->endXml('episodedetails');
+
+            $nfoPath = preg_replace('/\.strm$/i', '.nfo', $filePath);
+
+            return $this->writeFileWithHash($nfoPath, $xml, $mapping);
+        } catch (\Throwable $e) {
+            Log::error("NfoService: Error generating sports event NFO for {$series->name}/{$episode->title}: {$e->getMessage()}");
+
+            return false;
+        }
+    }
+
     /**
      * Generate a tvshow.nfo file for a series (Kodi/Emby/Jellyfin format)
      *

--- a/app/Services/SportsPathBuilder.php
+++ b/app/Services/SportsPathBuilder.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Channel;
+use App\Models\Episode;
+use App\Models\Group;
+use App\Models\Series;
+use Carbon\Carbon;
+
+class SportsPathBuilder
+{
+    public function resolveLeagueForChannel(Channel $channel, array $settings): string
+    {
+        $source = $settings['sports_league_source'] ?? 'group';
+        $groupModel = $channel->relationLoaded('group')
+            ? $channel->getRelation('group')
+            : null;
+        $groupName = $groupModel instanceof Group
+            ? (string) ($groupModel->name ?? $groupModel->name_internal ?? '')
+            : '';
+        $channelGroupName = is_string($channel->group) ? $channel->group : '';
+        $resolvedGroupName = trim($channelGroupName) !== '' ? $channelGroupName : $groupName;
+
+        return match ($source) {
+            'category' => (string) ($resolvedGroupName !== '' ? $resolvedGroupName : 'Sports'),
+            'vod_title' => (string) ($channel->title_custom ?? $channel->title ?? 'Sports'),
+            'static' => (string) ($settings['sports_static_league'] ?? 'Sports'),
+            default => (string) ($resolvedGroupName !== '' ? $resolvedGroupName : 'Sports'),
+        };
+    }
+
+    public function resolveLeagueForSeries(Series $series, array $settings): string
+    {
+        $source = $settings['sports_league_source'] ?? 'series_name';
+
+        return match ($source) {
+            'category' => (string) ($series->category?->name ?? 'Sports'),
+            'static' => (string) ($settings['sports_static_league'] ?? 'Sports'),
+            default => (string) ($series->name ?? 'Sports'),
+        };
+    }
+
+    public function resolveSeasonYearForChannel(Channel $channel, array $settings): int
+    {
+        $source = $settings['sports_season_source'] ?? 'title_year';
+
+        if ($source === 'release_date') {
+            $fromDate = $this->extractYear((string) ($channel->year ?? ''));
+            if ($fromDate !== null) {
+                return $fromDate;
+            }
+
+            $infoDate = $channel->info['releasedate'] ?? $channel->info['release_date'] ?? $channel->info['air_date'] ?? null;
+            $fromInfo = $this->extractYear((string) $infoDate);
+            if ($fromInfo !== null) {
+                return $fromInfo;
+            }
+        }
+
+        if ($source === 'current_year') {
+            return (int) now()->year;
+        }
+
+        $title = (string) ($channel->title_custom ?? $channel->title ?? '');
+        $fromTitle = $this->extractYear($title);
+        if ($fromTitle !== null) {
+            return $fromTitle;
+        }
+
+        $fromYearField = $this->extractYear((string) ($channel->year ?? ''));
+
+        return $fromYearField ?? (int) now()->year;
+    }
+
+    public function resolveSeasonYearForEpisode(Episode $episode, Series $series, array $settings): int
+    {
+        $source = $settings['sports_season_source'] ?? 'title_year';
+
+        if ($source === 'release_date') {
+            $airDate = $episode->info['air_date'] ?? $episode->info['releasedate'] ?? null;
+            $fromAirDate = $this->extractYear((string) $airDate);
+            if ($fromAirDate !== null) {
+                return $fromAirDate;
+            }
+
+            $fromSeriesDate = $this->extractYear((string) ($series->release_date ?? ''));
+            if ($fromSeriesDate !== null) {
+                return $fromSeriesDate;
+            }
+        }
+
+        if ($source === 'current_year') {
+            return (int) now()->year;
+        }
+
+        $fromTitle = $this->extractYear((string) ($episode->title ?? ''));
+        if ($fromTitle !== null) {
+            return $fromTitle;
+        }
+
+        $fromSeriesTitle = $this->extractYear((string) ($series->name ?? ''));
+        if ($fromSeriesTitle !== null) {
+            return $fromSeriesTitle;
+        }
+
+        $fromSeriesDate = $this->extractYear((string) ($series->release_date ?? ''));
+
+        return $fromSeriesDate ?? (int) now()->year;
+    }
+
+    public function resolveEventDateForChannel(Channel $channel): ?Carbon
+    {
+        $date = $channel->info['releasedate'] ?? $channel->info['release_date'] ?? $channel->info['air_date'] ?? null;
+
+        return $this->toCarbon($date);
+    }
+
+    public function resolveEventDateForEpisode(Episode $episode): ?Carbon
+    {
+        $date = $episode->info['air_date'] ?? $episode->info['releasedate'] ?? null;
+
+        return $this->toCarbon($date);
+    }
+
+    public function buildEpisodeCode(int $seasonYear, int $sequence, string $strategy = 'sequential_per_season', ?Carbon $eventDate = null, ?int $episodeNumber = null): string
+    {
+        if ($strategy === 'from_episode_field' && $episodeNumber !== null) {
+            return sprintf('S%dE%02d', $seasonYear, max(1, $episodeNumber));
+        }
+
+        if ($strategy === 'date_code') {
+            $dateCode = ($eventDate ?? now())->format('Ymd');
+
+            return sprintf('S%dE%s%02d', $seasonYear, $dateCode, max(1, $sequence));
+        }
+
+        return sprintf('S%dE%02d', $seasonYear, max(1, $sequence));
+    }
+
+    public function extractYear(string $value): ?int
+    {
+        if (preg_match('/\b(19|20)\d{2}\b/', $value, $matches) === 1) {
+            return (int) $matches[0];
+        }
+
+        return null;
+    }
+
+    private function toCarbon(mixed $date): ?Carbon
+    {
+        if (! is_string($date) || trim($date) === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($date);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/database/migrations/2026_04_23_094000_add_sports_schema_to_stream_file_settings_table.php
+++ b/database/migrations/2026_04_23_094000_add_sports_schema_to_stream_file_settings_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('stream_file_settings', function (Blueprint $table) {
+            $table->string('sports_league_source')->default('group')->after('tmdb_id_apply_to');
+            $table->string('sports_static_league')->nullable()->after('sports_league_source');
+            $table->string('sports_season_source')->default('title_year')->after('sports_static_league');
+            $table->string('sports_episode_strategy')->default('sequential_per_season')->after('sports_season_source');
+            $table->boolean('sports_repeat_league_in_filename')->default(true)->after('sports_episode_strategy');
+            $table->boolean('sports_include_event_title')->default(true)->after('sports_repeat_league_in_filename');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('stream_file_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'sports_league_source',
+                'sports_static_league',
+                'sports_season_source',
+                'sports_episode_strategy',
+                'sports_repeat_league_in_filename',
+                'sports_include_event_title',
+            ]);
+        });
+    }
+};

--- a/tests/Pure/SportsPathBuilderPureTest.php
+++ b/tests/Pure/SportsPathBuilderPureTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Episode;
+use App\Models\Series;
+use App\Services\SportsPathBuilder;
+
+test('extracts season year from title and builds sequential episode code', function () {
+    $builder = new SportsPathBuilder;
+    $channel = new Channel;
+    $channel->title = 'Formel 1 GP Japan - Qualifying 2026';
+    $channel->group = 'Formula 1';
+
+    $year = $builder->resolveSeasonYearForChannel($channel, ['sports_season_source' => 'title_year']);
+    $code = $builder->buildEpisodeCode($year, 1, 'sequential_per_season');
+
+    expect($year)->toBe(2026)
+        ->and($code)->toBe('S2026E01');
+});
+
+test('falls back to current year when no season year can be parsed', function () {
+    $builder = new SportsPathBuilder;
+    $channel = new Channel;
+    $channel->title = 'MotoGPItaly';
+    $channel->group = 'MotoGP';
+
+    $year = $builder->resolveSeasonYearForChannel($channel, ['sports_season_source' => 'title_year']);
+
+    expect($year)->toBe((int) date('Y'));
+});
+
+test('resolves league and year for series episodes and date-code strategy', function () {
+    $builder = new SportsPathBuilder;
+
+    $series = new Series;
+    $series->name = 'American NFL';
+    $series->release_date = '2015-09-01';
+
+    $episode = new Episode;
+    $episode->title = 'American NFL Season Opener';
+    $episode->episode_num = 1;
+    $episode->info = ['air_date' => '2015-09-10'];
+
+    $league = $builder->resolveLeagueForSeries($series, ['sports_league_source' => 'series_name']);
+    $year = $builder->resolveSeasonYearForEpisode($episode, $series, ['sports_season_source' => 'release_date']);
+    $dateCode = $builder->buildEpisodeCode($year, 1, 'date_code', $builder->resolveEventDateForEpisode($episode));
+
+    expect($league)->toBe('American NFL')
+        ->and($year)->toBe(2015)
+        ->and($dateCode)->toBe('S2015E2015091001');
+});

--- a/tests/Pure/StreamFileSettingSportsSyncPayloadPureTest.php
+++ b/tests/Pure/StreamFileSettingSportsSyncPayloadPureTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\StreamFileSetting;
+
+test('toSyncSettings includes sports schema defaults and type', function () {
+    $setting = new StreamFileSetting;
+    $setting->type = 'sports';
+    $setting->enabled = true;
+    $setting->location = '/sports';
+    $setting->sports_league_source = 'group';
+    $setting->sports_season_source = 'title_year';
+    $setting->sports_episode_strategy = 'sequential_per_season';
+    $setting->sports_repeat_league_in_filename = true;
+    $setting->sports_include_event_title = true;
+
+    $payload = $setting->toSyncSettings();
+
+    expect($payload['type'])->toBe('sports')
+        ->and($payload['sports_league_source'])->toBe('group')
+        ->and($payload['sports_season_source'])->toBe('title_year')
+        ->and($payload['sports_episode_strategy'])->toBe('sequential_per_season')
+        ->and($payload['sports_repeat_league_in_filename'])->toBeTrue()
+        ->and($payload['sports_include_event_title'])->toBeTrue();
+});


### PR DESCRIPTION
This pull request introduces comprehensive support for a new "sports" schema in the stream file settings and sync logic. The changes impact both the Filament resource for stream file settings and the background jobs that generate `.strm` files for series and VOD content. The main focus is on enabling flexible handling and naming of sports events, leagues, and seasons, with new configuration options and filename/path generation logic.

**Key changes include:**

### Sports Schema Support in UI and Configuration

* Added a new "sports" type option to the stream file settings, with a dedicated configuration fieldset for sports-specific options (league/season sources, episode strategy, filename options, etc.) in `StreamFileSettingResource.php`. [[1]](diffhunk://#diff-ff571341d5866257f9519f589aa17f5804a8bb8f2cd937f41b8dd01cdfc84d47R86) [[2]](diffhunk://#diff-ff571341d5866257f9519f589aa17f5804a8bb8f2cd937f41b8dd01cdfc84d47R432-R481)
* Updated the path structure and metadata options to support sports-specific folders (league, season) and filename conventions, including live preview for sports paths. [[1]](diffhunk://#diff-ff571341d5866257f9519f589aa17f5804a8bb8f2cd937f41b8dd01cdfc84d47R95-R105) [[2]](diffhunk://#diff-ff571341d5866257f9519f589aa17f5804a8bb8f2cd937f41b8dd01cdfc84d47L304-R354) [[3]](diffhunk://#diff-ff571341d5866257f9519f589aa17f5804a8bb8f2cd937f41b8dd01cdfc84d47R231-R259)

### Sports Path and Filename Logic in Sync Jobs

* Integrated the new `SportsPathBuilder` service into both `SyncSeriesStrmFiles` and `SyncVodStrmFiles` jobs to generate correct folder structures and filenames for sports content, including league, season, and event title handling. [[1]](diffhunk://#diff-6977b9ded091090418328419078b240c9c0b72bab2243974813ae84f1e0ac084R13) [[2]](diffhunk://#diff-6977b9ded091090418328419078b240c9c0b72bab2243974813ae84f1e0ac084R405) [[3]](diffhunk://#diff-057318256e012ee92c46ab32fcfb6616fbbc69b9fbb692d79d2a0888a8bfddfdR13) [[4]](diffhunk://#diff-057318256e012ee92c46ab32fcfb6616fbbc69b9fbb692d79d2a0888a8bfddfdR236-R237)
* Implemented per-league and per-season episode counters and flexible episode code strategies for sports, ensuring unique and correctly formatted filenames. [[1]](diffhunk://#diff-6977b9ded091090418328419078b240c9c0b72bab2243974813ae84f1e0ac084R617) [[2]](diffhunk://#diff-6977b9ded091090418328419078b240c9c0b72bab2243974813ae84f1e0ac084R630-R719) [[3]](diffhunk://#diff-057318256e012ee92c46ab32fcfb6616fbbc69b9fbb692d79d2a0888a8bfddfdR36-R40)

### NFO Generation and Miscellaneous

* Adjusted NFO generation logic to handle sports-specific NFO files at the league and event level, skipping series-level NFOs for sports. [[1]](diffhunk://#diff-6977b9ded091090418328419078b240c9c0b72bab2243974813ae84f1e0ac084L583-R605) [[2]](diffhunk://#diff-6977b9ded091090418328419078b240c9c0b72bab2243974813ae84f1e0ac084R630-R719)
* Updated table display and selection options in the Filament resource to include the new sports type, with appropriate color coding and labels. [[1]](diffhunk://#diff-ff571341d5866257f9519f589aa17f5804a8bb8f2cd937f41b8dd01cdfc84d47R594) [[2]](diffhunk://#diff-ff571341d5866257f9519f589aa17f5804a8bb8f2cd937f41b8dd01cdfc84d47R625)

These changes collectively enable robust and configurable support for sports content in the application's stream file handling workflows.