### PR TITLE
ui: widen Copilot chat from max-w-md to max-w-2xl

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -86,6 +86,11 @@
     overflow-y: auto;
 } */
 
+/* Copilot Chat — widen the slide-over drawer from max-w-md to max-w-2xl */
+.copilot-chat-widget {
+    max-width: 42rem !important;
+}
+
 /* DVR Status Animations */
 @keyframes dvr-status-spin {
     0% { transform: rotate(0deg); }


### PR DESCRIPTION
## Summary

- Widens the Copilot chat slide-over drawer by overriding `.copilot-chat-widget` in `app.css`
- Changes `max-width` from `max-w-md` (28rem) to `max-w-2xl` (42rem) for a more comfortable chat experience

## Changes

- `resources/css/app.css` — adds a single CSS utility override for `.copilot-chat-widget`

🤖 Generated with [Claude Code](https://claude.com/claude-code)