### PR TITLE
feat: Adaptive (rule-based) stream profiles

### DIFF
--- a/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
+++ b/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
@@ -99,9 +99,13 @@ class ListStreamProfiles extends ListRecords
 
     public function getTabs(): array
     {
-        $userId = auth()->id();
-        $totalCount = StreamProfile::where('user_id', $userId)->count();
-        $adaptiveCount = StreamProfile::where('user_id', $userId)->where('backend', 'adaptive')->count();
+        $counts = StreamProfile::where('user_id', auth()->id())
+            ->selectRaw('backend, COUNT(*) as cnt')
+            ->groupBy('backend')
+            ->pluck('cnt', 'backend');
+
+        $adaptiveCount = (int) $counts->get('adaptive', 0);
+        $totalCount = (int) $counts->sum();
         $transcodingCount = $totalCount - $adaptiveCount;
 
         return [

--- a/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
+++ b/app/Filament/Resources/StreamProfiles/Pages/ListStreamProfiles.php
@@ -7,6 +7,7 @@ use App\Models\StreamProfile;
 use Filament\Actions;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Schemas\Components\Tabs\Tab;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -94,5 +95,25 @@ class ListStreamProfiles extends ListRecords
     {
         return static::getResource()::getEloquentQuery()
             ->where('user_id', auth()->id());
+    }
+
+    public function getTabs(): array
+    {
+        $userId = auth()->id();
+        $totalCount = StreamProfile::where('user_id', $userId)->count();
+        $adaptiveCount = StreamProfile::where('user_id', $userId)->where('backend', 'adaptive')->count();
+        $transcodingCount = $totalCount - $adaptiveCount;
+
+        return [
+            'all' => Tab::make(__('All'))
+                ->badge($totalCount),
+            'transcoding' => Tab::make(__('Transcoding'))
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('backend', '!=', 'adaptive'))
+                ->badge($transcodingCount),
+            'adaptive' => Tab::make(__('Adaptive'))
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('backend', 'adaptive'))
+                ->badge($adaptiveCount)
+                ->badgeColor('success'),
+        ];
     }
 }

--- a/app/Filament/Resources/StreamProfiles/StreamProfileResource.php
+++ b/app/Filament/Resources/StreamProfiles/StreamProfileResource.php
@@ -227,7 +227,8 @@ class StreamProfileResource extends Resource implements CopilotResource
                                             ->label(__('Operator'))
                                             ->options(fn (Get $get): array => self::operatorsForField($get('field')))
                                             ->required()
-                                            ->live(),
+                                            ->live()
+                                            ->afterStateUpdated(fn (?string $state, Set $set) => $set('value', in_array($state, ['in', 'not_in'], true) ? [] : null)),
                                         TextInput::make('value')
                                             ->label(__('Value'))
                                             ->required()
@@ -236,8 +237,9 @@ class StreamProfileResource extends Resource implements CopilotResource
                                         TagsInput::make('value')
                                             ->label(__('Values'))
                                             ->required()
+                                            ->splitKeys([',', 'Tab'])
                                             ->visible(fn (Get $get): bool => in_array($get('op'), ['in', 'not_in'], true))
-                                            ->helperText(__('Press Enter after each value.')),
+                                            ->helperText(__('Press Enter, comma, or Tab after each value.')),
                                     ]),
                                 Select::make('stream_profile_id')
                                     ->label(__('Use this profile'))

--- a/app/Filament/Resources/StreamProfiles/StreamProfileResource.php
+++ b/app/Filament/Resources/StreamProfiles/StreamProfileResource.php
@@ -8,11 +8,14 @@ use App\Services\M3uProxyService;
 use EslamRedaDiv\FilamentCopilot\Contracts\CopilotResource;
 use Filament\Actions;
 use Filament\Actions\Action;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
@@ -74,6 +77,7 @@ class StreamProfileResource extends Resource implements CopilotResource
                         'ffmpeg' => 'FFmpeg (transcoding)',
                         'streamlink' => 'Streamlink',
                         'ytdlp' => 'yt-dlp',
+                        'adaptive' => 'Adaptive (rule-based)',
                     ])
                     ->searchable()
                     ->default('ffmpeg')
@@ -95,7 +99,7 @@ class StreamProfileResource extends Resource implements CopilotResource
                         }
                     })
                     ->columnSpanFull()
-                    ->helperText(__('FFmpeg re-encodes the stream. Streamlink and yt-dlp extract and deliver streams directly from supported platforms (Twitch, YouTube, etc.) without re-encoding.')),
+                    ->helperText(__('FFmpeg re-encodes the stream. Streamlink and yt-dlp extract and deliver streams directly from supported platforms (Twitch, YouTube, etc.) without re-encoding. Adaptive delegates to one of your existing transcoding profiles based on probed channel metadata.')),
 
                 Textarea::make('args')
                     ->label(fn (Get $get): string => match ($get('backend')) {
@@ -103,7 +107,8 @@ class StreamProfileResource extends Resource implements CopilotResource
                         'ytdlp' => __('Format Selector & Options'),
                         default => __('FFmpeg Template'),
                     })
-                    ->required()
+                    ->required(fn (Get $get): bool => $get('backend') !== 'adaptive')
+                    ->visible(fn (Get $get): bool => $get('backend') !== 'adaptive')
                     ->columnSpanFull()
                     ->rows(4)
                     ->hintAction(
@@ -183,13 +188,189 @@ class StreamProfileResource extends Resource implements CopilotResource
                         'mp3' => 'MP3 (.mp3)',
                     ])
                     ->default('ts')
-                    ->required()
+                    ->required(fn (Get $get): bool => $get('backend') !== 'adaptive')
+                    ->visible(fn (Get $get): bool => $get('backend') !== 'adaptive')
                     ->helperText(fn (Get $get): string => match ($get('backend')) {
                         'streamlink' => __('The container format Streamlink will output. This sets the URL extension (e.g. .ts, .mp4) so players know how to handle the stream. Must match the format Streamlink actually produces for the selected quality.'),
                         'ytdlp' => __('The container format yt-dlp will output. This sets the URL extension (e.g. .ts, .mp4) so players know how to handle the stream. Must match the format produced by your yt-dlp format selector.'),
                         default => __('The container format FFmpeg will produce. Must match the -f muxer argument in your FFmpeg template above.'),
                     }),
