### PR TITLE
fix(merge): respect exclude_disabled_groups for master selection and re-enable

### DIFF
--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -141,8 +141,10 @@ class MergeChannels implements ShouldQueue
                 continue; // Skip if no valid master found
             }
 
-            // Ensure master is enabled in case it was previously disabled
-            if (! $master->enabled) {
+            // Ensure master is enabled in case it was previously disabled,
+            // but never silently re-enable a master that lives in a disabled group
+            // when the user opted in to exclude_disabled_groups.
+            if (! $master->enabled && ! in_array($master->group_id, $this->disabledGroupIds, true)) {
                 $master->update(['enabled' => true]);
             }
 
@@ -304,12 +306,15 @@ class MergeChannels implements ShouldQueue
      */
     protected function selectMasterChannel(Collection $group, array $playlistPriority): ?Channel
     {
-        // Filter out channels from disabled groups if enabled
+        // Filter out channels from disabled groups if enabled.
+        // When the user opted in to exclude_disabled_groups, we must NOT fall back
+        // to the unfiltered group: that would silently pick (and later re-enable)
+        // a channel from a disabled group as master, which is exactly what the
+        // option is supposed to prevent.
         $eligibleGroup = $this->filterDisabledGroups($group);
 
         if ($eligibleGroup->isEmpty()) {
-            // Fallback to original group if all were filtered
-            $eligibleGroup = $group;
+            return null;
         }
 
         // Use weighted priority system if config provided

--- a/tests/Feature/MergeDisabledGroupsTest.php
+++ b/tests/Feature/MergeDisabledGroupsTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use App\Jobs\MergeChannels;
+use App\Models\Channel;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    Notification::fake();
+
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+
+    $this->playlist = Playlist::factory()->createQuietly([
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->enabledGroup = Group::factory()->createQuietly([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'enabled' => true,
+    ]);
+
+    $this->disabledGroup = Group::factory()->createQuietly([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'enabled' => false,
+    ]);
+});
+
+it('does not select a channel from a disabled group as master when exclude_disabled_groups is enabled', function () {
+    // The disabled-group channel has the better sort (= would normally win)
+    $disabledMaster = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->disabledGroup->id,
+        'stream_id' => 'shared-id',
+        'name' => 'Disabled Group Channel',
+        'sort' => 1.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    $enabledCandidate = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->enabledGroup->id,
+        'stream_id' => 'shared-id',
+        'name' => 'Enabled Group Channel',
+        'sort' => 5.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
+    (new MergeChannels(
+        user: $this->user,
+        playlists: $playlists,
+        playlistId: $this->playlist->id,
+        weightedConfig: [
+            'priority_keywords' => [],
+            'prefer_codec' => null,
+            'exclude_disabled_groups' => true,
+            'group_priorities' => [],
+            'priority_attributes' => ['playlist_priority'],
+        ],
+    ))->handle();
+
+    // The enabled-group channel must be master, the disabled-group channel its failover.
+    $this->assertDatabaseCount('channel_failovers', 1);
+    $this->assertDatabaseHas('channel_failovers', [
+        'channel_id' => $enabledCandidate->id,
+        'channel_failover_id' => $disabledMaster->id,
+    ]);
+    $this->assertDatabaseMissing('channel_failovers', [
+        'channel_id' => $disabledMaster->id,
+    ]);
+});
+
+it('skips merge entirely when every candidate sits in a disabled group', function () {
+    // Two channels share a stream id, but BOTH live in disabled groups.
+    // With exclude_disabled_groups=true the job must not pick a master at all
+    // (no failover row, no enable side-effect on either channel).
+    $a = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->disabledGroup->id,
+        'stream_id' => 'orphan-id',
+        'name' => 'Disabled A',
+        'sort' => 1.0,
+        'enabled' => false,
+        'can_merge' => true,
+    ]);
+
+    $b = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->disabledGroup->id,
+        'stream_id' => 'orphan-id',
+        'name' => 'Disabled B',
+        'sort' => 2.0,
+        'enabled' => false,
+        'can_merge' => true,
+    ]);
+
+    $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
+    (new MergeChannels(
+        user: $this->user,
+        playlists: $playlists,
+        playlistId: $this->playlist->id,
+        weightedConfig: [
+            'priority_keywords' => [],
+            'prefer_codec' => null,
+            'exclude_disabled_groups' => true,
+            'group_priorities' => [],
+            'priority_attributes' => ['playlist_priority'],
+        ],
+    ))->handle();
+
+    $this->assertDatabaseCount('channel_failovers', 0);
+    expect($a->fresh()->enabled)->toBeFalse();
+    expect($b->fresh()->enabled)->toBeFalse();
+});
+
+it('does not silently re-enable a disabled master that lives in a disabled group', function () {
+    // One enabled candidate (will become master), one disabled candidate in a
+    // disabled group. The enabled candidate must NOT be touched, and the
+    // disabled-group failover must NOT be auto-enabled.
+    $disabledFailover = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->disabledGroup->id,
+        'stream_id' => 'mix-id',
+        'name' => 'Disabled Group Failover',
+        'sort' => 1.0,
+        'enabled' => false,
+        'can_merge' => true,
+    ]);
+
+    $enabledMaster = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $this->enabledGroup->id,
+        'stream_id' => 'mix-id',
+        'name' => 'Enabled Master',
+        'sort' => 5.0,
+        'enabled' => true,
+        'can_merge' => true,
+    ]);
+
+    $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
+    (new MergeChannels(
+        user: $this->user,
+        playlists: $playlists,
+        playlistId: $this->playlist->id,
+        weightedConfig: [
+            'priority_keywords' => [],
+            'prefer_codec' => null,
+            'exclude_disabled_groups' => true,
+            'group_priorities' => [],
+            'priority_attributes' => ['playlist_priority'],
+        ],
+    ))->handle();
+
+    // The disabled-group channel stays disabled; it became a failover, not master.
+    expect($disabledFailover->fresh()->enabled)->toBeFalse();
+    expect($enabledMaster->fresh()->enabled)->toBeTrue();
+    $this->assertDatabaseHas('channel_failovers', [
+        'channel_id' => $enabledMaster->id,
+        'channel_failover_id' => $disabledFailover->id,
+    ]);
+});


