### PR TITLE
fix(vod): group bulk strm sync into single job to dedupe media-server refresh

### DIFF
--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -998,12 +998,15 @@ class VodResource extends Resource implements CopilotResource
                 BulkAction::make('sync')
                     ->label(__('Sync VOD .strm files'))
                     ->action(function ($records) {
-                        foreach ($records as $record) {
-                            app('Illuminate\Contracts\Bus\Dispatcher')
-                                ->dispatch(new SyncVodStrmFiles(
-                                    channel: $record,
-                                ));
+                        $channelIds = collect($records)->pluck('id')->filter()->unique()->values()->all();
+                        if (empty($channelIds)) {
+                            return;
                         }
+                        app('Illuminate\Contracts\Bus\Dispatcher')
+                            ->dispatch(new SyncVodStrmFiles(
+                                user_id: auth()->id(),
+                                channel_ids: $channelIds,
+                            ));
                     })->after(function () {
                         Notification::make()
                             ->success()


### PR DESCRIPTION
The bulk "Sync VOD .strm files" action on VodResource dispatched one SyncVodStrmFiles job per selected record. Each job ran an independent media-server refresh at the end, so selecting N VOD channels triggered N library scans on Emby/Jellyfin/Plex.

Switch the bulk action to the channel_ids[] dispatch path already used by SeriesResource bulk sync and the VodGroup actions. The job groups all selected channels into one chain of batches and emits exactly one RefreshMediaServerLibraryJob per integration at the end.

Single-record action (line 654) and single-playlist action (ListVod) are unchanged; they only ever dispatch one job each.