+
+                Section::make(__('Adaptive rules'))
+                    ->description(__('Pick a transcoding profile based on probed channel metadata. Rules are evaluated top to bottom; the first matching rule wins. Conditions inside a rule are ANDed; to express OR, add another rule pointing at the same profile.'))
+                    ->visible(fn (Get $get): bool => $get('backend') === 'adaptive')
+                    ->columnSpanFull()
+                    ->schema([
+                        Repeater::make('rules')
+                            ->label(__('Rules'))
+                            ->required(fn (Get $get): bool => $get('backend') === 'adaptive')
+                            ->minItems(1)
+                            ->reorderable(true)
+                            ->collapsible()
+                            ->itemLabel(fn (array $state): ?string => self::summarizeRule($state))
+                            ->addActionLabel(__('Add rule'))
+                            ->schema([
+                                Repeater::make('conditions')
+                                    ->label(__('All of these conditions must be true (AND)'))
+                                    ->minItems(1)
+                                    ->reorderable(false)
+                                    ->addActionLabel(__('Add condition'))
+                                    ->columns(3)
+                                    ->schema([
+                                        Select::make('field')
+                                            ->label(__('Field'))
+                                            ->options(self::ruleFieldOptions())
+                                            ->required()
+                                            ->searchable()
+                                            ->live(),
+                                        Select::make('op')
+                                            ->label(__('Operator'))
+                                            ->options(fn (Get $get): array => self::operatorsForField($get('field')))
+                                            ->required()
+                                            ->live(),
+                                        TextInput::make('value')
+                                            ->label(__('Value'))
+                                            ->required()
+                                            ->visible(fn (Get $get): bool => ! in_array($get('op'), ['in', 'not_in'], true))
+                                            ->placeholder(fn (Get $get): string => self::valuePlaceholder($get('field'))),
+                                        TagsInput::make('value')
+                                            ->label(__('Values'))
+                                            ->required()
+                                            ->visible(fn (Get $get): bool => in_array($get('op'), ['in', 'not_in'], true))
+                                            ->helperText(__('Press Enter after each value.')),
+                                    ]),
+                                Select::make('stream_profile_id')
+                                    ->label(__('Use this profile'))
+                                    ->options(fn (?StreamProfile $record) => self::transcodingProfileOptions($record))
+                                    ->required()
+                                    ->searchable()
+                                    ->preload(),
+                            ])
+                            ->columnSpanFull(),
+
+                        Select::make('else_stream_profile_id')
+                            ->label(__('Otherwise (fallback)'))
+                            ->options(fn (?StreamProfile $record) => self::transcodingProfileOptions($record))
+                            ->required(fn (Get $get): bool => $get('backend') === 'adaptive')
+                            ->searchable()
+                            ->preload()
+                            ->helperText(__('Used when no rule matches and when probe data is missing for a channel.')),
+                    ]),
             ]);
+    }
+
+    /**
+     * Grouped list of probe fields a rule condition can match on.
+     */
+    public static function ruleFieldOptions(): array
+    {
+        return [
+            __('Video') => [
+                'video.codec_name' => __('Codec'),
+                'video.height' => __('Height (px)'),
+                'video.width' => __('Width (px)'),
+                'video.bit_rate' => __('Bitrate (bps)'),
+                'video.frame_rate' => __('Frame rate (fps)'),
+                'video.profile' => __('Profile'),
+                'video.display_aspect_ratio' => __('Aspect ratio'),
+            ],
+            __('Audio') => [
+                'audio.codec_name' => __('Codec'),
+                'audio.channels' => __('Channels'),
+                'audio.sample_rate' => __('Sample rate (Hz)'),
+            ],
+            __('Format') => [
+                'format.format_name' => __('Format name'),
+            ],
+        ];
+    }
+
+    /**
+     * Operators that make sense for a given probe field. Numeric fields
+     * support comparison; string fields support equality and list membership.
+     */
+    public static function operatorsForField(?string $field): array
+    {
+        $numericFields = [
+            'video.height', 'video.width', 'video.bit_rate', 'video.frame_rate',
+            'audio.channels', 'audio.sample_rate',
+        ];
+
+        if (in_array($field, $numericFields, true)) {
+            return [
+                '=' => '=',
+                '!=' => '≠',
+                '>' => '>',
+                '>=' => '≥',
+                '<' => '<',
+                '<=' => '≤',
+            ];
+        }
+
+        return [
+            '=' => '=',
+            '!=' => '≠',
+            'in' => __('is one of'),
+            'not_in' => __('is not one of'),
+        ];
+    }
+
+    public static function valuePlaceholder(?string $field): string
+    {
+        return match ($field) {
+            'video.codec_name' => 'hevc',
+            'video.height' => '1080',
+            'video.width' => '1920',
+            'video.bit_rate' => '5000000',
+            'video.frame_rate' => '60',
+            'video.profile' => 'High',
+            'video.display_aspect_ratio' => '16:9',
+            'audio.codec_name' => 'aac',
+            'audio.channels' => '2',
+            'audio.sample_rate' => '48000',
+            'format.format_name' => 'hls',
+            default => '',
+        };
+    }
+
+    /**
+     * Profile options for use as an adaptive rule target — excludes other
+     * adaptive profiles (no chaining) and excludes the current record
+     * (no self-reference).
+     */
+    public static function transcodingProfileOptions(?StreamProfile $record): array
+    {
+        return StreamProfile::query()
+            ->where('user_id', auth()->id())
+            ->where('backend', '!=', 'adaptive')
+            ->when($record?->exists, fn ($q) => $q->where('id', '!=', $record->id))
+            ->orderBy('name')
+            ->pluck('name', 'id')
+            ->all();
+    }
+
+    /**
+     * Compact label for the collapsed rule item header.
+     */
+    public static function summarizeRule(array $state): ?string
+    {
+        $conditions = $state['conditions'] ?? [];
+        if (empty($conditions)) {
+            return null;
+        }
+
+        $parts = [];
+        foreach ($conditions as $condition) {
+            $field = $condition['field'] ?? '';
+            $op = $condition['op'] ?? '';
+            $value = $condition['value'] ?? '';
+            if (is_array($value)) {
+                $value = implode(', ', $value);
+            }
+            $parts[] = trim("{$field} {$op} {$value}");
+        }
+
+        return implode(' AND ', $parts);
     }
 
     public static function defaultArgsForBackend(?string $backend): string
