### PR TITLE
feat: Show live media info and failover channel name on Stream Monitor

### DIFF
--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Facades\LogoFacade;
+use App\Facades\PlaylistFacade;
 use App\Models\Channel;
 use App\Models\Episode;
 use App\Models\Network;
@@ -11,6 +12,7 @@ use App\Models\PlaylistAlias;
 use App\Models\PlaylistProfile;
 use App\Models\StreamProfile;
 use App\Services\M3uProxyService;
+use App\Services\PlaylistUrlService;
 use Carbon\Carbon;
 use Exception;
 use Filament\Actions\Action;
@@ -358,13 +360,48 @@ class M3uProxyStreamMonitor extends Page
                     }
                 }
 
-                // Resolve the active failover channel (1-based index → 0-based offset)
-                // so the UI can show "Primary → Failover" instead of just a raw URL.
+                // Resolve the active failover channel so the UI can show
+                // "Primary → Failover" instead of a raw URL. Match by URL —
+                // index-based mapping is unreliable in dynamic resolver mode
+                // because the resolver can skip candidates (capacity / fail
+                // conditions) so current_failover_index doesn't always equal
+                // the position in failoverChannels.
                 $failoverChannel = null;
                 $currentFailoverIndex = $stream['current_failover_index'] ?? 0;
-                if ($channel && $currentFailoverIndex > 0) {
-                    $failoverIdx = $currentFailoverIndex - 1;
-                    $failoverModel = $channel->failoverChannels[$failoverIdx] ?? null;
+                $currentUrl = $stream['current_url'] ?? null;
+                $isUsingFailover = $currentFailoverIndex > 0
+                    || ($stream['failover_attempts'] ?? 0) > 0;
+                if ($channel && $isUsingFailover && $currentUrl) {
+                    $contextPlaylist = ! empty($stream['metadata']['playlist_uuid'])
+                        ? PlaylistFacade::resolvePlaylistByUuid($stream['metadata']['playlist_uuid'])
+                        : null;
+                    $failoverModel = null;
+                    foreach ($channel->failoverChannels as $candidate) {
+                        $candidateContext = $contextPlaylist
+                            ?? $candidate->getEffectivePlaylist();
+                        if (! $candidateContext) {
+                            continue;
+                        }
+                        try {
+                            $candidateUrl = PlaylistUrlService::getChannelUrl(
+                                $candidate,
+                                $candidateContext
+                            );
+                        } catch (Exception $e) {
+                            continue;
+                        }
+                        if ($candidateUrl !== '' && $candidateUrl === $currentUrl) {
+                            $failoverModel = $candidate;
+                            break;
+                        }
+                    }
+                    // Fallback for the static failover-list path: the URLs are
+                    // built in the same order as failoverChannels, so the index
+                    // mapping is correct when no candidate URL matched above.
+                    if (! $failoverModel && $currentFailoverIndex > 0) {
+                        $failoverModel = $channel->failoverChannels[$currentFailoverIndex - 1]
+                            ?? null;
+                    }
                     if ($failoverModel) {
                         $failoverChannel = [
                             'title' => $failoverModel->name_custom

--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -297,7 +297,10 @@ class M3uProxyStreamMonitor extends Page
                 ->values();
 
             $channelsById = $channelIds->isNotEmpty()
-                ? Channel::whereIn('id', $channelIds)->get()->keyBy('id')
+                ? Channel::whereIn('id', $channelIds)
+                    ->with('failoverChannels')
+                    ->get()
+                    ->keyBy('id')
                 : collect();
             $episodesById = $episodeIds->isNotEmpty()
                 ? Episode::whereIn('id', $episodeIds)->get()->keyBy('id')
@@ -330,6 +333,7 @@ class M3uProxyStreamMonitor extends Page
                 $model = [];
                 $title = null;
                 $logo = null;
+                $channel = null;
                 if (isset($stream['metadata']['type']) && isset($stream['metadata']['id'])) {
                     $modelType = $stream['metadata']['type'];
                     $modelId = $stream['metadata']['id'];
@@ -350,6 +354,23 @@ class M3uProxyStreamMonitor extends Page
                         $model = [
                             'title' => $title ?? 'N/A',
                             'logo' => $logo,
+                        ];
+                    }
+                }
+
+                // Resolve the active failover channel (1-based index → 0-based offset)
+                // so the UI can show "Primary → Failover" instead of just a raw URL.
+                $failoverChannel = null;
+                $currentFailoverIndex = $stream['current_failover_index'] ?? 0;
+                if ($channel && $currentFailoverIndex > 0) {
+                    $failoverIdx = $currentFailoverIndex - 1;
+                    $failoverModel = $channel->failoverChannels[$failoverIdx] ?? null;
+                    if ($failoverModel) {
+                        $failoverChannel = [
+                            'title' => $failoverModel->name_custom
+                                ?? $failoverModel->name
+                                ?? $failoverModel->title,
+                            'logo' => LogoFacade::getChannelLogoUrl($failoverModel),
                         ];
                     }
                 }
@@ -462,12 +483,16 @@ class M3uProxyStreamMonitor extends Page
                     // Failover details
                     'failover_urls' => $stream['failover_urls'] ?? [],
                     'failover_resolver_url' => $stream['failover_resolver_url'] ?? null,
-                    'current_failover_index' => $stream['current_failover_index'] ?? 0,
+                    'current_failover_index' => $currentFailoverIndex,
                     'failover_attempts' => $stream['failover_attempts'] ?? 0,
                     'last_failover_time' => isset($stream['last_failover_time'])
                         ? Carbon::parse($stream['last_failover_time'], 'UTC')->format('Y-m-d H:i:s')
                         : null,
-                    'using_failover' => ($stream['current_failover_index'] ?? 0) > 0 || ($stream['failover_attempts'] ?? 0) > 0,
+                    'using_failover' => $currentFailoverIndex > 0 || ($stream['failover_attempts'] ?? 0) > 0,
+                    'failover_channel' => $failoverChannel,
+                    // Live media info from the proxy. Only populated for transcoded
+                    // (ffmpeg) streams — empty for plain HTTP-proxy streams.
+                    'media_info' => $stream['media_info'] ?? [],
                 ];
             }
         }
