### PR TITLE
feat(channels): add resolution filtered find replace

### DIFF
--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -883,6 +883,8 @@ class ChannelResource extends Resource implements CopilotResource
                                     $set('column', $rule['column'] ?? 'title');
                                     $set('find_replace', $rule['find_replace'] ?? '');
                                     $set('replace_with', $rule['replace_with'] ?? '');
+                                    $set('resolution_filter_enabled', $rule['resolution_filter_enabled'] ?? false);
+                                    $set('required_resolution', $rule['required_resolution'] ?? '');
                                 })
                                 ->dehydrated(false),
                             Toggle::make('use_regex')
@@ -918,6 +920,17 @@ class ChannelResource extends Resource implements CopilotResource
                             TextInput::make('replace_with')
                                 ->label(__('Replace with (optional)'))
                                 ->placeholder(__('Leave empty to remove')),
+                            Toggle::make('resolution_filter_enabled')
+                                ->label(__('Only apply to a probed resolution'))
+                                ->live()
+                                ->helperText(__('Optional. This only works for channels that were probed first, because it reads the saved stream resolution from stream stats.'))
+                                ->default(false),
+                            TextInput::make('required_resolution')
+                                ->label(__('Required probed resolution'))
+                                ->placeholder('1920x1080')
+                                ->helperText(__('Example: 1920x1080. Channels without matching probed stream stats will be skipped.'))
+                                ->required(fn (Get $get): bool => (bool) $get('resolution_filter_enabled'))
+                                ->visible(fn (Get $get): bool => (bool) $get('resolution_filter_enabled')),
                         ];
                     })
                     ->action(function (Collection $records, array $data): void {
@@ -928,7 +941,9 @@ class ChannelResource extends Resource implements CopilotResource
                                 column: $data['column'] ?? 'title',
                                 find_replace: $data['find_replace'] ?? null,
                                 replace_with: $data['replace_with'] ?? '',
-                                channels: $records
+                                channels: $records,
+                                resolution_filter_enabled: (bool) ($data['resolution_filter_enabled'] ?? false),
+                                required_resolution: $data['required_resolution'] ?? null,
                             ));
                     })->after(function () {
                         Notification::make()

--- a/app/Filament/Resources/Channels/Pages/ListChannels.php
+++ b/app/Filament/Resources/Channels/Pages/ListChannels.php
@@ -177,6 +177,8 @@ class ListChannels extends ListRecords
                                     $set('column', $rule['column'] ?? 'title');
                                     $set('find_replace', $rule['find_replace'] ?? '');
                                     $set('replace_with', $rule['replace_with'] ?? '');
+                                    $set('resolution_filter_enabled', $rule['resolution_filter_enabled'] ?? false);
+                                    $set('required_resolution', $rule['required_resolution'] ?? '');
                                 })
                                 ->dehydrated(false),
                             Toggle::make('all_playlists')
@@ -224,6 +226,17 @@ class ListChannels extends ListRecords
                             TextInput::make('replace_with')
                                 ->label(__('Replace with (optional)'))
                                 ->placeholder(__('Leave empty to remove')),
+                            Toggle::make('resolution_filter_enabled')
+                                ->label(__('Only apply to a probed resolution'))
+                                ->live()
+                                ->helperText(__('Optional. This only works for channels that were probed first, because it reads the saved stream resolution from stream stats.'))
+                                ->default(false),
+                            TextInput::make('required_resolution')
+                                ->label(__('Required probed resolution'))
+                                ->placeholder('1920x1080')
+                                ->helperText(__('Example: 1920x1080. Channels without matching probed stream stats will be skipped.'))
+                                ->required(fn (Get $get): bool => (bool) $get('resolution_filter_enabled'))
+                                ->visible(fn (Get $get): bool => (bool) $get('resolution_filter_enabled')),
                         ];
                     })
                     ->action(function (array $data): void {
@@ -235,7 +248,9 @@ class ListChannels extends ListRecords
                                 use_regex: $data['use_regex'] ?? true,
                                 column: $data['column'] ?? 'title',
                                 find_replace: $data['find_replace'] ?? null,
-                                replace_with: $data['replace_with'] ?? ''
+                                replace_with: $data['replace_with'] ?? '',
+                                resolution_filter_enabled: (bool) ($data['resolution_filter_enabled'] ?? false),
+                                required_resolution: $data['required_resolution'] ?? null,
                             ));
                     })->after(function () {
                         Notification::make()

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2284,6 +2284,20 @@ class PlaylistResource extends Resource implements CopilotResource
                                 ->label(__('Replace with'))
                                 ->placeholder(__('Leave empty to remove'))
                                 ->columnSpan(3),
+                            Toggle::make('resolution_filter_enabled')
+                                ->label(__('Only apply to a probed resolution'))
+                                ->live()
+                                ->helperText(__('Optional. This only works for live and VOD channels that were probed first, because it reads the saved stream resolution from stream stats.'))
+                                ->default(false)
+                                ->visible(fn (Get $get): bool => in_array($get('target'), ['channels', 'vod_channels'], true))
+                                ->columnSpan(3),
+                            TextInput::make('required_resolution')
+                                ->label(__('Required probed resolution'))
+                                ->placeholder('1920x1080')
+                                ->helperText(__('Example: 1920x1080. Channels without matching probed stream stats will be skipped.'))
+                                ->required(fn (Get $get): bool => (bool) $get('resolution_filter_enabled'))
+                                ->visible(fn (Get $get): bool => in_array($get('target'), ['channels', 'vod_channels'], true) && (bool) $get('resolution_filter_enabled'))
+                                ->columnSpan(3),
                         ])
                         ->columns(7)
                         ->reorderable()