@@ -219,13 +400,18 @@ class StreamProfileResource extends Resource implements CopilotResource
                     ->formatStateUsing(fn (string $state): string => match ($state) {
                         'streamlink' => 'Streamlink',
                         'ytdlp' => 'yt-dlp',
+                        'adaptive' => 'Adaptive',
                         default => 'FFmpeg',
                     })
                     ->color(fn (string $state): string => match ($state) {
                         'streamlink' => 'info',
                         'ytdlp' => 'warning',
+                        'adaptive' => 'success',
                         default => 'gray',
                     })
+                    ->icon(fn (string $state): ?string => $state === 'adaptive'
+                        ? 'heroicon-o-arrows-right-left'
+                        : null)
                     ->sortable(),
                 TextColumn::make('format')
                     ->label(__('Format'))

--- a/app/Filament/Resources/StreamProfiles/StreamProfileResource.php
+++ b/app/Filament/Resources/StreamProfiles/StreamProfileResource.php
@@ -426,6 +426,21 @@ class StreamProfileResource extends Resource implements CopilotResource
             ])
             ->recordActions([
                 Actions\DeleteAction::make()
+                    ->before(function (StreamProfile $record, Actions\DeleteAction $action): void {
+                        $referencing = $record->getReferencingAdaptiveProfiles();
+                        if ($referencing->isEmpty()) {
+                            return;
+                        }
+
+                        Notification::make()
+                            ->danger()
+                            ->title(__('Profile in use'))
+                            ->body(__('This profile is referenced by the following adaptive profiles: ').$referencing->pluck('name')->join(', ').'. '.__('Remove the references before deleting.'))
+                            ->persistent()
+                            ->send();
+
+                        $action->halt();
+                    })
                     ->button()->hiddenLabel()->size('sm'),
                 Actions\EditAction::make()
                     ->slideOver()
@@ -433,7 +448,25 @@ class StreamProfileResource extends Resource implements CopilotResource
             ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
                 Actions\BulkActionGroup::make([
-                    Actions\DeleteBulkAction::make(),
+                    Actions\DeleteBulkAction::make()
+                        ->before(function ($records, Actions\DeleteBulkAction $action): void {
+                            $blocked = $records->filter(
+                                fn (StreamProfile $record) => $record->getReferencingAdaptiveProfiles()->isNotEmpty()
+                            );
+
+                            if ($blocked->isEmpty()) {
+                                return;
+                            }
+
+                            Notification::make()
+                                ->danger()
+                                ->title(__('Some profiles could not be deleted'))
+                                ->body(__('The following profiles are referenced by adaptive profiles and cannot be deleted: ').$blocked->pluck('name')->join(', ').'. '.__('Remove the references before deleting.'))
+                                ->persistent()
+                                ->send();
+
+                            $action->halt();
+                        }),
                 ]),
             ]);
     }

--- a/app/Http/Controllers/Api/M3uProxyApiController.php
+++ b/app/Http/Controllers/Api/M3uProxyApiController.php
@@ -13,6 +13,7 @@ use App\Models\StreamProfile;
 use App\Services\M3uProxyService;
 use App\Services\NetworkBroadcastService;
 use App\Services\ProfileService;
+use App\Services\StreamProfileRuleEvaluator;
 use App\Settings\GeneralSettings;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -59,8 +60,11 @@ class M3uProxyApiController extends Controller
 
         // Channel-level profile takes priority over the playlist-level profile.
         // If neither is set, the stream is proxied directly without transcoding.
+        // An adaptive profile (backend === 'adaptive') is unwrapped to its
+        // concrete target via the channel's cached probe data.
         $profile = $channel->streamProfile
             ?? ($channel->is_vod ? $playlist->vodStreamProfile : $playlist->streamProfile);
