### PR TITLE
feat(channel): derive video bitrate from container for live MPEG-TS streams

### DIFF
--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -367,7 +367,7 @@ class Channel extends Model
                 return [];
             }
 
-            $process = new SymfonyProcess(['ffprobe', '-v', 'quiet', '-print_format', 'json', '-show_streams', $url]);
+            $process = new SymfonyProcess(['ffprobe', '-v', 'quiet', '-print_format', 'json', '-show_streams', '-show_format', $url]);
             $process->setTimeout($timeout);
             $process->run();
 
@@ -404,6 +404,15 @@ class Channel extends Model
                     }
                 }
 
+                // MPEG-TS live streams typically don't expose a per-stream video
+                // bit_rate (no CBR container, unknown duration). Capture the
+                // container-level bit_rate from -show_format so we can derive a
+                // sensible video bitrate fallback in getEmbyStreamStats().
+                $formatBitRate = $json['format']['bit_rate'] ?? null;
+                if ($formatBitRate !== null) {
+                    $streamStats[] = ['format' => ['bit_rate' => $formatBitRate]];
+                }
+
                 return $streamStats;
             }
         } catch (Exception $e) {
@@ -427,7 +436,13 @@ class Channel extends Model
 
         $video = null;
         $audio = null;
+        $formatBitRate = null;
         foreach ($stats as $entry) {
+            if (isset($entry['format']['bit_rate'])) {
+                $formatBitRate = $entry['format']['bit_rate'];
+
+                continue;
+            }
             $stream = $entry['stream'] ?? $entry;
             if (($stream['codec_type'] ?? '') === 'video' && ! $video) {
                 $video = $stream;
@@ -462,8 +477,19 @@ class Channel extends Model
                 $result['source_fps'] = $fps ? (float) $fps : null;
             }
 
-            // Convert bps to kbps
+            // Convert bps to kbps. For MPEG-TS live streams ffprobe usually
+            // reports no per-stream bit_rate on the video elementary stream
+            // (no CBR container, unknown duration). Fall back to
+            // container_bitrate - audio_bitrate, which is a tight upper bound
+            // for the video bitrate on a typical 1 video + 1 audio TS mux.
             $bitRate = $video['bit_rate'] ?? null;
+            if ($bitRate === null && $formatBitRate !== null) {
+                $audioBps = isset($audio['bit_rate']) ? (float) $audio['bit_rate'] : 0.0;
+                $derived = (float) $formatBitRate - $audioBps;
+                if ($derived > 0) {
+                    $bitRate = $derived;
+                }
+            }
             $result['ffmpeg_output_bitrate'] = $bitRate ? round((float) $bitRate / 1000, 1) : null;
         }
 

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -357,7 +357,15 @@ class Channel extends Model
     /**
      * Run ffprobe against this channel's stream URL and return parsed stats.
      *
-     * @return array{streams: array<int, array{codec_type: string, codec_name: string, codec_long_name: ?string, profile: ?string, width: ?int, height: ?int, bit_rate: ?string, avg_frame_rate: ?string, display_aspect_ratio: ?string, sample_rate: ?string, channels: ?int, channel_layout: ?string, level: ?int, bits_per_raw_sample: ?string}>}
+     * Returns a flat list of entries, each with one of two shapes:
+     *   - Stream entry:  ['stream' => ['codec_type' => string, 'codec_name' => string, ...]]
+     *   - Format entry:  ['format' => ['bit_rate' => string]]  (appended once when available)
+     *
+     * The format entry carries the container-level bit_rate from `-show_format`. It is used
+     * as a fallback video bitrate for live MPEG-TS streams where ffprobe cannot determine
+     * a per-stream bit_rate. See getEmbyStreamStats() for the derivation logic.
+     *
+     * @return list<array{stream: array{codec_type: string, codec_name: string, codec_long_name: ?string, profile: ?string, width: ?int, height: ?int, bit_rate: ?string, avg_frame_rate: ?string, display_aspect_ratio: ?string, sample_rate: ?string, channels: ?int, channel_layout: ?string, level: ?int, bits_per_raw_sample: ?string, refs: ?int, tags: array<string, string>}}|array{format: array{bit_rate: string}}>
      */
     public function probeStreamStats(int $timeout = 15): array
     {
@@ -482,6 +490,8 @@ class Channel extends Model
             // (no CBR container, unknown duration). Fall back to
             // container_bitrate - audio_bitrate, which is a tight upper bound
             // for the video bitrate on a typical 1 video + 1 audio TS mux.
+            // NOTE: only the first audio track's bitrate is subtracted, so streams
+            // with multiple audio tracks will produce a slightly overstated value.
             $bitRate = $video['bit_rate'] ?? null;
             if ($bitRate === null && $formatBitRate !== null) {
                 $audioBps = isset($audio['bit_rate']) ? (float) $audio['bit_rate'] : 0.0;

--- a/tests/Feature/ChannelStreamStatsTest.php
+++ b/tests/Feature/ChannelStreamStatsTest.php
@@ -3,8 +3,10 @@
 use App\Models\Channel;
 use App\Models\Playlist;
 use App\Models\User;
+use Illuminate\Support\Facades\Event;
 
 beforeEach(function () {
+    Event::fake();
     $this->user = User::factory()->create();
     $this->playlist = Playlist::factory()->for($this->user)->createQuietly();
 });
@@ -110,6 +112,78 @@ it('defaults video_bit_depth to 8 when bits_per_raw_sample is not set', function
     ]);
 
     expect($channel->getEmbyStreamStats()['video_bit_depth'])->toBe(8);
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Live MPEG-TS bitrate fallback – derive video bitrate from container bitrate
+// ──────────────────────────────────────────────────────────────────────────────
+
+it('derives video bitrate from container bit_rate when video stream has none (live MPEG-TS)', function () {
+    $channel = Channel::factory()->for($this->playlist)->create([
+        'stream_stats' => [
+            ['stream' => [
+                'codec_type' => 'video',
+                'codec_name' => 'h264',
+                'width' => 1920,
+                'height' => 1080,
+                // Live TS: no per-stream video bit_rate
+                'bit_rate' => null,
+            ]],
+            ['stream' => [
+                'codec_type' => 'audio',
+                'codec_name' => 'ac3',
+                'channels' => 6,
+                'sample_rate' => '48000',
+                'bit_rate' => '448000',
+            ]],
+            // ffprobe -show_format container bitrate (e.g. 5 Mbit/s mux)
+            ['format' => ['bit_rate' => '5000000']],
+        ],
+    ]);
+
+    $result = $channel->getEmbyStreamStats();
+
+    // 5 000 000 - 448 000 = 4 552 000 bps -> 4552.0 kbps
+    expect($result['ffmpeg_output_bitrate'])->toBe(4552.0)
+        ->and($result['audio_bitrate'])->toBe(448.0);
+});
+
+it('prefers per-stream video bit_rate over container fallback when both exist', function () {
+    $channel = Channel::factory()->for($this->playlist)->create([
+        'stream_stats' => [
+            ['stream' => [
+                'codec_type' => 'video',
+                'codec_name' => 'h264',
+                'width' => 1920,
+                'height' => 1080,
+                'bit_rate' => '3000000',
+            ]],
+            ['stream' => [
+                'codec_type' => 'audio',
+                'codec_name' => 'aac',
+                'channels' => 2,
+                'bit_rate' => '128000',
+            ]],
+            ['format' => ['bit_rate' => '9999999']],
+        ],
+    ]);
+
+    expect($channel->getEmbyStreamStats()['ffmpeg_output_bitrate'])->toBe(3000.0);
+});
+
+it('leaves video bitrate null when container bitrate is missing and stream has none', function () {
+    $channel = Channel::factory()->for($this->playlist)->create([
+        'stream_stats' => [
+            ['stream' => [
+                'codec_type' => 'video',
+                'codec_name' => 'h264',
+                'width' => 1920,
+                'height' => 1080,
+            ]],
+        ],
+    ]);
+
+    expect($channel->getEmbyStreamStats()['ffmpeg_output_bitrate'])->toBeNull();
 });
 
 it('handles 10-bit video correctly', function () {


### PR DESCRIPTION
ffprobe does not expose a per-stream `bit_rate` on the video elementary stream of live MPEG-TS feeds (no CBR container, unknown duration), so `getEmbyStreamStats()` returned `ffmpeg_output_bitrate = null`. Downstream consumers (e.g. emby-xtream) then fell back to the audio bitrate as the MediaSource bitrate, which is wildly wrong (e.g. 384 kbps for a 1080p mux).

This is the cheapest fix that gets a useful value:

- Add `-show_format` to the existing ffprobe call (one extra section, no extra round-trip, no extra timeout).
- Persist the container `format.bit_rate` alongside the streams in `stream_stats` as a `['format' => ['bit_rate' => …]]` entry (kept separate from stream entries so existing consumers still iterate streams unchanged).
- In `getEmbyStreamStats()`, prefer the per-stream video `bit_rate` when present; otherwise fall back to `format.bit_rate - audio.bit_rate`, which is a tight upper bound for the video bitrate on a typical 1 video + 1 audio TS mux.

Tests cover all three paths: live TS fallback, per-stream value wins when both are available, and null when neither is available.