### PR TITLE
feat: Layer live proxy media info on Stream Monitor + failover channel name

### DIFF
--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -11,6 +11,7 @@ use App\Models\PlaylistAlias;
 use App\Models\PlaylistProfile;
 use App\Models\StreamProfile;
 use App\Services\M3uProxyService;
+use App\Services\PlaylistUrlService;
 use Carbon\Carbon;
 use Exception;
 use Filament\Actions\Action;
@@ -297,7 +298,10 @@ class M3uProxyStreamMonitor extends Page
                 ->values();
 
             $channelsById = $channelIds->isNotEmpty()
-                ? Channel::whereIn('id', $channelIds)->get()->keyBy('id')
+                ? Channel::whereIn('id', $channelIds)
+                    ->with('failoverChannels')
+                    ->get()
+                    ->keyBy('id')
                 : collect();
             $episodesById = $episodeIds->isNotEmpty()
                 ? Episode::whereIn('id', $episodeIds)->get()->keyBy('id')
@@ -330,6 +334,7 @@ class M3uProxyStreamMonitor extends Page
                 $model = [];
                 $title = null;
                 $logo = null;
+                $failoverChannel = null;
                 if (isset($stream['metadata']['type']) && isset($stream['metadata']['id'])) {
                     $modelType = $stream['metadata']['type'];
                     $modelId = $stream['metadata']['id'];
@@ -353,23 +358,78 @@ class M3uProxyStreamMonitor extends Page
                         ];
                     }
 
-                    // Enrich with media info (video/audio metadata) from stored stream stats
+                    // Enrich with media info. Live ffmpeg data from the proxy wins where
+                    // present; stored ffprobe stats fill in everything else (and act as
+                    // the sole source for plain HTTP-proxy streams that don't transcode).
                     if ($modelType === 'channel') {
                         $channel = $channelsById[$modelId] ?? null;
                         if ($channel) {
                             $emby = $channel->getEmbyStreamStats();
-                            if (! empty($emby)) {
-                                $model['media_info'] = [
-                                    'resolution' => $emby['resolution'] ?? null,
-                                    'video_codec' => $emby['video_codec'] ?? null,
-                                    'video_profile' => $emby['video_profile'] ?? null,
-                                    'source_fps' => $emby['source_fps'] ?? null,
-                                    'video_bitrate_kbps' => $emby['ffmpeg_output_bitrate'] ?? null,
-                                    'audio_codec' => $emby['audio_codec'] ?? null,
-                                    'audio_channels' => $emby['audio_channels'] ?? null,
-                                    'audio_bitrate_kbps' => $emby['audio_bitrate'] ?? null,
-                                    'audio_language' => $emby['audio_language'] ?? null,
-                                ];
+                            $probeMediaInfo = ! empty($emby) ? [
+                                'resolution' => $emby['resolution'] ?? null,
+                                'video_codec' => $emby['video_codec'] ?? null,
+                                'video_profile' => $emby['video_profile'] ?? null,
+                                'source_fps' => $emby['source_fps'] ?? null,
+                                'video_bitrate_kbps' => $emby['ffmpeg_output_bitrate'] ?? null,
+                                'audio_codec' => $emby['audio_codec'] ?? null,
+                                'audio_channels' => $emby['audio_channels'] ?? null,
+                                'audio_bitrate_kbps' => $emby['audio_bitrate'] ?? null,
+                                'audio_language' => $emby['audio_language'] ?? null,
+                            ] : [];
+
+                            $liveMediaInfo = $stream['media_info'] ?? [];
+                            if (! empty($liveMediaInfo)) {
+                                $live = array_filter([
+                                    'resolution' => $liveMediaInfo['resolution'] ?? null,
+                                    'video_codec' => $liveMediaInfo['video_codec'] ?? null,
+                                    'source_fps' => $liveMediaInfo['fps'] ?? null,
+                                    'video_bitrate_kbps' => $liveMediaInfo['bitrate_kbps'] ?? null,
+                                    'audio_codec' => $liveMediaInfo['audio_codec'] ?? null,
+                                    'audio_channels' => $liveMediaInfo['audio_channels'] ?? null,
+                                ], fn ($v) => $v !== null && $v !== '');
+                                $merged = array_merge($probeMediaInfo, $live);
+                            } else {
+                                $merged = $probeMediaInfo;
+                            }
+
+                            if (! empty($merged)) {
+                                $model['media_info'] = $merged;
+                            }
+
+                            // When the proxy is on a failover URL, identify which configured
+                            // failover channel is currently in use. URL match handles dynamic
+                            // resolver mode (where current_failover_index doesn't necessarily
+                            // line up with the candidate's slot in failoverChannels). We fall
+                            // back to index lookup for the static-list mode.
+                            $currentUrl = (string) ($stream['current_url'] ?? '');
+                            $originalUrl = (string) ($stream['original_url'] ?? '');
+                            $currentFailoverIndex = (int) ($stream['current_failover_index'] ?? 0);
+                            $failoverActive = $currentFailoverIndex > 0
+                                || ($stream['failover_attempts'] ?? 0) > 0;
+
+                            if ($failoverActive && $currentUrl !== '' && $currentUrl !== $originalUrl) {
+                                foreach ($channel->failoverChannels as $candidate) {
+                                    try {
+                                        $candidateUrl = PlaylistUrlService::getChannelUrl($candidate);
+                                    } catch (Exception $e) {
+                                        continue;
+                                    }
+                                    if ($candidateUrl !== '' && $candidateUrl === $currentUrl) {
+                                        $failoverChannel = [
+                                            'title' => $candidate->name_custom ?? $candidate->name ?? $candidate->title,
+                                        ];
+                                        break;
+                                    }
+                                }
+
+                                if (! $failoverChannel && $currentFailoverIndex > 0) {
+                                    $candidate = $channel->failoverChannels[$currentFailoverIndex - 1] ?? null;
+                                    if ($candidate) {
+                                        $failoverChannel = [
+                                            'title' => $candidate->name_custom ?? $candidate->name ?? $candidate->title,
+                                        ];
+                                    }
+                                }
                             }
                         }
                     }
@@ -489,6 +549,7 @@ class M3uProxyStreamMonitor extends Page
                         ? Carbon::parse($stream['last_failover_time'], 'UTC')->format('Y-m-d H:i:s')
                         : null,
                     'using_failover' => ($stream['current_failover_index'] ?? 0) > 0 || ($stream['failover_attempts'] ?? 0) > 0,
+                    'failover_channel' => $failoverChannel,
                 ];
             }
         }
