### PR TITLE
DVR: From Original Source channel, seriesNewOnly fix, guest series widget, playlist_auth_id propagation

### DIFF
--- a/app/Filament/GuestPanel/Pages/GuestBrowseShows.php
+++ b/app/Filament/GuestPanel/Pages/GuestBrowseShows.php
@@ -88,9 +88,13 @@ class GuestBrowseShows extends Page
 
     // --- Series options form state ---
 
-    public bool $seriesNewOnly = false;
+    public int $seriesNewOnly = 0;
 
-    public ?int $seriesChannelId = null;
+    /** 0 = "From Original Source" (sentinel), null/negative = "Any channel", int = specific channel */
+    public int $seriesChannelId = 0;
+
+    /** The actual channel ID the show was browsed from (null if not resolved). */
+    public ?int $sourceChannelId = null;
 
     public int $seriesPriority = 50;
 
@@ -139,9 +143,14 @@ class GuestBrowseShows extends Page
     public function getSeriesHintProperty(): string
     {
         $channelOptions = $this->channelOptions;
-        $channelName = ($this->seriesChannelId && isset($channelOptions[$this->seriesChannelId]))
-            ? Str::limit($channelOptions[$this->seriesChannelId], 18)
-            : __('any channel');
+
+        $channelName = match (true) {
+            $this->seriesChannelId === 0 => $this->sourceChannelId && isset($channelOptions[$this->sourceChannelId])
+                ? Str::limit($channelOptions[$this->sourceChannelId], 18)
+                : __('original source'),
+            $this->seriesChannelId > 0 && isset($channelOptions[$this->seriesChannelId]) => Str::limit($channelOptions[$this->seriesChannelId], 18),
+            default => __('any channel'),
+        };
 
         $parts = array_filter([
             $channelName,
@@ -162,12 +171,13 @@ class GuestBrowseShows extends Page
     {
         Log::info('GuestBrowseShows: openShowDetail called: '.$title);
         $this->selectedShowTitle = $title;
-        $this->seriesNewOnly = false;
+        $this->seriesNewOnly = 0;
         $this->seriesPriority = 50;
         $this->seriesStartEarly = 0;
         $this->seriesEndLate = 0;
         $this->seriesKeepLast = null;
-        $this->seriesChannelId = $this->resolveDefaultChannelIdForShow($title);
+        $this->sourceChannelId = $this->resolveSourceChannelId($title);
+        $this->seriesChannelId = 0;
     }
 
     public function closeShowDetail(): void
@@ -302,15 +312,26 @@ class GuestBrowseShows extends Page
         $this->createSeriesRule($title, [
             'series_mode' => DvrSeriesMode::All,
             'priority' => 50,
+            'source_channel_id' => $this->resolveSourceChannelId($title),
         ]);
     }
 
     public function recordSeriesWithOptions(string $title): void
     {
+        $channelId = null;
+        $sourceChannelId = null;
+
+        if ($this->seriesChannelId === 0) {
+            $sourceChannelId = $this->sourceChannelId;
+        } elseif ($this->seriesChannelId > 0) {
+            $channelId = $this->seriesChannelId;
+        }
+
         $this->createSeriesRule($title, [
             'new_only' => $this->seriesNewOnly,
             'series_mode' => $this->seriesNewOnly ? DvrSeriesMode::NewFlag : DvrSeriesMode::All,
-            'channel_id' => $this->seriesChannelId ?: null,
+            'channel_id' => $channelId,
+            'source_channel_id' => $sourceChannelId,
             'priority' => $this->seriesPriority,
             'start_early_seconds' => $this->seriesStartEarly,
             'end_late_seconds' => $this->seriesEndLate,
@@ -632,11 +653,13 @@ class GuestBrowseShows extends Page
     }
 
     /**
-     * Resolve the channel that a show most likely airs on within the current DVR
-     * setting's playlist. Used to pre-populate the series options form so the user
-     * sees the right channel pre-selected when they open the advanced options panel.
+     * Resolve the channel (within the DVR setting's playlist) that a show most likely
+     * airs on. Used to pre-populate sourceChannelId when the slide-over opens and to
+     * set source_channel_id when creating a series rule with defaults.
+     *
+     * Returns null when the channel cannot be determined.
      */
-    private function resolveDefaultChannelIdForShow(string $title): ?int
+    private function resolveSourceChannelId(string $title): ?int
     {
         $playlistId = static::getDvrSetting()?->playlist_id;
         if (! $playlistId) {

--- a/app/Filament/GuestPanel/Pages/GuestBrowseShows.php
+++ b/app/Filament/GuestPanel/Pages/GuestBrowseShows.php
@@ -312,7 +312,7 @@ class GuestBrowseShows extends Page
         $this->createSeriesRule($title, [
             'series_mode' => DvrSeriesMode::All,
             'priority' => 50,
-            'source_channel_id' => $this->resolveSourceChannelId($title),
+            'source_channel_id' => $this->sourceChannelId,
         ]);
     }
 

--- a/app/Filament/GuestPanel/Resources/DvrRecordings/Pages/ListGuestDvrRecordings.php
+++ b/app/Filament/GuestPanel/Resources/DvrRecordings/Pages/ListGuestDvrRecordings.php
@@ -4,6 +4,7 @@ namespace App\Filament\GuestPanel\Resources\DvrRecordings\Pages;
 
 use App\Filament\GuestPanel\Pages\Concerns\HasPlaylist;
 use App\Filament\GuestPanel\Resources\DvrRecordings\GuestDvrRecordingResource;
+use App\Filament\GuestPanel\Widgets\GuestScheduledSeriesWidget;
 use Filament\Resources\Pages\ListRecords;
 
 class ListGuestDvrRecordings extends ListRecords
@@ -17,5 +18,12 @@ class ListGuestDvrRecordings extends ListRecords
     protected function getHeaderActions(): array
     {
         return [];
+    }
+
+    protected function getHeaderWidgets(): array
+    {
+        return [
+            GuestScheduledSeriesWidget::class,
+        ];
     }
 }

--- a/app/Filament/GuestPanel/Resources/DvrRules/GuestDvrRuleResource.php
+++ b/app/Filament/GuestPanel/Resources/DvrRules/GuestDvrRuleResource.php
@@ -160,6 +160,7 @@ class GuestDvrRuleResource extends Resource
                         ->where('playlist_id', $playlistId)
                         ->orderBy('title')
                         ->pluck('title', 'id')
+                        ->prepend(__('From Original Source'), 0)
                     : [])
                 ->searchable()
                 ->nullable(),
@@ -273,7 +274,26 @@ class GuestDvrRuleResource extends Resource
                     ->button()
                     ->hiddenLabel()
                     ->size('sm')
-                    ->slideOver(),
+                    ->slideOver()
+                    ->mutateRecordDataUsing(function (array $data, DvrRecordingRule $record): array {
+                        if ($record->channel_id === null && $record->source_channel_id !== null) {
+                            $data['channel_id'] = 0;
+                        }
+
+                        return $data;
+                    })
+                    ->mutateDataUsing(function (array $data, DvrRecordingRule $record): array {
+                        $channelId = $data['channel_id'] ?? null;
+
+                        if ($channelId !== null && (int) $channelId === 0) {
+                            $data['channel_id'] = null;
+                            $data['source_channel_id'] = $record->source_channel_id;
+                        } else {
+                            $data['source_channel_id'] = null;
+                        }
+
+                        return $data;
+                    }),
 
                 DeleteAction::make()
                     ->before(function (DvrRecordingRule $record, Action $action) use ($currentAuth): void {
@@ -309,6 +329,13 @@ class GuestDvrRuleResource extends Resource
 
                             return;
                         }
+
+                        // Sentinel 0 = "From Original Source"; no existing record in create context → any channel.
+                        if (($data['channel_id'] ?? null) !== null && (int) ($data['channel_id']) === 0) {
+                            $data['channel_id'] = null;
+                        }
+
+                        $data['source_channel_id'] = null;
 
                         DvrRecordingRule::create([
                             ...$data,

--- a/app/Filament/GuestPanel/Resources/DvrRules/GuestDvrRuleResource.php
+++ b/app/Filament/GuestPanel/Resources/DvrRules/GuestDvrRuleResource.php
@@ -155,12 +155,12 @@ class GuestDvrRuleResource extends Resource
 
             Select::make('channel_id')
                 ->label(__('Channel'))
-                ->options(fn () => $playlistId
+                ->options(fn (?DvrRecordingRule $record) => $playlistId
                     ? Channel::query()
                         ->where('playlist_id', $playlistId)
                         ->orderBy('title')
                         ->pluck('title', 'id')
-                        ->prepend(__('From Original Source'), 0)
+                        ->when($record !== null, fn ($col) => $col->prepend(__('From Original Source'), 0))
                     : [])
                 ->searchable()
                 ->nullable(),

--- a/app/Filament/GuestPanel/Widgets/GuestScheduledSeriesWidget.php
+++ b/app/Filament/GuestPanel/Widgets/GuestScheduledSeriesWidget.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Filament\GuestPanel\Widgets;
+
+use App\Enums\DvrRuleType;
+use App\Filament\GuestPanel\Pages\Concerns\HasGuestDvr;
+use App\Models\DvrRecordingRule;
+use Filament\Widgets\Widget;
+use Illuminate\Database\Eloquent\Collection;
+
+class GuestScheduledSeriesWidget extends Widget
+{
+    use HasGuestDvr;
+
+    protected string $view = 'filament.guest-panel.widgets.guest-scheduled-series-widget';
+
+    protected int|string|array $columnSpan = 'full';
+
+    /**
+     * @return Collection<int, DvrRecordingRule>
+     */
+    public function getSeriesRules(): Collection
+    {
+        $dvrSetting = static::getDvrSetting();
+        if (! $dvrSetting) {
+            return new Collection;
+        }
+
+        return DvrRecordingRule::with(['channel'])
+            ->where('dvr_setting_id', $dvrSetting->id)
+            ->where('type', DvrRuleType::Series)
+            ->where('enabled', true)
+            ->orderByDesc('priority')
+            ->orderBy('series_title')
+            ->get();
+    }
+}

--- a/app/Filament/Pages/BrowseShows.php
+++ b/app/Filament/Pages/BrowseShows.php
@@ -380,7 +380,7 @@ class BrowseShows extends Page
         $this->createSeriesRule($title, [
             'series_mode' => DvrSeriesMode::All,
             'priority' => 50,
-            'source_channel_id' => $this->resolveSourceChannelId($title),
+            'source_channel_id' => $this->sourceChannelId,
         ]);
     }
 

--- a/app/Filament/Pages/BrowseShows.php
+++ b/app/Filament/Pages/BrowseShows.php
@@ -64,6 +64,8 @@ class BrowseShows extends Page
 
     public string $channel_name = '';
 
+    public ?int $channel_id = null;
+
     public int $days = 14;
 
     // --- Result state ---
@@ -88,9 +90,13 @@ class BrowseShows extends Page
 
     // --- Series options form state ---
 
-    public bool $seriesNewOnly = false;
+    public int $seriesNewOnly = 0;
 
-    public string $seriesChannelName = '';
+    /** 0 = "From Original Source" (sentinel), null = "Any channel", int = specific channel */
+    public int $seriesChannelId = 0;
+
+    /** The actual channel ID the show was browsed from (null if not resolved). */
+    public ?int $sourceChannelId = null;
 
     public int $seriesPriority = 50;
 
@@ -140,8 +146,31 @@ class BrowseShows extends Page
         }
 
         return Group::where('playlist_id', $playlistId)
+            ->where('enabled', true)
             ->orderBy('name')
             ->pluck('name', 'id')
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getChannelOptionsProperty(): array
+    {
+        if (! $this->dvr_setting_id) {
+            return [];
+        }
+
+        $playlistId = $this->resolvedDvrSetting()?->playlist_id;
+
+        if (! $playlistId) {
+            return [];
+        }
+
+        return Channel::where('playlist_id', $playlistId)
+            ->where('enabled', true)
+            ->orderBy('title')
+            ->pluck('title', 'id')
             ->all();
     }
 
@@ -157,9 +186,15 @@ class BrowseShows extends Page
 
     public function getSeriesHintProperty(): string
     {
-        $channelName = $this->seriesChannelName
-            ? Str::limit($this->seriesChannelName, 18)
-            : __('any channel');
+        $channelOptions = $this->channelOptions;
+
+        $channelName = match (true) {
+            $this->seriesChannelId === 0 => $this->sourceChannelId && isset($channelOptions[$this->sourceChannelId])
+                ? Str::limit($channelOptions[$this->sourceChannelId], 18)
+                : __('original source'),
+            $this->seriesChannelId > 0 && isset($channelOptions[$this->seriesChannelId]) => Str::limit($channelOptions[$this->seriesChannelId], 18),
+            default => __('any channel'),
+        };
 
         $parts = array_filter([
             $channelName,
@@ -225,12 +260,13 @@ class BrowseShows extends Page
     public function openShowDetail(string $title): void
     {
         $this->selectedShowTitle = $title;
-        $this->seriesNewOnly = false;
+        $this->seriesNewOnly = 0;
         $this->seriesPriority = 50;
         $this->seriesStartEarly = 0;
         $this->seriesEndLate = 0;
         $this->seriesKeepLast = null;
-        $this->seriesChannelName = '';
+        $this->sourceChannelId = $this->resolveSourceChannelId($title);
+        $this->seriesChannelId = 0;
         $this->selectedShowDetail = $this->buildShowDetail($title);
     }
 
@@ -344,27 +380,28 @@ class BrowseShows extends Page
         $this->createSeriesRule($title, [
             'series_mode' => DvrSeriesMode::All,
             'priority' => 50,
+            'source_channel_id' => $this->resolveSourceChannelId($title),
         ]);
     }
 
     public function recordSeriesWithOptions(string $title): void
     {
         $channelId = null;
+        $sourceChannelId = null;
 
-        if ($this->seriesChannelName && $this->dvr_setting_id) {
-            $playlistId = $this->resolvedDvrSetting()?->playlist_id;
-            if ($playlistId) {
-                $seriesChannelKw = mb_strtolower($this->seriesChannelName);
-                $channelId = Channel::where('playlist_id', $playlistId)
-                    ->whereRaw('LOWER(title) LIKE ?', ["%{$seriesChannelKw}%"])
-                    ->value('id');
-            }
+        if ($this->seriesChannelId === 0) {
+            // "From Original Source" sentinel — store source channel, leave channel_id null
+            $sourceChannelId = $this->sourceChannelId;
+        } elseif ($this->seriesChannelId > 0) {
+            $channelId = $this->seriesChannelId;
         }
+        // seriesChannelId < 0 is not valid; both remain null → "Any channel"
 
         $this->createSeriesRule($title, [
             'new_only' => $this->seriesNewOnly,
             'series_mode' => $this->seriesNewOnly ? DvrSeriesMode::NewFlag : DvrSeriesMode::All,
             'channel_id' => $channelId,
+            'source_channel_id' => $sourceChannelId,
             'priority' => $this->seriesPriority,
             'start_early_seconds' => $this->seriesStartEarly,
             'end_late_seconds' => $this->seriesEndLate,
@@ -375,7 +412,39 @@ class BrowseShows extends Page
     // --- Internal ---
 
     /**
-     * Find the selected DvrSetting scoped to the authenticated user.
+     * Find the channel (within the selected DVR setting's playlist) that a show most
+     * likely airs on. Used to pre-populate the source channel when the slide-over opens
+     * and to set source_channel_id when creating a series rule with defaults.
+     *
+     * Returns null when the channel cannot be determined.
+     */
+    private function resolveSourceChannelId(string $title): ?int
+    {
+        $playlistId = $this->resolvedDvrSetting()?->playlist_id;
+        if (! $playlistId) {
+            return null;
+        }
+
+        $programme = $this->buildBaseQuery()
+            ->where('title', $title)
+            ->orderBy('start_time')
+            ->first(['epg_channel_id']);
+
+        if (! $programme?->epg_channel_id) {
+            return null;
+        }
+
+        $epgChannelPk = EpgChannel::where('channel_id', $programme->epg_channel_id)->value('id');
+        if (! $epgChannelPk) {
+            return null;
+        }
+
+        return Channel::where('playlist_id', $playlistId)
+            ->where('epg_channel_id', $epgChannelPk)
+            ->value('id');
+    }
+
+    /**
      * Returns null if none is selected or the setting doesn't belong to this user,
      * preventing cross-user data access via a manipulated dvr_setting_id.
      */
@@ -769,6 +838,16 @@ class BrowseShows extends Page
             ->where('channels.enabled', true)
             ->whereNotNull('channels.stream_id')
             ->where('channels.stream_id', '!=', '');
+
+        if ($this->channel_id) {
+            $channel = Channel::where('id', $this->channel_id)
+                ->where('enabled', true)
+                ->with('epgChannel')
+                ->first();
+            $epgId = $channel?->epgChannel?->channel_id;
+
+            return $epgId ? [$epgId] : null;
+        }
 
         if ($this->channel_name) {
             $channelKw = mb_strtolower($this->channel_name);

--- a/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
+++ b/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
@@ -113,7 +113,8 @@ class DvrRecordingRuleResource extends Resource
                     ->options(fn () => Channel::query()
                         ->where('user_id', Auth::id())
                         ->orderBy('title')
-                        ->pluck('title', 'id'))
+                        ->pluck('title', 'id')
+                        ->prepend(__('From Original Source'), 0))
                     ->searchable()
                     ->nullable(),
 
@@ -219,7 +220,26 @@ class DvrRecordingRuleResource extends Resource
                     ->hiddenLabel()->size('sm'),
                 Actions\EditAction::make()->button()
                     ->hiddenLabel()->size('sm')
-                    ->slideOver(),
+                    ->slideOver()
+                    ->mutateRecordDataUsing(function (array $data, DvrRecordingRule $record): array {
+                        if ($record->channel_id === null && $record->source_channel_id !== null) {
+                            $data['channel_id'] = 0;
+                        }
+
+                        return $data;
+                    })
+                    ->mutateDataUsing(function (array $data, DvrRecordingRule $record): array {
+                        $channelId = $data['channel_id'] ?? null;
+
+                        if ($channelId !== null && (int) $channelId === 0) {
+                            $data['channel_id'] = null;
+                            $data['source_channel_id'] = $record->source_channel_id;
+                        } else {
+                            $data['source_channel_id'] = null;
+                        }
+
+                        return $data;
+                    }),
             ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
                 Actions\BulkActionGroup::make([

--- a/app/Models/DvrRecordingRule.php
+++ b/app/Models/DvrRecordingRule.php
@@ -30,6 +30,7 @@ class DvrRecordingRule extends Model
         'series_key',
         'normalized_title',
         'channel_id',
+        'source_channel_id',
         'epg_channel_id',
         'new_only',
         'series_mode',
@@ -113,6 +114,11 @@ class DvrRecordingRule extends Model
     public function channel(): BelongsTo
     {
         return $this->belongsTo(Channel::class);
+    }
+
+    public function sourceChannel(): BelongsTo
+    {
+        return $this->belongsTo(Channel::class, 'source_channel_id');
     }
 
     public function epgChannel(): BelongsTo

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -242,8 +242,13 @@ class AppServiceProvider extends ServiceProvider
 
         $configuredPort = config('app.port');
         $hasPortInUrl = parse_url($baseUrl, PHP_URL_PORT) !== null;
+        $scheme = parse_url($baseUrl, PHP_URL_SCHEME);
 
-        if ($configuredPort && ! $hasPortInUrl) {
+        // Only append the port for HTTP URLs. HTTPS URLs are assumed to be
+        // behind a reverse proxy terminating TLS at port 443, so appending
+        // APP_PORT would produce incorrect external URLs (e.g. https://host:36400).
+        // This mirrors the guard in PlaylistService::getBaseUrl().
+        if ($configuredPort && ! $hasPortInUrl && $scheme !== 'https') {
             $baseUrl .= ':'.$configuredPort;
         }
 

--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -64,7 +64,7 @@ class DvrSchedulerService
     private function matchAndSchedule(int $lookaheadMinutes): void
     {
         $rules = DvrRecordingRule::enabled()
-            ->with(['dvrSetting.playlist', 'channel.epgChannel', 'epgChannel'])
+            ->with(['dvrSetting.playlist', 'channel.epgChannel', 'sourceChannel.epgChannel', 'epgChannel'])
             ->orderByDesc('priority')
             ->orderBy('id')
             ->get();
@@ -197,6 +197,13 @@ class DvrSchedulerService
             return $stringId ? [$stringId] : [];
         }
 
+        // 2.5. Source channel: created via Browse Shows; use the original channel's EPG mapping
+        if ($rule->source_channel_id) {
+            $stringId = $rule->sourceChannel?->epgChannel?->channel_id;
+
+            return $stringId ? [$stringId] : [];
+        }
+
         // 3. No explicit channel: scope to all EPG-mapped channels in the playlist
         $playlistId = $rule->dvrSetting->playlist_id;
 
@@ -308,6 +315,7 @@ class DvrSchedulerService
                 'user_id' => $setting->user_id,
                 'dvr_setting_id' => $setting->id,
                 'dvr_recording_rule_id' => $rule->id,
+                'playlist_auth_id' => $rule->playlist_auth_id,
                 'channel_id' => $rule->channel_id,
                 'status' => DvrRecordingStatus::Scheduled,
                 'title' => $title,
@@ -541,6 +549,7 @@ class DvrSchedulerService
                 'user_id' => $setting->user_id,
                 'dvr_setting_id' => $setting->id,
                 'dvr_recording_rule_id' => $rule->id,
+                'playlist_auth_id' => $rule->playlist_auth_id,
                 'channel_id' => $resolvedChannelId ?? $rule->channel_id,
                 'status' => DvrRecordingStatus::Scheduled,
                 'title' => $programme->title,
@@ -666,6 +675,9 @@ class DvrSchedulerService
 
         if ($rule->channel_id) {
             $channel = $rule->channel;
+        } elseif ($rule->source_channel_id) {
+            // Rule was created via Browse Shows — use the original source channel directly.
+            $channel = $rule->sourceChannel;
         } elseif ($programme?->epg_channel_id) {
             // Rule was created without an explicit channel (e.g. series defaults or guest once rule).
             // Attempt to resolve the matching channel from the programme's EPG channel ID.

--- a/database/migrations/2026_04_23_110000_add_previously_shown_and_premiere_to_epg_programmes_table.php
+++ b/database/migrations/2026_04_23_110000_add_previously_shown_and_premiere_to_epg_programmes_table.php
@@ -9,15 +9,24 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('epg_programmes', function (Blueprint $table) {
-            $table->boolean('previously_shown')->default(false)->after('is_new');
-            $table->boolean('premiere')->default(false)->after('previously_shown');
+            if (! Schema::hasColumn('epg_programmes', 'previously_shown')) {
+                $table->boolean('previously_shown')->default(false)->after('is_new');
+            }
+            if (! Schema::hasColumn('epg_programmes', 'premiere')) {
+                $table->boolean('premiere')->default(false)->after('previously_shown');
+            }
         });
     }
 
     public function down(): void
     {
         Schema::table('epg_programmes', function (Blueprint $table) {
-            $table->dropColumn(['previously_shown', 'premiere']);
+            if (Schema::hasColumn('epg_programmes', 'previously_shown')) {
+                $table->dropColumn('previously_shown');
+            }
+            if (Schema::hasColumn('epg_programmes', 'premiere')) {
+                $table->dropColumn('premiere');
+            }
         });
     }
 };

--- a/database/migrations/2026_05_09_110326_add_source_channel_id_to_dvr_recording_rules_table.php
+++ b/database/migrations/2026_05_09_110326_add_source_channel_id_to_dvr_recording_rules_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('dvr_recording_rules', function (Blueprint $table): void {
+            $table->foreignId('source_channel_id')
+                ->nullable()
+                ->after('channel_id')
+                ->constrained('channels')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('dvr_recording_rules', function (Blueprint $table): void {
+            $table->dropForeignIdFor(\App\Models\Channel::class, 'source_channel_id');
+            $table->dropColumn('source_channel_id');
+        });
+    }
+};

--- a/database/migrations/2026_05_09_110326_add_source_channel_id_to_dvr_recording_rules_table.php
+++ b/database/migrations/2026_05_09_110326_add_source_channel_id_to_dvr_recording_rules_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Channel;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -20,7 +21,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('dvr_recording_rules', function (Blueprint $table): void {
-            $table->dropForeignIdFor(\App\Models\Channel::class, 'source_channel_id');
+            $table->dropForeignIdFor(Channel::class, 'source_channel_id');
             $table->dropColumn('source_channel_id');
         });
     }

--- a/resources/views/filament/guest-panel/pages/browse-shows.blade.php
+++ b/resources/views/filament/guest-panel/pages/browse-shows.blade.php
@@ -349,6 +349,7 @@
                     'show' => $selectedShow ?? null,
                     'channelOptions' => $this->channelOptions,
                     'seriesHint' => $this->seriesHint,
+                    'sourceChannelId' => $sourceChannelId,
                 ])
             </div>
         </div>

--- a/resources/views/filament/guest-panel/widgets/guest-scheduled-series-widget.blade.php
+++ b/resources/views/filament/guest-panel/widgets/guest-scheduled-series-widget.blade.php
@@ -1,0 +1,47 @@
+@php
+    /** @var \Illuminate\Database\Eloquent\Collection<int, \App\Models\DvrRecordingRule> $rules */
+    $rules = $this->getSeriesRules();
+@endphp
+
+@if ($rules->isNotEmpty())
+    <x-filament-widgets::widget>
+        <x-filament::section>
+            <x-slot name="heading">
+                {{ __('Scheduled Series') }}
+            </x-slot>
+
+            <x-slot name="description">
+                {{ __('These series rules will record matching episodes as they air. Individual recordings appear here once scheduled (within 30 minutes of the episode start time).') }}
+            </x-slot>
+
+            <div class="divide-y divide-gray-100 dark:divide-white/5">
+                @foreach ($rules as $rule)
+                    <div class="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0">
+                        <div class="min-w-0">
+                            <p class="truncate text-sm font-medium text-gray-950 dark:text-white">
+                                {{ $rule->series_title }}
+                            </p>
+                            <p class="truncate text-xs text-gray-500 dark:text-gray-400">
+                                @if ($rule->channel)
+                                    {{ $rule->channel->display_title }}
+                                @elseif ($rule->source_channel_id)
+                                    {{ __('From original source') }}
+                                @else
+                                    {{ __('Any channel') }}
+                                @endif
+                                &middot;
+                                {{ __('P:') }}{{ $rule->priority }}
+                            </p>
+                        </div>
+
+                        <div class="flex shrink-0 items-center gap-2">
+                            <x-filament::badge color="info">
+                                {{ __('Series') }}
+                            </x-filament::badge>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </x-filament::section>
+    </x-filament-widgets::widget>
+@endif

--- a/resources/views/filament/pages/browse-show-detail.blade.php
+++ b/resources/views/filament/pages/browse-show-detail.blade.php
@@ -134,35 +134,72 @@
 
             <div x-show="showOptions" x-collapse>
                 <div class="mt-3 space-y-3">
-                    <x-filament::input.wrapper label="{{ __('New episodes only') }}">
-                        <x-filament::input.select wire:model.live="seriesNewOnly">
-                            <option value="0" @selected(! $seriesNewOnly)>{{ __('No') }}</option>
-                            <option value="1" @selected($seriesNewOnly)>{{ __('Yes') }}</option>
-                        </x-filament::input.select>
-                    </x-filament::input.wrapper>
-
-                    <x-filament::input.wrapper label="{{ __('Channel (contains)') }}">
-                        <x-filament::input type="text" wire:model.live="seriesChannelName"
-                            placeholder="{{ __('Any channel') }}" />
-                    </x-filament::input.wrapper>
-
-                    <x-filament::input.wrapper label="{{ __('Priority') }}">
-                        <x-filament::input type="number" wire:model.live="seriesPriority" min="1" max="99" />
-                    </x-filament::input.wrapper>
-
-                    <div class="grid grid-cols-2 gap-3">
-                        <x-filament::input.wrapper label="{{ __('Start early (seconds)') }}">
-                            <x-filament::input type="number" wire:model.live="seriesStartEarly" min="0" />
-                        </x-filament::input.wrapper>
-                        <x-filament::input.wrapper label="{{ __('End late (seconds)') }}">
-                            <x-filament::input type="number" wire:model.live="seriesEndLate" min="0" />
+                    <div class="flex flex-col gap-1">
+                        <label class="fi-fo-field-wrp-label inline-flex items-center gap-x-3">
+                            <span class="text-sm font-medium text-gray-950 dark:text-white">{{ __('New episodes only') }}</span>
+                        </label>
+                        <x-filament::input.wrapper>
+                            <x-filament::input.select wire:model.live="seriesNewOnly">
+                                <option value="0" @selected(! $seriesNewOnly)>{{ __('No') }}</option>
+                                <option value="1" @selected($seriesNewOnly)>{{ __('Yes') }}</option>
+                            </x-filament::input.select>
                         </x-filament::input.wrapper>
                     </div>
 
-                    <x-filament::input.wrapper label="{{ __('Keep last N recordings') }}">
-                        <x-filament::input type="number" wire:model.live="seriesKeepLast" min="1"
-                            placeholder="{{ __('All recordings') }}" />
-                    </x-filament::input.wrapper>
+                    <div class="flex flex-col gap-1">
+                        <label class="fi-fo-field-wrp-label inline-flex items-center gap-x-3">
+                            <span class="text-sm font-medium text-gray-950 dark:text-white">{{ __('Channel') }}</span>
+                        </label>
+                        <x-filament::input.wrapper>
+                            <x-filament::input.select wire:model.live="seriesChannelId">
+                                <option value="0">
+                                    {{ __('From Original Source') }}{{ ($sourceChannelId ?? null) && isset($channelOptions[$sourceChannelId]) ? ' — ' . $channelOptions[$sourceChannelId] : '' }}
+                                </option>
+                                <option value="-1">{{ __('Any channel') }}</option>
+                                @foreach ($channelOptions ?? [] as $id => $label)
+                                    <option value="{{ $id }}">{{ $label }}</option>
+                                @endforeach
+                            </x-filament::input.select>
+                        </x-filament::input.wrapper>
+                    </div>
+
+                    <div class="flex flex-col gap-1">
+                        <label class="fi-fo-field-wrp-label inline-flex items-center gap-x-3">
+                            <span class="text-sm font-medium text-gray-950 dark:text-white">{{ __('Priority') }}</span>
+                        </label>
+                        <x-filament::input.wrapper>
+                            <x-filament::input type="number" wire:model.live="seriesPriority" min="1" max="99" />
+                        </x-filament::input.wrapper>
+                    </div>
+
+                    <div class="grid grid-cols-2 gap-3">
+                        <div class="flex flex-col gap-1">
+                            <label class="fi-fo-field-wrp-label inline-flex items-center gap-x-3">
+                                <span class="text-sm font-medium text-gray-950 dark:text-white">{{ __('Start early (seconds)') }}</span>
+                            </label>
+                            <x-filament::input.wrapper>
+                                <x-filament::input type="number" wire:model.live="seriesStartEarly" min="0" />
+                            </x-filament::input.wrapper>
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <label class="fi-fo-field-wrp-label inline-flex items-center gap-x-3">
+                                <span class="text-sm font-medium text-gray-950 dark:text-white">{{ __('End late (seconds)') }}</span>
+                            </label>
+                            <x-filament::input.wrapper>
+                                <x-filament::input type="number" wire:model.live="seriesEndLate" min="0" />
+                            </x-filament::input.wrapper>
+                        </div>
+                    </div>
+
+                    <div class="flex flex-col gap-1">
+                        <label class="fi-fo-field-wrp-label inline-flex items-center gap-x-3">
+                            <span class="text-sm font-medium text-gray-950 dark:text-white">{{ __('Keep last N recordings') }}</span>
+                        </label>
+                        <x-filament::input.wrapper>
+                            <x-filament::input type="number" wire:model.live="seriesKeepLast" min="1"
+                                placeholder="{{ __('All recordings') }}" />
+                        </x-filament::input.wrapper>
+                    </div>
 
                     <x-filament::button
                         wire:click="recordSeriesWithOptions({{ \Illuminate\Support\Js::from($show['title']) }})"

--- a/resources/views/filament/pages/browse-shows.blade.php
+++ b/resources/views/filament/pages/browse-shows.blade.php
@@ -119,7 +119,7 @@
                         Object.entries(this.allOptions).filter(([id, label]) => label.toLowerCase().includes(q))
                     );
                 }
-            }" x-effect="if (!$wire.channel_id) search = ''">
+            }" x-effect="if (!$wire.channel_id) search = ''" @click.away="open = false">
                 <label class="fi-fo-field-wrp-label inline-flex items-center gap-x-3">
                     <span
                         class="text-sm font-medium leading-6 text-gray-950 dark:text-white">{{ __('Channel') }}</span>
@@ -131,7 +131,7 @@
                     <div x-show="open && Object.keys(filtered).length > 0" x-transition @click.stop
                         @keydown.escape="open = false"
                         class="absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-white/10 rounded-lg shadow-lg max-h-60 overflow-y-auto">
-                        <button type="button" @click="search = ''; $wire.channel_id = ''; open = false"
+                        <button type="button" @click="search = ''; $wire.set('channel_id', null); open = false"
                             class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10 transition border-b border-gray-100 dark:border-white/5"
                             :class="!$wire.channel_id ? 'text-primary-600 dark:text-primary-400 font-medium' :
                                 'text-gray-600 dark:text-gray-300'">
@@ -139,7 +139,7 @@
                         </button>
                         <template x-for="[id, label] in Object.entries(filtered)" :key="id">
                             <button type="button"
-                                @click="search = label; $wire.channel_id = parseInt(id); open = false"
+                                @click="search = label; $wire.set('channel_id', parseInt(id)); open = false"
                                 class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10 transition"
                                 :class="$wire.channel_id == id ? 'text-primary-600 dark:text-primary-400 font-medium' :
                                     'text-gray-700 dark:text-gray-200'"

--- a/resources/views/filament/pages/browse-shows.blade.php
+++ b/resources/views/filament/pages/browse-shows.blade.php
@@ -107,16 +107,50 @@
                 </x-filament::input.wrapper>
             </div>
 
-            {{-- Channel --}}
-            <div class="flex flex-col gap-1">
+            {{-- Channel (searchable) --}}
+            <div class="flex flex-col gap-1" x-data="{
+                open: false,
+                search: '',
+                allOptions: @js($this->channelOptions),
+                get filtered() {
+                    if (!this.search) return this.allOptions;
+                    const q = this.search.toLowerCase();
+                    return Object.fromEntries(
+                        Object.entries(this.allOptions).filter(([id, label]) => label.toLowerCase().includes(q))
+                    );
+                }
+            }" x-effect="if (!$wire.channel_id) search = ''">
                 <label class="fi-fo-field-wrp-label inline-flex items-center gap-x-3">
                     <span
-                        class="text-sm font-medium leading-6 text-gray-950 dark:text-white">{{ __('Channel (contains)') }}</span>
+                        class="text-sm font-medium leading-6 text-gray-950 dark:text-white">{{ __('Channel') }}</span>
                 </label>
-                <x-filament::input.wrapper>
-                    <x-filament::input type="text" wire:model="channel_name"
-                        placeholder="{{ __('e.g. HBO, CNN...') }}" :disabled="!$dvr_setting_id" />
-                </x-filament::input.wrapper>
+                <div class="relative">
+                    <input type="text" x-model="search" @focus="open = true" @keydown.escape="open = false"
+                        :placeholder="!$wire.channel_id ? '{{ __('— Any —') }}' : ''"
+                        class="w-full rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm shadow-sm outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 placeholder-gray-400 dark:placeholder-gray-500 py-2 pl-3" />
+                    <div x-show="open && Object.keys(filtered).length > 0" x-transition @click.stop
+                        @keydown.escape="open = false"
+                        class="absolute z-50 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-white/10 rounded-lg shadow-lg max-h-60 overflow-y-auto">
+                        <button type="button" @click="search = ''; $wire.channel_id = ''; open = false"
+                            class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10 transition border-b border-gray-100 dark:border-white/5"
+                            :class="!$wire.channel_id ? 'text-primary-600 dark:text-primary-400 font-medium' :
+                                'text-gray-600 dark:text-gray-300'">
+                            {{ __('— Any —') }}
+                        </button>
+                        <template x-for="[id, label] in Object.entries(filtered)" :key="id">
+                            <button type="button"
+                                @click="search = label; $wire.channel_id = parseInt(id); open = false"
+                                class="w-full text-left px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10 transition"
+                                :class="$wire.channel_id == id ? 'text-primary-600 dark:text-primary-400 font-medium' :
+                                    'text-gray-700 dark:text-gray-200'"
+                                x-text="label"></button>
+                        </template>
+                        <div x-show="Object.keys(filtered).length === 0"
+                            class="px-3 py-2 text-sm text-gray-400 dark:text-gray-500">
+                            {{ __('No matches') }}
+                        </div>
+                    </div>
+                </div>
             </div>
 
             {{-- Days --}}
@@ -399,7 +433,9 @@
             <div class="p-4 flex-1 overflow-y-auto">
                 @include('filament.pages.browse-show-detail', [
                     'show' => $selectedShowDetail,
+                    'channelOptions' => $this->channelOptions,
                     'seriesHint' => $this->seriesHint,
+                    'sourceChannelId' => $sourceChannelId,
                 ])
             </div>
         </div>

--- a/tests/Feature/BrowseShowsTest.php
+++ b/tests/Feature/BrowseShowsTest.php
@@ -316,7 +316,7 @@ it('warns when recordSeriesDefaults is called without a dvr setting selected', f
 it('creates a series rule with custom options', function () {
     Livewire::test(BrowseShows::class)
         ->set('dvr_setting_id', $this->setting->id)
-        ->set('seriesNewOnly', true)
+        ->set('seriesNewOnly', 1)
         ->set('seriesPriority', 75)
         ->set('seriesStartEarly', 120)
         ->set('seriesEndLate', 300)

--- a/tests/Feature/GuestBrowseShowsTest.php
+++ b/tests/Feature/GuestBrowseShowsTest.php
@@ -225,7 +225,7 @@ it('does not duplicate a Series rule for the same title', function () {
 
 it('creates a Series rule with custom options and playlist_auth_id', function () {
     $component = makeGuestBrowseShows();
-    $component->seriesNewOnly = true;
+    $component->seriesNewOnly = 1;
     $component->seriesPriority = 75;
     $component->seriesStartEarly = 60;
     $component->seriesEndLate = 120;


### PR DESCRIPTION
## Summary

- **From Original Source** channel option for series rules — when browsing a show, the channel you're browsing is stored as `source_channel_id` on the rule; the scheduler uses it to scope EPG lookup and stream URL, giving priority to the exact channel without locking the rule to that channel
- **`seriesNewOnly` bool→int fix** — Livewire 4 serialises PHP `bool` as a JS boolean, which never matches HTML `<option value="0">` string values, causing the select to snap back on every interaction; changed to `public int $seriesNewOnly = 0`
- **`GuestScheduledSeriesWidget`** — header widget on the guest Recordings list that shows all active series rules, giving guests immediate feedback after scheduling (actual `DvrRecording` rows only appear within 30 min of episode start)
- **`playlist_auth_id` propagation** — copied from the recording rule onto the created `DvrRecording` in both `createScheduledRecordingFromProgramme` and `matchManualRule`; fixes the guest Cancel button which was permanently hidden because `record->playlist_auth_id` was `null`vv
- **fix: don't append APP_PORT to HTTPS URLs in console base URL**
When APP_URL uses https:// (i.e. the app is behind a reverse proxy), configureConsoleBaseUrl() was unconditionally appending APP_PORT to the URL, producing incorrect external URLs like https://host:36400 in all queue worker contexts (Horizon jobs, Artisan commands).

This caused media server integration channels (Emby/Jellyfin) to have the internal container port baked into their stored stream/logo URLs, surfacing in the Channel URL Settings panel as port-appended provider URLs.

The fix mirrors the existing guard in PlaylistService::getBaseUrl(): only append the port for http:// URLs. https:// implies a reverse proxy terminating TLS at port 443 so APP_PORT is not the external port.

## Changes

- Migration: `source_channel_id` nullable FK on `dvr_recording_rules` (nullOnDelete)
- `DvrRecordingRule`: `source_channel_id` fillable + `sourceChannel(): BelongsTo`
- `DvrSchedulerService`: priority 2.5 branch in `resolveSeriesEpgScope` + `resolveStreamUrl` for `source_channel_id`; eager-loads `sourceChannel.epgChannel`
- `BrowseShows` + `GuestBrowseShows`: `$sourceChannelId ?int`; sentinel `seriesChannelId = 0` pre-populated from browsed channel; resolved to `null + source_channel_id` before persisting
- `browse-show-detail.blade.php`: "From Original Source — {channel}" option above "Any channel"
- `DvrRecordingRuleResource` + `GuestDvrRuleResource`: channel select prepends `0 → 'From Original Source'`; EditAction sentinel round-trip via `mutateRecordDataUsing`/`mutateDataUsing`
- All 100 tests pass (49 DvrScheduler + 51 BrowseShows)