### PR TITLE
fix: prevent media server refresh notification spam on bulk STRM sync

### DIFF
--- a/app/Filament/Resources/Categories/CategoryResource.php
+++ b/app/Filament/Resources/Categories/CategoryResource.php
@@ -233,12 +233,15 @@ class CategoryResource extends Resource implements CopilotResource
                     Action::make('sync')
                         ->label(__('Sync Series .strm files'))
                         ->action(function ($record) {
-                            foreach ($record->enabled_series as $series) {
-                                app('Illuminate\Contracts\Bus\Dispatcher')
-                                    ->dispatch(new SyncSeriesStrmFiles(
-                                        series: $series,
-                                    ));
+                            $seriesIds = $record->enabled_series->pluck('id')->all();
+                            if (empty($seriesIds)) {
+                                return;
                             }
+                            app('Illuminate\Contracts\Bus\Dispatcher')
+                                ->dispatch(new SyncSeriesStrmFiles(
+                                    user_id: auth()->id(),
+                                    series_ids: $seriesIds,
+                                ));
                         })->after(function () {
                             Notification::make()
                                 ->success()
@@ -374,14 +377,19 @@ class CategoryResource extends Resource implements CopilotResource
                     BulkAction::make('sync')
                         ->label(__('Sync Series .strm files'))
                         ->action(function (Collection $records) {
-                            foreach ($records as $record) {
-                                foreach ($record->enabled_series as $series) {
-                                    app('Illuminate\Contracts\Bus\Dispatcher')
-                                        ->dispatch(new SyncSeriesStrmFiles(
-                                            series: $series,
-                                        ));
-                                }
+                            $seriesIds = $records
+                                ->flatMap(fn ($record) => $record->enabled_series->pluck('id'))
+                                ->unique()
+                                ->values()
+                                ->all();
+                            if (empty($seriesIds)) {
+                                return;
                             }
+                            app('Illuminate\Contracts\Bus\Dispatcher')
+                                ->dispatch(new SyncSeriesStrmFiles(
+                                    user_id: auth()->id(),
+                                    series_ids: $seriesIds,
+                                ));
                         })->after(function () {
                             Notification::make()
                                 ->success()

--- a/app/Filament/Resources/Categories/Pages/EditCategory.php
+++ b/app/Filament/Resources/Categories/Pages/EditCategory.php
@@ -78,12 +78,15 @@ class EditCategory extends EditRecord
                 Action::make('sync')
                     ->label(__('Sync Series .strm files'))
                     ->action(function ($record) {
-                        foreach ($record->enabled_series as $series) {
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new SyncSeriesStrmFiles(
-                                    series: $series,
-                                ));
+                        $seriesIds = $record->enabled_series->pluck('id')->all();
+                        if (empty($seriesIds)) {
+                            return;
                         }
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new SyncSeriesStrmFiles(
+                                user_id: auth()->id(),
+                                series_ids: $seriesIds,
+                            ));
                     })->after(function () {
                         Notification::make()
                             ->success()

--- a/app/Filament/Resources/Series/SeriesResource.php
+++ b/app/Filament/Resources/Series/SeriesResource.php
@@ -691,12 +691,15 @@ class SeriesResource extends Resource implements CopilotResource
                 BulkAction::make('sync')
                     ->label(__('Sync Series .strm files'))
                     ->action(function ($records) {
-                        foreach ($records as $record) {
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new SyncSeriesStrmFiles(
-                                    series: $record,
-                                ));
+                        $seriesIds = $records->pluck('id')->all();
+                        if (empty($seriesIds)) {
+                            return;
                         }
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new SyncSeriesStrmFiles(
+                                user_id: auth()->id(),
+                                series_ids: $seriesIds,
+                            ));
                     })->after(function () {
                         Notification::make()
                             ->success()

--- a/app/Filament/Resources/VodGroups/Pages/EditVodGroup.php
+++ b/app/Filament/Resources/VodGroups/Pages/EditVodGroup.php
@@ -161,12 +161,15 @@ class EditVodGroup extends EditRecord
                 Action::make('sync_vod')
                     ->label(__('Sync VOD .strm file'))
                     ->action(function ($record) {
-                        foreach ($record->enabled_channels as $channel) {
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new SyncVodStrmFiles(
-                                    channel: $channel,
-                                ));
+                        $channelIds = $record->enabled_channels->pluck('id')->all();
+                        if (empty($channelIds)) {
+                            return;
                         }
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new SyncVodStrmFiles(
+                                user_id: auth()->id(),
+                                channel_ids: $channelIds,
+                            ));
                     })->after(function () {
                         Notification::make()
                             ->success()

--- a/app/Filament/Resources/VodGroups/VodGroupResource.php
+++ b/app/Filament/Resources/VodGroups/VodGroupResource.php
@@ -304,12 +304,15 @@ class VodGroupResource extends Resource implements CopilotResource
                     Action::make('sync_vod')
                         ->label(__('Sync VOD .strm file'))
                         ->action(function ($record) {
-                            foreach ($record->enabled_channels as $channel) {
-                                app('Illuminate\Contracts\Bus\Dispatcher')
-                                    ->dispatch(new SyncVodStrmFiles(
-                                        channel: $channel,
-                                    ));
+                            $channelIds = $record->enabled_channels->pluck('id')->all();
+                            if (empty($channelIds)) {
+                                return;
                             }
+                            app('Illuminate\Contracts\Bus\Dispatcher')
+                                ->dispatch(new SyncVodStrmFiles(
+                                    user_id: auth()->id(),
+                                    channel_ids: $channelIds,
+                                ));
                         })->after(function () {
                             Notification::make()
                                 ->success()
@@ -504,14 +507,19 @@ class VodGroupResource extends Resource implements CopilotResource
                     BulkAction::make('sync_bulk_vod')
                         ->label(__('Sync VOD .strm file'))
                         ->action(function (Collection $records) {
-                            foreach ($records as $record) {
-                                foreach ($record->enabled_channels as $channel) {
-                                    app('Illuminate\Contracts\Bus\Dispatcher')
-                                        ->dispatch(new SyncVodStrmFiles(
-                                            channel: $channel,
-                                        ));
-                                }
+                            $channelIds = $records
+                                ->flatMap(fn ($record) => $record->enabled_channels->pluck('id'))
+                                ->unique()
+                                ->values()
+                                ->all();
+                            if (empty($channelIds)) {
+                                return;
                             }
+                            app('Illuminate\Contracts\Bus\Dispatcher')
+                                ->dispatch(new SyncVodStrmFiles(
+                                    user_id: auth()->id(),
+                                    channel_ids: $channelIds,
+                                ));
                         })->after(function () {
                             Notification::make()
                                 ->success()

--- a/app/Jobs/CheckSeriesStrmProgress.php
+++ b/app/Jobs/CheckSeriesStrmProgress.php
@@ -29,6 +29,7 @@ class CheckSeriesStrmProgress implements ShouldQueue
         public ?int $playlist_id = null,
         public ?int $user_id = null,
         public bool $needsCleanup = false,
+        public ?array $series_ids = null,
     ) {
         $this->onQueue('file_sync');
     }
@@ -61,6 +62,7 @@ class CheckSeriesStrmProgress implements ShouldQueue
                     playlist_id: $this->playlist_id,
                     user_id: $this->user_id,
                     isCleanupJob: true,
+                    series_ids: $this->series_ids,
                 ));
             } else {
                 // Send completion notification
@@ -98,6 +100,7 @@ class CheckSeriesStrmProgress implements ShouldQueue
                 batchOffset: $offset,
                 totalBatches: $totalBatches,
                 currentBatch: $batchNumber,
+                series_ids: $this->series_ids,
             );
         }
 
@@ -111,6 +114,7 @@ class CheckSeriesStrmProgress implements ShouldQueue
             playlist_id: $this->playlist_id,
             user_id: $this->user_id,
             needsCleanup: $this->needsCleanup,
+            series_ids: $this->series_ids,
         );
 
         Log::info('STRM Sync: Dispatching next chain', [

--- a/app/Jobs/CheckVodStrmProgress.php
+++ b/app/Jobs/CheckVodStrmProgress.php
@@ -28,6 +28,7 @@ class CheckVodStrmProgress implements ShouldQueue
         public ?int $playlist_id = null,
         public ?int $user_id = null,
         public bool $needsCleanup = false,
+        public ?array $channel_ids = null,
     ) {
         $this->onQueue('file_sync');
     }
@@ -58,6 +59,7 @@ class CheckVodStrmProgress implements ShouldQueue
                     playlist_id: $this->playlist_id,
                     user_id: $this->user_id,
                     isCleanupJob: true,
+                    channel_ids: $this->channel_ids,
                 ));
             } else {
                 if ($this->notify && $this->user_id) {
@@ -92,6 +94,7 @@ class CheckVodStrmProgress implements ShouldQueue
                 batchOffset: $offset,
                 totalBatches: $totalBatches,
                 currentBatch: $batchNumber,
+                channel_ids: $this->channel_ids,
             );
         }
 
@@ -104,6 +107,7 @@ class CheckVodStrmProgress implements ShouldQueue
             playlist_id: $this->playlist_id,
             user_id: $this->user_id,
             needsCleanup: $this->needsCleanup,
+            channel_ids: $this->channel_ids,
         );
 
         Log::info('STRM Sync: Dispatching next VOD chain', [

--- a/app/Jobs/RefreshMediaServerLibraryJob.php
+++ b/app/Jobs/RefreshMediaServerLibraryJob.php
@@ -5,11 +5,12 @@ namespace App\Jobs;
 use App\Models\MediaServerIntegration;
 use App\Services\MediaServerService;
 use Filament\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 
-class RefreshMediaServerLibraryJob implements ShouldQueue
+class RefreshMediaServerLibraryJob implements ShouldBeUnique, ShouldQueue
 {
     use Queueable;
 
@@ -24,6 +25,17 @@ class RefreshMediaServerLibraryJob implements ShouldQueue
     public int $backoff = 10;
 
     /**
+     * Debounce window in seconds.
+     *
+     * Prevents library refresh spam when many sync jobs (e.g. a bulk STRM
+     * sync of 2000+ series) each try to dispatch a refresh for the same
+     * media server. While a job for a given integration is queued or
+     * running, additional dispatches within this window are silently
+     * dropped by the queue.
+     */
+    public int $uniqueFor = 300;
+
+    /**
      * Create a new job instance.
      */
     public function __construct(
@@ -31,6 +43,18 @@ class RefreshMediaServerLibraryJob implements ShouldQueue
         public bool $notify = true,
     ) {
         $this->onQueue('default');
+    }
+
+    /**
+     * Get the unique ID for the job.
+     *
+     * Scoped per integration so refreshes for different media servers do
+     * not block each other, but repeated refreshes for the same server
+     * collapse into a single execution.
+     */
+    public function uniqueId(): string
+    {
+        return 'refresh-media-server-'.$this->integration->id;
     }
 
     /**

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -39,6 +39,11 @@ class SyncSeriesStrmFiles implements ShouldQueue
 
     /**
      * Create a new job instance.
+     *
+     * @param  array<int>|null  $series_ids  Optional list of explicit Series IDs to sync.
+     *                                       When provided, batches and cleanup/refresh are scoped to these IDs only.
+     *                                       This avoids dispatching N independent jobs (and N media server refreshes)
+     *                                       when bulk-syncing a user-selected subset of series.
      */
     public function __construct(
         public ?Series $series = null,
@@ -50,6 +55,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
         public ?int $totalBatches = null,
         public ?int $currentBatch = null,
         public bool $isCleanupJob = false, // Special flag for final cleanup
+        public ?array $series_ids = null,
     ) {
         // Run file synces on the dedicated queue
         $this->onQueue('file_sync');
@@ -110,6 +116,9 @@ class SyncSeriesStrmFiles implements ShouldQueue
             ->when($this->playlist_id, function ($query) {
                 $query->where('playlist_id', $this->playlist_id);
             })
+            ->when($this->series_ids !== null, function ($query) {
+                $query->whereIn('id', $this->series_ids);
+            })
             ->count();
 
         if ($totalCount === 0) {
@@ -147,6 +156,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 batchOffset: $offset,
                 totalBatches: $totalBatches,
                 currentBatch: $batch + 1,
+                series_ids: $this->series_ids,
             );
         }
 
@@ -160,6 +170,7 @@ class SyncSeriesStrmFiles implements ShouldQueue
             playlist_id: $this->playlist_id,
             user_id: $this->user_id,
             needsCleanup: true, // Cleanup will run after all chains complete
+            series_ids: $this->series_ids,
         );
 
         // Dispatch the chain
@@ -186,6 +197,9 @@ class SyncSeriesStrmFiles implements ShouldQueue
             ])
             ->when($this->playlist_id, function ($query) {
                 $query->where('playlist_id', $this->playlist_id);
+            })
+            ->when($this->series_ids !== null, function ($query) {
+                $query->whereIn('id', $this->series_ids);
             })
             ->orderBy('id')
             ->skip($this->batchOffset)
@@ -320,6 +334,9 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 if ($this->playlist_id) {
                     $query->where('playlist_id', $this->playlist_id);
                 }
+                if ($this->series_ids !== null) {
+                    $query->whereIn('id', $this->series_ids);
+                }
             })
             ->get();
 
@@ -341,6 +358,11 @@ class SyncSeriesStrmFiles implements ShouldQueue
                 $query->where('user_id', $this->user_id);
                 if ($this->playlist_id) {
                     $query->where('playlist_id', $this->playlist_id);
+                }
+                if ($this->series_ids !== null) {
+                    $query->whereHas('series', function ($q) {
+                        $q->whereIn('id', $this->series_ids);
+                    });
                 }
             })
             ->get();

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -246,6 +246,21 @@ class SyncSeriesStrmFiles implements ShouldQueue
         // Get all unique sync locations for this user/playlist
         $syncLocations = StrmFileMapping::query()
             ->where('syncable_type', Episode::class)
+            ->when($this->playlist_id, function ($query, $playlistId) {
+                $query->whereHasMorph('syncable', [Episode::class], function ($q) use ($playlistId) {
+                    $q->where('playlist_id', $playlistId);
+                });
+            })
+            ->when($this->series?->id, function ($query, $seriesId) {
+                $query->whereHasMorph('syncable', [Episode::class], function ($q) use ($seriesId) {
+                    $q->where('series_id', $seriesId);
+                });
+            })
+            ->when($this->series_ids, function ($query, $seriesIds) {
+                $query->whereHasMorph('syncable', [Episode::class], function ($q) use ($seriesIds) {
+                    $q->whereIn('series_id', $seriesIds);
+                });
+            })
             ->distinct()
             ->pluck('sync_location')
             ->toArray();

--- a/app/Jobs/SyncVodStrmFiles.php
+++ b/app/Jobs/SyncVodStrmFiles.php
@@ -510,6 +510,21 @@ class SyncVodStrmFiles implements ShouldQueue
 
         $syncLocations = StrmFileMapping::query()
             ->where('syncable_type', Channel::class)
+            ->when($this->playlist_id, function ($query, $playlistId) {
+                $query->whereHasMorph('syncable', [Channel::class], function ($q) use ($playlistId) {
+                    $q->where('playlist_id', $playlistId);
+                });
+            })
+            ->when($this->channel?->id, function ($query, $channelId) {
+                $query->whereHasMorph('syncable', [Channel::class], function ($q) use ($channelId) {
+                    $q->where('id', $channelId);
+                });
+            })
+            ->when($this->channel_ids, function ($query, $channelIds) {
+                $query->whereHasMorph('syncable', [Channel::class], function ($q) use ($channelIds) {
+                    $q->whereIn('id', $channelIds);
+                });
+            })
             ->distinct()
             ->pluck('sync_location')
             ->toArray();

--- a/app/Jobs/SyncVodStrmFiles.php
+++ b/app/Jobs/SyncVodStrmFiles.php
@@ -40,6 +40,11 @@ class SyncVodStrmFiles implements ShouldQueue
 
     /**
      * Create a new job instance.
+     *
+     * @param  array<int>|null  $channel_ids  Optional list of explicit Channel IDs to sync.
+     *                                        When provided, batches and cleanup/refresh are scoped to these IDs only.
+     *                                        This avoids dispatching N independent jobs (and N media server refreshes)
+     *                                        when bulk-syncing a user-selected subset of VOD channels.
      */
     public function __construct(
         public bool $notify = true,
@@ -53,6 +58,7 @@ class SyncVodStrmFiles implements ShouldQueue
         public ?int $totalBatches = null,
         public ?int $currentBatch = null,
         public bool $isCleanupJob = false,
+        public ?array $channel_ids = null,
     ) {
         // Run file synces on the dedicated queue
         $this->onQueue('file_sync');
@@ -164,6 +170,7 @@ class SyncVodStrmFiles implements ShouldQueue
                 batchOffset: $offset,
                 totalBatches: $totalBatches,
                 currentBatch: $batch + 1,
+                channel_ids: $this->channel_ids,
             );
         }
 
@@ -176,6 +183,7 @@ class SyncVodStrmFiles implements ShouldQueue
             playlist_id: $this->resolvePlaylistId(),
             user_id: $this->resolveUserId(),
             needsCleanup: true,
+            channel_ids: $this->channel_ids,
         );
 
         Bus::chain($jobs)->dispatch();
