### PR TITLE
Feat/probe hdr detection and tech details

### DIFF
--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -428,6 +428,13 @@ class Channel extends Model
                             'channel_layout' => $stream['channel_layout'] ?? null,
                             'bits_per_raw_sample' => $stream['bits_per_raw_sample'] ?? null,
                             'refs' => $stream['refs'] ?? null,
+                            'pix_fmt' => $stream['pix_fmt'] ?? null,
+                            'color_transfer' => $stream['color_transfer'] ?? null,
+                            'color_space' => $stream['color_space'] ?? null,
+                            'color_primaries' => $stream['color_primaries'] ?? null,
+                            'color_range' => $stream['color_range'] ?? null,
+                            'codec_tag_string' => $stream['codec_tag_string'] ?? null,
+                            'side_data_list' => $stream['side_data_list'] ?? null,
                             'tags' => $stream['tags'] ?? [],
                         ];
                     }

--- a/app/Models/Episode.php
+++ b/app/Models/Episode.php
@@ -309,6 +309,13 @@ class Episode extends Model
                             'channel_layout' => $stream['channel_layout'] ?? null,
                             'bits_per_raw_sample' => $stream['bits_per_raw_sample'] ?? null,
                             'refs' => $stream['refs'] ?? null,
+                            'pix_fmt' => $stream['pix_fmt'] ?? null,
+                            'color_transfer' => $stream['color_transfer'] ?? null,
+                            'color_space' => $stream['color_space'] ?? null,
+                            'color_primaries' => $stream['color_primaries'] ?? null,
+                            'color_range' => $stream['color_range'] ?? null,
+                            'codec_tag_string' => $stream['codec_tag_string'] ?? null,
+                            'side_data_list' => $stream['side_data_list'] ?? null,
                             'tags' => $stream['tags'] ?? [],
                         ];
                     }

--- a/app/Services/StreamStatsService.php
+++ b/app/Services/StreamStatsService.php
@@ -57,9 +57,42 @@ class StreamStatsService
             'color_transfer' => $video['color_transfer'] ?? null,
             'color_space' => $video['color_space'] ?? null,
             'color_primaries' => $video['color_primaries'] ?? null,
+            'color_range' => $video['color_range'] ?? null,
+            'pix_fmt' => $video['pix_fmt'] ?? null,
+            'codec_tag_string' => $video['codec_tag_string'] ?? null,
+            'side_data_list' => $video['side_data_list'] ?? null,
+            'bit_depth' => self::extractBitDepth($video),
             'audio_codec' => $audio['codec_name'] ?? null,
+            'audio_profile' => $audio['profile'] ?? null,
             'audio_channels' => $audio['channels'] ?? $audio['channel_layout'] ?? null,
         ];