@@ -533,6 +594,7 @@ class M3uProxyStreamMonitor extends Page
                     'transcoding' => false,
                     'transcoding_format' => null,
                     'using_failover' => false,
+                    'failover_channel' => null,
                     'broadcast' => true,
                     'alias_name' => null,
                 ];

--- a/app/Filament/Pages/M3uProxyStreamMonitor.php
+++ b/app/Filament/Pages/M3uProxyStreamMonitor.php
@@ -378,6 +378,7 @@ class M3uProxyStreamMonitor extends Page
                             ] : [];
 
                             $liveMediaInfo = $stream['media_info'] ?? [];
+                            $live = [];
                             if (! empty($liveMediaInfo)) {
                                 $live = array_filter([
                                     'resolution' => $liveMediaInfo['resolution'] ?? null,
@@ -387,12 +388,13 @@ class M3uProxyStreamMonitor extends Page
                                     'audio_codec' => $liveMediaInfo['audio_codec'] ?? null,
                                     'audio_channels' => $liveMediaInfo['audio_channels'] ?? null,
                                 ], fn ($v) => $v !== null && $v !== '');
-                                $merged = array_merge($probeMediaInfo, $live);
-                            } else {
-                                $merged = $probeMediaInfo;
                             }
+                            $merged = array_merge($probeMediaInfo, $live);
 
                             if (! empty($merged)) {
+                                if (! empty($live)) {
+                                    $merged['is_live'] = true;
+                                }
                                 $model['media_info'] = $merged;
                             }
 

--- a/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
+++ b/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
@@ -183,7 +183,13 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
                                                                                 <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
                                                                                     Stream {{ substr($stream['stream_id'], -8) }}
                                                                                 </h3>
-                                                                                <p class="text-sm text-gray-500 dark:text-gray-400 font-mono">{{ $stream['model']['title'] ?? 'N/A' }}</p>
+                                                                                <p class="text-sm text-gray-500 dark:text-gray-400 font-mono">
+                                                                                    {{ $stream['model']['title'] ?? 'N/A' }}
+                                                                                    @if(!empty($stream['failover_channel']['title']))
+                                                                                        <span class="text-gray-400 dark:text-gray-500 mx-1">&rarr;</span>
+                                                                                        <span class="text-orange-600 dark:text-orange-400 font-medium">{{ $stream['failover_channel']['title'] }}</span>
+                                                                                    @endif
+                                                                                </p>
                                                                                 <p class="text-sm text-gray-500 dark:text-gray-400 font-mono truncate">{{ $stream['source_url'] }}</p>
                                                                             </div>
                                                                         </div>

