### PR TITLE
fix: preserve unicode in EPG XML output

### DIFF
--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -31,6 +31,14 @@ class EpgGenerateController extends Controller
     private const CACHE_TTL_HOURS = 6; // Cache files for 6 hours
 
     /**
+     * Escape XML text and attribute values using UTF-8 explicitly.
+     */
+    private function escapeXml(mixed $value): string
+    {
+        return htmlspecialchars((string) $value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+    }
+
+    /**
      * Generate the EPG XML file
      *
      * @return Response
@@ -155,7 +163,7 @@ class EpgGenerateController extends Controller
 
             // Output the <channel> tag
             $title = $channel->title_custom ?? $channel->title;
-            $title = htmlspecialchars($title);
+            $title = $this->escapeXml($title);
 
             // Get the EPG channel data
             $epgData = $channel->epgChannel ?? null;
@@ -198,7 +206,7 @@ class EpgGenerateController extends Controller
                     echo '    <display-name>'.$channelNo.'</display-name>';
                 }
                 if ($icon) {
-                    echo PHP_EOL.'    <icon src="'.htmlspecialchars($icon).'"/>';
+                    echo PHP_EOL.'    <icon src="'.$this->escapeXml($icon).'"/>';
                 }
                 echo PHP_EOL.'  </channel>'.PHP_EOL;
             } elseif ($dummyEpgEnabled) {
@@ -207,7 +215,7 @@ class EpgGenerateController extends Controller
                 if (empty($icon)) {
                     $icon = url('/placeholder.png');
                 }
-                $icon = htmlspecialchars($icon);
+                $icon = $this->escapeXml($icon);
                 if ($logoProxyEnabled) {
                     $icon = LogoProxyController::generateProxyUrl($icon);
                 }
@@ -313,7 +321,7 @@ class EpgGenerateController extends Controller
                                 }
 
                                 // Build programme XML in buffer for batch output
-                                $progXml = '  <programme channel="'.htmlspecialchars($mappedChannelId).'"';
+                                $progXml = '  <programme channel="'.$this->escapeXml($mappedChannelId).'"';
                                 if ($start) {
                                     $progXml .= ' start="'.$start.'"';
                                 }
@@ -323,22 +331,22 @@ class EpgGenerateController extends Controller
                                 $progXml .= '>'.PHP_EOL;
 
                                 if ($programme['title']) {
-                                    $progXml .= '    <title>'.htmlspecialchars($programme['title']).'</title>'.PHP_EOL;
+                                    $progXml .= '    <title>'.$this->escapeXml($programme['title']).'</title>'.PHP_EOL;
                                 }
                                 if ($programme['subtitle']) {
-                                    $progXml .= '    <sub-title>'.htmlspecialchars($programme['subtitle']).'</sub-title>'.PHP_EOL;
+                                    $progXml .= '    <sub-title>'.$this->escapeXml($programme['subtitle']).'</sub-title>'.PHP_EOL;
                                 }
                                 if ($programme['desc']) {
-                                    $progXml .= '    <desc>'.htmlspecialchars($programme['desc']).'</desc>'.PHP_EOL;
+                                    $progXml .= '    <desc>'.$this->escapeXml($programme['desc']).'</desc>'.PHP_EOL;
                                 }
                                 if ($programme['category']) {
-                                    $progXml .= '    <category>'.htmlspecialchars($programme['category']).'</category>'.PHP_EOL;
+                                    $progXml .= '    <category>'.$this->escapeXml($programme['category']).'</category>'.PHP_EOL;
                                 }
                                 if ($programme['episode_num']) {
-                                    $progXml .= '    <episode-num system="xmltv_ns">'.htmlspecialchars($programme['episode_num']).'</episode-num>'.PHP_EOL;
+                                    $progXml .= '    <episode-num system="xmltv_ns">'.$this->escapeXml($programme['episode_num']).'</episode-num>'.PHP_EOL;
                                 }
                                 if ($programme['icon']) {
-                                    $icon = htmlspecialchars($programme['icon']);
+                                    $icon = $this->escapeXml($programme['icon']);
                                     if ($logoProxyEnabled) {
                                         $icon = LogoProxyController::generateProxyUrl($icon);
                                     }
@@ -347,23 +355,23 @@ class EpgGenerateController extends Controller
                                 // Program artwork images (NEW)
                                 if (! empty($programme['images'] ?? null) && is_array($programme['images'])) {
                                     foreach ($programme['images'] as $image) {
-                                        $rawUrl = htmlspecialchars($image['url'] ?? '');
+                                        $rawUrl = $this->escapeXml($image['url'] ?? '');
                                         $proxiedUrl = $logoProxyEnabled && $rawUrl
                                             ? LogoProxyController::generateProxyUrl($rawUrl)
                                             : $rawUrl;
 
                                         $url = $proxiedUrl;
-                                        $type = htmlspecialchars($image['type'], ENT_XML1);
-                                        $width = htmlspecialchars($image['width'], ENT_XML1);
-                                        $height = htmlspecialchars($image['height'], ENT_XML1);
-                                        $orient = htmlspecialchars($image['orient'], ENT_XML1);
-                                        $size = htmlspecialchars($image['size'], ENT_XML1);
+                                        $type = $this->escapeXml($image['type']);
+                                        $width = $this->escapeXml($image['width']);
+                                        $height = $this->escapeXml($image['height']);
+                                        $orient = $this->escapeXml($image['orient']);
+                                        $size = $this->escapeXml($image['size']);
 
                                         $progXml .= "    <icon src=\"{$url}\" type=\"{$type}\" width=\"{$width}\" height=\"{$height}\" orient=\"{$orient}\" size=\"{$size}\" />\n";
                                     }
                                 }
                                 if ($programme['rating']) {
-                                    $progXml .= '    <rating><value>'.htmlspecialchars($programme['rating']).'</value></rating>'.PHP_EOL;
+                                    $progXml .= '    <rating><value>'.$this->escapeXml($programme['rating']).'</value></rating>'.PHP_EOL;
                                 }
                                 if (! empty($programme['new']) && $programme['new']) {
                                     $progXml .= '    <new />'.PHP_EOL;
@@ -405,10 +413,10 @@ class EpgGenerateController extends Controller
 
             // Generate programmes for each channel using pre-calculated time slots
             foreach ($dummyEpgChannels as $dummyEpgChannel) {
-                $tvgId = $dummyEpgChannel['tvg_id'];
+                $tvgId = $this->escapeXml($dummyEpgChannel['tvg_id']);
                 $title = $dummyEpgChannel['title'];
                 $icon = $dummyEpgChannel['icon'];
-                $group = $dummyEpgChannel['group'];
+                $group = $this->escapeXml($dummyEpgChannel['group']);
                 $includeCategory = $dummyEpgChannel['include_category'];
 
                 // Build all programmes for this channel in one string buffer
@@ -445,12 +453,12 @@ class EpgGenerateController extends Controller
                 foreach ($network->programmes as $programme) {
                     $start = str_replace(':', '', $programme->start_time->format('YmdHis O'));
                     $stop = str_replace(':', '', $programme->end_time->format('YmdHis O'));
-                    $title = htmlspecialchars($programme->title, ENT_XML1);
-                    $desc = $programme->description ? htmlspecialchars($programme->description, ENT_XML1) : '';
-                    $icon = $programme->image ? htmlspecialchars($programme->image, ENT_XML1) : '';
+                    $title = $this->escapeXml($programme->title);
+                    $desc = $programme->description ? $this->escapeXml($programme->description) : '';
+                    $icon = $programme->image ? $this->escapeXml($programme->image) : '';
                     $category = $programme->contentable_type === 'App\\Models\\Episode' ? 'Series' : 'Movie';
 
-                    echo '  <programme channel="'.$tvgId.'" start="'.$start.'" stop="'.$stop.'">'.PHP_EOL;
+                    echo '  <programme channel="'.$this->escapeXml($tvgId).'" start="'.$start.'" stop="'.$stop.'">'.PHP_EOL;
                     echo '    <title>'.$title.'</title>'.PHP_EOL;
                     if ($desc) {
                         echo '    <desc>'.$desc.'</desc>'.PHP_EOL;

--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -215,10 +215,10 @@ class EpgGenerateController extends Controller
                 if (empty($icon)) {
                     $icon = url('/placeholder.png');
                 }
-                $icon = $this->escapeXml($icon);
                 if ($logoProxyEnabled) {
                     $icon = LogoProxyController::generateProxyUrl($icon);
                 }
+                $icon = $this->escapeXml($icon);
 
                 // Keep track of which channels need a dummy EPG program
                 // Need this to output the <programme> tags later
@@ -346,21 +346,20 @@ class EpgGenerateController extends Controller
                                     $progXml .= '    <episode-num system="xmltv_ns">'.$this->escapeXml($programme['episode_num']).'</episode-num>'.PHP_EOL;
                                 }
                                 if ($programme['icon']) {
-                                    $icon = $this->escapeXml($programme['icon']);
-                                    if ($logoProxyEnabled) {
-                                        $icon = LogoProxyController::generateProxyUrl($icon);
-                                    }
-                                    $progXml .= '    <icon src="'.$icon.'"/>'.PHP_EOL;
+                                    $icon = $logoProxyEnabled
+                                        ? LogoProxyController::generateProxyUrl($programme['icon'])
+                                        : $programme['icon'];
+                                    $progXml .= '    <icon src="'.$this->escapeXml($icon).'"/>'.PHP_EOL;
                                 }
                                 // Program artwork images (NEW)
                                 if (! empty($programme['images'] ?? null) && is_array($programme['images'])) {
                                     foreach ($programme['images'] as $image) {
-                                        $rawUrl = $this->escapeXml($image['url'] ?? '');
+                                        $rawUrl = $image['url'] ?? '';
                                         $proxiedUrl = $logoProxyEnabled && $rawUrl
                                             ? LogoProxyController::generateProxyUrl($rawUrl)
                                             : $rawUrl;
 
-                                        $url = $proxiedUrl;
+                                        $url = $this->escapeXml($proxiedUrl);
                                         $type = $this->escapeXml($image['type']);
                                         $width = $this->escapeXml($image['width']);
                                         $height = $this->escapeXml($image['height']);

--- a/tests/Feature/EpgGenerateControllerTest.php
+++ b/tests/Feature/EpgGenerateControllerTest.php
@@ -1,16 +1,32 @@
 <?php
 
+use App\Events\EpgCreated;
+use App\Events\EpgDeleted;
+use App\Events\EpgUpdated;
+use App\Events\PlaylistCreated;
+use App\Events\PlaylistDeleted;
+use App\Events\PlaylistUpdated;
 use App\Models\Channel;
 use App\Models\Epg;
 use App\Models\EpgChannel;
 use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    Event::fake([
+        EpgCreated::class,
+        EpgDeleted::class,
+        EpgUpdated::class,
+        PlaylistCreated::class,
+        PlaylistDeleted::class,
+        PlaylistUpdated::class,
+    ]);
+
     // Clean up any leftover playlist EPG cache files from previous runs
     Storage::disk('local')->deleteDirectory('playlist-epg-files');
 });
@@ -97,4 +113,40 @@ test('epg download does not crash when epg source file is corrupted', function (
 
     // Cleanup
     Storage::disk('local')->delete($epg->file_path);
+});
+
+test('epg xml generation preserves albanian characters with explicit utf8 escaping', function () {
+    $previousCharset = ini_get('default_charset');
+    ini_set('default_charset', 'ISO-8859-1');
+
+    try {
+        $user = User::factory()->create();
+
+        $playlist = Playlist::factory()->for($user)->create([
+            'dummy_epg' => true,
+            'dummy_epg_length' => 60,
+        ]);
+
+        Channel::factory()->create([
+            'playlist_id' => $playlist->id,
+            'user_id' => $user->id,
+            'enabled' => true,
+            'is_vod' => false,
+            'title' => 'Çështje të Ëmbla & "Special"',
+            'name' => 'RTK Çifteli',
+            'stream_id' => 'rtk-cifteli',
+            'channel' => 1,
+        ]);
+
+        $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/gzip');
+
+        $content = gzdecode($response->getContent());
+
+        expect($content)->toContain('<display-name>Çështje të Ëmbla &amp; &quot;Special&quot;</display-name>');
+    } finally {
+        ini_set('default_charset', $previousCharset ?: 'UTF-8');
+    }
 });


### PR DESCRIPTION
## Summary
- Escape generated EPG XML with explicit UTF-8 handling instead of relying on PHP default_charset.
- Use a shared XML escaping helper for channel, programme, icon, category, episode, and rating fields.
- Add a regression test with Albanian characters and XML-sensitive entities under a non-UTF-8 default charset.

## Testing
- `docker run --rm -v "$PWD":/app -w /app -e APP_ENV=testing -e APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= -e REVERB_APP_SECRET=test-secret -e DB_CONNECTION=sqlite_testing -e CACHE_STORE=array -e SESSION_DRIVER=array -e QUEUE_CONNECTION=sync composer:2 sh -lc 'touch database/jobs.sqlite .env && trap "rm -f database/jobs.sqlite .env" EXIT && apk add --no-cache icu-dev >/dev/null && docker-php-ext-install bcmath intl pcntl >/dev/null && php artisan test tests/Feature/EpgGenerateControllerTest.php --display-warnings'`
- `docker run --rm -v "$PWD":/app -w /app composer:2 sh -lc 'vendor/bin/pint --test app/Http/Controllers/EpgGenerateController.php tests/Feature/EpgGenerateControllerTest.php'`
- `git diff --check`