+    }
+
+    /**
+     * Try to derive bit depth from a video stream entry.
+     *
+     * @param  array<string, mixed>|null  $video
+     */
+    private static function extractBitDepth(?array $video): ?int
+    {
+        if (! is_array($video)) {
+            return null;
+        }
+
+        $bps = $video['bits_per_raw_sample'] ?? null;
+        if (is_numeric($bps) && (int) $bps > 0) {
+            return (int) $bps;
+        }
+
+        $pix = strtolower((string) ($video['pix_fmt'] ?? ''));
+        if ($pix !== '' && preg_match('/(\d{1,2})(?:le|be)?p?$/', $pix, $m) === 1) {
+            $depth = (int) $m[1];
+            if ($depth >= 8 && $depth <= 16) {
+                return $depth;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -147,18 +180,53 @@ class StreamStatsService
         $colorTransfer = Str::of(self::stringValue($stats['color_transfer'] ?? null))->lower();
         $colorSpace = Str::of(self::stringValue($stats['color_space'] ?? null))->lower();
         $colorPrimaries = Str::of(self::stringValue($stats['color_primaries'] ?? null))->lower();
+        $codecTag = Str::of(self::stringValue($stats['codec_tag_string'] ?? null))->lower();
 
-        $combined = Str::of($hdr.' '.$profile.' '.$colorTransfer.' '.$colorSpace.' '.$colorPrimaries);
+        // ffprobe encodes HDR side data (mastering display, content light level,
+        // dynamic metadata, Dolby Vision configuration) as a list under side_data_list.
+        $sideDataDump = '';
+        $sideData = $stats['side_data_list'] ?? null;
+        if (is_array($sideData)) {
+            $flat = [];
+            array_walk_recursive($sideData, static function ($value) use (&$flat) {
+                if (is_scalar($value)) {
+                    $flat[] = (string) $value;
+                }
+            });
+            $sideDataDump = strtolower(implode(' ', $flat));
+        }
 
-        if ($combined->contains(['dolby vision', 'dovi', 'dvhe'])) {
+        $combined = Str::of($hdr.' '.$profile.' '.$colorTransfer.' '.$colorSpace.' '.$colorPrimaries.' '.$codecTag.' '.$sideDataDump);
+
+        // Dolby Vision: dvh1/dvhe codec tag, profile string, or DOVI configuration record.
+        if (
+            $combined->contains(['dolby vision', 'dovi', 'dvhe', 'dvh1', 'dolby_vision', 'dovi configuration'])
+            || $codecTag->is(['dvh1', 'dvhe', 'dav1', 'dva1'])
+        ) {
             return 'DV';
         }
 
-        if ($combined->contains(['hdr10+', 'smpte2094'])) {
+        // HDR10+: SMPTE2094-40 dynamic metadata.
+        if ($combined->contains(['hdr10+', 'hdr10plus', 'smpte2094-40', 'smpte 2094-40', 'smpte2094_40', 'st2094-40'])) {
             return 'HDR10+';
         }
 
-        if ($combined->contains(['hdr', 'smpte2084', 'arib-std-b67', 'hlg', 'bt2020'])) {
+        // HDR10: PQ transfer (smpte2084) plus mastering metadata. We emit "HDR10"
+        // explicitly when the mastering display / content light level side data is
+        // present, otherwise fall back to generic "HDR".
+        $hasPq = $colorTransfer->contains(['smpte2084', 'st2084']);
+        $hasMastering = str_contains($sideDataDump, 'mastering display')
+            || str_contains($sideDataDump, 'content light level');
+
+        if ($hasPq && $hasMastering) {
+            return 'HDR10';
+        }
+
+        if ($combined->contains(['hdr10'])) {
+            return 'HDR10';
+        }
+
+        if ($combined->contains(['hdr', 'smpte2084', 'st2084', 'arib-std-b67', 'hlg', 'bt2020'])) {
             return 'HDR';
         }
 

--- a/resources/views/filament/partials/probed-stream-info-series.blade.php
+++ b/resources/views/filament/partials/probed-stream-info-series.blade.php
@@ -1,0 +1,82 @@
+@php
+    /**
+     * @var \App\Models\Series $record
+     */
+    use App\Services\StreamStatsService;
+
+    $probedEpisodes = $record->episodes()
+        ->whereNotNull('stream_stats_probed_at')
+        ->get(['id', 'stream_stats', 'stream_stats_probed_at']);
+
+    $totalEpisodes = $record->episodes()->count();
+    $probedCount = $probedEpisodes->count();
+
+    $aggregator = [];
+    $fieldsToTrack = [
+        'video_codec', 'audio_codec', 'resolution', 'video_profile', 'pix_fmt',
+        'color_transfer', 'color_space', 'color_primaries', 'codec_tag_string',
+        'audio_channels', 'audio_profile', 'bit_depth',
+    ];
+    $hdrValues = [];
+    $qualityValues = [];
+
+    foreach ($probedEpisodes as $episode) {
+        $raw = is_array($episode->stream_stats) ? $episode->stream_stats : [];
+        $stats = StreamStatsService::normalize($raw);
+
+        $hdrValues[] = StreamStatsService::detectHdr($stats) ?: 'SDR';
+        $qualityValues[] = StreamStatsService::detectQuality($stats) ?: '';
+
+        foreach ($fieldsToTrack as $field) {
+            $value = $stats[$field] ?? null;
+            if ($value !== null && $value !== '') {
+                $aggregator[$field][] = is_scalar($value) ? (string) $value : json_encode($value);
+            }
+        }
+    }
+
+    $renderField = function (string $label, array $values) {
+        $unique = array_values(array_unique($values));
+        if (empty($unique)) {
+            return null;
+        }
+        if (count($unique) === 1) {
+            return ['label' => $label, 'value' => $unique[0], 'mixed' => false];
+        }
+        return ['label' => $label, 'value' => 'Mixed (' . count($unique) . ' variants)', 'mixed' => true];
+    };
+
+    $rows = [];
+    $rows[] = $renderField('Detected Quality', $qualityValues);
+    $rows[] = $renderField('Detected HDR', $hdrValues);
+    foreach ($fieldsToTrack as $field) {
+        $label = ucwords(str_replace('_', ' ', $field));
+        $rows[] = $renderField($label, $aggregator[$field] ?? []);
+    }
+    $rows = array_filter($rows);
+@endphp
+
+@if ($probedCount > 0)
+    <div class="mb-6">
+        <x-filament::section
+            icon="heroicon-o-cog-6-tooth"
+            :heading="__('Probed Stream Info (Series Aggregate)')"
+            :description="__(':probed of :total episodes probed. Mixed values mean episodes differ.', ['probed' => $probedCount, 'total' => $totalEpisodes])"
+            collapsible
+            collapsed>
+            <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
+                @foreach ($rows as $row)
+                    <div>
+                        <span class="text-sm text-gray-500">{{ $row['label'] }}</span>
+                        <div class="font-medium {{ $row['mixed'] ? 'text-amber-600 dark:text-amber-400' : '' }}">
+                            {{ $row['value'] }}
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+            <div class="mt-3 text-xs text-gray-500">
+                {{ __('Open a season modal and click an episode for per-episode probed stream details.') }}
+            </div>
+        </x-filament::section>
+    </div>
+@endif

--- a/resources/views/filament/partials/probed-stream-info.blade.php
+++ b/resources/views/filament/partials/probed-stream-info.blade.php
@@ -1,0 +1,108 @@
+@php
+    /**
+     * @var \App\Models\Channel|\App\Models\Episode|null $record
+     */
+    use App\Services\StreamStatsService;
+
+    $rawStats = is_array($record?->stream_stats ?? null) ? $record->stream_stats : [];
+    $stats = StreamStatsService::normalize($rawStats);
+    $hasStats = ! empty(array_filter($stats, fn ($v) => $v !== null && $v !== ''));
+
+    $probedAt = $record?->stream_stats_probed_at ?? null;
+
+    // Pull container bitrate from raw ffprobe output if it was stored as ['format' => [...]]
+    $formatBitrate = null;
+    foreach ($rawStats as $entry) {
+        if (is_array($entry) && isset($entry['format']) && is_array($entry['format'])) {
+            $formatBitrate = $entry['format']['bit_rate'] ?? null;
+            break;
+        }
+    }
+
+    $resolution = $stats['resolution'] ?? null;
+    if (! $resolution && ($stats['width'] ?? null) && ($stats['height'] ?? null)) {
+        $resolution = $stats['width'] . 'x' . $stats['height'];
+    }
+
+    $quality = $hasStats ? StreamStatsService::detectQuality($stats) : '';
+    $videoCodec = $hasStats ? StreamStatsService::detectVideoCodec($stats) : '';
+    $audioCodec = $hasStats ? StreamStatsService::detectAudio($stats) : '';
+    $hdr = $hasStats ? StreamStatsService::detectHdr($stats) : '';
+
+    $bitrateMbps = null;
+    foreach ([$stats['bitrate'] ?? null, $stats['bit_rate'] ?? null, $formatBitrate] as $candidate) {
+        if (is_numeric($candidate) && (int) $candidate > 0) {
+            $bitrateMbps = round(((int) $candidate) / 1_000_000, 2);
+            break;
+        }
+    }
+
+    $fields = [
+        'Detected Quality'  => $quality,
+        'Detected Video'    => $videoCodec,
+        'Detected Audio'    => $audioCodec,
+        'Detected HDR'      => $hdr ?: ($hasStats ? 'SDR' : ''),
+        'Resolution'        => $resolution,
+        'Video Profile'     => $stats['video_profile'] ?? null,
+        'Pixel Format'      => $stats['pix_fmt'] ?? null,
+        'Bit Depth'         => isset($stats['bit_depth']) && $stats['bit_depth'] ? $stats['bit_depth'] . '-bit' : null,
+        'Color Transfer'    => $stats['color_transfer'] ?? null,
+        'Color Space'       => $stats['color_space'] ?? null,
+        'Color Primaries'   => $stats['color_primaries'] ?? null,
+        'Color Range'       => $stats['color_range'] ?? null,
+        'Codec Tag'         => $stats['codec_tag_string'] ?? null,
+        'Audio Channels'    => $stats['audio_channels'] ?? null,
+        'Audio Profile'     => $stats['audio_profile'] ?? null,
+        'Bitrate'           => $bitrateMbps !== null ? $bitrateMbps . ' Mbps' : null,
+    ];
+
+    $sideData = $stats['side_data_list'] ?? null;
+    $sideDataLabels = [];
+    if (is_array($sideData)) {
+        foreach ($sideData as $sd) {
+            if (! is_array($sd)) {
+                continue;
+            }
+            $type = $sd['side_data_type'] ?? null;
+            if (is_string($type) && $type !== '') {
+                $sideDataLabels[] = $type;
+            }
+        }
+    }
+@endphp
+
+@if ($hasStats)
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-4 mt-2">
+        @foreach ($fields as $label => $value)
+            @if ($value !== null && $value !== '')
+                <div>
+                    <span class="text-sm text-gray-500">{{ $label }}</span>
+                    <div class="font-medium">{{ $value }}</div>
+                </div>
+            @endif
+        @endforeach
+    </div>
+
+    @if (! empty($sideDataLabels))
+        <div class="mt-3">
+            <span class="text-sm text-gray-500">Side Data</span>
+            <div class="flex flex-wrap gap-1 mt-1">
+                @foreach (array_unique($sideDataLabels) as $label)
+                    <span class="inline-block text-xs px-2 py-0.5 rounded bg-gray-200 dark:bg-gray-700">
+                        {{ $label }}
+                    </span>
+                @endforeach
+            </div>
+        </div>
+    @endif
+
+    @if ($probedAt)
+        <div class="mt-3 text-xs text-gray-500">
+            {{ __('Last probed') }}: {{ \Illuminate\Support\Carbon::parse($probedAt)->diffForHumans() }}
+        </div>
+    @endif
+@else
+    <div class="text-sm text-gray-500 italic">
+        {{ __('No probed stream data yet. Run a stream probe to populate this section.') }}
+    </div>
+@endif

--- a/resources/views/filament/resources/series/pages/view-series.blade.php
+++ b/resources/views/filament/resources/series/pages/view-series.blade.php
@@ -202,6 +202,9 @@
         </div>
     @endif
 
+    {{-- Probed Stream Info (aggregated across episodes) --}}
+    @include('filament.partials.probed-stream-info-series', ['record' => $record])
+
     {{-- Seasons Grid --}}
     @php
         // Fetch all episodes with season relationship, ordered by season and episode number
@@ -341,6 +344,26 @@
                                                 </span>
                                             @endif
                                         </div>
+
+                                        @if($episode->stream_stats_probed_at)
+                                            @php
+                                                $epStats = \App\Services\StreamStatsService::normalize(is_array($episode->stream_stats) ? $episode->stream_stats : []);
+                                                $epQuality = \App\Services\StreamStatsService::detectQuality($epStats);
+                                                $epHdr = \App\Services\StreamStatsService::detectHdr($epStats);
+                                                $epVideo = \App\Services\StreamStatsService::detectVideoCodec($epStats);
+                                                $epAudio = \App\Services\StreamStatsService::detectAudio($epStats);
+                                                $badges = array_filter([$epQuality, $epHdr, $epVideo, $epAudio]);
+                                            @endphp
+                                            @if(! empty($badges))
+                                                <div class="flex flex-wrap gap-1 pt-1">
+                                                    @foreach($badges as $badge)
+                                                        <span class="inline-block text-[10px] px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700">
+                                                            {{ $badge }}
+                                                        </span>
+                                                    @endforeach
+                                                </div>
+                                            @endif
+                                        @endif
                                     </div>
                                 </div>
                             @endforeach

--- a/resources/views/filament/resources/vods/pages/view-vod.blade.php
+++ b/resources/views/filament/resources/vods/pages/view-vod.blade.php
@@ -300,6 +300,12 @@
                     </div>
                 </div>
             </div>
+
+            {{-- Probed stream info (ffprobe) --}}
+            <div class="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
+                <h3 class="text-sm font-semibold mb-2">{{ __('Probed Stream Info') }}</h3>
+                @include('filament.partials.probed-stream-info', ['record' => $record])
+            </div>
         </x-filament::section>
     </div>
 </x-filament-panels::page>

--- a/tests/Unit/SerieFileNameServiceTest.php
+++ b/tests/Unit/SerieFileNameServiceTest.php
@@ -139,7 +139,7 @@ it('detects hdr through filename generation', function () {
     ]);
 
     expect((new SerieFileNameService)->generateEpisodeFileName($episode, $setting))
-        ->toBe('Show [HDR]');
+        ->toBe('Show [HDR10]');
 });
 
 it('generates full path with all components', function () {
@@ -179,7 +179,7 @@ it('generates episode extras bracket from stream stats', function () {
 
     $extras = (new SerieFileNameService)->generateEpisodeExtras($episode, $setting);
 
-    expect($extras)->toBe('[1080p H.265 E-AC-3 5.1 HDR]');
+    expect($extras)->toBe('[1080p H.265 E-AC-3 5.1 HDR10]');
 });
 
 it('returns empty episode extras when stream_stats are absent', function () {

--- a/tests/Unit/StreamStatsServiceHdrDetectionTest.php
+++ b/tests/Unit/StreamStatsServiceHdrDetectionTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Services\StreamStatsService;
+
+it('detects Dolby Vision from codec_tag_string dvh1', function () {
+    $stats = StreamStatsService::normalize([
+        ['codec_type' => 'video', 'codec_name' => 'hevc', 'codec_tag_string' => 'dvh1', 'width' => 3840, 'height' => 2160],
+    ]);
+
+    expect(StreamStatsService::detectHdr($stats))->toBe('DV');
+});
+
+it('detects Dolby Vision from side_data_list DOVI configuration record', function () {
+    $stats = StreamStatsService::normalize([
+        [
+            'codec_type' => 'video',
+            'codec_name' => 'hevc',
+            'side_data_list' => [
+                ['side_data_type' => 'DOVI configuration record', 'dv_profile' => 8, 'dv_level' => 6],
+            ],
+        ],
+    ]);
+
+    expect(StreamStatsService::detectHdr($stats))->toBe('DV');
+});
+
+it('detects HDR10+ from SMPTE2094-40 dynamic metadata', function () {
+    $stats = StreamStatsService::normalize([
+        [
+            'codec_type' => 'video',
+            'codec_name' => 'hevc',
+            'color_transfer' => 'smpte2084',
+            'side_data_list' => [
+                ['side_data_type' => 'HDR Dynamic Metadata SMPTE2094-40 (HDR10+)'],
+            ],
+        ],
+    ]);
+
+    expect(StreamStatsService::detectHdr($stats))->toBe('HDR10+');
+});
+
+it('detects HDR10 from PQ transfer plus mastering display side data', function () {
+    $stats = StreamStatsService::normalize([
+        [
+            'codec_type' => 'video',
+            'codec_name' => 'hevc',
+            'color_transfer' => 'smpte2084',
+            'color_space' => 'bt2020nc',
+            'color_primaries' => 'bt2020',
+            'side_data_list' => [
+                ['side_data_type' => 'Mastering display metadata'],
+                ['side_data_type' => 'Content light level metadata'],
+            ],
+        ],
+    ]);
+
+    expect(StreamStatsService::detectHdr($stats))->toBe('HDR10');
+});
+
+it('detects HLG from arib-std-b67 transfer', function () {
+    $stats = StreamStatsService::normalize([
+        ['codec_type' => 'video', 'codec_name' => 'hevc', 'color_transfer' => 'arib-std-b67'],
+    ]);
+
+    expect(StreamStatsService::detectHdr($stats))->toBe('HDR');
+});
+
+it('returns empty for SDR streams without color metadata', function () {
+    $stats = StreamStatsService::normalize([
+        ['codec_type' => 'video', 'codec_name' => 'h264', 'color_transfer' => 'bt709', 'color_space' => 'bt709'],
+    ]);
+
+    expect(StreamStatsService::detectHdr($stats))->toBe('');
+});
+
+it('preserves color metadata fields through normalize for nested ffprobe shape', function () {
+    $stats = StreamStatsService::normalize([
+        [
+            'codec_type' => 'video',
+            'codec_name' => 'hevc',
+            'color_transfer' => 'smpte2084',
+            'color_space' => 'bt2020nc',
+            'color_primaries' => 'bt2020',
+            'codec_tag_string' => 'dvh1',
+        ],
+    ]);
+
+    expect($stats)
+        ->toHaveKey('color_transfer', 'smpte2084')
+        ->toHaveKey('color_space', 'bt2020nc')
+        ->toHaveKey('color_primaries', 'bt2020')
+        ->toHaveKey('codec_tag_string', 'dvh1');
+});


### PR DESCRIPTION
This pull request enhances stream probing and HDR detection for video/audio streams, improving both backend data normalization and frontend display of stream metadata. It adds support for more detailed ffprobe metadata, significantly improves HDR format detection (including Dolby Vision, HDR10, and HDR10+), and updates the UI to show this information at both the episode and series level. Unit tests have been added and updated to ensure the correctness of HDR detection and filename generation.

**Backend: Stream Probing & Normalization Improvements**
- Added extraction of additional ffprobe metadata fields (e.g., `pix_fmt`, `color_transfer`, `color_space`, `color_primaries`, `color_range`, `codec_tag_string`, `side_data_list`) in `Channel` and `Episode` models and normalization logic, including new bit depth and audio profile derivation. [[1]](diffhunk://#diff-1deafffe8d882fa37262d46d1df1cd058bb196d10b243ff801ae2dfc892b275fR431-R437) [[2]](diffhunk://#diff-be2ebf5576aafbeebfcb171e9ce72460a844bb9412486caefe707e37e47ec956R312-R318) [[3]](diffhunk://#diff-09a1b42ed3c281099a773d7600a973ff2012badd4ce6271b9f5e26a4f47798f2R60-R97)
- Improved HDR detection logic in `StreamStatsService` to more accurately identify Dolby Vision (DV), HDR10, and HDR10+ using codec tags and side data.

**Frontend: Display Enhancements**
- Added partials to display detailed probed stream info for individual episodes/VODs and aggregate info for series, including HDR, codec, resolution, and other metadata, with clear indication of mixed values across episodes. [[1]](diffhunk://#diff-7038b9e3de70e93eafeb64e945c73f9cc00a9eebc87e6c1a792a048611fe77a4R1-R108) [[2]](diffhunk://#diff-d063afcf9b3d4f37b0d7d0e8bf42a7a075463347a58f71f94d8f9888b847a29dR1-R82) [[3]](diffhunk://#diff-f7b13c8d38111729b924fd4e85e8f8a81d703b07e0c354a7db2b3abcedcd1888R205-R207) [[4]](diffhunk://#diff-ff80e8b48c62c9be3843bccc54fc75c84f36d3d6c53f86b54a0e829121b6e998R303-R308)
- Updated the series episode list to show badges for detected quality, HDR, video, and audio codecs per episode.

**Testing and Validation**
- Added comprehensive unit tests for HDR detection, covering Dolby Vision, HDR10, HDR10+, HLG, and SDR scenarios, as well as preservation of color metadata.
- Updated filename generation tests to reflect improved HDR detection (now outputs `HDR10` instead of generic `HDR`). [[1]](diffhunk://#diff-e9dae9bcd9665d81162f90609b8cc83e8bfee1f9071305a6d6017cc4e20326bdL142-R142) [[2]](diffhunk://#diff-e9dae9bcd9665d81162f90609b8cc83e8bfee1f9071305a6d6017cc4e20326bdL182-R182)