### PR TITLE
feat(api): add PATCH /playlist/{uuid} to update source URL

### DIFF
--- a/app/Http/Controllers/PlaylistController.php
+++ b/app/Http/Controllers/PlaylistController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\PlaylistSourceType;
 use App\Facades\PlaylistFacade;
 use App\Jobs\MergeChannels;
 use App\Jobs\ProcessM3uImport;
@@ -44,6 +45,124 @@ class PlaylistController extends Controller
 
         return response()->json([
             'message' => "Playlist \"{$playlist->name}\" is currently being synced...",
+        ]);
+    }
+
+    /**
+     * Update the playlist source URL.
+     *
+     * Update the playlist's source URL (and optionally credentials for Xtream playlists).
+     * For M3U playlists the `url` column is updated. For Xtream playlists, `xtream_config.url`
+     * is updated, and `username`/`password` may be provided to rotate credentials.
+     *
+     * Pass `resync=true` to dispatch an immediate import job after saving the changes.
+     *
+     * @response 200 {
+     *   "success": true,
+     *   "message": "Playlist updated successfully",
+     *   "data": {
+     *     "uuid": "abc-123-def",
+     *     "name": "My Provider",
+     *     "url": "https://provider.com:8080",
+     *     "resync_dispatched": true
+     *   }
+     * }
+     * @response 403 {
+     *   "success": false,
+     *   "message": "You do not have permission to update this playlist"
+     * }
+     * @response 404 {
+     *   "success": false,
+     *   "message": "Playlist not found"
+     * }
+     * @response 422 {
+     *   "message": "The given data was invalid.",
+     *   "errors": {
+     *     "url": ["The url must be a valid URL."]
+     *   }
+     * }
+     */
+    public function update(Request $request, string $uuid): JsonResponse
+    {
+        $user = $request->user();
+
+        $playlist = PlaylistFacade::resolvePlaylistByUuid($uuid);
+        if (! $playlist) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Playlist not found',
+            ], 404);
+        }
+
+        if (! $playlist instanceof Playlist) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Only standard playlists support this update endpoint',
+            ], 422);
+        }
+
+        if ($playlist->user_id !== $user->id) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You do not have permission to update this playlist',
+            ], 403);
+        }
+
+        $validated = $request->validate([
+            'url' => 'required|url|max:4000',
+            'username' => 'sometimes|nullable|string|max:255',
+            'password' => 'sometimes|nullable|string|max:255',
+            'resync' => 'sometimes|boolean',
+        ]);
+
+        $normalizedUrl = rtrim($validated['url'], '/');
+
+        if ($playlist->source_type === PlaylistSourceType::Xtream) {
+            $config = $playlist->xtream_config ?? [];
+            $config['url'] = $normalizedUrl;
+
+            if (array_key_exists('username', $validated) && $validated['username'] !== null) {
+                $config['username'] = $validated['username'];
+            }
+
+            if (array_key_exists('password', $validated) && $validated['password'] !== null) {
+                $config['password'] = $validated['password'];
+            }
+
+            $playlist->xtream_config = $config;
+        } else {
+            if ($request->has('username') || $request->has('password')) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Credentials are only supported for Xtream playlists',
+                ], 422);
+            }
+
+            $playlist->url = $normalizedUrl;
+        }
+
+        if ($playlist->isDirty()) {
+            $playlist->save();
+        }
+
+        $resync = (bool) ($validated['resync'] ?? false);
+        if ($resync) {
+            dispatch(new ProcessM3uImport($playlist, force: true));
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => $resync
+                ? 'Playlist updated successfully and resync dispatched'
+                : 'Playlist updated successfully',
+            'data' => [
+                'uuid' => $playlist->uuid,
+                'name' => $playlist->name,
+                'url' => $playlist->source_type === PlaylistSourceType::Xtream
+                    ? ($playlist->xtream_config['url'] ?? null)
+                    : $playlist->url,
+                'resync_dispatched' => $resync,
+            ],
         ]);
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -32,6 +32,7 @@ return Application::configure(basePath: dirname(__DIR__))
                 'channel/*',
                 'group',
                 'group/*',