--- a/app/Filament/Resources/Vods/Pages/ListVod.php
+++ b/app/Filament/Resources/Vods/Pages/ListVod.php
@@ -234,7 +234,7 @@ class ListVod extends ListRecords
                         $counter = 0;
                         foreach (Playlist::where('user_id', auth()->id())->get() as $playlist) {
                             foreach ($playlist->find_replace_rules ?? [] as $rule) {
-                                if (is_array($rule) && ($rule['target'] ?? 'channels') === 'channels') {
+                                if (is_array($rule) && ($rule['target'] ?? 'channels') === 'vod_channels') {
                                     $savedPatterns[$counter] = "{$playlist->name} - ".($rule['name'] ?? 'Unnamed');
                                     $savedPatternRules[$counter] = $rule;
                                     $counter++;
@@ -262,6 +262,8 @@ class ListVod extends ListRecords
                                     $set('column', $rule['column'] ?? 'title');
                                     $set('find_replace', $rule['find_replace'] ?? '');
                                     $set('replace_with', $rule['replace_with'] ?? '');
+                                    $set('resolution_filter_enabled', $rule['resolution_filter_enabled'] ?? false);
+                                    $set('required_resolution', $rule['required_resolution'] ?? '');
                                 })
                                 ->dehydrated(false),
                             Toggle::make('all_playlists')
@@ -311,6 +313,17 @@ class ListVod extends ListRecords
                             TextInput::make('replace_with')
                                 ->label(__('Replace with (optional)'))
                                 ->placeholder(__('Leave empty to remove')),
+                            Toggle::make('resolution_filter_enabled')
+                                ->label(__('Only apply to a probed resolution'))
+                                ->live()
+                                ->helperText(__('Optional. This only works for channels that were probed first, because it reads the saved stream resolution from stream stats.'))
+                                ->default(false),
+                            TextInput::make('required_resolution')
+                                ->label(__('Required probed resolution'))
+                                ->placeholder('1920x1080')
+                                ->helperText(__('Example: 1920x1080. Channels without matching probed stream stats will be skipped.'))
+                                ->required(fn (Get $get): bool => (bool) $get('resolution_filter_enabled'))
+                                ->visible(fn (Get $get): bool => (bool) $get('resolution_filter_enabled')),
                         ];
                     })
                     ->action(function (array $data): void {
@@ -322,7 +335,10 @@ class ListVod extends ListRecords
                                 use_regex: $data['use_regex'] ?? true,
                                 column: $data['column'] ?? 'title',
                                 find_replace: $data['find_replace'] ?? null,
-                                replace_with: $data['replace_with'] ?? ''
+                                replace_with: $data['replace_with'] ?? '',
+                                is_vod: true,
+                                resolution_filter_enabled: (bool) ($data['resolution_filter_enabled'] ?? false),
+                                required_resolution: $data['required_resolution'] ?? null,
                             ));
                     })->after(function () {
                         Notification::make()

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -1035,7 +1035,7 @@ class VodResource extends Resource implements CopilotResource
                         $counter = 0;
                         foreach (Playlist::where('user_id', auth()->id())->get() as $playlist) {
                             foreach ($playlist->find_replace_rules ?? [] as $rule) {
-                                if (is_array($rule) && ($rule['target'] ?? 'channels') === 'channels') {
+                                if (is_array($rule) && ($rule['target'] ?? 'channels') === 'vod_channels') {
                                     $savedPatterns[$counter] = "{$playlist->name} - ".($rule['name'] ?? 'Unnamed');
                                     $savedPatternRules[$counter] = $rule;
                                     $counter++;
@@ -1063,6 +1063,8 @@ class VodResource extends Resource implements CopilotResource
                                     $set('column', $rule['column'] ?? 'title');
                                     $set('find_replace', $rule['find_replace'] ?? '');
                                     $set('replace_with', $rule['replace_with'] ?? '');
+                                    $set('resolution_filter_enabled', $rule['resolution_filter_enabled'] ?? false);
+                                    $set('required_resolution', $rule['required_resolution'] ?? '');
                                 })
                                 ->dehydrated(false),
                             Toggle::make('use_regex')
@@ -1100,6 +1102,17 @@ class VodResource extends Resource implements CopilotResource
                             TextInput::make('replace_with')
                                 ->label(__('Replace with (optional)'))
                                 ->placeholder(__('Leave empty to remove')),
+                            Toggle::make('resolution_filter_enabled')
+                                ->label(__('Only apply to a probed resolution'))
+                                ->live()
+                                ->helperText(__('Optional. This only works for channels that were probed first, because it reads the saved stream resolution from stream stats.'))
+                                ->default(false),
+                            TextInput::make('required_resolution')
+                                ->label(__('Required probed resolution'))
+                                ->placeholder('1920x1080')
+                                ->helperText(__('Example: 1920x1080. Channels without matching probed stream stats will be skipped.'))
+                                ->required(fn (Get $get): bool => (bool) $get('resolution_filter_enabled'))
+                                ->visible(fn (Get $get): bool => (bool) $get('resolution_filter_enabled')),
                         ];
                     })
                     ->action(function (Collection $records, array $data): void {
@@ -1110,7 +1123,10 @@ class VodResource extends Resource implements CopilotResource
                                 column: $data['column'] ?? 'title',
                                 find_replace: $data['find_replace'] ?? null,
                                 replace_with: $data['replace_with'] ?? '',
-                                channels: $records
+                                channels: $records,
+                                is_vod: true,
+                                resolution_filter_enabled: (bool) ($data['resolution_filter_enabled'] ?? false),
+                                required_resolution: $data['required_resolution'] ?? null,
                             ));
                     })->after(function () {
                         Notification::make()

--- a/app/Jobs/ChannelFindAndReplace.php
+++ b/app/Jobs/ChannelFindAndReplace.php
@@ -28,6 +28,8 @@ class ChannelFindAndReplace implements ShouldQueue
         public ?int $playlist_id = null,
         public bool $silent = false,
         public ?bool $is_vod = null,
+        public bool $resolution_filter_enabled = false,
+        public ?string $required_resolution = null,
     ) {
         //
     }
@@ -109,6 +111,10 @@ class ChannelFindAndReplace implements ShouldQueue
         $replace = $this->replace_with;
 
         foreach ($channels as $channel) {
+            if (! $this->channelMatchesResolutionFilter($channel)) {
+                continue;
+            }
+
             $newValue = null;
 
             // Check if this is a JSON column
@@ -164,6 +170,30 @@ class ChannelFindAndReplace implements ShouldQueue
         }
 
         return 0;
+    }
+
+    private function channelMatchesResolutionFilter(Channel $channel): bool
+    {
+        if (! $this->resolution_filter_enabled) {
+            return true;
+        }
+
+        $requiredResolution = trim((string) $this->required_resolution);
+        if ($requiredResolution === '') {
+            return false;
+        }
+
+        $streamStats = $channel->stream_stats;
+        if (! $channel->stream_stats_probed_at || ! is_array($streamStats)) {
+            return false;
+        }
+
+        $channelResolution = trim((string) ($streamStats['resolution'] ?? ''));
+        if ($channelResolution === '') {
+            return false;
+        }
+
+        return strcasecmp($channelResolution, $requiredResolution) === 0;
     }
 
     /**

--- a/app/Jobs/RunPlaylistFindReplaceRules.php
+++ b/app/Jobs/RunPlaylistFindReplaceRules.php
@@ -64,6 +64,8 @@ class RunPlaylistFindReplaceRules implements ShouldQueue
                     playlist_id: $this->playlist->id,
                     silent: true,
                     is_vod: false,
+                    resolution_filter_enabled: (bool) ($rule['resolution_filter_enabled'] ?? false),
+                    required_resolution: $rule['required_resolution'] ?? null,
                 ))->handle();
                 $liveChannelRulesRun++;
             } elseif ($target === 'vod_channels') {
@@ -77,6 +79,8 @@ class RunPlaylistFindReplaceRules implements ShouldQueue
                     playlist_id: $this->playlist->id,
                     silent: true,
                     is_vod: true,
+                    resolution_filter_enabled: (bool) ($rule['resolution_filter_enabled'] ?? false),
+                    required_resolution: $rule['required_resolution'] ?? null,
                 ))->handle();
                 $vodChannelRulesRun++;
             } elseif ($target === 'series') {

--- a/tests/Feature/ChannelResolutionFindAndReplaceTest.php
+++ b/tests/Feature/ChannelResolutionFindAndReplaceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Jobs\ChannelFindAndReplace;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+
+it('only renames channels whose probed resolution matches the requested resolution', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->createQuietly();
+
+    $matchingChannel = Channel::factory()
+        ->for($user)
+        ->for($playlist)
+        ->createQuietly([
+            'title' => 'Example 4K',
+            'title_custom' => null,
+            'stream_stats' => ['resolution' => '1920x1080'],
+            'stream_stats_probed_at' => now(),
+        ]);
+
+    $wrongResolutionChannel = Channel::factory()
+        ->for($user)
+        ->for($playlist)
+        ->createQuietly([
+            'title' => 'Other 4K',
+            'title_custom' => null,
+            'stream_stats' => ['resolution' => '3840x2160'],
+            'stream_stats_probed_at' => now(),
+        ]);
+
+    $unprobedChannel = Channel::factory()
+        ->for($user)
+        ->for($playlist)
+        ->createQuietly([
+            'title' => 'Unprobed 4K',
+            'title_custom' => null,
+            'stream_stats' => null,
+            'stream_stats_probed_at' => null,
+        ]);
+
+    (new ChannelFindAndReplace(
+        user_id: $user->id,
+        use_regex: false,
+        column: 'title',
+        find_replace: '4K',
+        replace_with: 'HD',
+        all_playlists: true,
+        silent: true,
+        resolution_filter_enabled: true,
+        required_resolution: '1920x1080',
+    ))->handle();
+
+    expect($matchingChannel->fresh()->title_custom)->toBe('Example HD')
+        ->and($wrongResolutionChannel->fresh()->title_custom)->toBeNull()
+        ->and($unprobedChannel->fresh()->title_custom)->toBeNull();
+});
+
+it('keeps find and replace unchanged when the resolution filter is disabled', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->createQuietly();
+
+    $unprobedChannel = Channel::factory()
+        ->for($user)
+        ->for($playlist)
+        ->createQuietly([
+            'title' => 'Unprobed 4K',
+            'title_custom' => null,
+            'stream_stats' => null,
+            'stream_stats_probed_at' => null,
+        ]);
+
+    (new ChannelFindAndReplace(
+        user_id: $user->id,
+        use_regex: false,
+        column: 'title',
+        find_replace: '4K',
+        replace_with: 'HD',
+        all_playlists: true,
+        silent: true,
+        resolution_filter_enabled: false,
+        required_resolution: '1920x1080',
+    ))->handle();
+
+    expect($unprobedChannel->fresh()->title_custom)->toBe('Unprobed HD');
+});


### PR DESCRIPTION
## Summary
- Add an optional probed-resolution gate to channel find and replace.
- Let users replace arbitrary text, for example `4K` to `HD`, only when saved stream stats match a chosen resolution such as `1920x1080`.
- Expose the filter in live channel, VOD, and saved playlist find and replace flows.
- Add helper text that the filter only works after channels have been probed.
- Fix VOD find and replace saved-pattern loading to use `vod_channels` rules and dispatch VOD jobs with `is_vod: true`.

## Testing
- `docker compose -f docker-compose.dev.yml --profile test run --rm m3u-editor-dev-test tests/Feature/ChannelResolutionFindAndReplaceTest.php --display-warnings`
  - Passes with 2 warnings from missing `/var/www/html/.env`, same warning class as existing tests in the local Docker profile.
- Full Pint check in Docker: `vendor/bin/pint --test`
  - Passes, 1231 files.
- PHP syntax checks for changed files.
  - Passes.
- Composer audit via `composer:2` image.
  - No security vulnerability advisories found.
- `npm ci --include=dev && npm run build`
  - Passes. Note: local npm config omits dev dependencies by default, so `--include=dev` was needed to match CI behavior.
- Full local Docker Pest suite compared against `upstream/dev`:
  - Feature branch: 328 failed, 27 skipped, 1027 passed, 2628 assertions.
  - `upstream/dev`: 328 failed, 27 skipped, 1025 passed, 2624 assertions.
  - Delta is the 2 new passing tests and 4 new assertions from this PR. The shared local failures are pre-existing environment-sensitive failures, mainly Redis/TMDB related.
- Docker build validation:
  - `docker build --build-arg GIT_BRANCH=feat/resolution-based-channel-renames --build-arg GIT_COMMIT=<sha> -t m3u-editor:pr-local-resolution-check .`
  - Passes.