### PR DESCRIPTION
## Problem

The `exclude_disabled_groups` option on the merge-by-stream-id flow is silently bypassed in two places, with the combined effect that channels in disabled groups are picked as master and then auto-enabled — the exact opposite of what the option promises.

The UI helper text states:

> Channels from disabled groups will never be selected as master.

…but they currently are, and they get re-enabled in the process.

## Root cause

Two related bugs in `app/Jobs/MergeChannels.php`:

1. **`selectMasterChannel()` falls back to the unfiltered group.** It filters candidates by enabled groups, but when every candidate is filtered out it falls back to the original group and picks a master from a disabled group anyway.

   ```php
   $eligibleGroup = $this->filterDisabledGroups($group);
   if ($eligibleGroup->isEmpty()) {
       // Fallback to original group if all were filtered
       $eligibleGroup = $group;
   }
   ```

2. **`handle()` unconditionally re-enables the chosen master.** Combined with bug 1 this also re-enables channels that live in disabled groups — so toggling the option on actively flips disabled channels to enabled.

   ```php
   if (! $master->enabled) {
       $master->update(['enabled' => true]);
   }
   ```

## Fix

1. `selectMasterChannel()` returns `null` when no eligible candidate exists. No master is picked, no failover row is created, no channel is touched.
2. `handle()` only auto-enables the master when its `group_id` is not in `$this->disabledGroupIds`.

## Tests

New `tests/Feature/MergeDisabledGroupsTest.php` (3 cases, all green):

- master is taken from the enabled group even when the disabled-group candidate has the better sort
- merge is skipped entirely when every candidate is in a disabled group (no failover rows, channels stay disabled)
- a disabled-group channel that becomes a failover stays `enabled = false`; the master from the enabled group is the only one enabled

Existing `MergeChannelOrderingTest.php` still passes (3/3). `vendor/bin/pint --dirty` clean.

## Behavior change

Only when `exclude_disabled_groups = true`:

- Before: master could be picked from a disabled group; that master was re-enabled.
- After: candidates in disabled groups can still become failovers under an enabled master, but never master themselves, and they are never silently re-enabled.

When `exclude_disabled_groups = false` behavior is unchanged.
