### PR TITLE
fix: add playlist auth functionality to playlist aliases

### DIFF
--- a/app/Filament/Resources/PlaylistAliases/Pages/ListPlaylistAliases.php
+++ b/app/Filament/Resources/PlaylistAliases/Pages/ListPlaylistAliases.php
@@ -7,6 +7,7 @@ use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class ListPlaylistAliases extends ListRecords
 {
@@ -21,7 +22,17 @@ class ListPlaylistAliases extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->slideOver(),
+                ->slideOver()
+                ->using(function (array $data, string $model): Model {
+                    $assignedAuthIds = PlaylistAliasResource::pullAssignedAuthIdsFromFormData($data);
+                    $record = $model::create($data);
+
+                    if ($assignedAuthIds !== null) {
+                        PlaylistAliasResource::syncAssignedAuths($record, $assignedAuthIds);
+                    }
+
+                    return $record;
+                }),
         ];
     }
 

--- a/app/Filament/Resources/PlaylistAliases/PlaylistAliasResource.php
+++ b/app/Filament/Resources/PlaylistAliases/PlaylistAliasResource.php
@@ -11,6 +11,7 @@ use App\Filament\Tables\SourceGroupsTable;
 use App\Models\CustomPlaylist;
 use App\Models\Playlist;
 use App\Models\PlaylistAlias;
+use App\Models\PlaylistAuth;
 use App\Models\SourceCategory;
 use App\Models\SourceGroup;
 use App\Models\StreamProfile;
@@ -218,6 +219,17 @@ class PlaylistAliasResource extends Resource implements CopilotResource
                 ])->button()->hiddenLabel()->size('sm'),
                 Actions\EditAction::make()
                     ->slideOver()
+                    ->using(function (PlaylistAlias $record, array $data): PlaylistAlias {
+                        $assignedAuthIds = self::pullAssignedAuthIdsFromFormData($data);
+
+                        $record->update($data);
+
+                        if ($assignedAuthIds !== null) {
+                            self::syncAssignedAuths($record, $assignedAuthIds);
+                        }
+
+                        return $record;
+                    })
                     ->button()->hiddenLabel()->size('sm'),
             ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
@@ -531,33 +543,9 @@ class PlaylistAliasResource extends Resource implements CopilotResource
                         ])->hidden(fn (Get $get): bool => ! $get('enable_proxy')),
                 ])->columnSpanFull(),
 
-            Schemas\Components\Fieldset::make(__('Auth (optional)'))
-                ->columns(2)
+            Schemas\Components\Fieldset::make(__('Auth'))
                 ->schema([
-                    Forms\Components\TextInput::make('username')
-                        ->label(__('Username'))
-                        ->helperText(__('Optional: Set credentials to access this alias via Xtream API. Must be unique across all aliases and playlist auths.'))
-                        ->rules(function ($record) {
-                            return [
-                                'nullable',
-                                Rule::unique('playlist_aliases', 'username')->ignore($record?->id),
-                                Rule::unique('playlist_auths', 'username'),
-                            ];
-                        })
-                        ->columnSpan(1),
-                    Forms\Components\TextInput::make('password')
-                        ->label(__('Password'))
-                        ->columnSpan(1)
-                        ->password()
-                        ->revealable(),
-                    Forms\Components\DateTimePicker::make('expires_at')
-                        ->label(__('Expiration (date & time)'))
-                        ->seconds(false)
-                        ->native(false)
-                        ->prefixIcon('heroicon-o-calendar')
-                        ->helperText(__('If set, this alias credentials will stop working at that exact time.'))
-                        ->nullable()
-                        ->columnSpan(2),
+                    self::assignedAuthsSelect(),
                 ]),
 
             Schemas\Components\Fieldset::make(__('Channel Filter (optional)'))
@@ -787,6 +775,94 @@ class PlaylistAliasResource extends Resource implements CopilotResource
                         ]),
                 ]),
         ];