@@ -514,6 +539,8 @@ class M3uProxyStreamMonitor extends Page
                     'using_failover' => false,
                     'broadcast' => true,
                     'alias_name' => null,
+                    'failover_channel' => null,
+                    'media_info' => [],
                 ];
             }
         }

--- a/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
+++ b/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
@@ -183,7 +183,13 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
                                         <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
                                             Stream {{ substr($stream['stream_id'], -8) }}
                                         </h3>
-                                        <p class="text-sm text-gray-500 dark:text-gray-400 font-mono">{{ $stream['model']['title'] ?? 'N/A' }}</p>
+                                        <p class="text-sm text-gray-500 dark:text-gray-400 font-mono">
+                                            {{ $stream['model']['title'] ?? 'N/A' }}
+                                            @if(!empty($stream['failover_channel']['title']))
+                                                <span class="text-gray-400 dark:text-gray-500 mx-1">&rarr;</span>
+                                                <span class="text-orange-600 dark:text-orange-400 font-medium">{{ $stream['failover_channel']['title'] }}</span>
+                                            @endif
+                                        </p>
                                         <p class="text-sm text-gray-500 dark:text-gray-400 font-mono truncate">{{ $stream['source_url'] }}</p>
                                     </div>
                                 </div>
@@ -266,6 +272,56 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
                                     <div class="text-lg font-semibold text-gray-900 dark:text-white">{{ $stream['uptime'] }}</div>
                                 </div>
                             </div>
