### PR TITLE
feat: Add HLS fMP4 default profile preset

### DIFF
--- a/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
+++ b/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
@@ -46,6 +46,14 @@ class ListStreamProfiles extends ListRecords
                         ],
                         [
                             'user_id' => $userId,
+                            'name' => 'Default HLS fMP4 Profile',
+                            'description' => 'HLS with fragmented MP4 (CMAF) segments — required for Apple AVKit on tvOS to play HEVC/H.265 streams.',
+                            'backend' => 'ffmpeg',
+                            'format' => 'm3u8',
+                            'args' => '-fflags +genpts+discardcorrupt+igndts -i {input_url} -c:v libx264 -preset faster -b:v {bitrate|2000k} -maxrate {maxrate|2500k} -bufsize {bufsize|2500k} -c:a aac -b:a {audio_bitrate|128k} -hls_time 2 -hls_list_size 30 -hls_flags program_date_time -hls_segment_type fmp4 -f hls {output_args|index.m3u8}',
+                        ],
+                        [
+                            'user_id' => $userId,
                             'name' => 'Default Streamlink Profile',
                             'description' => 'For platforms like Twitch and YouTube — extracts the stream directly without re-encoding.',
                             'backend' => 'streamlink',


### PR DESCRIPTION
## Summary

- Adds a fifth preset, **"Default HLS fMP4 Profile"**, to the *Generate Default Profiles* action on the Stream Profiles list page
- Mirrors the existing "Default HLS Profile" exactly except it flips `-hls_segment_type fmp4`, so ffmpeg emits an `init.mp4` + `*.m4s` segments instead of `.ts` segments

## Why

Pairs with m3ue/m3u-proxy#52, which fixes pass-through of fMP4 segments. Together they let users:

- Pass through provider-supplied fMP4/CMAF streams cleanly (proxy-side fix)
- Or transcode any source — including TS upstreams — to fMP4 HLS output via this new profile preset, for Apple AVKit / tvOS / Safari compatibility (this PR)

## What changed

One file — `app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php`. New entry in the `defaultProfiles` array, mirroring the existing HLS preset structure. No schema change, no new dependencies.

## Test plan

- [x] Pint clean
- [x] End-to-end verified: assigned the new preset to a live channel, ffmpeg generated `init.mp4` + `index*.m4s` files in the proxy's `hls_dir`, manifest served to the player references `/segment.m4s` and `/segment.mp4` URLs (via the paired m3u-proxy PR), playback confirmed in the floating player

Note: this preset assumes the paired m3u-proxy PR is deployed — without it, fMP4 segments still get served with the wrong Content-Type and players reject them.