+        $profile = app(StreamProfileRuleEvaluator::class)->unwrap($profile, $channel->stream_stats);
 
         $url = app(M3uProxyService::class)
             ->getChannelUrl(
@@ -153,6 +157,7 @@ class M3uProxyApiController extends Controller
             : ($settings->default_stream_profile_id ?? null);
         $profile = $channel->streamProfile
             ?? ($globalProfileId ? StreamProfile::find($globalProfileId) : null);
+        $profile = app(StreamProfileRuleEvaluator::class)->unwrap($profile, $channel->stream_stats);
 
         $url = app(M3uProxyService::class)
             ->getChannelUrl(

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -7,6 +7,7 @@ use App\Enums\PlaylistSourceType;
 use App\Jobs\FetchTmdbIds;
 use App\Observers\ChannelObserver;
 use App\Services\PlaylistService;
+use App\Services\StreamProfileRuleEvaluator;
 use App\Services\XtreamService;
 use App\Settings\GeneralSettings;
 use Exception;
@@ -74,6 +75,23 @@ class Channel extends Model
     public function streamProfile(): BelongsTo
     {
         return $this->belongsTo(StreamProfile::class);
+    }
+
+    /**
+     * Resolve the channel's stream profile to a concrete transcoding profile,
+     * unwrapping an adaptive profile (backend === 'adaptive') by evaluating
+     * its rules against the channel's cached probe data. Use this anywhere
+     * the profile is consumed for actual streaming; use $channel->streamProfile
+     * when showing the user-assigned value (it may itself be adaptive).
+     */
+    public function getEffectiveStreamProfile(): ?StreamProfile
+    {
+        $profile = $this->relationLoaded('streamProfile')
+            ? $this->streamProfile
+            : $this->streamProfile()->first();
+
+        return app(StreamProfileRuleEvaluator::class)
+            ->unwrap($profile, $this->stream_stats);
     }
 
     /**
@@ -201,6 +219,7 @@ class Channel extends Model
             ? $this->streamProfile
             : $this->streamProfile()->first();
         $profile ??= ($globalProfileId ? StreamProfile::find($globalProfileId) : null);
+        $profile = app(StreamProfileRuleEvaluator::class)->unwrap($profile, $this->stream_stats);
 
         // When no transcoding profile is set, the proxy delivers raw bytes (direct proxy),
         // not an HLS manifest. For VOD channels, use the actual container extension for both

--- a/app/Models/StreamProfile.php
+++ b/app/Models/StreamProfile.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -69,6 +70,36 @@ class StreamProfile extends Model
     public function isAdaptive(): bool
     {
         return $this->backend === 'adaptive';
+    }
+
+    /**
+     * Return all adaptive profiles (owned by the same user) that reference
+     * this profile — either as a rule target or as the else fallback.
+     * Used to guard against accidental deletion of profiles in use.
+     *
+     * @return Collection<int, self>
+     */
+    public function getReferencingAdaptiveProfiles(): Collection
+    {
+        return static::query()
+            ->where('user_id', $this->user_id)
+            ->where('backend', 'adaptive')
+            ->where('id', '!=', $this->id)
+            ->get(['id', 'name', 'rules', 'else_stream_profile_id'])
+            ->filter(function (self $adaptive): bool {
+                if ($adaptive->else_stream_profile_id === $this->id) {
+                    return true;
+                }
+
+                foreach ($adaptive->rules ?? [] as $rule) {
+                    if ((int) ($rule['stream_profile_id'] ?? 0) === $this->id) {
+                        return true;
+                    }
+                }
+
+                return false;
+            })
+            ->values();
     }
 
     /**

--- a/app/Models/StreamProfile.php
+++ b/app/Models/StreamProfile.php
@@ -11,9 +11,19 @@ class StreamProfile extends Model
 {
     use HasFactory;
 
+    protected $casts = [
+        'rules' => 'array',
+        'else_stream_profile_id' => 'integer',
+    ];
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function elseStreamProfile(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'else_stream_profile_id');
     }
 
     public function playlists(): HasMany
@@ -48,6 +58,17 @@ class StreamProfile extends Model
     public function isResolver(): bool
     {
         return in_array($this->backend, ['streamlink', 'ytdlp'], strict: true);
+    }
+
+    /**
+     * Whether this profile is adaptive (rule-based) — it delegates to
+     * another profile based on probed channel metadata. Adaptive profiles
+     * carry no transcoder args of their own; they resolve to a concrete
+     * transcoding profile at stream-start time via StreamProfileRuleEvaluator.
+     */
+    public function isAdaptive(): bool
+    {
+        return $this->backend === 'adaptive';
     }
 
     /**

--- a/app/Services/StreamProfileRuleEvaluator.php
+++ b/app/Services/StreamProfileRuleEvaluator.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\StreamProfile;
+
+class StreamProfileRuleEvaluator
+{
+    /**
+     * Resolve an adaptive profile to the id of the transcoding profile that
+     * should run for the given channel based on probed metadata.
+     *
+     * @param  StreamProfile  $adaptive  Profile with backend === 'adaptive'.
+     * @param  array|null  $streamStats  Decoded contents of channels.stream_stats.
+     * @return int|null Resolved transcoding profile id, or null when no rule
+     *                  matches and no else fallback is set.
+     */
+    public function resolve(StreamProfile $adaptive, ?array $streamStats): ?int
+    {
+        $context = $this->buildContext($streamStats);
+
+        foreach ($adaptive->rules ?? [] as $rule) {
+            if ($this->ruleMatches($rule, $context)) {
+                return isset($rule['stream_profile_id'])
+                    ? (int) $rule['stream_profile_id']
+                    : null;
+            }
+        }
+
+        return $adaptive->else_stream_profile_id;
+    }
+
+    /**
+     * Pass-through helper: returns non-adaptive profiles unchanged, resolves
+     * adaptive ones against the supplied probe data. Use this at any call
+     * site that has already picked a candidate profile (e.g., after walking
+     * a channel → playlist fallback chain) and wants the concrete profile
+     * to actually run.
+     */
+    public function unwrap(?StreamProfile $profile, ?array $streamStats): ?StreamProfile
+    {
+        if (! $profile || ! $profile->isAdaptive()) {
+            return $profile;
+        }
+
+        $resolvedId = $this->resolve($profile, $streamStats);
+
+        return $resolvedId ? StreamProfile::find($resolvedId) : null;
+    }
+
+    /**
+     * Flatten the probe payload into a single dot-keyed map so condition
+     * lookups become a flat array access. Picks the first video stream,
+     * the first audio stream, and the format object — that's what users
+     * write rules against.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildContext(?array $streamStats): array
+    {
+        $context = [];
+        $videoSeen = false;
+        $audioSeen = false;
+        $formatSeen = false;
+
+        foreach ($streamStats ?? [] as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            if (! $videoSeen && isset($entry['stream']) && ($entry['stream']['codec_type'] ?? null) === 'video') {
+                $stream = $entry['stream'];
+                $context['video.codec_name'] = $stream['codec_name'] ?? null;
+                $context['video.profile'] = $stream['profile'] ?? null;
+                $context['video.height'] = $this->numeric($stream['height'] ?? null);
+                $context['video.width'] = $this->numeric($stream['width'] ?? null);
+                $context['video.bit_rate'] = $this->numeric($stream['bit_rate'] ?? null);
+                $context['video.frame_rate'] = $this->parseFrameRate($stream['avg_frame_rate'] ?? null);
+                $context['video.display_aspect_ratio'] = $stream['display_aspect_ratio'] ?? null;
+                $videoSeen = true;
+
+                continue;
+            }
+
+            if (! $audioSeen && isset($entry['stream']) && ($entry['stream']['codec_type'] ?? null) === 'audio') {
+                $stream = $entry['stream'];
+                $context['audio.codec_name'] = $stream['codec_name'] ?? null;
+                $context['audio.channels'] = $this->numeric($stream['channels'] ?? null);
+                $context['audio.sample_rate'] = $this->numeric($stream['sample_rate'] ?? null);
+                $audioSeen = true;
+
+                continue;
+            }
+
+            if (! $formatSeen && isset($entry['format'])) {
+                $context['format.format_name'] = $entry['format']['format_name'] ?? null;
+                $formatSeen = true;
+            }
+        }
+
+        return $context;
+    }
+
+    /**
+     * @param  array<string, mixed>  $rule
+     * @param  array<string, mixed>  $context
+     */
+    private function ruleMatches(array $rule, array $context): bool
+    {
+        $conditions = $rule['conditions'] ?? [];
+        if (empty($conditions)) {
+            return false;
+        }
+
+        foreach ($conditions as $condition) {
+            if (! $this->conditionMatches($condition, $context)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $condition
+     * @param  array<string, mixed>  $context
+     */
+    private function conditionMatches(array $condition, array $context): bool
+    {
+        $field = $condition['field'] ?? null;
+        $op = $condition['op'] ?? null;
+        if ($field === null || $op === null) {
+            return false;
+        }
+
+        $actual = $context[$field] ?? null;
+        $expected = $condition['value'] ?? null;
+
+        // Missing probe value can never satisfy a condition.
+        if ($actual === null) {
+            return false;
+        }
+
+        return match ($op) {
+            '=' => $this->scalarEquals($actual, $expected),
+            '!=' => ! $this->scalarEquals($actual, $expected),
+            '>' => is_numeric($actual) && is_numeric($expected) && $actual > $expected,
+            '>=' => is_numeric($actual) && is_numeric($expected) && $actual >= $expected,
+            '<' => is_numeric($actual) && is_numeric($expected) && $actual < $expected,
+            '<=' => is_numeric($actual) && is_numeric($expected) && $actual <= $expected,
+            'in' => is_array($expected) && in_array($actual, $expected, strict: false),
+            'not_in' => is_array($expected) && ! in_array($actual, $expected, strict: false),
+            default => false,
+        };
+    }
+
+    /**
+     * Loose equality so "1080" (int) matches "1080" (string from form input)
+     * and codec strings compare case-insensitively.
+     */
+    private function scalarEquals(mixed $actual, mixed $expected): bool
+    {
+        if (is_numeric($actual) && is_numeric($expected)) {
+            return (float) $actual === (float) $expected;
+        }
+
+        if (is_string($actual) && is_string($expected)) {
+            return strcasecmp($actual, $expected) === 0;
+        }
+
+        return $actual == $expected;
+    }
+
+    private function numeric(mixed $value): int|float|null
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (is_int($value) || is_float($value)) {
+            return $value;
+        }
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * ffprobe reports avg_frame_rate as a "num/den" string. "0/0" means
+     * unknown, treated as missing.
+     */
+    private function parseFrameRate(?string $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (! str_contains($value, '/')) {
+            return is_numeric($value) ? (float) $value : null;
+        }
+        [$num, $den] = array_pad(explode('/', $value, 2), 2, null);
+        if (! is_numeric($num) || ! is_numeric($den) || (float) $den === 0.0) {
+            return null;
+        }
+
+        return (float) $num / (float) $den;
+    }
+}

--- a/app/Services/StreamProfileRuleEvaluator.php
+++ b/app/Services/StreamProfileRuleEvaluator.php
@@ -44,8 +44,13 @@ class StreamProfileRuleEvaluator
         }
 
         $resolvedId = $this->resolve($profile, $streamStats);
+        if (! $resolvedId) {
+            return null;
+        }
 
-        return $resolvedId ? StreamProfile::find($resolvedId) : null;
+        static $cache = [];
+
+        return $cache[$resolvedId] ??= StreamProfile::find($resolvedId);
     }
 
     /**
@@ -141,6 +146,18 @@ class StreamProfileRuleEvaluator
             return false;
         }
 
+        // Normalise for list operators: wrap stray strings defensively and
+        // apply case-insensitive comparison to match the behaviour of scalarEquals.
+        $normaliseList = function (mixed $list, mixed $value): array {
+            $list = is_array($list) ? $list : (array) $list;
+            if (is_string($value)) {
+                return array_map('strtolower', $list);
+            }
+
+            return $list;
+        };
+        $normalisedActual = is_string($actual) ? strtolower($actual) : $actual;
+
         return match ($op) {
             '=' => $this->scalarEquals($actual, $expected),
             '!=' => ! $this->scalarEquals($actual, $expected),
@@ -148,8 +165,8 @@ class StreamProfileRuleEvaluator
             '>=' => is_numeric($actual) && is_numeric($expected) && $actual >= $expected,
             '<' => is_numeric($actual) && is_numeric($expected) && $actual < $expected,
             '<=' => is_numeric($actual) && is_numeric($expected) && $actual <= $expected,
-            'in' => is_array($expected) && in_array($actual, $expected, strict: false),
-            'not_in' => is_array($expected) && ! in_array($actual, $expected, strict: false),
+            'in' => in_array($normalisedActual, $normaliseList($expected, $actual), strict: false),
+            'not_in' => ! in_array($normalisedActual, $normaliseList($expected, $actual), strict: false),
             default => false,
         };
     }
@@ -180,7 +197,7 @@ class StreamProfileRuleEvaluator
             return $value;
         }
         if (is_numeric($value)) {
-            return (int) $value;
+            return (float) $value;
         }
 
         return null;

--- a/database/migrations/2026_05_01_000000_add_rule_columns_to_stream_profiles_table.php
+++ b/database/migrations/2026_05_01_000000_add_rule_columns_to_stream_profiles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('stream_profiles', function (Blueprint $table) {
+            $table->jsonb('rules')->nullable()->after('args');
+            $table->foreignId('else_stream_profile_id')
+                ->nullable()
+                ->after('rules')
+                ->constrained('stream_profiles')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('stream_profiles', function (Blueprint $table) {
+            $table->dropForeign(['else_stream_profile_id']);
+            $table->dropColumn(['rules', 'else_stream_profile_id']);
+        });
+    }
+};

--- a/tests/Feature/StreamProfileAdaptiveTest.php
+++ b/tests/Feature/StreamProfileAdaptiveTest.php
@@ -1,0 +1,312 @@
+<?php
+
+use App\Filament\Resources\StreamProfiles\StreamProfileResource;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\StreamProfile;
+use App\Models\User;
+use App\Services\StreamProfileRuleEvaluator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    $this->playlist = Playlist::factory()->for($this->user)->createQuietly();
+
+    $this->target = StreamProfile::factory()->for($this->user)->create([
+        'name' => 'Heavy Profile',
+        'backend' => 'ffmpeg',
+    ]);
+    $this->fallback = StreamProfile::factory()->for($this->user)->create([
+        'name' => 'Light Profile',
+        'backend' => 'ffmpeg',
+    ]);
+
+    $this->evaluator = app(StreamProfileRuleEvaluator::class);
+});
+
+/**
+ * Build an adaptive (backend=adaptive) StreamProfile with the given rules and else fallback.
+ *
+ * @param  array<int, array{conditions: array, stream_profile_id: int}>  $rules
+ */
+function makeAdaptiveProfile(User $user, array $rules, ?int $elseProfileId = null): StreamProfile
+{
+    return StreamProfile::factory()->for($user)->create([
+        'name' => 'Auto Adaptive',
+        'backend' => 'adaptive',
+        'args' => '',
+        'rules' => $rules,
+        'else_stream_profile_id' => $elseProfileId,
+    ]);
+}
+
+/**
+ * Real-shaped probe payload, parameterised so each test can exercise
+ * exactly the codec/resolution/etc. it needs.
+ */
+function probe(array $video = [], array $audio = [], array $format = []): array
+{
+    return [
+        ['stream' => array_merge([
+            'codec_type' => 'video',
+            'codec_name' => 'h264',
+            'width' => 1920,
+            'height' => 1080,
+            'bit_rate' => '4000000',
+            'avg_frame_rate' => '25/1',
+            'profile' => 'High',
+            'display_aspect_ratio' => '16:9',
+        ], $video)],
+        ['stream' => array_merge([
+            'codec_type' => 'audio',
+            'codec_name' => 'aac',
+            'channels' => 2,
+            'sample_rate' => '48000',
+        ], $audio)],
+        ['format' => array_merge([
+            'format_name' => 'hls',
+        ], $format)],
+    ];
+}
+
+// ── Evaluator: rule matching ─────────────────────────────────────────────────
+
+it('returns the first matching rule target', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc']], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    $resolved = $this->evaluator->resolve($adaptive, probe(['codec_name' => 'hevc']));
+
+    expect($resolved)->toBe($this->target->id);
+});
+
+it('falls through to the else profile when no rule matches', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc']], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    $resolved = $this->evaluator->resolve($adaptive, probe(['codec_name' => 'h264']));
+
+    expect($resolved)->toBe($this->fallback->id);
+});
+
+it('falls through to else when probe data is null', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc']], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    expect($this->evaluator->resolve($adaptive, null))->toBe($this->fallback->id);
+});
+
+it('falls through to else when probe data is malformed', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.height', 'op' => '>', 'value' => 1080]], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    expect($this->evaluator->resolve($adaptive, ['not-an-entry', null]))->toBe($this->fallback->id);
+});
+
+it('returns null when nothing matches and no else is set', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc']], 'stream_profile_id' => $this->target->id],
+    ]);
+
+    expect($this->evaluator->resolve($adaptive, probe(['codec_name' => 'h264'])))->toBeNull();
+});
+
+it('walks rules in order and stops at the first match', function () {
+    $other = StreamProfile::factory()->for($this->user)->create(['backend' => 'ffmpeg']);
+
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.height', 'op' => '>=', 'value' => 1080]], 'stream_profile_id' => $this->target->id],
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'h264']], 'stream_profile_id' => $other->id],
+    ], elseProfileId: $this->fallback->id);
+
+    expect($this->evaluator->resolve($adaptive, probe()))->toBe($this->target->id);
+});
+
+// ── Evaluator: numeric & string operators ────────────────────────────────────
+
+it('evaluates numeric comparison operators correctly', function (string $op, int $value, bool $expected) {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.height', 'op' => $op, 'value' => $value]], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    $resolved = $this->evaluator->resolve($adaptive, probe(['height' => 1080]));
+    expect($resolved)->toBe($expected ? $this->target->id : $this->fallback->id);
+})->with([
+    ['=', 1080, true],
+    ['=', 720, false],
+    ['!=', 720, true],
+    ['!=', 1080, false],
+    ['>', 720, true],
+    ['>', 1080, false],
+    ['>=', 1080, true],
+    ['<', 1080, false],
+    ['<=', 1080, true],
+]);
+
+it('evaluates string equality case-insensitively', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'HEVC']], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    expect($this->evaluator->resolve($adaptive, probe(['codec_name' => 'hevc'])))->toBe($this->target->id);
+});
+
+it('evaluates the in operator against a list', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => 'in', 'value' => ['hevc', 'av1']]], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    expect($this->evaluator->resolve($adaptive, probe(['codec_name' => 'av1'])))->toBe($this->target->id);
+    expect($this->evaluator->resolve($adaptive, probe(['codec_name' => 'h264'])))->toBe($this->fallback->id);
+});
+
+it('evaluates the not_in operator against a list', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'audio.codec_name', 'op' => 'not_in', 'value' => ['aac', 'mp3']]], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    expect($this->evaluator->resolve($adaptive, probe(audio: ['codec_name' => 'eac3'])))->toBe($this->target->id);
+    expect($this->evaluator->resolve($adaptive, probe(audio: ['codec_name' => 'aac'])))->toBe($this->fallback->id);
+});
+
+// ── Evaluator: AND across conditions, missing fields ─────────────────────────
+
+it('requires all conditions in a rule to match', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        [
+            'conditions' => [
+                ['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc'],
+                ['field' => 'video.height', 'op' => '>=', 'value' => 2160],
+            ],
+            'stream_profile_id' => $this->target->id,
+        ],
+    ], elseProfileId: $this->fallback->id);
+
+    // both true → match
+    expect($this->evaluator->resolve($adaptive, probe(['codec_name' => 'hevc', 'height' => 2160])))->toBe($this->target->id);
+    // codec matches but height doesn't → fall through
+    expect($this->evaluator->resolve($adaptive, probe(['codec_name' => 'hevc', 'height' => 1080])))->toBe($this->fallback->id);
+});
+
+it('treats a missing probe field as a failed condition', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'audio.codec_name', 'op' => '=', 'value' => 'aac']], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    // payload with no audio entry at all
+    $videoOnly = [['stream' => ['codec_type' => 'video', 'codec_name' => 'h264', 'height' => 1080, 'width' => 1920]]];
+    expect($this->evaluator->resolve($adaptive, $videoOnly))->toBe($this->fallback->id);
+});
+
+// ── Evaluator: frame-rate parsing ────────────────────────────────────────────
+
+it('parses avg_frame_rate as a num/den fraction', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.frame_rate', 'op' => '>', 'value' => 50]], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    expect($this->evaluator->resolve($adaptive, probe(['avg_frame_rate' => '60000/1001'])))->toBe($this->target->id);
+    expect($this->evaluator->resolve($adaptive, probe(['avg_frame_rate' => '25/1'])))->toBe($this->fallback->id);
+});
+
+it('treats 0/0 frame rate as missing', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.frame_rate', 'op' => '>', 'value' => 0]], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    expect($this->evaluator->resolve($adaptive, probe(['avg_frame_rate' => '0/0'])))->toBe($this->fallback->id);
+});
+
+// ── Channel::getEffectiveStreamProfile() ─────────────────────────────────────
+
+it('returns null when the channel has no profile assigned', function () {
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)
+        ->create(['stream_profile_id' => null]);
+
+    expect($channel->getEffectiveStreamProfile())->toBeNull();
+});
+
+it('returns the profile unchanged when its backend is not rules', function () {
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)
+        ->create(['stream_profile_id' => $this->target->id]);
+
+    expect($channel->getEffectiveStreamProfile()?->id)->toBe($this->target->id);
+});
+
+it('unwraps a adaptive profile to its rule target', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc']], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'stream_profile_id' => $adaptive->id,
+        'stream_stats' => probe(['codec_name' => 'hevc']),
+    ]);
+
+    expect($channel->getEffectiveStreamProfile()?->id)->toBe($this->target->id);
+});
+
+it('unwraps a adaptive profile to its else fallback when no rule matches', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc']], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'stream_profile_id' => $adaptive->id,
+        'stream_stats' => probe(['codec_name' => 'h264']),
+    ]);
+
+    expect($channel->getEffectiveStreamProfile()?->id)->toBe($this->fallback->id);
+});
+
+it('returns null when an adaptive profile resolves to a missing target', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc']], 'stream_profile_id' => 99999],
+    ]);
+
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'stream_profile_id' => $adaptive->id,
+        'stream_stats' => probe(['codec_name' => 'hevc']),
+    ]);
+
+    expect($channel->getEffectiveStreamProfile())->toBeNull();
+});
+
+// ── Form-level chaining block ────────────────────────────────────────────────
+
+it('excludes adaptive profiles from the rule target options (chaining block)', function () {
+    $transcoder = StreamProfile::factory()->for($this->user)->create([
+        'name' => 'Transcoder One',
+        'backend' => 'ffmpeg',
+    ]);
+    $adaptive = makeAdaptiveProfile($this->user, []);
+
+    $options = StreamProfileResource::transcodingProfileOptions(null);
+
+    expect($options)->toHaveKey($transcoder->id);
+    expect($options)->not->toHaveKey($adaptive->id);
+});
+
+it('excludes the current record from its own target options (no self-reference)', function () {
+    $other = StreamProfile::factory()->for($this->user)->create(['backend' => 'ffmpeg']);
+    $adaptive = makeAdaptiveProfile($this->user, []);
+
+    $options = StreamProfileResource::transcodingProfileOptions($adaptive);
+
+    expect($options)->toHaveKey($other->id);
+    expect($options)->not->toHaveKey($adaptive->id);
+});
+
+it('isAdaptive helper returns true only for backend = adaptive', function () {
+    expect($this->target->isAdaptive())->toBeFalse();
+
+    $adaptive = makeAdaptiveProfile($this->user, []);
+    expect($adaptive->isAdaptive())->toBeTrue();
+});

