### PR TITLE
fix: use playlist auths for playlist aliases

### DIFF
--- a/app/Filament/Resources/PlaylistAliases/Pages/ListPlaylistAliases.php
+++ b/app/Filament/Resources/PlaylistAliases/Pages/ListPlaylistAliases.php
@@ -7,6 +7,7 @@ use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class ListPlaylistAliases extends ListRecords
 {
@@ -21,7 +22,17 @@ class ListPlaylistAliases extends ListRecords
     {
         return [
             Actions\CreateAction::make()
-                ->slideOver(),
+                ->slideOver()
+                ->using(function (array $data, string $model): Model {
+                    $assignedAuthIds = PlaylistAliasResource::pullAssignedAuthIdsFromFormData($data);
+                    $record = $model::create($data);
+
+                    if ($assignedAuthIds !== null) {
+                        PlaylistAliasResource::syncAssignedAuths($record, $assignedAuthIds);
+                    }
+
+                    return $record;
+                }),
         ];
     }
 

--- a/app/Filament/Resources/PlaylistAliases/PlaylistAliasResource.php
+++ b/app/Filament/Resources/PlaylistAliases/PlaylistAliasResource.php
@@ -11,6 +11,7 @@ use App\Filament\Tables\SourceGroupsTable;
 use App\Models\CustomPlaylist;
 use App\Models\Playlist;
 use App\Models\PlaylistAlias;
+use App\Models\PlaylistAuth;
 use App\Models\SourceCategory;
 use App\Models\SourceGroup;
 use App\Models\StreamProfile;
@@ -218,6 +219,17 @@ class PlaylistAliasResource extends Resource implements CopilotResource
                 ])->button()->hiddenLabel()->size('sm'),
                 Actions\EditAction::make()
                     ->slideOver()
+                    ->using(function (PlaylistAlias $record, array $data): PlaylistAlias {
+                        $assignedAuthIds = self::pullAssignedAuthIdsFromFormData($data);
+
+                        $record->update($data);
+
+                        if ($assignedAuthIds !== null) {
+                            self::syncAssignedAuths($record, $assignedAuthIds);
+                        }
+
+                        return $record;
+                    })
                     ->button()->hiddenLabel()->size('sm'),
             ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
@@ -531,33 +543,9 @@ class PlaylistAliasResource extends Resource implements CopilotResource
                         ])->hidden(fn (Get $get): bool => ! $get('enable_proxy')),
                 ])->columnSpanFull(),
 
-            Schemas\Components\Fieldset::make(__('Auth (optional)'))
-                ->columns(2)
+            Schemas\Components\Fieldset::make(__('Auth'))
                 ->schema([
-                    Forms\Components\TextInput::make('username')
-                        ->label(__('Username'))
-                        ->helperText(__('Optional: Set credentials to access this alias via Xtream API. Must be unique across all aliases and playlist auths.'))
-                        ->rules(function ($record) {
-                            return [
-                                'nullable',
-                                Rule::unique('playlist_aliases', 'username')->ignore($record?->id),
-                                Rule::unique('playlist_auths', 'username'),
-                            ];
-                        })
-                        ->columnSpan(1),
-                    Forms\Components\TextInput::make('password')
-                        ->label(__('Password'))
-                        ->columnSpan(1)
-                        ->password()
-                        ->revealable(),
-                    Forms\Components\DateTimePicker::make('expires_at')
-                        ->label(__('Expiration (date & time)'))
-                        ->seconds(false)
-                        ->native(false)
-                        ->prefixIcon('heroicon-o-calendar')
-                        ->helperText(__('If set, this alias credentials will stop working at that exact time.'))
-                        ->nullable()
-                        ->columnSpan(2),
+                    self::assignedAuthsSelect(),
                 ]),
 
             Schemas\Components\Fieldset::make(__('Channel Filter (optional)'))
@@ -787,6 +775,94 @@ class PlaylistAliasResource extends Resource implements CopilotResource
                         ]),
                 ]),
         ];
