### PR TITLE
fix(probe): aggregate manual bulk-probe completion via Bus::batch

### DIFF
--- a/app/Filament/Resources/Series/RelationManagers/EpisodesRelationManager.php
+++ b/app/Filament/Resources/Series/RelationManagers/EpisodesRelationManager.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Resources\Series\RelationManagers;
 
 use App\Filament\Tables\ProbeStatusColumn;
-use App\Jobs\ProbeVodStreamsChunk;
+use App\Jobs\ProbeManualComplete;
 use Filament\Actions;
 use Filament\Actions\Action;
 use Filament\Actions\ViewAction;
@@ -254,19 +254,11 @@ class EpisodesRelationManager extends RelationManager
                     Actions\BulkAction::make('probe-streams')
                         ->label(__('Probe Streams'))
                         ->action(function (Collection $records): void {
-                            $ids = $records->pluck('id')->all();
-                            $total = count($ids);
-                            $chunks = array_chunk($ids, 50);
-                            $last = count($chunks) - 1;
-                            foreach ($chunks as $i => $chunk) {
-                                dispatch(new ProbeVodStreamsChunk(
-                                    episodeIds: $chunk,
-                                    probeTimeout: 15,
-                                    notifyUserId: $i === $last ? auth()->id() : null,
-                                    notifyLabel: $i === $last ? __('Episode stream probing') : null,
-                                    notifyTotal: $i === $last ? $total : null,
-                                ));
-                            }
+                            ProbeManualComplete::dispatchBulk(
+                                notifyUserId: auth()->id(),
+                                notifyLabel: __('Episode stream probing'),
+                                episodeIds: $records->pluck('id')->all(),
+                            );
                         })->after(function () {
                             Notification::make()
                                 ->success()

--- a/app/Filament/Resources/Series/SeriesResource.php
+++ b/app/Filament/Resources/Series/SeriesResource.php
@@ -14,7 +14,7 @@ use App\Filament\Resources\Series\Pages\ViewSeries;
 use App\Filament\Resources\Series\RelationManagers\EpisodesRelationManager;
 use App\Forms\Components\TmdbSearchResults;
 use App\Jobs\FetchTmdbIds;
-use App\Jobs\ProbeVodStreamsChunk;
+use App\Jobs\ProbeManualComplete;
 use App\Jobs\ProcessM3uImportSeriesEpisodes;
 use App\Jobs\SeriesFindAndReplace;
 use App\Jobs\SyncSeriesStrmFiles;
@@ -531,18 +531,11 @@ class SeriesResource extends Resource implements CopilotResource
                             ->pluck('id')
                             ->all();
                         if (! empty($episodeIds)) {
-                            $total = count($episodeIds);
-                            $chunks = array_chunk($episodeIds, 50);
-                            $last = count($chunks) - 1;
-                            foreach ($chunks as $i => $chunk) {
-                                dispatch(new ProbeVodStreamsChunk(
-                                    episodeIds: $chunk,
-                                    probeTimeout: 15,
-                                    notifyUserId: $i === $last ? auth()->id() : null,
-                                    notifyLabel: $i === $last ? __('Series stream probing') : null,
-                                    notifyTotal: $i === $last ? $total : null,
-                                ));
-                            }
+                            ProbeManualComplete::dispatchBulk(
+                                notifyUserId: auth()->id(),
+                                notifyLabel: __('Series stream probing'),
+                                episodeIds: $episodeIds,
+                            );
                         }
                     })->after(function () {
                         Notification::make()
@@ -953,18 +946,11 @@ class SeriesResource extends Resource implements CopilotResource
                             ->pluck('id')
                             ->all();
                         if (! empty($episodeIds)) {
-                            $total = count($episodeIds);
-                            $chunks = array_chunk($episodeIds, 50);
-                            $last = count($chunks) - 1;
-                            foreach ($chunks as $i => $chunk) {
-                                dispatch(new ProbeVodStreamsChunk(
-                                    episodeIds: $chunk,
-                                    probeTimeout: 15,
-                                    notifyUserId: $i === $last ? auth()->id() : null,
-                                    notifyLabel: $i === $last ? __('Series stream probing') : null,
-                                    notifyTotal: $i === $last ? $total : null,
-                                ));
-                            }
+                            ProbeManualComplete::dispatchBulk(
+                                notifyUserId: auth()->id(),
+                                notifyLabel: __('Series stream probing'),
+                                episodeIds: $episodeIds,
+                            );
                         }
                     })->after(function () {
                         Notification::make()

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -15,6 +15,7 @@ use App\Forms\Components\TmdbSearchResults;
 use App\Jobs\ChannelFindAndReplace;
 use App\Jobs\ChannelFindAndReplaceReset;
 use App\Jobs\FetchTmdbIds;
+use App\Jobs\ProbeManualComplete;
 use App\Jobs\ProbeVodStreamsChunk;
 use App\Jobs\ProcessVodChannels;
 use App\Jobs\SyncPlexDvrJob;
@@ -1378,19 +1379,11 @@ class VodResource extends Resource implements CopilotResource
                 BulkAction::make('probe-streams')
                     ->label(__('Probe Streams'))
                     ->action(function (Collection $records): void {
-                        $ids = $records->pluck('id')->all();
-                        $total = count($ids);
-                        $chunks = array_chunk($ids, 50);
-                        $last = count($chunks) - 1;
-                        foreach ($chunks as $i => $chunk) {
-                            dispatch(new ProbeVodStreamsChunk(
-                                channelIds: $chunk,
-                                probeTimeout: 15,
-                                notifyUserId: $i === $last ? auth()->id() : null,
-                                notifyLabel: $i === $last ? __('VOD stream probing') : null,
-                                notifyTotal: $i === $last ? $total : null,
-                            ));
-                        }
+                        ProbeManualComplete::dispatchBulk(
+                            notifyUserId: auth()->id(),
+                            notifyLabel: __('VOD stream probing'),
+                            channelIds: $records->pluck('id')->all(),
+                        );
                     })->after(function () {
                         Notification::make()
                             ->success()

--- a/app/Jobs/ProbeManualComplete.php
+++ b/app/Jobs/ProbeManualComplete.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Channel;
+use App\Models\Episode;
+use App\Models\User;
+use Carbon\Carbon;
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Batch;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Aggregated completion notification for manual bulk-probe actions.
+ *
+ * Bulk-probe UI actions dispatch many ProbeVodStreamsChunk jobs via Bus::batch().
+ * The batch's then() callback queues this job once all chunks finish, so we count
+ * how many of the originally selected records were actually persisted with fresh
+ * stream stats during this run.
+ *
+ * This replaces the previous per-chunk notification, which fired on the last
+ * dispatched chunk and reported only that chunk's count, producing incorrect
+ * totals like "3 of 156" while the rest of the batch was still running.
+ */
+class ProbeManualComplete implements ShouldQueue
+{
+    use Queueable;
+
+    public $tries = 1;
+
+    public $deleteWhenMissingModels = true;
+
+    /**
+     * @param  array<int>  $channelIds  Channel IDs included in the batch (may be empty)
+     * @param  array<int>  $episodeIds  Episode IDs included in the batch (may be empty)
+     */
+    public function __construct(
+        public int $notifyUserId,
+        public string $notifyLabel,
+        public int $total,
+        public Carbon $start,
+        public array $channelIds = [],
+        public array $episodeIds = [],
+    ) {}
+
+    public function handle(): void
+    {
+        $probedChannels = $this->channelIds
+            ? Channel::whereIn('id', $this->channelIds)
+                ->where('stream_stats_probed_at', '>=', $this->start)
+                ->count()
+            : 0;
+
+        $probedEpisodes = $this->episodeIds
+            ? Episode::whereIn('id', $this->episodeIds)
+                ->where('stream_stats_probed_at', '>=', $this->start)
+                ->count()
+            : 0;
+
+        $probed = $probedChannels + $probedEpisodes;
+        $failed = max(0, $this->total - $probed);
+
+        Log::info("ProbeManualComplete[{$this->notifyLabel}]: Probed {$probed}/{$this->total} (failed={$failed})");
+
+        $user = User::find($this->notifyUserId);
+        if (! $user) {
+            return;
+        }
+
+        $body = __(':probed of :total stream(s) probed successfully.', [
+            'probed' => $probed,
+            'total' => $this->total,
+        ]);
+        if ($failed > 0) {
+            $body .= ' ('.__(':failed failed', ['failed' => $failed]).')';
+        }
+
+        Notification::make()
+            ->success()
+            ->title($this->notifyLabel.' '.__('complete'))
+            ->body($body)
+            ->broadcast($user)
+            ->sendToDatabase($user);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Log::error("ProbeManualComplete failed: {$exception->getMessage()}");
+
+        $user = User::find($this->notifyUserId);
+        if ($user) {
+            Notification::make()
+                ->danger()
+                ->title(__('Stream probing failed'))
+                ->body($exception->getMessage())
+                ->broadcast($user)
+                ->sendToDatabase($user);
+        }
+    }
+
+    /**
+     * Dispatch a manual bulk-probe batch for VOD channels and/or episodes.
+     *
+     * Splits the IDs into 50-item chunks, wraps them in Bus::batch() so the
+     * aggregated completion notification is sent only after every chunk has
+     * finished. This replaces the old "notify on the last dispatched chunk"
+     * approach which produced incorrect "X of Y" counts when chunks ran
+     * out of order.
+     *
+     * @param  array<int>  $channelIds  VOD channel IDs to probe (may be empty)
+     * @param  array<int>  $episodeIds  Episode IDs to probe (may be empty)
+     */
+    public static function dispatchBulk(
+        int $notifyUserId,
+        string $notifyLabel,
+        int $probeTimeout = 15,
+        array $channelIds = [],
+        array $episodeIds = [],
+    ): ?Batch {
+        $total = count($channelIds) + count($episodeIds);
+        if ($total === 0) {
+            return null;
+        }
+
+        $start = now();
+        $jobs = [];
+
+        foreach (array_chunk($channelIds, 50) as $chunk) {
+            $jobs[] = new ProbeVodStreamsChunk(
+                channelIds: $chunk,
+                probeTimeout: $probeTimeout,
+            );
+        }
+
+        foreach (array_chunk($episodeIds, 50) as $chunk) {
+            $jobs[] = new ProbeVodStreamsChunk(
+                episodeIds: $chunk,
+                probeTimeout: $probeTimeout,
+            );
+        }
+
+        return Bus::batch($jobs)
+            ->name($notifyLabel)
+            ->allowFailures()
+            ->finally(function (Batch $batch) use ($notifyUserId, $notifyLabel, $total, $start, $channelIds, $episodeIds): void {
+                dispatch(new self(
+                    notifyUserId: $notifyUserId,
+                    notifyLabel: $notifyLabel,
+                    total: $total,
+                    start: $start,
+                    channelIds: $channelIds,
+                    episodeIds: $episodeIds,
+                ));
+            })
+            ->dispatch();
+    }
+}


### PR DESCRIPTION
The bulk "Probe Streams" actions in VodResource, SeriesResource and the EpisodesRelationManager dispatched ProbeVodStreamsChunk jobs in a loop and asked only the last-dispatched chunk to send the completion notification with the total count.

This was wrong on two counts:
1. Loose chunks have no ordering guarantee. The last-dispatched chunk often finished first, firing a notification like "3 of 156 probed successfully" while 100+ records were still being processed.
2. Even when chunks finished in order, the per-chunk counter only reflected that final chunk's work, not the whole batch.

Fix: introduce ProbeManualComplete, a dedicated completion job dispatched through Bus::batch()->finally(). It records the start timestamp and, when the entire batch finishes, counts how many of the originally selected channels/episodes have stream_stats_probed_at >= start. That is the real "probed successfully" number and the user only sees one accurate notification at the end.

Refactor target call sites:
- app/Filament/Resources/Vods/VodResource.php (bulk action)
- app/Filament/Resources/Series/SeriesResource.php (single-record series-probe action and bulk action)
- app/Filament/Resources/Series/RelationManagers/EpisodesRelationManager.php (bulk action)

Single-record probe actions on individual VOD channels (VodResource line 670) keep dispatching ProbeVodStreamsChunk directly, because a single chunk has no ordering bug.

The job_batches table is already provisioned (see the existing remove_batch_job_tables migration which only truncates, never drops it), and Bus::batch is already in use elsewhere in the probe subsystem (ProbeChannelStreams, ProbeVodStreams), so no infra changes are needed.