--- a/tests/Feature/StreamProfileAdaptiveTest.php
+++ b/tests/Feature/StreamProfileAdaptiveTest.php
@@ -321,3 +321,36 @@ it('isAdaptive helper returns true only for backend = adaptive', function () {
     $adaptive = makeAdaptiveProfile($this->user, []);
     expect($adaptive->isAdaptive())->toBeTrue();
 });
+
+// ── Delete guard: getReferencingAdaptiveProfiles() ───────────────────────────
+
+it('getReferencingAdaptiveProfiles returns profiles that use this profile as a rule target', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc']], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    expect($this->target->getReferencingAdaptiveProfiles()->pluck('id')->all())->toBe([$adaptive->id]);
+});
+
+it('getReferencingAdaptiveProfiles returns profiles that use this profile as the else fallback', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc']], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    expect($this->fallback->getReferencingAdaptiveProfiles()->pluck('id')->all())->toBe([$adaptive->id]);
+});
+
+it('getReferencingAdaptiveProfiles returns empty collection when profile is not referenced', function () {
+    $unreferenced = StreamProfile::factory()->for($this->user)->create(['backend' => 'ffmpeg']);
+
+    expect($unreferenced->getReferencingAdaptiveProfiles())->toBeEmpty();
+});
+
+it('getReferencingAdaptiveProfiles does not include profiles belonging to other users', function () {
+    $otherUser = User::factory()->create();
+    makeAdaptiveProfile($otherUser, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => '=', 'value' => 'hevc']], 'stream_profile_id' => $this->target->id],
+    ]);
+
+    expect($this->target->getReferencingAdaptiveProfiles())->toBeEmpty();
+});