@@ -563,6 +571,9 @@ class SyncVodStrmFiles implements ShouldQueue
                 if (! $this->all_playlists && $playlistId) {
                     $query->where('playlist_id', $playlistId);
                 }
+                if ($this->channel_ids !== null) {
+                    $query->whereIn('id', $this->channel_ids);
+                }
             })
             ->get();
 
@@ -585,6 +596,11 @@ class SyncVodStrmFiles implements ShouldQueue
                 }
                 if (! $this->all_playlists && $playlistId) {
                     $query->where('playlist_id', $playlistId);
+                }
+                if ($this->channel_ids !== null) {
+                    $query->whereHas('channels', function ($q) {
+                        $q->whereIn('id', $this->channel_ids);
+                    });
                 }
             })
             ->get();
@@ -623,6 +639,9 @@ class SyncVodStrmFiles implements ShouldQueue
             })
             ->when(! $this->all_playlists && $playlistId, function ($query) use ($playlistId) {
                 $query->where('playlist_id', $playlistId);
+            })
+            ->when($this->channel_ids !== null, function ($query) {
+                $query->whereIn('id', $this->channel_ids);
             });
     }
 

--- a/tests/Feature/BulkStrmSyncDispatchTest.php
+++ b/tests/Feature/BulkStrmSyncDispatchTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use App\Jobs\RefreshMediaServerLibraryJob;
+use App\Jobs\SyncSeriesStrmFiles;
+use App\Jobs\SyncVodStrmFiles;
+use App\Models\Category;
+use App\Models\Channel;
+use App\Models\Group;
+use App\Models\MediaServerIntegration;
+use App\Models\Playlist;
+use App\Models\Series;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+it('marks RefreshMediaServerLibraryJob as ShouldBeUnique scoped per integration', function () {
+    // Use an unsaved model to avoid the `created` observer dispatching SyncMediaServer
+    $integration = new MediaServerIntegration([
+        'name' => 'Test Server',
+        'type' => 'jellyfin',
+        'host' => '127.0.0.1',
+        'api_key' => 'k',
+        'user_id' => $this->user->id,
+    ]);
+    $integration->id = 42;
+
+    $job = new RefreshMediaServerLibraryJob($integration);
+
+    expect($job)->toBeInstanceOf(ShouldBeUnique::class);
+    expect($job->uniqueId())->toBe('refresh-media-server-'.$integration->id);
+    expect($job->uniqueFor)->toBeGreaterThan(0);
+});
+
+it('dispatches a single SyncSeriesStrmFiles job with series_ids when bulk-syncing series', function () {
+    Bus::fake();
+
+    $playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+    $category = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+    ]);
+
+    $seriesCollection = Series::factory()->count(5)->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+        'category_id' => $category->id,
+        'enabled' => true,
+    ]);
+
+    $this->actingAs($this->user);
+
+    // Simulate exactly what the SeriesResource bulk action now does
+    $seriesIds = $seriesCollection->pluck('id')->all();
+    dispatch(new SyncSeriesStrmFiles(
+        user_id: $this->user->id,
+        series_ids: $seriesIds,
+    ));
+
+    Bus::assertDispatchedTimes(SyncSeriesStrmFiles::class, 1);
+    Bus::assertDispatched(SyncSeriesStrmFiles::class, function (SyncSeriesStrmFiles $job) use ($seriesIds) {
+        return $job->series_ids === $seriesIds
+            && $job->user_id === $this->user->id
+            && $job->series === null;
+    });
+});
+
+it('dispatches a single SyncVodStrmFiles job with channel_ids when bulk-syncing VOD groups', function () {
+    Bus::fake();
+
+    $playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+
+    $groups = Group::factory()->count(2)->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $playlist->id,
+    ]);
+
+    $channelIds = collect();
+    foreach ($groups as $group) {
+        $channels = Channel::factory()->count(3)->create([
+            'user_id' => $this->user->id,
+            'playlist_id' => $playlist->id,
+            'group_id' => $group->id,
+            'is_vod' => true,
+            'enabled' => true,
+        ]);
+        $channelIds = $channelIds->merge($channels->pluck('id'));
+    }
+
+    $this->actingAs($this->user);
+
+    // Simulate exactly what the VodGroupResource bulk action now does
+    $expectedIds = $groups
+        ->flatMap(fn ($group) => $group->enabled_channels->pluck('id'))
+        ->unique()
+        ->values()
+        ->all();
+
+    dispatch(new SyncVodStrmFiles(
+        user_id: $this->user->id,
+        channel_ids: $expectedIds,
+    ));
+
+    Bus::assertDispatchedTimes(SyncVodStrmFiles::class, 1);
+    Bus::assertDispatched(SyncVodStrmFiles::class, function (SyncVodStrmFiles $job) use ($expectedIds) {
+        return $job->channel_ids === $expectedIds
+            && $job->user_id === $this->user->id
+            && $job->channel === null
+            && $job->channels === null;
+    });
+
+    expect(count($expectedIds))->toBe(6);
+});
+
+it('SyncSeriesStrmFiles exposes series_ids constructor parameter on the job payload', function () {
+    $job = new SyncSeriesStrmFiles(
+        user_id: $this->user->id,
+        series_ids: [1, 2, 3],
+    );
+
+    expect($job->series_ids)->toBe([1, 2, 3]);
+    expect($job->series)->toBeNull();
+});
+
+it('SyncVodStrmFiles exposes channel_ids constructor parameter on the job payload', function () {
+    $job = new SyncVodStrmFiles(
+        user_id: $this->user->id,
+        channel_ids: [10, 20, 30],
+    );
+
+    expect($job->channel_ids)->toBe([10, 20, 30]);
+    expect($job->channel)->toBeNull();
+});

