### PR TITLE
fix: logo proxy rejecting images when remote omits Content-Type

### DIFF
--- a/app/Http/Controllers/LogoProxyController.php
+++ b/app/Http/Controllers/LogoProxyController.php
@@ -124,18 +124,24 @@ class LogoProxyController extends Controller
                 return null;
             }
 
-            $contentType = $response->header('Content-Type');
-
-            // Validate that it's an image
-            if (! str_starts_with($contentType, 'image/')) {
-                return null;
-            }
-
             $content = $response->body();
 
             // Check file size (limit to 5MB)
             if (strlen($content) > 5 * 1024 * 1024) {
                 return null;
+            }
+
+            $contentType = $response->header('Content-Type');
+
+            // Some CDNs/origins (notably Cloudflare workers and Express-based image
+            // servers) return image bytes without a Content-Type header. Fall back
+            // to sniffing the body so those logos still proxy correctly.
+            if (! $contentType || ! str_starts_with($contentType, 'image/')) {
+                $sniffed = $this->sniffImageMimeType($content);
+                if (! $sniffed) {
+                    return null;
+                }
+                $contentType = $sniffed;
             }
 
             return [
@@ -222,6 +228,32 @@ class LogoProxyController extends Controller
         $ip = gethostbyname($host);
 
         return ! filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
+    }
+
+    /**
+     * Detect image MIME type from raw bytes. Returns null if not a recognised image.
+     */
+    private function sniffImageMimeType(string $content): ?string
+    {
+        if ($content === '') {
+            return null;
+        }
+
+        $info = @getimagesizefromstring($content);
+        if (is_array($info) && ! empty($info['mime']) && str_starts_with($info['mime'], 'image/')) {
+            return $info['mime'];
+        }
+
+        // getimagesizefromstring does not recognise SVG. Detect it manually so
+        // SVG logos with missing/incorrect Content-Type still pass.
+        $head = ltrim(substr($content, 0, 1024));
+        if ($head !== '' && (str_starts_with($head, '<?xml') || str_starts_with($head, '<svg'))) {
+            if (stripos($head, '<svg') !== false) {
+                return 'image/svg+xml';
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Http/Controllers/LogoProxyController.php
+++ b/app/Http/Controllers/LogoProxyController.php
@@ -144,6 +144,14 @@ class LogoProxyController extends Controller
                 $contentType = $sniffed;
             }
 
+            // Sanitize SVG to strip potential XSS vectors before caching.
+            if ($contentType === 'image/svg+xml') {
+                $content = $this->sanitizeSvg($content);
+                if ($content === null) {
+                    return null;
+                }
+            }
+
             return [
                 'content' => $content,
                 'content_type' => $contentType,
@@ -244,16 +252,77 @@ class LogoProxyController extends Controller
             return $info['mime'];
         }
 
-        // getimagesizefromstring does not recognise SVG. Detect it manually so
-        // SVG logos with missing/incorrect Content-Type still pass.
+        // getimagesizefromstring does not recognise SVG — detect it via the opening tag.
         $head = ltrim(substr($content, 0, 1024));
-        if ($head !== '' && (str_starts_with($head, '<?xml') || str_starts_with($head, '<svg'))) {
-            if (stripos($head, '<svg') !== false) {
-                return 'image/svg+xml';
-            }
+        if ($head !== '' && preg_match('/^(<\?xml[^>]*>\s*)?<svg[\s>\/]/i', $head)) {
+            return 'image/svg+xml';
         }
 
         return null;
+    }
+
+    /**
+     * Strip XSS vectors from SVG bytes. Returns null if the SVG cannot be parsed.
+     */
+    private function sanitizeSvg(string $content): ?string
+    {
+        $dom = new \DOMDocument;
+        libxml_use_internal_errors(true);
+        $loaded = $dom->loadXML($content, LIBXML_NONET);
+        libxml_clear_errors();
+        libxml_use_internal_errors(false);
+
+        if (! $loaded || ! $dom->documentElement) {
+            return null;
+        }
+
+        $xpath = new \DOMXPath($dom);
+
+        // Remove elements that can execute code, using case-insensitive local-name matching.
+        $unsafeTagExpr = implode(' or ', array_map(
+            fn (string $tag) => "translate(local-name(),'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='{$tag}'",
+            ['script', 'foreignobject', 'iframe', 'object', 'embed']
+        ));
+        foreach (iterator_to_array($xpath->query("//*[{$unsafeTagExpr}]") ?: []) as $node) {
+            $node->parentNode?->removeChild($node);
+        }
+
+        // Strip event-handler attributes and dangerous URI values from all remaining elements.
+        foreach (iterator_to_array($dom->getElementsByTagName('*')) as $element) {
+            $toRemove = [];
+
+            foreach ($element->attributes ?? [] as $attr) {
+                if (preg_match('/^on\w+$/i', $attr->localName)) {
+                    $toRemove[] = $attr->nodeName;
+
+                    continue;
+                }
+
+                if (in_array(strtolower($attr->localName), ['href', 'src', 'action', 'formaction'])) {
+                    $normalized = strtolower(preg_replace('/[\x00-\x1f\s]/', '', $attr->value));
+                    if (str_starts_with($normalized, 'javascript:') || str_starts_with($normalized, 'data:text')) {
+                        $toRemove[] = $attr->nodeName;
+                    }
+                }
+            }
+
+            foreach ($toRemove as $attrName) {
+                $element->removeAttribute($attrName);
+            }
+
+            // xlink:href is a namespaced attribute and needs separate handling.
+            $xlinkHref = $element->getAttributeNS('http://www.w3.org/1999/xlink', 'href');
+            if ($xlinkHref !== '') {
+                $normalized = strtolower(preg_replace('/[\x00-\x1f\s]/', '', $xlinkHref));
+                if (str_starts_with($normalized, 'javascript:') || str_starts_with($normalized, 'data:text')) {
+                    $element->removeAttributeNS('http://www.w3.org/1999/xlink', 'href');
+                }
+            }
+        }
+
+        $sanitized = $dom->saveXML();
+
+        return $sanitized !== false ? $sanitized : null;
     }
 
     /**

--- a/tests/Feature/LogoProxyControllerTest.php
+++ b/tests/Feature/LogoProxyControllerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Services\LogoCacheService;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('local');
+});
+
+function pngBytes(): string
+{
+    // Minimal valid 1x1 PNG so getimagesizefromstring recognises it.
+    return base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=');
+}
+
+function proxyPathFor(string $url): string
+{
+    $encoded = rtrim(strtr(base64_encode($url), '+/', '-_'), '=');
+    $filename = LogoCacheService::buildProxyFilename($url);
+
+    return "/logo-proxy/{$encoded}/{$filename}";
+}
+
+it('serves a remote logo when Content-Type is image/*', function () {
+    $remoteUrl = 'https://example.com/with-content-type.png';
+
+    Http::fake([
+        $remoteUrl => Http::response(pngBytes(), 200, ['Content-Type' => 'image/png']),
+    ]);
+
+    $response = $this->get(proxyPathFor($remoteUrl));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toStartWith('image/');
+});
+
+it('serves a remote logo when the response has no Content-Type header', function () {
+    // Reproduces the bug: some EPG icon hosts (e.g. iptv-epg.org) return valid
+    // image bytes with no Content-Type header. The proxy should sniff the body
+    // and serve them instead of falling back to the placeholder.
+    $remoteUrl = 'https://example.com/no-content-type';
+
+    Http::fake([
+        $remoteUrl => Http::response(pngBytes(), 200),
+    ]);
+
+    $response = $this->get(proxyPathFor($remoteUrl));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toStartWith('image/');
+});
+
+it('serves a remote logo when Content-Type is a generic non-image type but bytes are an image', function () {
+    $remoteUrl = 'https://example.com/octet-stream';
+
+    Http::fake([
+        $remoteUrl => Http::response(pngBytes(), 200, ['Content-Type' => 'application/octet-stream']),
+    ]);
+
+    $response = $this->get(proxyPathFor($remoteUrl));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toStartWith('image/');
+});
+
+it('falls back to the placeholder when the body is not an image', function () {
+    $remoteUrl = 'https://example.com/not-an-image';
+
+    Http::fake([
+        $remoteUrl => Http::response('<html>not an image</html>', 200),
+    ]);
+
+    $response = $this->get(proxyPathFor($remoteUrl));
+
+    // Placeholder still returns 200 — assert it served the local placeholder
+    // bytes rather than the HTML payload.
+    $response->assertOk();
+    $response->assertDontSee('not an image');
+});

--- a/tests/Feature/LogoProxyControllerTest.php
+++ b/tests/Feature/LogoProxyControllerTest.php
@@ -8,6 +8,11 @@ beforeEach(function () {
     Storage::fake('local');
 });
 
+function svgBytes(): string
+{
+    return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>';
+}
+
 function pngBytes(): string
 {
     // Minimal valid 1x1 PNG so getimagesizefromstring recognises it.
@@ -62,6 +67,35 @@ it('serves a remote logo when Content-Type is a generic non-image type but bytes
 
     $response->assertOk();
     expect($response->headers->get('Content-Type'))->toStartWith('image/');
+});
+
+it('serves a remote SVG logo when the response has no Content-Type header', function () {
+    $remoteUrl = 'https://example.com/logo.svg';
+
+    Http::fake([
+        $remoteUrl => Http::response(svgBytes(), 200),
+    ]);
+
+    $response = $this->get(proxyPathFor($remoteUrl));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toStartWith('image/svg');
+});
+
+it('strips script tags and event handlers from proxied SVG logos', function () {
+    $remoteUrl = 'https://example.com/xss.svg';
+    $maliciousSvg = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><rect onclick="evil()" width="10" height="10"/></svg>';
+
+    Http::fake([
+        $remoteUrl => Http::response($maliciousSvg, 200, ['Content-Type' => 'image/svg+xml']),
+    ]);
+
+    $response = $this->get(proxyPathFor($remoteUrl));
+
+    $response->assertOk();
+    $response->assertDontSee('<script>', false);
+    $response->assertDontSee('onclick', false);
+    expect($response->headers->get('Content-Type'))->toStartWith('image/svg');
 });
 
 it('falls back to the placeholder when the body is not an image', function () {


### PR DESCRIPTION
## Summary

Some EPG icon hosts return valid image bytes with **no `Content-Type` header** (or a generic `application/octet-stream`). `LogoProxyController::fetchRemoteLogo` rejects those responses because of a strict `str_starts_with($contentType, 'image/')` check, so the proxy ends up serving `placeholder.png` for the affected channels even though the original logo URL is fine.

The fix:

- Move the 5 MB size cap above the type check so oversized responses are still rejected before any parsing.
- When the `Content-Type` header is missing or non-`image/*`, sniff the body with `getimagesizefromstring` and accept the response if it's a recognised image. Small manual SVG fallback included since `getimagesizefromstring` doesn't cover SVG.
- If neither the header nor the body looks like an image, still return `null` so the placeholder is used.

Heads-up: the placeholder response sets `Cache-Control: public, max-age=86400`, so anyone who's been hitting a broken logo will keep seeing the placeholder for up to a day after upgrading until that cache entry expires. Hard-reload doesn't bypass it; incognito does. Happy to follow up with a separate PR shortening that TTL if you'd like.

## Test plan

- [x] On a channel whose EPG icon comes from a host that doesn't set `Content-Type`, the M3U logo and the EPG viewer logo both resolve to the real image instead of the placeholder.
- [x] Channels whose icons come from a host that *does* set `Content-Type: image/png` still work (unchanged behaviour).
- [x] A non-image response (HTML/text) still falls back to the placeholder.