--- a/tests/Feature/StreamProfileAdaptiveTest.php
+++ b/tests/Feature/StreamProfileAdaptiveTest.php
@@ -167,6 +167,17 @@ it('evaluates the in operator against a list', function () {
     expect($this->evaluator->resolve($adaptive, probe(['codec_name' => 'h264'])))->toBe($this->fallback->id);
 });
 
+it('evaluates in operator case-insensitively', function () {
+    $adaptive = makeAdaptiveProfile($this->user, [
+        ['conditions' => [['field' => 'video.codec_name', 'op' => 'in', 'value' => ['HEVC', 'AV1']]], 'stream_profile_id' => $this->target->id],
+    ], elseProfileId: $this->fallback->id);
+
+    // lowercase probe value should match uppercase list entries
+    expect($this->evaluator->resolve($adaptive, probe(['codec_name' => 'hevc'])))->toBe($this->target->id);
+    expect($this->evaluator->resolve($adaptive, probe(['codec_name' => 'av1'])))->toBe($this->target->id);
+    expect($this->evaluator->resolve($adaptive, probe(['codec_name' => 'h264'])))->toBe($this->fallback->id);
+});
+
 it('evaluates the not_in operator against a list', function () {
     $adaptive = makeAdaptiveProfile($this->user, [
         ['conditions' => [['field' => 'audio.codec_name', 'op' => 'not_in', 'value' => ['aac', 'mp3']]], 'stream_profile_id' => $this->target->id],


### PR DESCRIPTION
## Summary

Adds a new **Adaptive** stream profile type that picks one of your existing transcoding profiles based on probed channel metadata, rather than carrying its own ffmpeg/streamlink/yt-dlp arguments. Useful for assigning a single profile to many channels (e.g. via the bulk action) and letting the system route each one to the right transcoder based on codec, resolution, audio channel count, etc.

**How rules work**

Each adaptive profile holds an ordered list of rules:

> if (all conditions match) → use Profile X
> if (all conditions match) → use Profile Y
> ...
> else → use Profile Z

Rules are evaluated top-to-bottom and the first match wins. Conditions inside a rule are ANDed; OR is expressed by writing multiple rules pointing at the same profile. The else fallback is mandatory and also catches the \"no probe data yet\" case.

Adaptive profiles cannot point at other adaptive profiles, so a stream always resolves in one hop. The target select inside the rules editor filters out adaptive profiles and the current record at the form layer.

**Available condition fields**

- **Video** — codec, height, width, bitrate, frame rate, profile, aspect ratio
- **Audio** — codec, channel count, sample rate
- **Format** — container format name

Operators are filtered to the field type — numeric comparisons (\`=\`, \`≠\`, \`>\`, \`≥\`, \`<\`, \`≤\`) for size/rate fields and equality / list-membership (\`is one of\`, \`is not one of\`) for codec/format strings.

**Where resolution happens**

A new \`StreamProfileRuleEvaluator\` service builds a flat dot-keyed context from the channel's cached \`stream_stats\` and walks the rule list. \`Channel::getEffectiveStreamProfile()\` unwraps an adaptive profile to its concrete target. Runtime call sites that consume the profile to actually run a stream — \`M3uProxyApiController::channel()\`, \`::channelPlayer()\`, and \`Channel::getFloatingPlayerAttributes()\` — now route through the evaluator's \`unwrap()\` helper, so a profile picked from the channel-level → playlist-level fallback chain resolves cleanly whether or not it's adaptive.

**UI**

On \`/stream-profiles\`:

- Backend select gains an **Adaptive (rule-based)** option that swaps the args / format / cookies fields for a rules editor.
- Backend column shows a green **Adaptive** badge with an \`arrows-right-left\` icon next to the existing FFmpeg / Streamlink / yt-dlp badges.
- List page now has **All / Transcoding / Adaptive** tabs.

**Schema**

\`stream_profiles.rules\` (jsonb, nullable) and \`stream_profiles.else_stream_profile_id\` (FK to \`stream_profiles\`, \`nullOnDelete\`).

## Test plan

- [x] Visit \`/stream-profiles\` — confirm the new **Adaptive** tab appears and is empty.
- [x] Create an Adaptive profile with two or three rules pointing at existing transcoding profiles, plus an else fallback. Verify the args / format / cookies fields hide when Adaptive is selected and reappear when switching back to FFmpeg.
- [x] Confirm the rule target select doesn't list other adaptive profiles or the profile being edited.
- [x] Save the profile — confirm it appears in the table with the green Adaptive badge and shows under the Adaptive tab.
- [x] Assign the adaptive profile to a probed channel (one with \`stream_stats\` populated) whose metadata matches the first rule — start a stream and confirm the right transcoder runs.
- [x] Assign it to a probed channel whose metadata doesn't match any rule — confirm the else fallback runs.
- [x] Assign it to an unprobed channel — confirm the else fallback runs.
- [x] Delete a target profile referenced by an adaptive rule — confirm the channel falls back gracefully (raw bytes / no transcoding) rather than erroring.