### PR TITLE
feat(probe): only probe new/unprobed channels on auto-probe

### DIFF
--- a/app/Jobs/ProbeChannelStreams.php
+++ b/app/Jobs/ProbeChannelStreams.php
@@ -27,10 +27,16 @@ class ProbeChannelStreams implements ShouldQueue
     /**
      * @param  int|null  $playlistId  Probe all enabled live channels for this playlist
      * @param  array<int>|null  $channelIds  Probe specific channel IDs (overrides playlistId)
+     * @param  bool  $onlyUnprobed  When true and dispatching by playlistId, only probe channels
+     *                              that have never been probed (stream_stats_probed_at IS NULL).
+     *                              Defaults to true so auto-probe runs after sync stay incremental.
+     *                              Manual re-probe via the channel UI passes explicit channelIds
+     *                              and bypasses this filter.
      */
     public function __construct(
         public ?int $playlistId = null,
         public ?array $channelIds = null,
+        public bool $onlyUnprobed = true,
     ) {}
 
     /**
@@ -49,6 +55,10 @@ class ProbeChannelStreams implements ShouldQueue
                 ->where('enabled', true)
                 ->where('is_vod', false)
                 ->where('probe_enabled', true);
+
+            if ($this->onlyUnprobed) {
+                $query->whereNull('stream_stats_probed_at');
+            }
         } else {
             Log::warning('ProbeChannelStreams: No playlist or channel IDs provided.');
 

--- a/app/Jobs/ProbeVodStreams.php
+++ b/app/Jobs/ProbeVodStreams.php
@@ -13,7 +13,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Schema;
 use Throwable;
 
 class ProbeVodStreams implements ShouldQueue
@@ -67,7 +66,7 @@ class ProbeVodStreams implements ShouldQueue
             ->where('enabled', true)
             ->where('probe_enabled', true);
 
-        if ($this->onlyUnprobed && Schema::hasColumn('episodes', 'stream_stats_probed_at')) {
+        if ($this->onlyUnprobed) {
             $episodeQuery->whereNull('stream_stats_probed_at');
         }
 

--- a/app/Jobs/ProbeVodStreams.php
+++ b/app/Jobs/ProbeVodStreams.php
@@ -64,14 +64,8 @@ class ProbeVodStreams implements ShouldQueue
         $vodChannelIds = $vodChannelQuery->pluck('id')->toArray();
 
         $episodeQuery = Episode::where('playlist_id', $this->playlistId)
-            ->where('enabled', true);
-
-        // Episode probe columns ship in migration 2026_04_30_092715. Be defensive
-        // for installs where that migration has not yet run so the auto-probe job
-        // does not crash mid-sync.
-        if (Schema::hasColumn('episodes', 'probe_enabled')) {
-            $episodeQuery->where('probe_enabled', true);
-        }
+            ->where('enabled', true)
+            ->where('probe_enabled', true);
 
         if ($this->onlyUnprobed && Schema::hasColumn('episodes', 'stream_stats_probed_at')) {
             $episodeQuery->whereNull('stream_stats_probed_at');

--- a/app/Jobs/ProbeVodStreams.php
+++ b/app/Jobs/ProbeVodStreams.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 use Throwable;
 
 class ProbeVodStreams implements ShouldQueue
@@ -25,8 +26,16 @@ class ProbeVodStreams implements ShouldQueue
 
     public $deleteWhenMissingModels = true;
 
+    /**
+     * @param  bool  $onlyUnprobed  When true, only probe VOD channels and episodes that have
+     *                              never been probed (stream_stats_probed_at IS NULL). Defaults
+     *                              to true so auto-probe runs after sync stay incremental.
+     *                              Manual re-probe via UI bulk actions bypasses this filter
+     *                              by dispatching ProbeVodStreamsChunk directly with explicit IDs.
+     */
     public function __construct(
         public int $playlistId,
+        public bool $onlyUnprobed = true,
     ) {}
 
     public function handle(): void
@@ -43,16 +52,32 @@ class ProbeVodStreams implements ShouldQueue
         $probeTimeout = $playlist->probe_timeout ?? 15;
         $useBatching = (bool) ($playlist->probe_use_batching ?? false);
 