+                'playlist/*',
                 'player_api.php',
                 'get.php',
             ])

--- a/routes/web.php
+++ b/routes/web.php
@@ -257,6 +257,8 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     // Playlist API routes (authenticated)
     Route::get('playlist/{uuid}/stats', [PlaylistController::class, 'stats'])
         ->name('api.playlist.stats');
+    Route::patch('playlist/{uuid}', [PlaylistController::class, 'update'])
+        ->name('api.playlist.update');
     Route::post('playlist/{uuid}/merge-channels', [PlaylistController::class, 'mergeChannels'])
         ->name('api.playlist.merge-channels');
 

--- a/tests/Feature/PlaylistUpdateApiTest.php
+++ b/tests/Feature/PlaylistUpdateApiTest.php
@@ -1,0 +1,186 @@
+<?php
+
+use App\Enums\PlaylistSourceType;
+use App\Jobs\ProcessM3uImport;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user, 'sanctum');
+});
+
+it('updates the url for an m3u playlist', function () {
+    Bus::fake();
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'source_type' => PlaylistSourceType::M3u,
+        'url' => 'https://old.example.com/playlist.m3u',
+    ]);
+
+    $response = $this->patchJson("/playlist/{$playlist->uuid}", [
+        'url' => 'https://new.example.com/playlist.m3u',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.url', 'https://new.example.com/playlist.m3u')
+        ->assertJsonPath('data.resync_dispatched', false)
+        ->assertJsonMissingPath('data.source_type');
+
+    expect($playlist->fresh()->url)->toBe('https://new.example.com/playlist.m3u');
+    Bus::assertNotDispatched(ProcessM3uImport::class);
+});
+
+it('dispatches a resync when resync=true is passed', function () {
+    Bus::fake();
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'source_type' => PlaylistSourceType::M3u,
+        'url' => 'https://old.example.com/playlist.m3u',
+    ]);
+
+    $response = $this->patchJson("/playlist/{$playlist->uuid}", [
+        'url' => 'https://new.example.com/playlist.m3u',
+        'resync' => true,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('data.resync_dispatched', true)
+        ->assertJsonPath('message', 'Playlist updated successfully and resync dispatched');
+
+    Bus::assertDispatched(
+        ProcessM3uImport::class,
+        fn (ProcessM3uImport $job) => $job->playlist->is($playlist) && $job->force === true,
+    );
+});
+
+it('does not dispatch a resync when resync=false', function () {
+    Bus::fake();
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'source_type' => PlaylistSourceType::M3u,
+        'url' => 'https://old.example.com/playlist.m3u',
+    ]);
+
+    $this->patchJson("/playlist/{$playlist->uuid}", [
+        'url' => 'https://new.example.com/playlist.m3u',
+        'resync' => false,
+    ])->assertOk()->assertJsonPath('data.resync_dispatched', false);
+
+    Bus::assertNotDispatched(ProcessM3uImport::class);
+});
+
+it('strips trailing slashes from the url', function () {
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'source_type' => PlaylistSourceType::M3u,
+        'url' => 'https://old.example.com/playlist.m3u',
+    ]);
+
+    $this->patchJson("/playlist/{$playlist->uuid}", [
+        'url' => 'https://new.example.com/',
+    ])->assertOk()->assertJsonPath('data.url', 'https://new.example.com');
+});
+
+it('updates xtream_config url and rotates credentials when provided', function () {
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'source_type' => PlaylistSourceType::Xtream,
+        'xtream_config' => [
+            'url' => 'https://old.example.com:8080',
+            'username' => 'olduser',
+            'password' => 'oldpass',
+            'output' => 'ts',
+        ],
+    ]);
+
+    $response = $this->patchJson("/playlist/{$playlist->uuid}", [
+        'url' => 'https://new.example.com:8080',
+        'username' => 'newuser',
+        'password' => 'newpass',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.url', 'https://new.example.com:8080');
+
+    $config = $playlist->fresh()->xtream_config;
+    expect($config['url'])->toBe('https://new.example.com:8080')
+        ->and($config['username'])->toBe('newuser')
+        ->and($config['password'])->toBe('newpass')
+        ->and($config['output'])->toBe('ts');
+});
+
+it('keeps existing xtream credentials when only url is updated', function () {
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'source_type' => PlaylistSourceType::Xtream,
+        'xtream_config' => [
+            'url' => 'https://old.example.com:8080',
+            'username' => 'keepme',
+            'password' => 'keepmepass',
+            'output' => 'm3u8',
+        ],
+    ]);
+
+    $this->patchJson("/playlist/{$playlist->uuid}", [
+        'url' => 'https://new.example.com:8080',
+    ])->assertOk();
+
+    $config = $playlist->fresh()->xtream_config;
+    expect($config['url'])->toBe('https://new.example.com:8080')
+        ->and($config['username'])->toBe('keepme')
+        ->and($config['password'])->toBe('keepmepass')
+        ->and($config['output'])->toBe('m3u8');
+});
+
+it('rejects credentials for non-xtream playlists', function () {
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'source_type' => PlaylistSourceType::M3u,
+        'url' => 'https://old.example.com/playlist.m3u',
+    ]);
+
+    $this->patchJson("/playlist/{$playlist->uuid}", [
+        'url' => 'https://new.example.com/playlist.m3u',
+        'username' => 'should-not-apply',
+    ])->assertStatus(422)
+        ->assertJsonPath('success', false);
+
+    expect($playlist->fresh()->url)->toBe('https://old.example.com/playlist.m3u');
+});
+
+it('returns 422 when url is missing', function () {
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'source_type' => PlaylistSourceType::M3u,
+    ]);
+
+    $this->patchJson("/playlist/{$playlist->uuid}", [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['url']);
+});
+
+it('returns 422 when url is invalid', function () {
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'source_type' => PlaylistSourceType::M3u,
+    ]);
+
+    $this->patchJson("/playlist/{$playlist->uuid}", ['url' => 'not-a-url'])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['url']);
+});
+
+it('returns 404 when playlist does not exist', function () {
+    $this->patchJson('/playlist/00000000-0000-0000-0000-000000000000', [
+        'url' => 'https://new.example.com/playlist.m3u',
+    ])->assertNotFound()->assertJsonPath('success', false);
+});
+
+it('returns 403 when playlist belongs to another user', function () {
+    $other = User::factory()->create();
+    $playlist = Playlist::factory()->for($other)->createQuietly([
+        'source_type' => PlaylistSourceType::M3u,
+        'url' => 'https://old.example.com/playlist.m3u',
+    ]);
+
+    $this->patchJson("/playlist/{$playlist->uuid}", [
+        'url' => 'https://new.example.com/playlist.m3u',
+    ])->assertForbidden()->assertJsonPath('success', false);
+
+    expect($playlist->fresh()->url)->toBe('https://old.example.com/playlist.m3u');
+});


### PR DESCRIPTION
## Summary

Adds `PATCH /playlist/{uuid}` to update a playlist's source URL via API. Useful when the IPTV provider rotates its URL periodically — no need to log into the admin UI to fix it.

- M3U: updates `url`.
- Xtream: updates `xtream_config.url`; optional `username` / `password` rotate credentials.
- Optional `resync=true` triggers an immediate import.
- Authenticated with Sanctum. `playlist/*` added to CSRF exceptions, matching the existing `channel/*` and `group/*` pattern.

## Test plan

- [x] `php artisan test --compact tests/Feature/PlaylistUpdateApiTest.php` (11 passing)
- [x] `vendor/bin/pint --dirty` clean