--- a/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
+++ b/resources/views/filament/pages/m3u-proxy-stream-monitor.blade.php
@@ -279,6 +279,9 @@ echo $totalBandwidth > 1000 ? round($totalBandwidth / 1000, 1) . ' Mbps' : $tota
                                                                         <div class="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400 mr-1">
                                                                             <x-heroicon-s-film class="w-3.5 h-3.5" />
                                                                             <span class="font-medium uppercase tracking-wide">Stream Info</span>
+                                                                            @if($mediaInfo['is_live'] ?? false)
+                                                                                <span class="ml-1 inline-block h-1.5 w-1.5 rounded-full bg-green-500 animate-pulse" title="Live data from active ffmpeg"></span>
+                                                                            @endif
                                                                         </div>
                                                                         @if($mediaInfo['resolution'] ?? false)
                                                                             <x-filament::badge color="info" size="sm" icon="heroicon-s-squares-2x2">

--- a/tests/Feature/StreamMonitorMediaInfoTest.php
+++ b/tests/Feature/StreamMonitorMediaInfoTest.php
@@ -1,0 +1,354 @@
+<?php
+
+use App\Filament\Pages\M3uProxyStreamMonitor;
+use App\Models\Channel;
+use App\Models\ChannelFailover;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->owner = User::factory()->create(['permissions' => ['use_proxy']]);
+    $this->playlist = Playlist::factory()->for($this->owner)->createQuietly();
+
+    $this->bindProxyMock = function (array $streams): void {
+        $service = Mockery::mock(M3uProxyService::class);
+        $service->shouldReceive('fetchActiveStreams')->andReturn([
+            'success' => true,
+            'streams' => $streams,
+        ]);
+        $service->shouldReceive('fetchActiveClients')->andReturn([
+            'success' => true,
+            'clients' => [],
+        ]);
+        $service->shouldReceive('fetchBroadcasts')->andReturn([
+            'success' => true,
+            'broadcasts' => [],
+        ]);
+        app()->instance(M3uProxyService::class, $service);
+    };
+
+    $this->actingAs($this->owner);
+});
+
+it('lets live proxy media_info win over stored probe data per-field', function () {
+    // Channel has stored probe data from a sync-time ffprobe run — slightly stale
+    // (was 1080p h264 50fps when probed). The proxy reports live ffmpeg data
+    // showing the stream is currently 1280x720 (e.g. provider re-encoded). Live
+    // values must win where present; probe-only fields stay.
+    $channel = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'BBC ONE',
+        'stream_stats' => [
+            ['stream' => [
+                'codec_type' => 'video',
+                'codec_name' => 'h264',
+                'profile' => 'High',
+                'width' => 1920,
+                'height' => 1080,
+                'avg_frame_rate' => '50/1',
+                'bit_rate' => '6500000',
+            ]],
+            ['stream' => [
+                'codec_type' => 'audio',
+                'codec_name' => 'aac',
+                'channels' => 2,
+                'bit_rate' => '192000',
+                'tags' => ['language' => 'eng'],
+            ]],
+        ],
+        'stream_stats_probed_at' => now(),
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'live-stream-1',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $channel->id,
+                'transcoding' => true,
+            ],
+            'original_url' => 'http://example.com/s',
+            'current_url' => 'http://example.com/s',
+            'stream_type' => 'mpegts',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 1024,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => false,
+            'error_count' => 0,
+            'media_info' => [
+                'resolution' => '1280x720',
+                'video_codec' => 'hevc',
+                'fps' => 30.0,
+                'bitrate_kbps' => 4500.0,
+                'audio_codec' => 'opus',
+                'audio_channels' => 'stereo',
+                'container' => 'MPEGTS',
+            ],
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            $info = $streams[0]['model']['media_info'] ?? [];
+
+            return $info['resolution'] === '1280x720'         // live wins
+                && $info['video_codec'] === 'hevc'             // live wins
+                && $info['source_fps'] === 30.0                // live wins
+                && $info['video_bitrate_kbps'] === 4500.0      // live wins
+                && $info['audio_codec'] === 'opus'             // live wins
+                && $info['video_profile'] === 'High'           // probe-only, kept
+                && $info['audio_language'] === 'eng'           // probe-only, kept
+                && $info['audio_bitrate_kbps'] === 192.0;      // probe-only, kept
+        });
+});
+
+it('falls back to stored probe data when the proxy reports no live media_info', function () {
+    // Plain HTTP-proxy stream — no transcoding, no live ffmpeg, no media_info from
+    // the proxy. The page should still surface badges from the stored probe data
+    // so non-transcoded streams aren't badge-less.
+    $channel = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'stream_stats' => [
+            ['stream' => [
+                'codec_type' => 'video',
+                'codec_name' => 'h264',
+                'width' => 1920,
+                'height' => 1080,
+                'avg_frame_rate' => '25/1',
+            ]],
+        ],
+        'stream_stats_probed_at' => now(),
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'plain-stream',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $channel->id,
+            ],
+            'original_url' => 'http://example.com/s',
+            'current_url' => 'http://example.com/s',
+            'stream_type' => 'hls',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 0,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => false,
+            'error_count' => 0,
+            // no media_info key — proxy isn't transcoding
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            $info = $streams[0]['model']['media_info'] ?? [];
+
+            return $info['resolution'] === '1920x1080'
+                && $info['video_codec'] === 'h264'
+                && $info['source_fps'] === 25.0;
+        });
+});
+
+it('omits media_info entirely when neither probe nor live data is available', function () {
+    $channel = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'stream_stats' => null,
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'bare-stream',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $channel->id,
+            ],
+            'original_url' => 'http://example.com/s',
+            'current_url' => 'http://example.com/s',
+            'stream_type' => 'hls',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 0,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => false,
+            'error_count' => 0,
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            return ! isset($streams[0]['model']['media_info']);
+        });
+});
+
+it('exposes the failover channel name by URL-matching the active failover candidate', function () {
+    $primary = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'UK: BBC ONE 4K',
+        'url' => 'http://example.com/primary',
+    ]);
+    $backup = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'UK: BBC ONE 720P',
+        'url' => 'http://example.com/backup',
+    ]);
+
+    ChannelFailover::create([
+        'user_id' => $this->owner->id,
+        'channel_id' => $primary->id,
+        'channel_failover_id' => $backup->id,
+        'sort' => 1,
+        'metadata' => '{}',
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'failover-stream',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $primary->id,
+            ],
+            'original_url' => 'http://example.com/primary',
+            'current_url' => 'http://example.com/backup',
+            'stream_type' => 'hls',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 0,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => true,
+            'error_count' => 0,
+            'current_failover_index' => 1,
+            'failover_attempts' => 1,
+            'failover_urls' => ['http://example.com/backup'],
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            $stream = $streams[0];
+
+            return ($stream['failover_channel']['title'] ?? null) === 'UK: BBC ONE 720P'
+                && $stream['using_failover'] === true;
+        });
+});
+
+it('matches the correct failover channel when the dynamic resolver skipped earlier candidates', function () {
+    // Dynamic resolver mode: the resolver skipped the first candidate (e.g. capacity
+    // full) and picked the second. current_failover_index increments by one per
+    // successful failover, so the index (1) does not line up with the picked
+    // candidate's slot (2). URL match is the only reliable identifier.
+    $primary = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Primary',
+        'url' => 'http://example.com/primary',
+    ]);
+    $skipped = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Skipped Backup',
+        'url' => 'http://example.com/backup-1',
+    ]);
+    $active = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Active Backup',
+        'url' => 'http://example.com/backup-2',
+    ]);
+
+    ChannelFailover::create([
+        'user_id' => $this->owner->id,
+        'channel_id' => $primary->id,
+        'channel_failover_id' => $skipped->id,
+        'sort' => 1,
+        'metadata' => '{}',
+    ]);
+    ChannelFailover::create([
+        'user_id' => $this->owner->id,
+        'channel_id' => $primary->id,
+        'channel_failover_id' => $active->id,
+        'sort' => 2,
+        'metadata' => '{}',
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'dynamic-failover-stream',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $primary->id,
+            ],
+            'original_url' => 'http://example.com/primary',
+            'current_url' => 'http://example.com/backup-2',
+            'stream_type' => 'hls',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 0,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => true,
+            'error_count' => 0,
+            'current_failover_index' => 1,
+            'failover_attempts' => 1,
+            'failover_resolver_url' => 'http://editor.test/api/m3u-proxy/failover-resolver',
+            'failover_urls' => [],
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            return ($streams[0]['failover_channel']['title'] ?? null) === 'Active Backup';
+        });
+});
+
+it('omits the failover channel when no failover is active', function () {
+    $channel = Channel::factory()->createQuietly([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    ($this->bindProxyMock)([
+        [
+            'stream_id' => 'plain-stream',
+            'metadata' => [
+                'playlist_uuid' => $this->playlist->uuid,
+                'type' => 'channel',
+                'id' => $channel->id,
+            ],
+            'original_url' => 'http://example.com/s',
+            'current_url' => 'http://example.com/s',
+            'stream_type' => 'hls',
+            'is_active' => true,
+            'client_count' => 1,
+            'total_bytes_served' => 0,
+            'total_segments_served' => 0,
+            'created_at' => now()->toIso8601String(),
+            'has_failover' => false,
+            'error_count' => 0,
+            'current_failover_index' => 0,
+        ],
+    ]);
+
+    Livewire::test(M3uProxyStreamMonitor::class)
+        ->assertSet('streams', function (array $streams) {
+            return $streams[0]['failover_channel'] === null
+                && $streams[0]['using_failover'] === false;
+        });
+});

--- a/tests/Feature/StreamMonitorMediaInfoTest.php
+++ b/tests/Feature/StreamMonitorMediaInfoTest.php
@@ -104,7 +104,8 @@ it('lets live proxy media_info win over stored probe data per-field', function (
                 && $info['audio_codec'] === 'opus'             // live wins
                 && $info['video_profile'] === 'High'           // probe-only, kept
                 && $info['audio_language'] === 'eng'           // probe-only, kept
-                && $info['audio_bitrate_kbps'] === 192.0;      // probe-only, kept
+                && $info['audio_bitrate_kbps'] === 192.0       // probe-only, kept
+                && $info['is_live'] === true;                  // flagged for the live indicator dot
         });
 });
 