+
+                            @php
+                                $mediaInfo = $stream['media_info'] ?? [];
+                                $mediaBadges = [];
+                                if (!empty($mediaInfo['resolution'])) {
+                                    $mediaBadges[] = ['label' => strtoupper($mediaInfo['resolution']), 'color' => 'sky'];
+                                }
+                                if (!empty($mediaInfo['fps'])) {
+                                    $mediaBadges[] = ['label' => $mediaInfo['fps'] . ' FPS', 'color' => 'amber'];
+                                }
+                                if (!empty($mediaInfo['video_codec'])) {
+                                    $mediaBadges[] = ['label' => strtoupper($mediaInfo['video_codec']), 'color' => 'rose'];
+                                }
+                                if (!empty($mediaInfo['audio_codec'])) {
+                                    $mediaBadges[] = ['label' => strtoupper($mediaInfo['audio_codec']), 'color' => 'fuchsia'];
+                                }
+                                if (!empty($mediaInfo['audio_channels'])) {
+                                    $mediaBadges[] = ['label' => strtoupper($mediaInfo['audio_channels']), 'color' => 'fuchsia'];
+                                }
+                                if (!empty($mediaInfo['container'])) {
+                                    $mediaBadges[] = ['label' => $mediaInfo['container'], 'color' => 'cyan'];
+                                }
+                                if (!empty($mediaInfo['bitrate_kbps'])) {
+                                    $bitrate = $mediaInfo['bitrate_kbps'] > 1000
+                                        ? round($mediaInfo['bitrate_kbps'] / 1000, 2) . ' Mbps'
+                                        : round($mediaInfo['bitrate_kbps'], 0) . ' kbps';
+                                    $mediaBadges[] = ['label' => $bitrate, 'color' => 'emerald'];
+                                }
+                                if (!empty($mediaInfo['speed'])) {
+                                    $mediaBadges[] = ['label' => $mediaInfo['speed'] . 'X', 'color' => 'lime'];
+                                }
+                                $badgeColors = [
+                                    'sky' => 'bg-sky-100 dark:bg-sky-900 text-sky-800 dark:text-sky-200',
+                                    'amber' => 'bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-200',
+                                    'rose' => 'bg-rose-100 dark:bg-rose-900 text-rose-800 dark:text-rose-200',
+                                    'fuchsia' => 'bg-fuchsia-100 dark:bg-fuchsia-900 text-fuchsia-800 dark:text-fuchsia-200',
+                                    'cyan' => 'bg-cyan-100 dark:bg-cyan-900 text-cyan-800 dark:text-cyan-200',
+                                    'emerald' => 'bg-emerald-100 dark:bg-emerald-900 text-emerald-800 dark:text-emerald-200',
+                                    'lime' => 'bg-lime-100 dark:bg-lime-900 text-lime-800 dark:text-lime-200',
+                                ];
+                            @endphp
+                            @if(!empty($mediaBadges))
+                                <div class="flex flex-wrap items-center gap-2 mb-4">
+                                    @foreach($mediaBadges as $badge)
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-mono font-semibold {{ $badgeColors[$badge['color']] }}">
+                                            {{ $badge['label'] }}
+                                        </span>
+                                    @endforeach
+                                </div>
+                            @endif
 
                             <!-- Action Buttons -->
                             <div class="flex items-center justify-between">

--- a/tests/Feature/StreamMonitorMediaInfoTest.php
+++ b/tests/Feature/StreamMonitorMediaInfoTest.php
@@ -85,16 +85,18 @@ it('passes through media_info from the proxy when ffmpeg is active', function ()
         });
 });
 