+    }
+
+    public static function pullAssignedAuthIdsFromFormData(array &$data): ?array
+    {
+        if (! array_key_exists('assigned_auth_ids', $data)) {
+            return null;
+        }
+
+        $assignedAuthIds = $data['assigned_auth_ids'];
+
+        unset($data['assigned_auth_ids']);
+
+        if (! is_array($assignedAuthIds)) {
+            return $assignedAuthIds ? [$assignedAuthIds] : [];
+        }
+
+        return $assignedAuthIds;
+    }
+
+    public static function syncAssignedAuths(PlaylistAlias $record, array $authIds): void
+    {
+        $currentAuthIds = $record->playlistAuths()
+            ->pluck('playlist_auths.id')
+            ->map(fn ($authId): int => (int) $authId)
+            ->all();
+
+        $newAuthIds = collect($authIds)
+            ->filter()
+            ->map(fn ($authId): int => (int) $authId)
+            ->unique()
+            ->values()
+            ->all();
+
+        foreach (array_diff($currentAuthIds, $newAuthIds) as $authId) {
+            PlaylistAuth::find($authId)?->clearAssignment();
+        }
+
+        PlaylistAuth::where('user_id', $record->user_id)
+            ->whereKey(array_diff($newAuthIds, $currentAuthIds))
+            ->whereDoesntHave('assignedPlaylist')
+            ->get()
+            ->each(function (PlaylistAuth $auth) use ($record): void {
+                $auth->assignTo($record);
+            });
+    }
+
+    private static function assignedAuthsSelect(): Forms\Components\Select
+    {
+        return Forms\Components\Select::make('assigned_auth_ids')
+            ->label(__('Assigned Auths'))
+            ->multiple()
+            ->options(function ($record) {
+                $options = [];
+
+                if ($record) {
+                    foreach ($record->playlistAuths()->get() as $auth) {
+                        $options[$auth->id] = $auth->name.' (currently assigned)';
+                    }
+                }
+
+                foreach (PlaylistAuth::where('user_id', auth()->id())
+                    ->whereDoesntHave('assignedPlaylist')
+                    ->get() as $auth) {
+                    $options[$auth->id] = $auth->name;
+                }
+
+                return $options;
+            })
+            ->searchable()
+            ->nullable()
+            ->placeholder(__('Select auths or leave empty'))
+            ->default(function ($record) {
+                if ($record) {
+                    return $record->playlistAuths()->pluck('playlist_auths.id')->toArray();
+                }
+
+                return [];
+            })
+            ->afterStateHydrated(function ($component, $state, $record): void {
+                if ($record) {
+                    $component->state($record->playlistAuths()->pluck('playlist_auths.id')->toArray());
+                }
+            })
+            ->hintIcon(
+                'heroicon-m-question-mark-circle',
+                tooltip: 'Only unassigned auths are available. Each auth can only be assigned to one playlist at a time. You will also be able to access the Xtream API using any assigned auths.'
+            )
+            ->helperText(__('Simple authentication for playlist alias access.'));
     }
 
     /**

--- a/database/migrations/2026_05_16_000001_migrate_playlist_alias_credentials_to_playlist_auths.php
+++ b/database/migrations/2026_05_16_000001_migrate_playlist_alias_credentials_to_playlist_auths.php
@@ -1,0 +1,114 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    private const PLAYLIST_ALIAS_TYPE = 'App\\Models\\PlaylistAlias';
+
+    public function up(): void
+    {
+        $now = now();
+
+        DB::table('playlist_aliases')
+            ->select(['id', 'user_id', 'name', 'username', 'password', 'expires_at'])
+            ->whereNotNull('username')
+            ->where('username', '!=', '')
+            ->whereNotNull('password')
+            ->where('password', '!=', '')
+            ->chunkById(100, function ($aliases) use ($now): void {
+                foreach ($aliases as $alias) {
+                    $playlistAuthId = $this->findOrCreatePlaylistAuth($alias, $now);
+
+                    if (! $playlistAuthId || ! $this->assignAuthToAlias($playlistAuthId, (int) $alias->id, $now)) {
+                        continue;
+                    }
+
+                    DB::table('playlist_aliases')
+                        ->where('id', $alias->id)
+                        ->update([
+                            'username' => null,
+                            'password' => null,
+                            'expires_at' => null,
+                            'updated_at' => $now,
+                        ]);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        DB::table('authenticatables')
+            ->join('playlist_auths', 'authenticatables.playlist_auth_id', '=', 'playlist_auths.id')
+            ->where('authenticatables.authenticatable_type', self::PLAYLIST_ALIAS_TYPE)
+            ->orderBy('authenticatables.id')
+            ->select([
+                'authenticatables.authenticatable_id',
+                'playlist_auths.username',
+                'playlist_auths.password',
+                'playlist_auths.expires_at',
+            ])
+            ->get()
+            ->each(function ($assignment): void {
+                DB::table('playlist_aliases')
+                    ->where('id', $assignment->authenticatable_id)
+                    ->whereNull('username')
+                    ->update([
+                        'username' => $assignment->username,
+                        'password' => $assignment->password,
+                        'expires_at' => $assignment->expires_at,
+                    ]);
+            });
+    }
+
+    private function findOrCreatePlaylistAuth(object $alias, Carbon $now): ?int
+    {
+        $existingAuth = DB::table('playlist_auths')
+            ->where('username', $alias->username)
+            ->first();
+
+        if ($existingAuth) {
+            if ($existingAuth->password !== $alias->password) {
+                return null;
+            }
+
+            return (int) $existingAuth->id;
+        }
+
+        return DB::table('playlist_auths')->insertGetId([
+            'name' => Str::limit('Migrated alias auth: '.$alias->name, 255, ''),
+            'enabled' => true,
+            'user_id' => $alias->user_id,
+            'username' => $alias->username,
+            'password' => $alias->password,
+            'expires_at' => $alias->expires_at,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    private function assignAuthToAlias(int $playlistAuthId, int $aliasId, Carbon $now): bool
+    {
+        $existingAssignment = DB::table('authenticatables')
+            ->where('playlist_auth_id', $playlistAuthId)
+            ->first();
+
+        if ($existingAssignment) {
+            return $existingAssignment->authenticatable_type === self::PLAYLIST_ALIAS_TYPE
+                && (int) $existingAssignment->authenticatable_id === $aliasId;
+        }
+
+        DB::table('authenticatables')->insert([
+            'playlist_auth_id' => $playlistAuthId,
+            'authenticatable_type' => self::PLAYLIST_ALIAS_TYPE,
+            'authenticatable_id' => $aliasId,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        return true;
+    }
+};

--- a/tests/Feature/PlaylistAliasTest.php
+++ b/tests/Feature/PlaylistAliasTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Filament\Resources\PlaylistAliases\PlaylistAliasResource;
 use App\Models\Channel;
 use App\Models\Playlist;
 use App\Models\PlaylistAlias;
@@ -8,6 +9,8 @@ use App\Models\Series;
 use App\Models\SourceCategory;
 use App\Models\User;
 use App\Services\PlaylistService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -84,11 +87,18 @@ describe('PlaylistService::authenticate() with aliases', function () {
             ->and($result[1])->toBe('playlist_auth');
     });
 
+    it('authenticates via owner username and alias UUID', function () {
+        $alias = makeAlias($this->user, $this->playlist);
+
+        $result = (new PlaylistService)->authenticate($this->user->name, $alias->uuid);
+
+        expect($result)->toBeArray()
+            ->and($result[0])->toBeInstanceOf(PlaylistAlias::class)
+            ->and($result[0]->id)->toBe($alias->id)
+            ->and($result[1])->toBe('owner_auth');
+    });
+
     it('PlaylistAuth (Method 1) is not short-circuited by an expired alias with the same credentials', function () {
-        // Core regression for the Method 1b control-flow bug:
-        // Before the fix, Method 1b ran unconditionally. An expired alias matching
-        // the same credentials as a valid PlaylistAuth would cause authenticate()
-        // to return false, denying access even though Method 1 had succeeded.
         $otherPlaylist = Playlist::factory()->for($this->user)->create();
 
         $auth = PlaylistAuth::factory()->create([
@@ -99,7 +109,6 @@ describe('PlaylistService::authenticate() with aliases', function () {
         ]);
         $auth->assignTo($otherPlaylist);
 
-        // Expired alias with the same credentials — must not block the PlaylistAuth path
         makeAlias($this->user, $this->playlist, [
             'username' => 'shared_user',
             'password' => 'shared_pass',
@@ -119,6 +128,24 @@ describe('PlaylistService::authenticate() with aliases', function () {
             'password' => 'expiredpass',
             'expires_at' => now()->subDay(),
         ]);
+
+        $result = (new PlaylistService)->authenticate('expireduser', 'expiredpass');
+
+        // authenticate() returns [null, 'none', ...] when no method matches
+        expect($result[0])->toBeNull();
+    });
+
+    it('rejects expired PlaylistAuth credentials assigned to an alias', function () {
+        $alias = makeAlias($this->user, $this->playlist);
+
+        $auth = PlaylistAuth::factory()->create([
+            'username' => 'expireduser',
+            'password' => 'expiredpass',
+            'enabled' => true,
+            'user_id' => $this->user->id,
+            'expires_at' => now()->subDay(),
+        ]);
+        $auth->assignTo($alias);
 
         $result = (new PlaylistService)->authenticate('expireduser', 'expiredpass');
 
@@ -151,6 +178,19 @@ describe('Xtream API panel action with aliases', function () {
             'action' => 'panel',
             'username' => 'aliasuser',
             'password' => 'aliaspass',
+        ]));
+
+        $response->assertOk()
+            ->assertJsonStructure(['user_info', 'server_info']);
+    });
+
+    it('returns panel response when authenticated via owner username and alias UUID', function () {
+        $alias = makeAlias($this->user, $this->playlist);
+
+        $response = $this->getJson(route('xtream.api.player').'?'.http_build_query([
+            'action' => 'panel',
+            'username' => $this->user->name,
+            'password' => $alias->uuid,
         ]));
 
         $response->assertOk()
@@ -202,6 +242,92 @@ describe('PlaylistAuth::assignTo() with PlaylistAlias', function () {
         $auth = PlaylistAuth::factory()->create();
 
         expect(fn () => $auth->assignTo(new User))->toThrow(InvalidArgumentException::class);
+    });
+
+    it('syncs selected PlaylistAuths from the alias modal form data', function () {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->create();
+        $alias = makeAlias($user, $playlist);
+
+        $firstAuth = PlaylistAuth::factory()->create(['user_id' => $user->id]);
+        $secondAuth = PlaylistAuth::factory()->create(['user_id' => $user->id]);
+
+        $data = [
+            'name' => 'Alias with Auths',
+            'assigned_auth_ids' => [$firstAuth->id, $secondAuth->id],
+        ];
+
+        $assignedAuthIds = PlaylistAliasResource::pullAssignedAuthIdsFromFormData($data);
+
+        expect($assignedAuthIds)->toBe([$firstAuth->id, $secondAuth->id])
+            ->and($data)->not->toHaveKey('assigned_auth_ids');
+
+        PlaylistAliasResource::syncAssignedAuths($alias, $assignedAuthIds);
+
+        expect($alias->playlistAuths()->pluck('playlist_auths.id')->all())
+            ->toEqualCanonicalizing([$firstAuth->id, $secondAuth->id]);
+
+        PlaylistAliasResource::syncAssignedAuths($alias, [$secondAuth->id]);
+
+        expect($alias->playlistAuths()->pluck('playlist_auths.id')->all())
+            ->toEqualCanonicalizing([$secondAuth->id])
+            ->and($firstAuth->refresh()->isAssigned())->toBeFalse();
+    });
+
+    it('migrates legacy alias credentials into an assigned PlaylistAuth without dropping owner auth', function () {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->create();
+        $alias = makeAlias($user, $playlist, [
+            'username' => 'legacy-user',
+            'password' => 'legacy-pass',
+            'expires_at' => now()->addDay()->startOfSecond(),
+        ]);
+
+        $migration = require database_path('migrations/2026_05_16_000001_migrate_playlist_alias_credentials_to_playlist_auths.php');
+        $migration->up();
+
+        $auth = $alias->playlistAuths()->where('username', 'legacy-user')->first();
+        $alias->refresh();
+
+        $playlistAuthResult = (new PlaylistService)->authenticate('legacy-user', 'legacy-pass');
+        $ownerAuthResult = (new PlaylistService)->authenticate($user->name, $alias->uuid);
+
+        expect(Schema::hasColumn('playlist_aliases', 'username'))->toBeTrue()
+            ->and($auth)->not->toBeNull()
+            ->and($auth->password)->toBe('legacy-pass')
+            ->and($auth->getAssignedModel()->is($alias))->toBeTrue()
+            ->and($alias->username)->toBeNull()
+            ->and($alias->password)->toBeNull()
+            ->and($alias->expires_at)->toBeNull()
+            ->and($playlistAuthResult[1])->toBe('playlist_auth')
+            ->and($playlistAuthResult[0]->is($alias))->toBeTrue()
+            ->and($ownerAuthResult[1])->toBe('owner_auth')
+            ->and($ownerAuthResult[0]->is($alias))->toBeTrue();
+    });
+
+    it('leaves legacy alias credentials untouched when a conflicting PlaylistAuth username exists', function () {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->create();
+        $alias = makeAlias($user, $playlist, [
+            'username' => 'conflict-user',
+            'password' => 'legacy-pass',
+        ]);
+
+        PlaylistAuth::factory()->create([
+            'username' => 'conflict-user',
+            'password' => 'different-pass',
+            'user_id' => $user->id,
+        ]);
+
+        $migration = require database_path('migrations/2026_05_16_000001_migrate_playlist_alias_credentials_to_playlist_auths.php');
+        $migration->up();
+
+        $alias->refresh();
+
+        expect($alias->username)->toBe('conflict-user')
+            ->and($alias->password)->toBe('legacy-pass')
+            ->and($alias->playlistAuths()->count())->toBe(0)
+            ->and(DB::table('playlist_auths')->where('username', 'conflict-user')->count())->toBe(1);
     });
 });
 


### PR DESCRIPTION
Migrates existing playlist alias auth credentials to Playlist Auths, and assigns them to the matching playlist alias.