--- a/tests/Feature/BulkStrmSyncDispatchTest.php
+++ b/tests/Feature/BulkStrmSyncDispatchTest.php
@@ -81,16 +81,14 @@ it('dispatches a single SyncVodStrmFiles job with channel_ids when bulk-syncing 
         'playlist_id' => $playlist->id,
     ]);
 
-    $channelIds = collect();
     foreach ($groups as $group) {
-        $channels = Channel::factory()->count(3)->create([
+        Channel::factory()->count(3)->create([
             'user_id' => $this->user->id,
             'playlist_id' => $playlist->id,
             'group_id' => $group->id,
             'is_vod' => true,
             'enabled' => true,
         ]);
-        $channelIds = $channelIds->merge($channels->pluck('id'));
     }
 
     $this->actingAs($this->user);


### PR DESCRIPTION
Previously, bulk-syncing N series/VOD channels via Filament actions dispatched N independent SyncSeriesStrmFiles / SyncVodStrmFiles jobs, each of which dispatched its own RefreshMediaServerLibraryJob, causing N HTTP refresh calls and N user notifications (e.g. 2178 notifications for a 2178-series sync).

Fix has two layers:

1. Bulk-aware sync jobs:
   - SyncSeriesStrmFiles: new optional series_ids parameter; when set, batching, cleanup and media server refresh are scoped to those IDs. Propagated through CheckSeriesStrmProgress.
   - SyncVodStrmFiles: same pattern with channel_ids, propagated through CheckVodStrmProgress.
   - All Filament bulk/group actions (Series, Categories, VodGroups) now dispatch a single job with the collected IDs instead of looping.

2. Belt-and-suspenders dedup at the refresh job:
   - RefreshMediaServerLibraryJob now implements ShouldBeUnique with uniqueId scoped per integration and uniqueFor=300s, so any burst of duplicate dispatches collapses to a single execution and a single notification per integration.