-it('exposes the failover channel name when current_failover_index > 0', function () {
+it('exposes the failover channel name by matching current_url to a failover candidate', function () {
     $primary = Channel::factory()->createQuietly([
         'user_id' => $this->owner->id,
         'playlist_id' => $this->playlist->id,
         'name' => 'UK: BBC ONE 4K',
+        'url' => 'http://example.com/primary',
     ]);
     $backup = Channel::factory()->createQuietly([
         'user_id' => $this->owner->id,
         'playlist_id' => $this->playlist->id,
         'name' => 'UK: BBC ONE 720P',
+        'url' => 'http://example.com/backup',
     ]);
 
     ChannelFailover::create([
@@ -137,6 +139,77 @@ it('exposes the failover channel name when current_failover_index > 0', function
             return ($stream['model']['title'] ?? null) === 'UK: BBC ONE 4K'
                 && ($stream['failover_channel']['title'] ?? null) === 'UK: BBC ONE 720P'
                 && $stream['using_failover'] === true;
+        });
+});
+
+it('matches the correct failover channel even when the resolver skipped earlier candidates', function () {
+    // Simulates dynamic resolver mode: the resolver skipped the first
+    // failover (e.g. capacity full) and picked the second. The proxy bumps
+    // current_failover_index by one per successful failover, so the index
+    // (1) does NOT line up with the picked candidate's position (2 in the
+    // failoverChannels list). URL match is the only reliable identifier.
+    $primary = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Primary',
+        'url' => 'http://example.com/primary',
+    ]);
+    $skippedBackup = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Skipped Backup',
+        'url' => 'http://example.com/backup-1',
+    ]);
+    $activeBackup = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Active Backup',
+        'url' => 'http://example.com/backup-2',
+    ]);
+
+    ChannelFailover::create([
+        'user_id' => $this->owner->id,
+        'channel_id' => $primary->id,
+        'channel_failover_id' => $skippedBackup->id,
+        'sort' => 1,
+        'metadata' => '{}',
+    ]);
+    ChannelFailover::create([
+        'user_id' => $this->owner->id,
+        'channel_id' => $primary->id,
+        'channel_failover_id' => $activeBackup->id,
+        'sort' => 2,
+        'metadata' => '{}',
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'dynamic-failover-stream',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $primary->id,
+            ],
+            'original_url' => 'http://example.com/primary',
+            'current_url' => 'http://example.com/backup-2',
+            'stream_type' => 'hls',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 0,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => true,
+            'error_count' => 0,
+            'current_failover_index' => 1,
+            'failover_attempts' => 1,
+            'failover_resolver_url' => 'http://editor.test/api/m3u-proxy/failover-resolver',
+            'failover_urls' => [],
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            return ($streams[0]['failover_channel']['title'] ?? null) === 'Active Backup';
         });
 });
 