+    }
+
+    public static function pullAssignedAuthIdsFromFormData(array &$data): ?array
+    {
+        if (! array_key_exists('assigned_auth_ids', $data)) {
+            return null;
+        }
+
+        $assignedAuthIds = $data['assigned_auth_ids'];
+
+        unset($data['assigned_auth_ids']);
+
+        if (! is_array($assignedAuthIds)) {
+            return $assignedAuthIds ? [$assignedAuthIds] : [];
+        }
+
+        return $assignedAuthIds;
+    }
+
+    public static function syncAssignedAuths(PlaylistAlias $record, array $authIds): void
+    {
+        $currentAuthIds = $record->playlistAuths()
+            ->pluck('playlist_auths.id')
+            ->map(fn ($authId): int => (int) $authId)
+            ->all();
+
+        $newAuthIds = collect($authIds)
+            ->filter()
+            ->map(fn ($authId): int => (int) $authId)
+            ->unique()
+            ->values()
+            ->all();
+
+        foreach (array_diff($currentAuthIds, $newAuthIds) as $authId) {
+            PlaylistAuth::find($authId)?->clearAssignment();
+        }
+
+        PlaylistAuth::where('user_id', $record->user_id)
+            ->whereKey(array_diff($newAuthIds, $currentAuthIds))
+            ->whereDoesntHave('assignedPlaylist')
+            ->get()
+            ->each(function (PlaylistAuth $auth) use ($record): void {
+                $auth->assignTo($record);
+            });
+    }
+
+    private static function assignedAuthsSelect(): Forms\Components\Select
+    {
+        return Forms\Components\Select::make('assigned_auth_ids')
+            ->label(__('Assigned Auths'))
+            ->multiple()
+            ->options(function ($record) {
+                $options = [];
+
+                if ($record) {
+                    foreach ($record->playlistAuths()->get() as $auth) {
+                        $options[$auth->id] = $auth->name.' (currently assigned)';
+                    }
+                }
+
+                foreach (PlaylistAuth::where('user_id', auth()->id())
+                    ->whereDoesntHave('assignedPlaylist')
+                    ->get() as $auth) {
+                    $options[$auth->id] = $auth->name;
+                }
+
+                return $options;
+            })
+            ->searchable()
+            ->nullable()
+            ->placeholder(__('Select auths or leave empty'))
+            ->default(function ($record) {
+                if ($record) {
+                    return $record->playlistAuths()->pluck('playlist_auths.id')->toArray();
+                }
+
+                return [];
+            })
+            ->afterStateHydrated(function ($component, $state, $record): void {
+                if ($record) {
+                    $component->state($record->playlistAuths()->pluck('playlist_auths.id')->toArray());
+                }
+            })
+            ->hintIcon(
+                'heroicon-m-question-mark-circle',
+                tooltip: 'Only unassigned auths are available. Each auth can only be assigned to one playlist at a time. You will also be able to access the Xtream API using any assigned auths.'
+            )
+            ->helperText(__('Simple authentication for playlist alias access.'));
     }
 
     /**

--- a/app/Filament/Resources/PlaylistAuths/PlaylistAuthResource.php
+++ b/app/Filament/Resources/PlaylistAuths/PlaylistAuthResource.php
@@ -170,7 +170,6 @@ class PlaylistAuthResource extends Resource implements CopilotResource
                         ->rules(function ($record) {
                             return [
                                 Rule::unique('playlist_auths', 'username')->ignore($record?->id),
-                                Rule::unique('playlist_aliases', 'username'),
                             ];
                         })
                         ->columnSpan(1),

--- a/app/Http/Controllers/PlaylistGenerateController.php
+++ b/app/Http/Controllers/PlaylistGenerateController.php
@@ -48,13 +48,6 @@ class PlaylistGenerateController extends Controller
 
         // Check auth
         $auths = $playlist->playlistAuths()->where('enabled', true)->get();
-        // For PlaylistAlias, also check direct alias credentials as fallback
-        if ($auths->isEmpty() && $playlist instanceof PlaylistAlias) {
-            $auth = $playlist->authObject;
-            if ($auth) {
-                $auths = collect([$auth]);
-            }
-        }
 
         $usedAuth = null;
         if ($auths->isNotEmpty()) {
@@ -407,12 +400,6 @@ class PlaylistGenerateController extends Controller
         $providedPassword = $password ?? $request->get('password');
 
         $auths = $playlist->playlistAuths()->where('enabled', true)->get();
-        if ($auths->isEmpty() && $playlist instanceof PlaylistAlias) {
-            $auth = $playlist->authObject;
-            if ($auth) {
-                $auths = collect([$auth]);
-            }
-        }
 
         if ($auths->isNotEmpty()) {
             $authenticated = false;
@@ -469,12 +456,6 @@ class PlaylistGenerateController extends Controller
 
         $usedAuth = null;
         $auths = $playlist->playlistAuths()->where('enabled', true)->get();
-        if ($auths->isEmpty() && $playlist instanceof PlaylistAlias) {
-            $auth = $playlist->authObject;
-            if ($auth) {
-                $auths = collect([$auth]);
-            }
-        }
 
         if ($auths->isNotEmpty()) {
             $authenticated = false;
@@ -600,12 +581,6 @@ class PlaylistGenerateController extends Controller
         $providedPassword = $password ?? $request->get('password');
 
         $auths = $playlist->playlistAuths()->where('enabled', true)->get();
-        if ($auths->isEmpty() && $playlist instanceof PlaylistAlias) {
-            $auth = $playlist->authObject;
-            if ($auth) {
-                $auths = collect([$auth]);
-            }
-        }
 
         if ($auths->isNotEmpty()) {
             foreach ($auths as $auth) {

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -2090,7 +2090,7 @@ class XtreamApiController extends Controller
      * Resolve viewer from request context, with fallback based on auth method:
      * - viewer_id param provided → use it
      * - playlist_auth → find or create PlaylistViewer linked to the PlaylistAuth
-     * - owner_auth / alias_auth → use the admin viewer for this playlist
+     * - owner_auth → use the admin viewer for this playlist
      */
     private function resolveContextViewer(Request $request, $playlist, string $authMethod, string $username, string $password): ?PlaylistViewer
     {

--- a/app/Models/PlaylistAlias.php
+++ b/app/Models/PlaylistAlias.php
@@ -29,7 +29,6 @@ class PlaylistAlias extends Model
         'proxy_options' => 'array',
         'enable_proxy' => 'boolean',
         'priority' => 'integer',
-        'expires_at' => 'datetime',
         'custom_headers' => 'array',
         'strict_live_ts' => 'boolean',
         'use_sticky_session' => 'boolean',
@@ -161,18 +160,6 @@ class PlaylistAlias extends Model
     public function customPlaylist(): BelongsTo
     {
         return $this->belongsTo(CustomPlaylist::class);
-    }
-
-    /**
-     * Determine whether this alias auth credential is expired.
-     */
-    public function isExpired(): bool
-    {
-        if ($this->expires_at === null) {
-            return false;
-        }
-
-        return now()->greaterThanOrEqualTo($this->expires_at);
     }
 
     /**
@@ -469,33 +456,6 @@ class PlaylistAlias extends Model
         return Attribute::make(
             get: fn () => $this->series()->count()
         );
-    }
-
-    /**
-     * Get the alias credentials (username/password) as an object instead of array.
-     *
-     * This normalises the alias authentication format so that controllers and
-     * services can safely access:
-     *
-     *      $auth->username
-     *      $auth->password
-     *
-     * regardless of whether the credentials originally came from PlaylistAlias
-     * (array) or PlaylistAuth (Eloquent model / object).
-     *
-     * @return object|null
-     */
-    public function getAuthObjectAttribute()
-    {
-        // If explicit alias-level credentials exist, always prefer them.
-        if ($this->username && $this->password) {
-            return (object) [
-                'username' => $this->username,
-                'password' => $this->password,
-            ];
-        }
-
-        return null;
     }
 
     /**

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -91,12 +91,6 @@ class PlaylistService
         if (method_exists($playlist, 'playlistAuths')) {
             $playlistAuth = $playlist->playlistAuths()->where('enabled', true)->first();
         }
-        // For PlaylistAlias, fall back to direct alias credentials if no PlaylistAuth found
-        if (! $playlistAuth && $playlist instanceof PlaylistAlias) {
-            $playlistAuth = $playlist->username && $playlist->password
-                ? (object) ['username' => $playlist->username, 'password' => $playlist->password]
-                : null;
-        }
         $auth = null;
         if ($playlistAuth) {
             $auth = '?username='.urlencode($playlistAuth->username).'&password='.urlencode($playlistAuth->password);
@@ -176,15 +170,6 @@ class PlaylistService
             'username' => $playlist->user->name,
             'password' => $playlist->uuid,
         ];
-        if ($playlist instanceof PlaylistAlias) {
-            // For PlaylistAlias, override default auth if set
-            if ($playlist->username && $playlist->password) {
-                $auth = [
-                    'username' => $playlist->username,
-                    'password' => $playlist->password,
-                ];
-            }
-        }
 
         // Return the results
         return [
@@ -218,13 +203,9 @@ class PlaylistService
     public function getMediaFlowProxyUrls($playlist)
     {
         // Get the first enabled auth (URLs can only contain one set of credentials)
+        $playlistAuth = null;
         if (method_exists($playlist, 'playlistAuths')) {
             $playlistAuth = $playlist->playlistAuths()->where('enabled', true)->first();
-        } elseif ($playlist instanceof PlaylistAlias) {
-            // If PlaylistAlias, check if direct authentication is set
-            $playlistAuth = $playlist->username && $playlist->password
-                ? (object) ['username' => $playlist->username, 'password' => $playlist->password]
-                : null;
         }
         $auth = '';
         if ($playlistAuth) {
@@ -459,27 +440,6 @@ class PlaylistService
             }
         }
 
-        // Method 1b: Direct authentication with PlaylistAlias credentials
-        // Only check if Method 1 didn't find a result
-        if (! $playlist) {
-            $alias = PlaylistAlias::where('username', $username)
-                ->where('password', $password)
-                ->with(['user', 'playlist', 'customPlaylist'])
-                ->first();
-
-            if ($alias) {
-                // If alias found but expired, fall through to Method 2
-                if (! $alias->isExpired()) {
-                    return [
-                        $alias,
-                        'alias_auth',
-                        $username,
-                        $password,
-                    ];
-                }
-            }
-        }
-
         // Method 2: Fall back to original authentication:
         //      (username = playlist owner, password = playlist UUID)
         if (! $playlist) {
@@ -609,11 +569,6 @@ class PlaylistService
 
             // If found, return the custom expiration timestamp
             return $playlistAuth?->expires_at?->timestamp ?? 0;
-        }
-
-        // Alias login
-        if ($authMethod === 'alias_auth' && $authRecord instanceof PlaylistAlias) {
-            return $authRecord?->expires_at?->timestamp ?? 0;
         }
 
         // Legacy (owner_auth) optional override

--- a/database/migrations/2026_05_16_000001_migrate_playlist_alias_credentials_to_playlist_auths.php
+++ b/database/migrations/2026_05_16_000001_migrate_playlist_alias_credentials_to_playlist_auths.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    private const PLAYLIST_ALIAS_TYPE = 'App\\Models\\PlaylistAlias';
+
+    public function up(): void
+    {
+        $now = now();
+
+        DB::table('playlist_aliases')
+            ->select(['id', 'user_id', 'name', 'username', 'password', 'expires_at'])
+            ->whereNotNull('username')
+            ->where('username', '!=', '')
+            ->whereNotNull('password')
+            ->where('password', '!=', '')
+            ->chunkById(100, function ($aliases) use ($now): void {
+                foreach ($aliases as $alias) {
+                    $playlistAuthId = DB::table('playlist_auths')->insertGetId([
+                        'name' => Str::limit('Migrated alias auth: '.$alias->name, 255, ''),
+                        'enabled' => true,
+                        'user_id' => $alias->user_id,
+                        'username' => $alias->username,
+                        'password' => $alias->password,
+                        'expires_at' => $alias->expires_at,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ]);
+
+                    DB::table('authenticatables')->insert([
+                        'playlist_auth_id' => $playlistAuthId,
+                        'authenticatable_type' => self::PLAYLIST_ALIAS_TYPE,
+                        'authenticatable_id' => $alias->id,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ]);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        // Intentionally do not delete generated Playlist Auth records on rollback.
+        // They may have been edited or used after the upgrade.
+    }
+};

--- a/database/migrations/2026_05_16_000002_drop_legacy_auth_columns_from_playlist_aliases.php
+++ b/database/migrations/2026_05_16_000002_drop_legacy_auth_columns_from_playlist_aliases.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const PLAYLIST_ALIAS_TYPE = 'App\\Models\\PlaylistAlias';
+
+    public function up(): void
+    {
+        Schema::table('playlist_aliases', function (Blueprint $table) {
+            $expiresAtIndex = collect(Schema::getIndexes('playlist_aliases'))
+                ->first(fn (array $index): bool => $index['columns'] === ['expires_at']);
+
+            if ($expiresAtIndex) {
+                $table->dropIndex($expiresAtIndex['name']);
+            }
+
+            $table->dropColumn(['username', 'password', 'expires_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('playlist_aliases', function (Blueprint $table) {
+            $table->string('username')->nullable()->after('priority');
+            $table->string('password')->nullable()->after('username');
+            $table->dateTime('expires_at')->nullable()->after('password')->index();
+        });
+
+        DB::table('authenticatables')
+            ->join('playlist_auths', 'authenticatables.playlist_auth_id', '=', 'playlist_auths.id')
+            ->where('authenticatables.authenticatable_type', self::PLAYLIST_ALIAS_TYPE)
+            ->orderBy('authenticatables.id')
+            ->select([
+                'authenticatables.authenticatable_id',
+                'playlist_auths.username',
+                'playlist_auths.password',
+                'playlist_auths.expires_at',
+            ])
+            ->get()
+            ->each(function ($assignment): void {
+                DB::table('playlist_aliases')
+                    ->where('id', $assignment->authenticatable_id)
+                    ->whereNull('username')
+                    ->update([
+                        'username' => $assignment->username,
+                        'password' => $assignment->password,
+                        'expires_at' => $assignment->expires_at,
+                    ]);
+            });
+    }
+};

--- a/tests/Feature/PlaylistAliasTest.php
+++ b/tests/Feature/PlaylistAliasTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Filament\Resources\PlaylistAliases\PlaylistAliasResource;
 use App\Models\Channel;
 use App\Models\Playlist;
 use App\Models\PlaylistAlias;
@@ -8,6 +9,9 @@ use App\Models\Series;
 use App\Models\SourceCategory;
 use App\Models\User;
 use App\Services\PlaylistService;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -51,20 +55,6 @@ describe('PlaylistService::authenticate() with aliases', function () {
         $this->playlist = Playlist::factory()->for($this->user)->create();
     });
 
-    it('authenticates via alias direct credentials (Method 1b)', function () {
-        $alias = makeAlias($this->user, $this->playlist, [
-            'username' => 'aliasuser',
-            'password' => 'aliaspass',
-        ]);
-
-        $result = (new PlaylistService)->authenticate('aliasuser', 'aliaspass');
-
-        expect($result)->toBeArray()
-            ->and($result[0])->toBeInstanceOf(PlaylistAlias::class)
-            ->and($result[0]->id)->toBe($alias->id)
-            ->and($result[1])->toBe('alias_auth');
-    });
-
     it('authenticates via PlaylistAuth assigned to alias (Method 1)', function () {
         $alias = makeAlias($this->user, $this->playlist);
 
@@ -84,41 +74,17 @@ describe('PlaylistService::authenticate() with aliases', function () {
             ->and($result[1])->toBe('playlist_auth');
     });
 
-    it('PlaylistAuth (Method 1) is not short-circuited by an expired alias with the same credentials', function () {
-        // Core regression for the Method 1b control-flow bug:
-        // Before the fix, Method 1b ran unconditionally. An expired alias matching
-        // the same credentials as a valid PlaylistAuth would cause authenticate()
-        // to return false, denying access even though Method 1 had succeeded.
-        $otherPlaylist = Playlist::factory()->for($this->user)->create();
+    it('rejects expired PlaylistAuth credentials assigned to an alias', function () {
+        $alias = makeAlias($this->user, $this->playlist);
 
         $auth = PlaylistAuth::factory()->create([
-            'username' => 'shared_user',
-            'password' => 'shared_pass',
-            'enabled' => true,
-            'user_id' => $this->user->id,
-        ]);
-        $auth->assignTo($otherPlaylist);
-
-        // Expired alias with the same credentials — must not block the PlaylistAuth path
-        makeAlias($this->user, $this->playlist, [
-            'username' => 'shared_user',
-            'password' => 'shared_pass',
-            'expires_at' => now()->subDay(),
-        ]);
-
-        $result = (new PlaylistService)->authenticate('shared_user', 'shared_pass');
-
-        expect($result)->toBeArray()
-            ->and($result[1])->toBe('playlist_auth')
-            ->and($result[0]->id)->toBe($otherPlaylist->id);
-    });
-
-    it('rejects expired alias direct credentials', function () {
-        makeAlias($this->user, $this->playlist, [
             'username' => 'expireduser',
             'password' => 'expiredpass',
+            'enabled' => true,
+            'user_id' => $this->user->id,
             'expires_at' => now()->subDay(),
         ]);
+        $auth->assignTo($alias);
 
         $result = (new PlaylistService)->authenticate('expireduser', 'expiredpass');
 
@@ -139,22 +105,6 @@ describe('Xtream API panel action with aliases', function () {
     beforeEach(function () {
         $this->user = User::factory()->create();
         $this->playlist = Playlist::factory()->for($this->user)->create();
-    });
-
-    it('returns panel response when authenticated via alias direct credentials', function () {
-        makeAlias($this->user, $this->playlist, [
-            'username' => 'aliasuser',
-            'password' => 'aliaspass',
-        ]);
-
-        $response = $this->getJson(route('xtream.api.player').'?'.http_build_query([
-            'action' => 'panel',
-            'username' => 'aliasuser',
-            'password' => 'aliaspass',
-        ]));
-
-        $response->assertOk()
-            ->assertJsonStructure(['user_info', 'server_info']);
     });
 
     it('returns panel response when authenticated via PlaylistAuth assigned to alias', function () {
@@ -202,6 +152,75 @@ describe('PlaylistAuth::assignTo() with PlaylistAlias', function () {
         $auth = PlaylistAuth::factory()->create();
 
         expect(fn () => $auth->assignTo(new User))->toThrow(InvalidArgumentException::class);
+    });
+
+    it('syncs selected PlaylistAuths from the alias modal form data', function () {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->create();
+        $alias = makeAlias($user, $playlist);
+
+        $firstAuth = PlaylistAuth::factory()->create(['user_id' => $user->id]);
+        $secondAuth = PlaylistAuth::factory()->create(['user_id' => $user->id]);
+
+        $data = [
+            'name' => 'Alias with Auths',
+            'assigned_auth_ids' => [$firstAuth->id, $secondAuth->id],
+        ];
+
+        $assignedAuthIds = PlaylistAliasResource::pullAssignedAuthIdsFromFormData($data);
+
+        expect($assignedAuthIds)->toBe([$firstAuth->id, $secondAuth->id])
+            ->and($data)->not->toHaveKey('assigned_auth_ids');
+
+        PlaylistAliasResource::syncAssignedAuths($alias, $assignedAuthIds);
+
+        expect($alias->playlistAuths()->pluck('playlist_auths.id')->all())
+            ->toEqualCanonicalizing([$firstAuth->id, $secondAuth->id]);
+
+        PlaylistAliasResource::syncAssignedAuths($alias, [$secondAuth->id]);
+
+        expect($alias->playlistAuths()->pluck('playlist_auths.id')->all())
+            ->toEqualCanonicalizing([$secondAuth->id])
+            ->and($firstAuth->refresh()->isAssigned())->toBeFalse();
+    });
+
+    it('migrates legacy alias credentials into an assigned PlaylistAuth', function () {
+        if (! Schema::hasColumn('playlist_aliases', 'username')) {
+            Schema::table('playlist_aliases', function (Blueprint $table): void {
+                $table->string('username')->nullable();
+                $table->string('password')->nullable();
+                $table->dateTime('expires_at')->nullable()->index();
+            });
+        }
+
+        try {
+            $user = User::factory()->create();
+            $playlist = Playlist::factory()->for($user)->create();
+            $alias = makeAlias($user, $playlist);
+            $expiresAt = now()->addDay()->startOfSecond();
+
+            DB::table('playlist_aliases')
+                ->where('id', $alias->id)
+                ->update([
+                    'username' => 'legacy-user',
+                    'password' => 'legacy-pass',
+                    'expires_at' => $expiresAt,
+                ]);
+
+            $migration = require database_path('migrations/2026_05_16_000001_migrate_playlist_alias_credentials_to_playlist_auths.php');
+            $migration->up();
+
+            $auth = $alias->playlistAuths()->first();
+
+            expect($auth)->not->toBeNull();
+            expect($auth->username)->toBe('legacy-user')
+                ->and($auth->password)->toBe('legacy-pass')
+                ->and($auth->expires_at->equalTo($expiresAt))->toBeTrue()
+                ->and($auth->getAssignedModel()->is($alias))->toBeTrue();
+        } finally {
+            $migration = require database_path('migrations/2026_05_16_000002_drop_legacy_auth_columns_from_playlist_aliases.php');
+            $migration->up();
+        }
     });
 });
 


### PR DESCRIPTION
Migrates existing playlist alias auth credentials to playlist aliases, and assigns it using the new modal