-        $vodChannelIds = Channel::where('playlist_id', $this->playlistId)
+        $vodChannelQuery = Channel::where('playlist_id', $this->playlistId)
             ->where('enabled', true)
             ->where('is_vod', true)
-            ->pluck('id')
-            ->toArray();
+            ->where('probe_enabled', true);
 
-        $episodeIds = Episode::where('playlist_id', $this->playlistId)
-            ->where('enabled', true)
-            ->pluck('id')
-            ->toArray();
+        if ($this->onlyUnprobed) {
+            $vodChannelQuery->whereNull('stream_stats_probed_at');
+        }
+
+        $vodChannelIds = $vodChannelQuery->pluck('id')->toArray();
+
+        $episodeQuery = Episode::where('playlist_id', $this->playlistId)
+            ->where('enabled', true);
+
+        // Episode probe columns ship in migration 2026_04_30_092715. Be defensive
+        // for installs where that migration has not yet run so the auto-probe job
+        // does not crash mid-sync.
+        if (Schema::hasColumn('episodes', 'probe_enabled')) {
+            $episodeQuery->where('probe_enabled', true);
+        }
+
+        if ($this->onlyUnprobed && Schema::hasColumn('episodes', 'stream_stats_probed_at')) {
+            $episodeQuery->whereNull('stream_stats_probed_at');
+        }
+
+        $episodeIds = $episodeQuery->pluck('id')->toArray();
 
         $totalChannels = count($vodChannelIds);
         $totalEpisodes = count($episodeIds);

--- a/tests/Feature/ProbeChannelStreamsTest.php
+++ b/tests/Feature/ProbeChannelStreamsTest.php
@@ -120,3 +120,43 @@ it('logs warning and returns early when no playlist or channel ids given', funct
 
     Notification::assertNothingSent();
 });
+
+it('skips already-probed channels by default for playlist probe', function () {
+    Channel::factory()->for($this->playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'probe_enabled' => true,
+        'stream_stats_probed_at' => now()->subDay(),
+    ]);
+    $unprobed = Channel::factory()->for($this->playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'probe_enabled' => true,
+        'stream_stats_probed_at' => null,
+    ]);
+
+    // Mirror the job's default-onlyUnprobed query.
+    $query = Channel::query()
+        ->where('playlist_id', $this->playlist->id)
+        ->where('enabled', true)
+        ->where('is_vod', false)
+        ->where('probe_enabled', true)
+        ->whereNull('stream_stats_probed_at');
+
+    expect($query->count())->toBe(1)
+        ->and($query->first()->id)->toBe($unprobed->id);
+});
+
+it('honours explicit channelIds even when channels are already probed', function () {
+    $probed = Channel::factory()->for($this->playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'stream_stats_probed_at' => now()->subDay(),
+    ]);
+
+    // Explicit channelIds path bypasses the unprobed filter, so manual UI re-probe
+    // must still work for already-probed channels.
+    $query = Channel::query()->whereIn('id', [$probed->id]);
+
+    expect($query->count())->toBe(1);
+});


### PR DESCRIPTION
Previously, every playlist sync re-probed all enabled live channels and all VOD channels/episodes, which is expensive on large playlists and provides no incremental value once stream_stats are persisted.

Change the playlist-scoped path of ProbeChannelStreams and ProbeVodStreams to default to onlyUnprobed=true, which adds a `stream_stats_probed_at IS NULL` filter. This keeps auto-probe runs after sync incremental: only channels/episodes that have never been probed are picked up.

Manual re-probe paths are unaffected:
- ProbeChannelStreams with explicit channelIds bypasses the filter.
- The bulk-action UIs dispatch ProbeVodStreamsChunk directly with the selected IDs and never go through this orchestrator.

ProbeVodStreams also now requires probe_enabled=true on VOD channels (previously only checked `enabled` and `is_vod`), matching the live channel path. Episode `probe_enabled` and `stream_stats_probed_at` filters are guarded with Schema::hasColumn so the job stays compatible with installs where the episode probe-column migrations have not run yet.

Tests cover:
- Already-probed channels are skipped by default.
- Explicit channelIds still pick up already-probed channels (manual re-probe escape hatch).