### PR TITLE
docs: Clarify transcoding profile priority in helper text

### DIFF
--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -803,7 +803,7 @@ class Preferences extends SettingsPage
                                                     ->openUrlInNewTab(false)
                                             )
                                             ->columnSpan(2)
-                                            ->helperText(__('The default transcoding profile used for the in-app player for Live content. Leave empty to disable transcoding (some streams may not be playable in the player).')),
+                                            ->helperText(__('The default transcoding profile used by the in-app player for Live content. A per-channel stream profile (if set) takes priority over this. Leave empty to disable transcoding (some streams may not be playable in the player).')),
                                         Select::make('default_vod_stream_profile_id')
                                             ->label(__('VOD and Series Transcoding Profile'))
                                             ->searchable()
@@ -820,7 +820,7 @@ class Preferences extends SettingsPage
                                                     ->openUrlInNewTab(false)
                                             )
                                             ->columnSpan(2)
-                                            ->helperText(__('The default transcoding profile used for the in-app player for VOD/Series content. Leave empty to disable transcoding (some streams may not be playable in the player).')),
+                                            ->helperText(__('The default transcoding profile used by the in-app player for VOD/Series content. A per-channel stream profile (if set) takes priority over this. Leave empty to disable transcoding (some streams may not be playable in the player).')),
                                         TextInput::make('max_concurrent_floating_players')
                                             ->label(__('Max Concurrent Players'))
                                             ->hintIcon(

--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -1774,7 +1774,7 @@ class ChannelResource extends Resource implements CopilotResource
                         ->nullable()
                         ->columnSpanFull()
                         ->visible(fn (Get $get, $record): bool => (bool) $get('enable_proxy') || (bool) ($record?->playlist?->enable_proxy ?? false))
-                        ->helperText(__('Transcode this channel using the selected profile. Overrides the playlist-level stream profile for this channel. Leave empty for direct stream proxying.')),
+                        ->helperText(__('Transcode this channel using the selected profile. Takes priority over both the playlist-level stream profile (used by external clients) and the in-app player default (Settings → Proxy → In-App Player Transcoding). Leave empty to fall back to those defaults.')),
                 ]),
             Fieldset::make(__('EPG Settings'))
                 ->schema([


### PR DESCRIPTION
## Summary

The per-channel \`stream_profile_id\` has always taken priority over the in-app player's default transcoding profile, but the helper text on each field only told half the story. This PR updates the wording on both sides so the behaviour is obvious from the form alone.

**Before**

- Per-channel field: \"Overrides the playlist-level stream profile for this channel.\"
- In-app default (Live): \"The default transcoding profile used for the in-app player for Live content.\"
- In-app default (VOD/Series): same shape as Live.

**After**

- Per-channel field now explicitly notes priority over **both** the playlist-level profile (for external clients) **and** the in-app player default in Settings → Proxy → In-App Player Transcoding.
- Both in-app default fields now mention that a per-channel profile, when set, takes priority over them.

No behaviour change — pure helper-text clarification.

## Test plan

- [x] On a channel edit page, expand Proxy Settings and read the **Stream Profile** helper text — confirm it mentions overriding both the playlist-level profile and the in-app player default.
- [x] In Settings → Proxy → In-App Player Transcoding, read the helper text on **Default Live Transcoding Profile** and **VOD and Series Transcoding Profile** — confirm both mention that a per-channel profile takes priority.