--- a/tests/Feature/StreamMonitorMediaInfoTest.php
+++ b/tests/Feature/StreamMonitorMediaInfoTest.php
@@ -1,0 +1,210 @@
+<?php
+
+use App\Filament\Pages\M3uProxyStreamMonitor;
+use App\Models\Channel;
+use App\Models\ChannelFailover;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->owner = User::factory()->create(['permissions' => ['use_proxy']]);
+    $this->playlist = Playlist::factory()->for($this->owner)->createQuietly();
+
+    $this->bindProxyMock = function (array $streams): void {
+        $service = Mockery::mock(M3uProxyService::class);
+        $service->shouldReceive('fetchActiveStreams')->andReturn([
+            'success' => true,
+            'streams' => $streams,
+        ]);
+        $service->shouldReceive('fetchActiveClients')->andReturn([
+            'success' => true,
+            'clients' => [],
+        ]);
+        $service->shouldReceive('fetchBroadcasts')->andReturn([
+            'success' => true,
+            'broadcasts' => [],
+        ]);
+        app()->instance(M3uProxyService::class, $service);
+    };
+
+    $this->actingAs($this->owner);
+});
+
+it('passes through media_info from the proxy when ffmpeg is active', function () {
+    $channel = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'BBC ONE',
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'live-stream-1',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $channel->id,
+                'transcoding' => true,
+            ],
+            'original_url' => 'http://example.com/s',
+            'current_url' => 'http://example.com/s',
+            'stream_type' => 'mpegts',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 1024,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => false,
+            'error_count' => 0,
+            'media_info' => [
+                'resolution' => '1920x1080',
+                'video_codec' => 'h264',
+                'fps' => 50.0,
+                'bitrate_kbps' => 6500.0,
+                'audio_codec' => 'aac',
+                'audio_channels' => 'stereo',
+                'container' => 'MPEGTS',
+            ],
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            expect($streams)->toHaveCount(1);
+            $info = $streams[0]['media_info'] ?? [];
+
+            return $info['resolution'] === '1920x1080'
+                && $info['video_codec'] === 'h264'
+                && $info['fps'] === 50.0
+                && $info['bitrate_kbps'] === 6500.0
+                && $info['audio_codec'] === 'aac'
+                && $info['audio_channels'] === 'stereo'
+                && $info['container'] === 'MPEGTS';
+        });
+});
+
+it('exposes the failover channel name when current_failover_index > 0', function () {
+    $primary = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'UK: BBC ONE 4K',
+    ]);
+    $backup = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'UK: BBC ONE 720P',
+    ]);
+
+    ChannelFailover::create([
+        'user_id' => $this->owner->id,
+        'channel_id' => $primary->id,
+        'channel_failover_id' => $backup->id,
+        'sort' => 1,
+        'metadata' => '{}',
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'failover-stream',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $primary->id,
+            ],
+            'original_url' => 'http://example.com/primary',
+            'current_url' => 'http://example.com/backup',
+            'stream_type' => 'hls',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 0,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => true,
+            'error_count' => 0,
+            'current_failover_index' => 1,
+            'failover_attempts' => 1,
+            'failover_urls' => ['http://example.com/backup'],
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            expect($streams)->toHaveCount(1);
+            $stream = $streams[0];
+
+            return ($stream['model']['title'] ?? null) === 'UK: BBC ONE 4K'
+                && ($stream['failover_channel']['title'] ?? null) === 'UK: BBC ONE 720P'
+                && $stream['using_failover'] === true;
+        });
+});
+
+it('omits the failover channel when no failover is active', function () {
+    $channel = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'plain-stream',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $channel->id,
+            ],
+            'original_url' => 'http://example.com/s',
+            'current_url' => 'http://example.com/s',
+            'stream_type' => 'hls',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 0,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => false,
+            'error_count' => 0,
+            'current_failover_index' => 0,
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            return $streams[0]['failover_channel'] === null
+                && $streams[0]['using_failover'] === false;
+        });
+});
+
+it('returns empty media_info when the proxy does not provide it', function () {
+    $channel = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'no-ffmpeg-stream',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $channel->id,
+            ],
+            'original_url' => 'http://example.com/s',
+            'current_url' => 'http://example.com/s',
+            'stream_type' => 'hls',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 0,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => false,
+            'error_count' => 0,
+            // no media_info key — plain HTTP-proxy stream
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            return $streams[0]['media_info'] === [];
+        });
+});


### PR DESCRIPTION
## Summary

Closes #1085. Stream Monitor now shows live media badges and the active failover channel name, matching the Dispatcharr-style readout requested in the issue.

Pairs with the proxy-side PR that publishes the data: m3ue/m3u-proxy#54.

## What changed

**Failover channel name** — when a stream is on a failover URL the title renders as `Primary Name → Failover Name`, with the failover name in orange to match the existing *Failover Active* badge styling. The active failover is identified by URL-matching `current_url` against `PlaylistUrlService::getChannelUrl()` for each candidate, which means it works correctly under the dynamic resolver (where the proxy's `current_failover_index` doesn't necessarily line up with the candidate's slot in `failoverChannels`). Falls back to index lookup for the static-list mode.

**Live media badges** — the page now shows resolution / fps / codec / audio / container / bitrate / speed when the proxy reports them. Badges are conditional on the proxy returning a non-empty `media_info`, so plain HTTP-proxy streams just don't show them rather than rendering empty placeholders.

The page only consumes data the proxy already publishes — there's no extra polling or work in the editor.

## Test plan

- [x] Open Stream Monitor while a transcoded stream is active — resolution, codec, fps and bitrate badges populate within a few seconds
- [x] Plain HTTP proxy stream — no badges (clean, not empty placeholders)
- [x] Trigger failover — title shows `Primary → Failover` with the failover name in orange; badges repopulate for the failover stream
- [x] With dynamic failover resolver enabled and the first candidate skipped, the title resolves to the *actually used* candidate (not the first one in the list)