### PR TITLE
feat: Bulk-assign stream profile to channels and groups

### DIFF
--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -978,6 +978,47 @@ class ChannelResource extends Resource implements CopilotResource
 
             // -- Streaming --
             BulkModalActionGroup::section('Streaming', [
+                BulkAction::make('set-stream-profile')
+                    ->label(__('Set Stream Profile'))
+                    ->schema([
+                        Select::make('stream_profile_id')
+                            ->label(__('Stream Profile'))
+                            ->options(fn () => StreamProfile::where('user_id', auth()->id())->pluck('name', 'id'))
+                            ->searchable()
+                            ->preload()
+                            ->nullable()
+                            ->placeholder(__('None (clear profile)'))
+                            ->helperText(__('The stored profile only takes effect when the channel (or its playlist) has proxy enabled.')),
+                        Toggle::make('overwrite_existing')
+                            ->label(__('Overwrite existing assignments'))
+                            ->helperText(__('When off, only channels without a stream profile will be updated. When on, all selected channels will be overwritten (including clearing back to none).'))
+                            ->default(false),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        $profileId = ! empty($data['stream_profile_id']) ? (int) $data['stream_profile_id'] : null;
+                        $overwrite = (bool) ($data['overwrite_existing'] ?? false);
+                        $updated = 0;
+
+                        foreach ($records->chunk(100) as $chunk) {
+                            $query = Channel::whereIn('id', $chunk->pluck('id'));
+                            if (! $overwrite) {
+                                $query->whereNull('stream_profile_id');
+                            }
+                            $updated += $query->update(['stream_profile_id' => $profileId]);
+                        }
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Stream profile updated'))
+                            ->body(trans_choice(':count channel updated|:count channels updated', $updated, ['count' => $updated]))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-cog-6-tooth')
+                    ->modalIcon('heroicon-o-cog-6-tooth')
+                    ->modalDescription(__('Assign (or clear) a stream profile for the selected channels.'))
+                    ->modalSubmitActionLabel(__('Apply')),
                 BulkAction::make('enable-merge')
                     ->label(__('Enable Merge'))
                     ->action(function (Collection $records, array $data): void {

--- a/app/Filament/Resources/Groups/GroupResource.php
+++ b/app/Filament/Resources/Groups/GroupResource.php
@@ -13,6 +13,7 @@ use App\Jobs\SyncPlexDvrJob;
 use App\Models\Channel;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Models\StreamProfile;
 use App\Services\DateFormatService;
 use App\Services\FindReplaceService;
 use App\Services\PlaylistService;
@@ -206,6 +207,52 @@ class GroupResource extends Resource implements CopilotResource
                         ->modalDescription(__('Move the group channels to the another group.'))
                         ->modalSubmitActionLabel(__('Move now')),
 
+                    Action::make('set-stream-profile')
+                        ->label(__('Set Stream Profile'))
+                        ->schema([
+                            Select::make('stream_profile_id')
+                                ->label(__('Stream Profile'))
+                                ->options(fn () => StreamProfile::where('user_id', auth()->id())->pluck('name', 'id'))
+                                ->searchable()
+                                ->preload()
+                                ->nullable()
+                                ->placeholder(__('None (clear profile)')),
+                            Toggle::make('overwrite_existing')
+                                ->label(__('Overwrite existing channel assignments'))
+                                ->helperText(__('When off, only channels without a stream profile will be updated. When on, all live channels in this group will be overwritten.'))
+                                ->default(false),
+                            Toggle::make('apply_to_new_channels')
+                                ->label(__('Apply to channels added later'))
+                                ->helperText(__('Save this profile on the group so future channels added to it inherit the assignment automatically. Disable to leave the saved group default unchanged.'))
+                                ->default(false),
+                        ])
+                        ->action(function (Group $record, array $data): void {
+                            $profileId = ! empty($data['stream_profile_id']) ? (int) $data['stream_profile_id'] : null;
+                            $overwrite = (bool) ($data['overwrite_existing'] ?? false);
+                            $persist = (bool) ($data['apply_to_new_channels'] ?? false);
+
+                            $query = $record->live_channels();
+                            if (! $overwrite) {
+                                $query->whereNull('stream_profile_id');
+                            }
+                            $updated = $query->update(['stream_profile_id' => $profileId]);
+
+                            if ($persist) {
+                                $record->update(['stream_profile_id' => $profileId]);
+                            }
+
+                            Notification::make()
+                                ->success()
+                                ->title(__('Stream profile updated'))
+                                ->body(trans_choice(':count channel updated|:count channels updated', $updated, ['count' => $updated]))
+                                ->send();
+                        })
+                        ->requiresConfirmation()
+                        ->icon('heroicon-o-cog-6-tooth')
+                        ->modalIcon('heroicon-o-cog-6-tooth')
+                        ->modalDescription(__('Assign a stream profile to all live channels in this group.'))
+                        ->modalSubmitActionLabel(__('Apply')),
+
                     Action::make('recount')
                         ->label(__('Recount Channels'))
                         ->icon('heroicon-o-hashtag')
@@ -396,6 +443,55 @@ class GroupResource extends Resource implements CopilotResource
                         ->modalIcon('heroicon-o-arrows-right-left')
                         ->modalDescription(__('Move the group channels to the another group.'))
                         ->modalSubmitActionLabel(__('Move now')),
+                    BulkAction::make('set-stream-profile')
+                        ->label(__('Set Stream Profile'))
+                        ->schema([
+                            Select::make('stream_profile_id')
+                                ->label(__('Stream Profile'))
+                                ->options(fn () => StreamProfile::where('user_id', auth()->id())->pluck('name', 'id'))
+                                ->searchable()
+                                ->preload()
+                                ->nullable()
+                                ->placeholder(__('None (clear profile)')),
+                            Toggle::make('overwrite_existing')
+                                ->label(__('Overwrite existing channel assignments'))
+                                ->helperText(__('When off, only channels without a stream profile will be updated. When on, all live channels in the selected groups will be overwritten.'))
+                                ->default(false),
+                            Toggle::make('apply_to_new_channels')
+                                ->label(__('Apply to channels added later'))
+                                ->helperText(__('Save this profile on the group so future channels added to it inherit the assignment automatically. Disable to leave the saved group default unchanged.'))
+                                ->default(false),
+                        ])
+                        ->action(function (Collection $records, array $data): void {
+                            $profileId = ! empty($data['stream_profile_id']) ? (int) $data['stream_profile_id'] : null;
+                            $overwrite = (bool) ($data['overwrite_existing'] ?? false);
+                            $persist = (bool) ($data['apply_to_new_channels'] ?? false);
+                            $updated = 0;
+
+                            foreach ($records as $group) {
+                                $query = $group->live_channels();
+                                if (! $overwrite) {
+                                    $query->whereNull('stream_profile_id');
+                                }
+                                $updated += $query->update(['stream_profile_id' => $profileId]);
+
+                                if ($persist) {
+                                    $group->update(['stream_profile_id' => $profileId]);
+                                }
+                            }
+
+                            Notification::make()
+                                ->success()
+                                ->title(__('Stream profile updated'))
+                                ->body(trans_choice(':count channel updated|:count channels updated', $updated, ['count' => $updated]))
+                                ->send();
+                        })
+                        ->deselectRecordsAfterCompletion()
+                        ->requiresConfirmation()
+                        ->icon('heroicon-o-cog-6-tooth')
+                        ->modalIcon('heroicon-o-cog-6-tooth')
+                        ->modalDescription(__('Assign a stream profile to all live channels in the selected group(s).'))
+                        ->modalSubmitActionLabel(__('Apply')),
                     BulkAction::make('enable')
                         ->label(__('Enable Group Channels'))
                         ->action(function (Collection $records): void {

--- a/app/Filament/Resources/VodGroups/VodGroupResource.php
+++ b/app/Filament/Resources/VodGroups/VodGroupResource.php
@@ -13,6 +13,7 @@ use App\Jobs\ProcessVodChannels;
 use App\Jobs\SyncVodStrmFiles;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Models\StreamProfile;
 use App\Services\DateFormatService;
 use App\Services\FindReplaceService;
 use App\Services\PlaylistService;
@@ -206,6 +207,52 @@ class VodGroupResource extends Resource implements CopilotResource
                         ->modalIcon('heroicon-o-arrows-right-left')
                         ->modalDescription(__('Move the group channels to the another group.'))
                         ->modalSubmitActionLabel(__('Move now')),
+
+                    Action::make('set-stream-profile')
+                        ->label(__('Set Stream Profile'))
+                        ->schema([
+                            Select::make('stream_profile_id')
+                                ->label(__('Stream Profile'))
+                                ->options(fn () => StreamProfile::where('user_id', auth()->id())->pluck('name', 'id'))
+                                ->searchable()
+                                ->preload()
+                                ->nullable()
+                                ->placeholder(__('None (clear profile)')),
+                            Toggle::make('overwrite_existing')
+                                ->label(__('Overwrite existing channel assignments'))
+                                ->helperText(__('When off, only channels without a stream profile will be updated. When on, all VOD channels in this group will be overwritten.'))
+                                ->default(false),
+                            Toggle::make('apply_to_new_channels')
+                                ->label(__('Apply to channels added later'))
+                                ->helperText(__('Save this profile on the group so future channels added to it inherit the assignment automatically. Disable to leave the saved group default unchanged.'))
+                                ->default(false),
+                        ])
+                        ->action(function (Group $record, array $data): void {
+                            $profileId = ! empty($data['stream_profile_id']) ? (int) $data['stream_profile_id'] : null;
+                            $overwrite = (bool) ($data['overwrite_existing'] ?? false);
+                            $persist = (bool) ($data['apply_to_new_channels'] ?? false);
+
+                            $query = $record->vod_channels();
+                            if (! $overwrite) {
+                                $query->whereNull('stream_profile_id');
+                            }
+                            $updated = $query->update(['stream_profile_id' => $profileId]);
+
+                            if ($persist) {
+                                $record->update(['stream_profile_id' => $profileId]);
+                            }
+
+                            Notification::make()
+                                ->success()
+                                ->title(__('Stream profile updated'))
+                                ->body(trans_choice(':count channel updated|:count channels updated', $updated, ['count' => $updated]))
+                                ->send();
+                        })
+                        ->requiresConfirmation()
+                        ->icon('heroicon-o-cog-6-tooth')
+                        ->modalIcon('heroicon-o-cog-6-tooth')
+                        ->modalDescription(__('Assign a stream profile to all VOD channels in this group.'))
+                        ->modalSubmitActionLabel(__('Apply')),
 
                     Action::make('recount')
                         ->label(__('Recount Channels'))
@@ -428,6 +475,55 @@ class VodGroupResource extends Resource implements CopilotResource
                         ->modalIcon('heroicon-o-arrows-right-left')
                         ->modalDescription(__('Move the group channels to the another group.'))
                         ->modalSubmitActionLabel(__('Move now')),
+                    BulkAction::make('set-stream-profile')
+                        ->label(__('Set Stream Profile'))
+                        ->schema([
+                            Select::make('stream_profile_id')
+                                ->label(__('Stream Profile'))
+                                ->options(fn () => StreamProfile::where('user_id', auth()->id())->pluck('name', 'id'))
+                                ->searchable()
+                                ->preload()
+                                ->nullable()
+                                ->placeholder(__('None (clear profile)')),
+                            Toggle::make('overwrite_existing')
+                                ->label(__('Overwrite existing channel assignments'))
+                                ->helperText(__('When off, only channels without a stream profile will be updated. When on, all VOD channels in the selected groups will be overwritten.'))
+                                ->default(false),
+                            Toggle::make('apply_to_new_channels')
+                                ->label(__('Apply to channels added later'))
+                                ->helperText(__('Save this profile on the group so future channels added to it inherit the assignment automatically. Disable to leave the saved group default unchanged.'))
+                                ->default(false),
+                        ])
+                        ->action(function (Collection $records, array $data): void {
+                            $profileId = ! empty($data['stream_profile_id']) ? (int) $data['stream_profile_id'] : null;
+                            $overwrite = (bool) ($data['overwrite_existing'] ?? false);
+                            $persist = (bool) ($data['apply_to_new_channels'] ?? false);
+                            $updated = 0;
+
+                            foreach ($records as $group) {
+                                $query = $group->vod_channels();
+                                if (! $overwrite) {
+                                    $query->whereNull('stream_profile_id');
+                                }
+                                $updated += $query->update(['stream_profile_id' => $profileId]);
+
+                                if ($persist) {
+                                    $group->update(['stream_profile_id' => $profileId]);
+                                }
+                            }
+
+                            Notification::make()
+                                ->success()
+                                ->title(__('Stream profile updated'))
+                                ->body(trans_choice(':count channel updated|:count channels updated', $updated, ['count' => $updated]))
+                                ->send();
+                        })
+                        ->deselectRecordsAfterCompletion()
+                        ->requiresConfirmation()
+                        ->icon('heroicon-o-cog-6-tooth')
+                        ->modalIcon('heroicon-o-cog-6-tooth')
+                        ->modalDescription(__('Assign a stream profile to all VOD channels in the selected group(s).'))
+                        ->modalSubmitActionLabel(__('Apply')),
                     BulkAction::make('enable')
                         ->label(__('Enable Group Channels'))
                         ->action(function (Collection $records): void {

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -1106,6 +1106,47 @@ class VodResource extends Resource implements CopilotResource
 
             // -- Streaming --
             BulkModalActionGroup::section('Streaming', [
+                BulkAction::make('set-stream-profile')
+                    ->label(__('Set Stream Profile'))
+                    ->schema([
+                        Select::make('stream_profile_id')
+                            ->label(__('Stream Profile'))
+                            ->options(fn () => StreamProfile::where('user_id', auth()->id())->pluck('name', 'id'))
+                            ->searchable()
+                            ->preload()
+                            ->nullable()
+                            ->placeholder(__('None (clear profile)'))
+                            ->helperText(__('The stored profile only takes effect when the channel (or its playlist) has proxy enabled.')),
+                        Toggle::make('overwrite_existing')
+                            ->label(__('Overwrite existing assignments'))
+                            ->helperText(__('When off, only channels without a stream profile will be updated. When on, all selected channels will be overwritten (including clearing back to none).'))
+                            ->default(false),
+                    ])
+                    ->action(function (Collection $records, array $data): void {
+                        $profileId = ! empty($data['stream_profile_id']) ? (int) $data['stream_profile_id'] : null;
+                        $overwrite = (bool) ($data['overwrite_existing'] ?? false);
+                        $updated = 0;
+
+                        foreach ($records->chunk(100) as $chunk) {
+                            $query = Channel::whereIn('id', $chunk->pluck('id'));
+                            if (! $overwrite) {
+                                $query->whereNull('stream_profile_id');
+                            }
+                            $updated += $query->update(['stream_profile_id' => $profileId]);
+                        }
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Stream profile updated'))
+                            ->body(trans_choice(':count channel updated|:count channels updated', $updated, ['count' => $updated]))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion()
+                    ->requiresConfirmation()
+                    ->icon('heroicon-o-cog-6-tooth')
+                    ->modalIcon('heroicon-o-cog-6-tooth')
+                    ->modalDescription(__('Assign (or clear) a stream profile for the selected channels.'))
+                    ->modalSubmitActionLabel(__('Apply')),
                 BulkAction::make('enable-merge')
                     ->label(__('Enable Merge'))
                     ->action(function (Collection $records, array $data): void {

--- a/app/Jobs/ProcessM3uImportChunk.php
+++ b/app/Jobs/ProcessM3uImportChunk.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Channel;
+use App\Models\Group;
 use App\Models\Job;
 use App\Models\Playlist;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -49,6 +50,12 @@ class ProcessM3uImportChunk implements ShouldQueue
             // Add the channel for insert/update
             $groupId = $job->variables['groupId'];
             $groupName = $job->variables['groupName'];
+            // Inherit the group's saved stream_profile_id for newly inserted rows.
+            // The upsert below excludes stream_profile_id from its update list, so
+            // existing channel profile assignments survive re-imports.
+            $groupProfileId = $groupId
+                ? Group::query()->whereKey($groupId)->value('stream_profile_id')
+                : null;
             foreach ($job->payload as $channel) {
                 // Make sure name is set
                 if (! isset($channel['name'])) {
@@ -56,11 +63,15 @@ class ProcessM3uImportChunk implements ShouldQueue
                 }
 
                 // Add the channel for insert/update
-                $bulk[] = [
+                $row = [
                     ...$channel,
                     'group' => $groupName ?? null,
                     'group_id' => $groupId ?? null,
                 ];
+                if ($groupProfileId !== null && empty($row['stream_profile_id'])) {
+                    $row['stream_profile_id'] = $groupProfileId;
+                }
+                $bulk[] = $row;
             }
 
             // Assign source_id via collision-relative hashing.

--- a/app/Jobs/ProcessM3uVodImportChunk.php
+++ b/app/Jobs/ProcessM3uVodImportChunk.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Channel;
+use App\Models\Group;
 use App\Models\Job;
 use App\Models\Playlist;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -49,6 +50,12 @@ class ProcessM3uVodImportChunk implements ShouldQueue
             // Add the channel for insert/update
             $groupId = $job->variables['groupId'];
             $groupName = $job->variables['groupName'];
+            // Inherit the group's saved stream_profile_id for newly inserted rows.
+            // The upsert below excludes stream_profile_id from its update list, so
+            // existing channel profile assignments survive re-imports.
+            $groupProfileId = $groupId
+                ? Group::query()->whereKey($groupId)->value('stream_profile_id')
+                : null;
             foreach ($job->payload as $channel) {
                 // Make sure name is set
                 if (! isset($channel['name'])) {
@@ -56,11 +63,15 @@ class ProcessM3uVodImportChunk implements ShouldQueue
                 }
 
                 // Add the channel for insert/update
-                $bulk[] = [
+                $row = [
                     ...$channel,
                     'group' => $groupName ?? null,
                     'group_id' => $groupId ?? null,
                 ];
+                if ($groupProfileId !== null && empty($row['stream_profile_id'])) {
+                    $row['stream_profile_id'] = $groupProfileId;
+                }
+                $bulk[] = $row;
             }
 
             // Assign source_id via collision-relative hashing.

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -21,6 +21,7 @@ class Group extends Model
         'id' => 'integer',
         'user_id' => 'integer',
         'playlist_id' => 'integer',
+        'stream_profile_id' => 'integer',
     ];
 
     public function user(): BelongsTo
@@ -36,6 +37,11 @@ class Group extends Model
     public function streamFileSetting(): BelongsTo
     {
         return $this->belongsTo(StreamFileSetting::class);
+    }
+
+    public function streamProfile(): BelongsTo
+    {
+        return $this->belongsTo(StreamProfile::class);
     }
 
     public function channels(): HasMany

--- a/app/Observers/ChannelObserver.php
+++ b/app/Observers/ChannelObserver.php
@@ -4,9 +4,32 @@ namespace App\Observers;
 
 use App\Jobs\SyncPlexDvrJob;
 use App\Models\Channel;
+use App\Models\Group;
 
 class ChannelObserver
 {
+    /**
+     * Handle the Channel "creating" event.
+     *
+     * Inherit the parent group's stream_profile_id when creating a new channel
+     * that has not been assigned one explicitly. Bulk imports via Channel::upsert()
+     * bypass model events; those paths inject the value into their payload directly.
+     */
+    public function creating(Channel $channel): void
+    {
+        if ($channel->stream_profile_id !== null || $channel->group_id === null) {
+            return;
+        }
+
+        $defaultProfileId = Group::query()
+            ->whereKey($channel->group_id)
+            ->value('stream_profile_id');
+
+        if ($defaultProfileId !== null) {
+            $channel->stream_profile_id = $defaultProfileId;
+        }
+    }
+
     /**
      * Handle the Channel "updated" event.
      *

--- a/database/migrations/2026_04_30_231322_add_stream_profile_id_to_groups_table.php
+++ b/database/migrations/2026_04_30_231322_add_stream_profile_id_to_groups_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->foreignId('stream_profile_id')
+                ->nullable()
+                ->after('playlist_id')
+                ->constrained()
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropForeign(['stream_profile_id']);
+            $table->dropColumn('stream_profile_id');
+        });
+    }
+};

--- a/tests/Feature/BulkSetStreamProfileTest.php
+++ b/tests/Feature/BulkSetStreamProfileTest.php
@@ -1,0 +1,373 @@
+<?php
+
+use App\Filament\Actions\BulkModalActionGroup;
+use App\Filament\Resources\Channels\ChannelResource;
+use App\Filament\Resources\Vods\VodResource;
+use App\Jobs\ProcessM3uImportChunk;
+use App\Models\Channel;
+use App\Models\Group;
+use App\Models\Job;
+use App\Models\Playlist;
+use App\Models\StreamProfile;
+use App\Models\User;
+use Filament\Actions\BulkAction;
+use Filament\Schemas\Components\Component;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    $this->playlist = Playlist::factory()->for($this->user)->createQuietly();
+    $this->profileA = StreamProfile::factory()->for($this->user)->create(['name' => 'Profile A']);
+    $this->profileB = StreamProfile::factory()->for($this->user)->create(['name' => 'Profile B']);
+});
+
+/**
+ * Flatten the names of every BulkAction registered inside a BulkModalActionGroup
+ * schema, regardless of whether they live under Fieldset sections or a flat Grid.
+ */
+function flattenBulkActionNames(array $bulkActions): array
+{
+    $group = $bulkActions[0];
+    $schemaProp = new ReflectionProperty($group, 'schema');
+    $outerSchema = $schemaProp->getValue($group);
+    $childProp = new ReflectionProperty(Component::class, 'childComponents');
+    $names = [];
+    foreach ($outerSchema as $component) {
+        $children = $childProp->getValue($component)['default'] ?? [];
+        foreach ($children as $child) {
+            if ($child instanceof BulkAction) {
+                $names[] = $child->getName();
+            }
+        }
+    }
+
+    return $names;
+}
+
+// ── Action registration ──────────────────────────────────────────────────────
+
+it('registers set-stream-profile inside the channel BulkModalActionGroup', function () {
+    expect(flattenBulkActionNames(ChannelResource::getTableBulkActions()))
+        ->toContain('set-stream-profile');
+});
+
+it('registers set-stream-profile inside the VOD BulkModalActionGroup', function () {
+    expect(flattenBulkActionNames(VodResource::getTableBulkActions()))
+        ->toContain('set-stream-profile');
+});
+
+// ── Channel bulk action: overwrite semantics ─────────────────────────────────
+
+/**
+ * Mirrors the SQL the bulk action executes. Returning the affected row count
+ * lets us assert on it the same way the action does for its success notification.
+ */
+function applyChannelStreamProfile($records, ?int $profileId, bool $overwrite): int
+{
+    $updated = 0;
+    foreach ($records->chunk(100) as $chunk) {
+        $query = Channel::whereIn('id', $chunk->pluck('id'));
+        if (! $overwrite) {
+            $query->whereNull('stream_profile_id');
+        }
+        $updated += $query->update(['stream_profile_id' => $profileId]);
+    }
+
+    return $updated;
+}
+
+it('assigns the profile to channels without one when overwrite is off', function () {
+    $channels = Channel::factory()->count(3)->for($this->user)->for($this->playlist)
+        ->create(['stream_profile_id' => null]);
+
+    $updated = applyChannelStreamProfile($channels, $this->profileA->id, overwrite: false);
+
+    expect($updated)->toBe(3);
+    foreach ($channels as $channel) {
+        expect($channel->fresh()->stream_profile_id)->toBe($this->profileA->id);
+    }
+});
+
+it('skips channels that already have a profile when overwrite is off', function () {
+    $assigned = Channel::factory()->for($this->user)->for($this->playlist)
+        ->create(['stream_profile_id' => $this->profileA->id]);
+    $blank = Channel::factory()->for($this->user)->for($this->playlist)
+        ->create(['stream_profile_id' => null]);
+
+    $updated = applyChannelStreamProfile(
+        Channel::whereIn('id', [$assigned->id, $blank->id])->get(),
+        $this->profileB->id,
+        overwrite: false,
+    );
+
+    expect($updated)->toBe(1);
+    expect($assigned->fresh()->stream_profile_id)->toBe($this->profileA->id);
+    expect($blank->fresh()->stream_profile_id)->toBe($this->profileB->id);
+});
+
+it('overwrites every selected channel when overwrite is on', function () {
+    $assigned = Channel::factory()->for($this->user)->for($this->playlist)
+        ->create(['stream_profile_id' => $this->profileA->id]);
+    $blank = Channel::factory()->for($this->user)->for($this->playlist)
+        ->create(['stream_profile_id' => null]);
+
+    $updated = applyChannelStreamProfile(
+        Channel::whereIn('id', [$assigned->id, $blank->id])->get(),
+        $this->profileB->id,
+        overwrite: true,
+    );
+
+    expect($updated)->toBe(2);
+    expect($assigned->fresh()->stream_profile_id)->toBe($this->profileB->id);
+    expect($blank->fresh()->stream_profile_id)->toBe($this->profileB->id);
+});
+
+it('clears profiles when null is passed with overwrite on', function () {
+    $channels = Channel::factory()->count(2)->for($this->user)->for($this->playlist)
+        ->create(['stream_profile_id' => $this->profileA->id]);
+
+    $updated = applyChannelStreamProfile($channels, null, overwrite: true);
+
+    expect($updated)->toBe(2);
+    foreach ($channels as $channel) {
+        expect($channel->fresh()->stream_profile_id)->toBeNull();
+    }
+});
+
+it('does not clear existing profiles when null is passed with overwrite off', function () {
+    $channels = Channel::factory()->count(2)->for($this->user)->for($this->playlist)
+        ->create(['stream_profile_id' => $this->profileA->id]);
+
+    $updated = applyChannelStreamProfile($channels, null, overwrite: false);
+
+    expect($updated)->toBe(0);
+    foreach ($channels as $channel) {
+        expect($channel->fresh()->stream_profile_id)->toBe($this->profileA->id);
+    }
+});
+
+// ── Group bulk action: only live, persistence toggle ─────────────────────────
+
+it('per-row action: updates only live channels in the single group', function () {
+    $group = Group::factory()->for($this->user)->for($this->playlist)
+        ->create(['type' => 'live', 'stream_profile_id' => null]);
+    $live = Channel::factory()->count(2)->for($this->user)->for($this->playlist)
+        ->create(['group_id' => $group->id, 'is_vod' => false, 'stream_profile_id' => null]);
+    $vod = Channel::factory()->for($this->user)->for($this->playlist)
+        ->create(['group_id' => $group->id, 'is_vod' => true, 'stream_profile_id' => null]);
+
+    $group->live_channels()->whereNull('stream_profile_id')
+        ->update(['stream_profile_id' => $this->profileA->id]);
+
+    foreach ($live as $channel) {
+        expect($channel->fresh()->stream_profile_id)->toBe($this->profileA->id);
+    }
+    expect($vod->fresh()->stream_profile_id)->toBeNull();
+});
+
+it('per-row action: persists group default when apply_to_new_channels is on', function () {
+    $group = Group::factory()->for($this->user)->for($this->playlist)
+        ->create(['type' => 'live', 'stream_profile_id' => null]);
+
+    $group->update(['stream_profile_id' => $this->profileA->id]);
+
+    expect($group->fresh()->stream_profile_id)->toBe($this->profileA->id);
+});
+
+it('updates only live channels when applying via a live group', function () {
+    $liveGroup = Group::factory()->for($this->user)->for($this->playlist)
+        ->create(['type' => 'live']);
+
+    $live = Channel::factory()->count(2)->for($this->user)->for($this->playlist)
+        ->create(['group_id' => $liveGroup->id, 'is_vod' => false, 'stream_profile_id' => null]);
+    $vod = Channel::factory()->for($this->user)->for($this->playlist)
+        ->create(['group_id' => $liveGroup->id, 'is_vod' => true, 'stream_profile_id' => null]);
+
+    $liveGroup->live_channels()->whereNull('stream_profile_id')
+        ->update(['stream_profile_id' => $this->profileA->id]);
+
+    foreach ($live as $channel) {
+        expect($channel->fresh()->stream_profile_id)->toBe($this->profileA->id);
+    }
+    expect($vod->fresh()->stream_profile_id)->toBeNull();
+});
+
+it('persists stream_profile_id on the group when apply_to_new_channels is on', function () {
+    $group = Group::factory()->for($this->user)->for($this->playlist)
+        ->create(['type' => 'live', 'stream_profile_id' => null]);
+
+    $group->update(['stream_profile_id' => $this->profileA->id]);
+
+    expect($group->fresh()->stream_profile_id)->toBe($this->profileA->id);
+});
+
+it('leaves the group default unchanged when apply_to_new_channels is off', function () {
+    $group = Group::factory()->for($this->user)->for($this->playlist)
+        ->create(['type' => 'live', 'stream_profile_id' => $this->profileA->id]);
+
+    Channel::factory()->for($this->user)->for($this->playlist)
+        ->create(['group_id' => $group->id, 'is_vod' => false, 'stream_profile_id' => null]);
+
+    $group->live_channels()->whereNull('stream_profile_id')
+        ->update(['stream_profile_id' => $this->profileB->id]);
+
+    expect($group->fresh()->stream_profile_id)->toBe($this->profileA->id);
+});
+
+// ── Observer: inherit group default on Channel::create() ─────────────────────
+
+it('inherits the group stream_profile_id when creating a channel without one', function () {
+    $group = Group::factory()->for($this->user)->for($this->playlist)
+        ->create(['type' => 'live', 'stream_profile_id' => $this->profileA->id]);
+
+    $channel = Channel::create([
+        'name' => 'Inheriting Channel',
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $group->id,
+        'is_vod' => false,
+    ]);
+
+    expect($channel->stream_profile_id)->toBe($this->profileA->id);
+});
+
+it('keeps an explicit channel stream_profile_id over the group default', function () {
+    $group = Group::factory()->for($this->user)->for($this->playlist)
+        ->create(['type' => 'live', 'stream_profile_id' => $this->profileA->id]);
+
+    $channel = Channel::create([
+        'name' => 'Explicit Channel',
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $group->id,
+        'is_vod' => false,
+        'stream_profile_id' => $this->profileB->id,
+    ]);
+
+    expect($channel->stream_profile_id)->toBe($this->profileB->id);
+});
+
+it('leaves stream_profile_id null when the group has no default', function () {
+    $group = Group::factory()->for($this->user)->for($this->playlist)
+        ->create(['type' => 'live', 'stream_profile_id' => null]);
+
+    $channel = Channel::create([
+        'name' => 'No Inheritance',
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $group->id,
+        'is_vod' => false,
+    ]);
+
+    expect($channel->stream_profile_id)->toBeNull();
+});
+
+it('leaves stream_profile_id null when the channel has no group', function () {
+    $channel = Channel::create([
+        'name' => 'Orphan Channel',
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => null,
+        'is_vod' => false,
+    ]);
+
+    expect($channel->stream_profile_id)->toBeNull();
+});
+
+// ── Import chunk: inject group default; preserve existing on re-import ───────
+
+beforeEach(function () {
+    $this->tempJobsDb = sys_get_temp_dir().'/jobs_test_'.uniqid().'.sqlite';
+    touch($this->tempJobsDb);
+    config(['database.connections.jobs.database' => $this->tempJobsDb]);
+    DB::purge('jobs');
+    $migration = require database_path('migrations/2025_02_13_215803_create_jobs_table.php');
+    $migration->up();
+});
+
+afterEach(function () {
+    DB::purge('jobs');
+    config(['database.connections.jobs.database' => database_path('jobs.sqlite')]);
+    if (isset($this->tempJobsDb) && file_exists($this->tempJobsDb)) {
+        @unlink($this->tempJobsDb);
+    }
+});
+
+it('injects the group stream_profile_id into newly imported channels', function () {
+    $group = Group::factory()->for($this->user)->for($this->playlist)
+        ->create(['type' => 'live', 'stream_profile_id' => $this->profileA->id]);
+
+    $job = Job::create([
+        'title' => 'Import test',
+        'batch_no' => 'test-batch-1',
+        'variables' => [
+            'playlistId' => $this->playlist->id,
+            'groupId' => $group->id,
+            'groupName' => $group->name,
+        ],
+        'payload' => [
+            [
+                'name' => 'New Live Channel',
+                'title' => 'New Live Channel',
+                'url' => 'http://example.test/stream/1',
+                'source_id' => 'new-channel-1',
+                'user_id' => $this->user->id,
+                'playlist_id' => $this->playlist->id,
+                'is_vod' => false,
+                'enabled' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ],
+    ]);
+
+    (new ProcessM3uImportChunk([$job->id], 1))->handle();
+
+    $channel = Channel::where('source_id', 'new-channel-1')->first();
+    expect($channel)->not->toBeNull();
+    expect($channel->stream_profile_id)->toBe($this->profileA->id);
+});
+
+it('does not overwrite an existing channel stream_profile_id on re-import', function () {
+    $group = Group::factory()->for($this->user)->for($this->playlist)
+        ->create(['type' => 'live', 'stream_profile_id' => $this->profileA->id]);
+
+    $existing = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'group_id' => $group->id,
+        'source_id' => 'existing-channel-1',
+        'is_vod' => false,
+        'stream_profile_id' => $this->profileB->id,
+    ]);
+
+    $job = Job::create([
+        'title' => 'Re-import test',
+        'batch_no' => 'test-batch-2',
+        'variables' => [
+            'playlistId' => $this->playlist->id,
+            'groupId' => $group->id,
+            'groupName' => $group->name,
+        ],
+        'payload' => [
+            [
+                'name' => $existing->name,
+                'title' => $existing->title ?? $existing->name,
+                'url' => 'http://example.test/stream/updated',
+                'source_id' => 'existing-channel-1',
+                'user_id' => $this->user->id,
+                'playlist_id' => $this->playlist->id,
+                'is_vod' => false,
+                'enabled' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ],
+    ]);
+
+    (new ProcessM3uImportChunk([$job->id], 1))->handle();
+
+    expect($existing->fresh()->stream_profile_id)->toBe($this->profileB->id);
+});


### PR DESCRIPTION
## Summary

Adds a **Set Stream Profile** action so a profile can be applied to many records in one step rather than opening each channel's edit pane individually.

**Where it lives:**
- Channel + VOD bulk modals — under the existing **Streaming** section
- Live + VOD group bulk toolbar
- Live + VOD group per-row (three-dots) menu

**Form:**
- `Stream Profile` — searchable select; pick `None` to clear
- `Overwrite existing assignments` — default **off**. When off, only channels with a null profile are touched; already-set channels (e.g. a hand-tuned BBC One) are preserved. When on, all selected channels are reassigned (or cleared if `None` is picked).
- Group actions add `Apply to channels added later` — saves the profile on the group itself so new channels imported into the group inherit it automatically.

**Auto-inheritance for new channels:**
- `ChannelObserver::creating()` covers `Channel::create()` / `updateOrCreate()` paths.
- `ProcessM3uImportChunk` and `ProcessM3uVodImportChunk` inject the group's `stream_profile_id` into their bulk payload, since `Channel::upsert()` bypasses model events.
- The upsert's `update:` list still excludes `stream_profile_id`, so re-imports never overwrite existing per-channel assignments.

**Schema change:** `groups.stream_profile_id` (nullable FK, `nullOnDelete`).

## Test plan

- [x] On the **Live Channels** list, multi-select a few channels with mixed profile state; run the bulk **Set Stream Profile** action with overwrite off — only previously-null channels should change.
- [x] Repeat with overwrite on — every selected channel switches to the chosen profile (including being cleared when `None` is picked).
- [x] Same on the **VOD** list.
- [x] On the **Live Groups** page, three-dots a single group → **Set Stream Profile** with `Apply to channels added later` on; confirm the group default sticks and existing live channels update.
- [x] Repeat from the bulk toolbar across multiple selected live groups; confirm only `live_channels` are touched (a VOD channel that happens to share the group is left alone).
- [x] Same flow on **VOD Groups**, mirrored.
- [ ] After setting a group default, run a playlist re-sync; newly imported channels in that group inherit the default while existing channels keep their previously-set profile.