### PR TITLE
feat: Sort Order for Series categories

### DIFF
--- a/app/Filament/Resources/Categories/CategoryResource.php
+++ b/app/Filament/Resources/Categories/CategoryResource.php
@@ -92,6 +92,12 @@ class CategoryResource extends Resource implements CopilotResource
                 ->label(__('Auto Enable New Channels'))
                 ->helperText(__('Automatically enable newly added channels to this group.'))
                 ->default(true),
+            TextInput::make('sort_order')
+                ->label(__('Sort Order'))
+                ->numeric()
+                ->default(9999)
+                ->helperText(__('Enter a number to define the sort order (e.g., 1, 2, 3). Lower numbers appear first.'))
+                ->rules(['integer', 'min:0']),
             Select::make('stream_file_setting_id')
                 ->label(__('Stream File Setting Profile'))
                 ->searchable()
@@ -145,6 +151,14 @@ class CategoryResource extends Resource implements CopilotResource
                             ->orderBy('name_internal', $direction)
                             ->orderBy('name', $direction);
                     })
+                    ->toggleable(),
+                TextInputColumn::make('sort_order')
+                    ->label(__('Sort Order'))
+                    ->rules(['min:0'])
+                    ->type('number')
+                    ->placeholder(__('Sort Order'))
+                    ->sortable()
+                    ->tooltip(__('Category sort order'))
                     ->toggleable(),
                 ToggleColumn::make('enabled')
                     ->label(__('Auto Enable'))

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -1347,7 +1347,8 @@ class XtreamApiController extends Controller
                     ->get()
                     ->pluck('category')
                     ->filter()
-                    ->unique('id');
+                    ->unique('id')
+                    ->sortBy('sort_order');
 
                 foreach ($categories as $category) {
                     $seriesCategories[] = [

--- a/tests/Feature/CategoryResourceSortOrderTest.php
+++ b/tests/Feature/CategoryResourceSortOrderTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Filament\Resources\Categories\Pages\EditCategory;
+use App\Filament\Resources\Categories\Pages\ListCategories;
+use App\Models\Category;
+use App\Models\Playlist;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+    $this->actingAs($this->user);
+});
+
+it('renders the sort_order column on the categories table', function () {
+    $category = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'sort_order' => 5,
+    ]);
+
+    Livewire::test(ListCategories::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertCanSeeTableRecords([$category])
+        ->assertTableColumnExists('sort_order');
+});
+
+it('sorts categories by sort_order ascending by default', function () {
+    $third = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'sort_order' => 30,
+    ]);
+    $first = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'sort_order' => 10,
+    ]);
+    $second = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'sort_order' => 20,
+    ]);
+
+    Livewire::test(ListCategories::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertCanSeeTableRecords([$first, $second, $third], inOrder: true);
+});
+
+it('persists sort_order edits made through the inline column', function () {
+    $category = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'sort_order' => 9999,
+    ]);
+
+    Livewire::test(ListCategories::class)
+        ->loadTable()
+        ->call('updateTableColumnState', 'sort_order', (string) $category->getKey(), '7');
+
+    expect($category->refresh()->sort_order)->toEqual(7);
+});
+
+it('persists sort_order edits made through the edit form', function () {
+    $category = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'sort_order' => 9999,
+    ]);
+
+    Livewire::test(EditCategory::class, ['record' => $category->getRouteKey()])
+        ->assertFormFieldExists('sort_order')
+        ->fillForm(['sort_order' => 42])
+        ->call('save');
+
+    expect($category->refresh()->sort_order)->toEqual(42);
+});

--- a/tests/Feature/XtreamApiControllerTest.php
+++ b/tests/Feature/XtreamApiControllerTest.php
@@ -710,6 +710,39 @@ class XtreamApiControllerTest extends TestCase
         $response->assertJsonCount(1);
     }
 
+    public function test_get_series_categories_orders_by_sort_order_for_regular_playlist(): void
+    {
+        $third = Category::factory()->for($this->user)->for($this->playlist)->create([
+            'name' => 'Third',
+            'sort_order' => 30,
+        ]);
+        $first = Category::factory()->for($this->user)->for($this->playlist)->create([
+            'name' => 'First',
+            'sort_order' => 10,
+        ]);
+        $second = Category::factory()->for($this->user)->for($this->playlist)->create([
+            'name' => 'Second',
+            'sort_order' => 20,
+        ]);
+
+        foreach ([$first, $second, $third] as $category) {
+            Series::factory()->create([
+                'user_id' => $this->user->id,
+                'playlist_id' => $this->playlist->id,
+                'category_id' => $category->id,
+                'enabled' => true,
+            ]);
+        }
+
+        $response = $this->getJson($this->getXtreamApiUrl('get_series_categories'));
+
+        $response->assertOk();
+        $this->assertSame(
+            ['First', 'Second', 'Third'],
+            array_column($response->json(), 'category_name'),
+        );
+    }
+
     public function test_get_live_streams_tv_archive_enabled_when_shift_set()
     {
         $group = Group::factory()->for($this->user)->create();


### PR DESCRIPTION
## Summary

Closes #1023.

Brings Series categories to parity with Live and VOD groups for sort ordering:

- **Editor UI** — adds the `Sort Order` column (inline-editable) and form field to the Series → Categories resource, mirroring the existing `GroupResource` / `VodGroupResource` layout. Drag-to-reorder already worked; this just exposes the value for direct editing.
- **Xtream API output** — `get_series_categories` on regular playlists / aliases now applies `sortBy('sort_order')`, so clients like TiVimate honor the custom order. Live and VOD already did this; series was the lone exception.

The `categories.sort_order` column itself already existed (default `9999`), so no migration is needed. Existing `auto_sort` import behavior is untouched — it only ever applied to Live/VOD groups, and that hasn't changed.

## Notes

- The tooltip on the Series category column reads `Category sort order` (no auto-sort warning), since `auto_sort` doesn't currently overwrite series categories during import.
- CustomPlaylist behavior is unchanged — that branch already sorted correctly.

## Test plan

- [x] Open Series → Categories: confirm new `Sort Order` column appears, edits persist, drag-reorder still works
- [x] Edit a category: confirm `Sort Order` field is on the form and saves
- [x] Hit `player_api.php?action=get_series_categories` on a regular playlist with reordered categories: confirm response order matches `sort_order` ASC
- [x] Verify TiVimate (or another Xtream client) reflects the new category order