@@ -155,7 +156,8 @@ it('falls back to stored probe data when the proxy reports no live media_info', 
 
             return $info['resolution'] === '1920x1080'
                 && $info['video_codec'] === 'h264'
-                && $info['source_fps'] === 25.0;
+                && $info['source_fps'] === 25.0
+                && ! isset($info['is_live']);                  // probe-only must not show the live dot
         });
 });
 


### PR DESCRIPTION
## Summary

Builds on the Stream Monitor media badges added in 0146613b. Layers two things on top:

1. **Live ffmpeg media info** from the proxy overrides the stored ffprobe data per-field, so badges reflect what's actually being streamed *right now* rather than what was probed at sync time. Probe data still fills in fields the proxy doesn't expose (video profile, audio language, audio bitrate) and remains the sole source for plain HTTP-proxy streams that don't transcode.
2. **Failover channel name** in the title — when on a failover URL the title renders as `Primary → Failover` with the failover name in orange, matching the existing Failover Active badge.

Closes #1085. Pairs with the proxy-side PR that publishes the live data: m3ue/m3u-proxy#54.

Supersedes #1088 (which was based on the previous dev HEAD before badges had landed there).

## What changed

**Live data layering** (`app/Filament/Pages/M3uProxyStreamMonitor.php`)

The existing block that pulls `getEmbyStreamStats()` for `media_info` now also reads `media_info` from the proxy stream payload. Proxy keys are mapped to the editor's existing field shape:

| Proxy field | Editor field |
| --- | --- |
| `resolution` | `resolution` |
| `video_codec` | `video_codec` |
| `fps` | `source_fps` |
| `bitrate_kbps` | `video_bitrate_kbps` |
| `audio_codec` | `audio_codec` |
| `audio_channels` | `audio_channels` |

`array_filter` strips empty live values so the merge only overrides where the proxy actually has data, keeping `video_profile`, `audio_language`, and `audio_bitrate_kbps` from the probe path. The blade renders unchanged keys, so no UI rework was needed.

**Failover channel resolution**

The active failover is identified by URL-matching `current_url` against `PlaylistUrlService::getChannelUrl()` for each candidate in `failoverChannels`. Static-list mode falls back to index lookup if the URL match fails. The dynamic resolver case (where the resolver skipped earlier candidates and `current_failover_index` doesn't line up with the candidate's slot) is the reason for the URL-match path — covered by a dedicated test.

`failoverChannels` is eager-loaded on the channel pre-fetch to keep this from regressing the page's N+1 budget.

**Title display** (blade)

Drops a `Primary → Failover` line into the existing title block when `failover_channel.title` is populated. Reuses the existing orange used by the Failover Active badge.

## Test plan

- [x] Open Stream Monitor with a transcoded stream that has stored probe data — badges populate immediately from probe, then live values overlay on resolution/fps/bitrate within ~1-3s
- [x] Plain HTTP proxy stream — badges still show from probe data only (no live data path)
- [x] Stream with no probe data and no transcoding — no badges (as before)
- [x] Trigger failover — title shows `Primary → Failover` in orange; badges repopulate from the failover stream's live data once the new ffmpeg starts emitting Stream lines
- [x] Dynamic failover resolver with the first candidate skipped — title resolves to the *actually used* candidate, not the first one in the list