### PR TITLE
feat(media): allow TMDB ID failover merge

### DIFF
--- a/app/Filament/Resources/Series/Pages/ListSeries.php
+++ b/app/Filament/Resources/Series/Pages/ListSeries.php
@@ -14,6 +14,7 @@ use App\Models\Channel;
 use App\Models\Group;
 use App\Models\Playlist;
 use App\Models\Series;
+use App\Services\PlaylistService;
 use App\Services\TmdbService;
 use App\Settings\GeneralSettings;
 use App\Traits\RenderlessColumnUpdates;
@@ -81,6 +82,14 @@ class ListSeries extends ListRecords
                 ->modalDescription(__('Select the playlist Series you would like to add.'))
                 ->modalSubmitActionLabel(__('Import Series Episodes & Metadata')),
             ActionGroup::make([
+                PlaylistService::getMergeAction(contentType: 'series')
+                    ->after(function () {
+                        Notification::make()
+                            ->success()
+                            ->title(__('Episode merge started'))
+                            ->body(__('Merging series episodes in the background. You will be notified once the process is complete.'))
+                            ->send();
+                    }),
                 Action::make('process')
                     ->label(__('Fetch Series Metadata'))
                     ->schema([

--- a/app/Filament/Resources/Vods/Pages/ListVod.php
+++ b/app/Filament/Resources/Vods/Pages/ListVod.php
@@ -71,7 +71,7 @@ class ListVod extends ListRecords
                 ))
                 ->slideOver(),
             ActionGroup::make([
-                PlaylistService::getMergeAction()
+                PlaylistService::getMergeAction(contentType: 'vod')
                     ->after(function () {
                         Notification::make()
                             ->success()

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -64,7 +64,16 @@ class MergeChannels implements ShouldQueue
         public ?bool $newChannelsOnly = null,
         public ?array $regexPatterns = null,
         public ?array $fallbackMergeConfig = null,
-    ) {}
+        public string $contentType = 'live',
+        public string $mergeKey = 'stream_id',
+    ) {
+        $this->contentType = in_array($this->contentType, ['live', 'vod'], true) ? $this->contentType : 'live';
+        $this->mergeKey = in_array($this->mergeKey, ['stream_id', 'tmdb_id'], true) ? $this->mergeKey : 'stream_id';
+
+        if ($this->contentType !== 'vod' && $this->mergeKey === 'tmdb_id') {
+            $this->mergeKey = 'stream_id';
+        }
+    }
 
     /**
      * Execute the job.
@@ -99,18 +108,21 @@ class MergeChannels implements ShouldQueue
             ->pluck('channel_failover_id')
             ->toArray();
 
-        // Get all channels with stream IDs in a single efficient query
-        // Exclude channels that are already configured as failovers (unless we're re-merging everything)
-        $shouldExcludeExistingFailovers = ! empty($existingFailoverChannelIds) && ! $this->forceCompleteRemerge;
+        // Get all channels for the requested content type and merge key.
+        // Exclude channels that are already configured as failovers (unless we're re-merging everything).
+        $shouldExcludeExistingFailovers = ! empty($existingFailoverChannelIds)
+            && ! $this->forceCompleteRemerge
+            && ! $this->deactivateFailoverChannels;
 
-        $allChannels = Channel::where([
+        $allChannelsQuery = Channel::where([
             ['user_id', $this->user->id],
             ['can_merge', true],
-        ])->whereIn('playlist_id', $playlistIds)
-            ->where(function ($query) {
-                $query->where('stream_id_custom', '!=', '')
-                    ->orWhere('stream_id', '!=', '');
-            })
+        ])->whereIn('playlist_id', $playlistIds);
+
+        $this->applyContentTypeScope($allChannelsQuery);
+        $this->applyMergeKeyPresenceScope($allChannelsQuery);
+
+        $allChannels = $allChannelsQuery
             ->when($this->groupId, function ($query) {
                 // Filter by group_id if specified
                 $query->where('group_id', $this->groupId);
@@ -124,12 +136,9 @@ class MergeChannels implements ShouldQueue
                 $query->where('new', true);
             })->cursor();
 
-        // Group channels by stream ID using LazyCollection
-        $groupedChannels = $allChannels->groupBy(function ($channel) {
-            $streamId = $channel->stream_id_custom ?: $channel->stream_id;
-
-            return strtolower(trim($streamId));
-        });
+        $groupedChannels = $allChannels
+            ->filter(fn ($channel) => $this->getChannelMergeKey($channel) !== null)
+            ->groupBy(fn ($channel) => $this->getChannelMergeKey($channel));
 
         $streamIdResults = $this->processGroupedChannels($groupedChannels, $playlistPriority);
         $processed += $streamIdResults['processed'];
@@ -150,6 +159,55 @@ class MergeChannels implements ShouldQueue
         $deactivatedCount += $regexResults['deactivated'];
 
         $this->sendCompletionNotification($processed, $deactivatedCount);
+    }
+
+    /**
+     * Apply live or VOD filtering so failover groups never mix content types.
+     */
+    protected function applyContentTypeScope($query): void
+    {
+        if ($this->contentType === 'vod') {
+            $query->where('is_vod', true);
+
+            return;
+        }
+
+        $query->where(function ($query) {
+            $query->where('is_vod', false)
+                ->orWhereNull('is_vod');
+        });
+    }
+
+    /**
+     * Keep the existing stream ID pre-filter for stream ID mode.
+     */
+    protected function applyMergeKeyPresenceScope($query): void
+    {
+        if ($this->mergeKey === 'tmdb_id') {
+            return;
+        }
+
+        $query->where(function ($query) {
+            $query->where('stream_id_custom', '!=', '')
+                ->orWhere('stream_id', '!=', '');
+        });
+    }
+
+    /**
+     * Resolve the current merge key for a channel.
+     */
+    protected function getChannelMergeKey(Channel $channel): ?string
+    {
+        if ($this->contentType === 'vod' && $this->mergeKey === 'tmdb_id') {
+            $tmdbId = $channel->getTmdbId();
+
+            return $tmdbId ? 'tmdb:'.$tmdbId : null;
+        }
+
+        $streamId = $channel->stream_id_custom ?: $channel->stream_id;
+        $streamId = is_string($streamId) ? trim($streamId) : '';
+
+        return $streamId !== '' ? 'stream:'.strtolower($streamId) : null;
     }
 
     /**
@@ -226,10 +284,14 @@ class MergeChannels implements ShouldQueue
             return ['processed' => 0, 'deactivated' => 0];
         }
 
-        $channels = Channel::where([
+        $channelsQuery = Channel::where([
             ['user_id', $this->user->id],
             ['can_merge', true],
-        ])->whereIn('playlist_id', $playlistIds)
+        ])->whereIn('playlist_id', $playlistIds);
+
+        $this->applyContentTypeScope($channelsQuery);
+
+        $channels = $channelsQuery
             ->where(function ($query) {
                 $query->whereNull('stream_id_custom')
                     ->orWhere('stream_id_custom', '');
@@ -294,9 +356,13 @@ class MergeChannels implements ShouldQueue
         // Memory is bounded by the chunk size regardless of catalogue size.
         $matchesByPattern = array_fill(0, count($validPatterns), []);
 
-        Channel::where('user_id', $this->user->id)
+        $regexChannelsQuery = Channel::where('user_id', $this->user->id)
             ->where('can_merge', true)
-            ->whereIn('playlist_id', $playlistIds)
+            ->whereIn('playlist_id', $playlistIds);
+
+        $this->applyContentTypeScope($regexChannelsQuery);
+
+        $regexChannelsQuery
             ->when($this->groupId, fn ($q) => $q->where('group_id', $this->groupId))
             ->select(['id', 'user_id', 'playlist_id', 'group_id', 'title', 'title_custom',
                 'name', 'name_custom', 'stream_id', 'stream_id_custom', 'sort',

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -6,6 +6,7 @@ use App\Models\Channel;
 use App\Models\ChannelFailover;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Models\User;
 use App\Services\ChannelMergeKeyService;
 use Filament\Notifications\Notification;
 use Illuminate\Bus\Queueable;
@@ -52,7 +53,7 @@ class MergeChannels implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(
-        public $user,
+        public readonly User $user,
         public Collection $playlists,
         public int $playlistId,
         public bool $checkResolution = false,

--- a/app/Jobs/MergeEpisodes.php
+++ b/app/Jobs/MergeEpisodes.php
@@ -4,6 +4,8 @@ namespace App\Jobs;
 
 use App\Models\Episode;
 use App\Models\EpisodeFailover;
+use App\Models\Series;
+use App\Models\User;
 use Filament\Notifications\Notification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -20,7 +22,7 @@ class MergeEpisodes implements ShouldQueue
      * Create a new job instance.
      */
     public function __construct(
-        public $user,
+        public User $user,
         public Collection $playlists,
         public int $playlistId,
         public bool $deactivateFailoverEpisodes = false,
@@ -50,21 +52,24 @@ class MergeEpisodes implements ShouldQueue
             ->pluck('episode_failover_id')
             ->toArray();
 
+        // Pre-load series TMDB IDs to avoid N+1 when computing merge keys over the cursor
+        $seriesTmdbIdMap = Series::whereIn('playlist_id', $playlistIds)
+            ->pluck('tmdb_id', 'id');
+
         $episodes = Episode::query()
-            ->with(['series', 'playlist'])
             ->where('user_id', $this->user->id)
             ->whereIn('playlist_id', $playlistIds)
             ->when(! empty($existingFailoverEpisodeIds) && ! $this->forceCompleteRemerge && ! $this->deactivateFailoverEpisodes, function ($query) use ($existingFailoverEpisodeIds) {
                 $query->whereNotIn('id', $existingFailoverEpisodeIds);
             })
-            ->get();
+            ->cursor();
 
         $processed = 0;
         $deactivatedCount = 0;
 
         $episodes
-            ->filter(fn (Episode $episode): bool => $this->getEpisodeMergeKey($episode) !== null)
-            ->groupBy(fn (Episode $episode): string => $this->getEpisodeMergeKey($episode))
+            ->filter(fn (Episode $episode): bool => $this->getEpisodeMergeKey($episode, $seriesTmdbIdMap) !== null)
+            ->groupBy(fn (Episode $episode): string => $this->getEpisodeMergeKey($episode, $seriesTmdbIdMap))
             ->each(function (Collection $group) use ($playlistPriority, &$processed, &$deactivatedCount): void {
                 if ($group->count() <= 1) {
                     return;
@@ -89,7 +94,7 @@ class MergeEpisodes implements ShouldQueue
                         ]
                     );
 
-                    if ($this->deactivateFailoverEpisodes && array_key_exists('enabled', $failover->getAttributes()) && $failover->enabled) {
+                    if ($this->deactivateFailoverEpisodes && $failover->enabled) {
                         $failover->update(['enabled' => false]);
                         $deactivatedCount++;
                     }
@@ -106,13 +111,13 @@ class MergeEpisodes implements ShouldQueue
             ->sendToDatabase($this->user);
     }
 
-    protected function getEpisodeMergeKey(Episode $episode): ?string
+    protected function getEpisodeMergeKey(Episode $episode, Collection $seriesTmdbIdMap): ?string
     {
         if (! empty($episode->tmdb_id)) {
             return 'episode:'.(int) $episode->tmdb_id;
         }
 
-        $seriesTmdbId = $episode->series?->tmdb_id;
+        $seriesTmdbId = $seriesTmdbIdMap[$episode->series_id] ?? null;
         $season = $episode->season;
         $episodeNumber = $episode->episode_num;
 

--- a/app/Jobs/MergeEpisodes.php
+++ b/app/Jobs/MergeEpisodes.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Episode;
+use App\Models\EpisodeFailover;
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class MergeEpisodes implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public $user,
+        public Collection $playlists,
+        public int $playlistId,
+        public bool $deactivateFailoverEpisodes = false,
+        public bool $forceCompleteRemerge = false,
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $playlistIds = $this->playlists->map(function ($item) {
+            return is_array($item) ? $item['playlist_failover_id'] : $item;
+        })->values();
+
+        if ($this->playlistId) {
+            $playlistIds->prepend($this->playlistId);
+        }
+
+        $playlistIds = $playlistIds->filter()->unique()->values()->toArray();
+        $playlistPriority = $playlistIds ? array_flip($playlistIds) : [];
+
+        $existingFailoverEpisodeIds = EpisodeFailover::where('user_id', $this->user->id)
+            ->whereHas('episodeFailover', function ($query) use ($playlistIds) {
+                $query->whereIn('playlist_id', $playlistIds);
+            })
+            ->pluck('episode_failover_id')
+            ->toArray();
+
+        $episodes = Episode::query()
+            ->with(['series', 'playlist'])
+            ->where('user_id', $this->user->id)
+            ->whereIn('playlist_id', $playlistIds)
+            ->when(! empty($existingFailoverEpisodeIds) && ! $this->forceCompleteRemerge && ! $this->deactivateFailoverEpisodes, function ($query) use ($existingFailoverEpisodeIds) {
+                $query->whereNotIn('id', $existingFailoverEpisodeIds);
+            })
+            ->get();
+
+        $processed = 0;
+        $deactivatedCount = 0;
+
+        $episodes
+            ->filter(fn (Episode $episode): bool => $this->getEpisodeMergeKey($episode) !== null)
+            ->groupBy(fn (Episode $episode): string => $this->getEpisodeMergeKey($episode))
+            ->each(function (Collection $group) use ($playlistPriority, &$processed, &$deactivatedCount): void {
+                if ($group->count() <= 1) {
+                    return;
+                }
+
+                $sorted = $this->sortEpisodesByPlaylistPriority($group, $playlistPriority);
+                $master = $sorted->first();
+                if (! $master) {
+                    return;
+                }
+
+                $sortOrder = 1;
+                foreach ($sorted->where('id', '!=', $master->id) as $failover) {
+                    EpisodeFailover::updateOrCreate(
+                        [
+                            'episode_id' => $master->id,
+                            'episode_failover_id' => $failover->id,
+                        ],
+                        [
+                            'user_id' => $this->user->id,
+                            'sort' => $sortOrder++,
+                        ]
+                    );
+
+                    if ($this->deactivateFailoverEpisodes && array_key_exists('enabled', $failover->getAttributes()) && $failover->enabled) {
+                        $failover->update(['enabled' => false]);
+                        $deactivatedCount++;
+                    }
+
+                    $processed++;
+                }
+            });
+
+        Notification::make()
+            ->success()
+            ->title('Episode merge completed')
+            ->body($processed.' episode failover relationship(s) created or updated.'.($deactivatedCount > 0 ? ' '.$deactivatedCount.' failover episode(s) deactivated.' : ''))
+            ->broadcast($this->user)
+            ->sendToDatabase($this->user);
+    }
+
+    protected function getEpisodeMergeKey(Episode $episode): ?string
+    {
+        if (! empty($episode->tmdb_id)) {
+            return 'episode:'.(int) $episode->tmdb_id;
+        }
+
+        $seriesTmdbId = $episode->series?->tmdb_id;
+        $season = $episode->season;
+        $episodeNumber = $episode->episode_num;
+
+        if (empty($seriesTmdbId) || empty($season) || empty($episodeNumber)) {
+            return null;
+        }
+
+        return 'series:'.(int) $seriesTmdbId.':s'.(int) $season.':e'.(int) $episodeNumber;
+    }
+
+    protected function sortEpisodesByPlaylistPriority(Collection $episodes, array $playlistPriority): Collection
+    {
+        return $episodes->sortBy([
+            fn (Episode $a, Episode $b): int => ($playlistPriority[$a->playlist_id] ?? PHP_INT_MAX) <=> ($playlistPriority[$b->playlist_id] ?? PHP_INT_MAX),
+            fn (Episode $a, Episode $b): int => $a->id <=> $b->id,
+        ])->values();
+    }
+}

--- a/app/Models/Episode.php
+++ b/app/Models/Episode.php
@@ -11,6 +11,8 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
@@ -84,6 +86,23 @@ class Episode extends Model
     public function strmFileMappings(): MorphMany
     {
         return $this->morphMany(StrmFileMapping::class, 'syncable');
+    }
+
+    public function failovers(): HasMany
+    {
+        return $this->hasMany(EpisodeFailover::class);
+    }
+
+    public function failoverEpisodes(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            Episode::class,
+            EpisodeFailover::class,
+            'episode_id',
+            'id',
+            'id',
+            'episode_failover_id'
+        )->orderBy('episode_failovers.sort');
     }
 
     /**

--- a/app/Models/EpisodeFailover.php
+++ b/app/Models/EpisodeFailover.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EpisodeFailover extends Model
+{
+    use HasFactory;
+
+    protected $casts = [
+        'id' => 'integer',
+        'user_id' => 'integer',
+        'episode_id' => 'integer',
+        'episode_failover_id' => 'integer',
+        'metadata' => 'array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function episode(): BelongsTo
+    {
+        return $this->belongsTo(Episode::class);
+    }
+
+    public function episodeFailover(): BelongsTo
+    {
+        return $this->belongsTo(Episode::class, 'episode_failover_id');
+    }
+}

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -2492,7 +2492,7 @@ class M3uProxyService
      * Supports cross-provider failover pooling by searching based on the ORIGINAL
      * requested channel, not the actual source channel (which may be a failover).
      *
-     * @param  int  $modelId  Original requested channel ID
+     * @param  int  $modelId  Original requested channel or episode ID
      * @param  string  $playlistUuid  Original requested playlist UUID
      * @param  int|null  $profileId  StreamProfile ID (transcoding profile)
      * @param  int|null  $providerProfileId  PlaylistProfile ID (provider profile)

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -1408,6 +1408,9 @@ class M3uProxyService
             $profileSourcePlaylist = $episode->playlist;
         }
 
+        // Cached failover episodes so the relationship is only queried once per request
+        $cachedFailoverEpisodes = null;
+
         // Check if playlist has stream limits and if it's at capacity
         // This check applies regardless of whether provider profiles are enabled —
         // available_streams is the authoritative proxy-level limit.
@@ -1436,7 +1439,8 @@ class M3uProxyService
 
                 // If still at capacity (either setting disabled or stop failed), try episode failovers.
                 if ($activeStreams >= $playlist->available_streams) {
-                    foreach ($requestedEpisode->failoverEpisodes()->with('playlist')->get() as $failoverEpisode) {
+                    $cachedFailoverEpisodes = $requestedEpisode->failoverEpisodes()->with('playlist')->get();
+                    foreach ($cachedFailoverEpisodes as $failoverEpisode) {
                         $failoverPlaylist = $failoverEpisode->getEffectivePlaylist();
                         if (! $failoverPlaylist) {
                             continue;
@@ -1496,18 +1500,16 @@ class M3uProxyService
         // Get any custom headers for the current playlist
         $headers = $playlist->custom_headers ?? [];
 
-        $episodeFailoverQuery = $requestedEpisode->failoverEpisodes()
-            ->with('playlist')
-            ->where('episodes.id', '!=', $actualEpisode->id);
+        $allFailoverEpisodes = $cachedFailoverEpisodes ?? $requestedEpisode->failoverEpisodes()->with('playlist')->get();
+        $remainingFailovers = $allFailoverEpisodes->filter(fn ($fe) => $fe->id !== $actualEpisode->id);
 
         $failovers = $this->usingResolver()
-            ? $episodeFailoverQuery->exists()
-            : $episodeFailoverQuery->get()
-                ->map(function ($failoverEpisode) {
-                    $failoverPlaylist = $failoverEpisode->getEffectivePlaylist();
+            ? $remainingFailovers->isNotEmpty()
+            : $remainingFailovers->map(function ($failoverEpisode) {
+                $failoverPlaylist = $failoverEpisode->getEffectivePlaylist();
 
-                    return $failoverPlaylist ? PlaylistUrlService::getEpisodeUrl($failoverEpisode, $failoverPlaylist) : null;
-                })
+                return $failoverPlaylist ? PlaylistUrlService::getEpisodeUrl($failoverEpisode, $failoverPlaylist) : null;
+            })
                 ->filter()
                 ->values()
                 ->toArray();

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -1526,7 +1526,7 @@ class M3uProxyService
             if (! $selectedProfile) {
                 // Check if reuse was detected inside the lock (another request is creating this stream).
                 if (ProfileService::isChannelStreamActive($originalEpisodeId, $originalPlaylistUuid, 'episode')) {
-                    $existingStreamId = $this->findExistingPooledStream($originalEpisodeId, $originalPlaylistUuid, $profile?->id, null);
+                    $existingStreamId = $this->findExistingPooledStream($originalEpisodeId, $originalPlaylistUuid, $profile?->id, null, 'episode');
 
                     if ($existingStreamId) {
                         Log::debug('Reusing existing pooled stream for episode', [
@@ -1598,7 +1598,7 @@ class M3uProxyService
             // First, check if there's already an active pooled transcoded stream for this episode
             // This allows multiple clients to share the same transcoded stream without consuming
             // additional provider connections
-            $existingStreamId = $this->findExistingPooledStream($originalEpisodeId, $originalPlaylistUuid, $profile->id, $selectedProfile?->id);
+            $existingStreamId = $this->findExistingPooledStream($originalEpisodeId, $originalPlaylistUuid, $profile->id, $selectedProfile?->id, 'episode');
 
             if ($existingStreamId) {
                 Log::debug('Reusing existing pooled transcoded stream', [
@@ -1626,7 +1626,7 @@ class M3uProxyService
                 'profile_id' => $profile->id,
                 'strict_live_ts' => $playlist->strict_live_ts ?? false,
                 'use_sticky_session' => $playlist->use_sticky_session ?? false,
-                'original_channel_id' => $originalEpisodeId,           // Enables findExistingPooledStream reuse
+                'original_episode_id' => $originalEpisodeId,           // Enables findExistingPooledStream reuse
                 'original_playlist_uuid' => $originalPlaylistUuid,
                 'is_failover' => $actualEpisode->id !== $originalEpisodeId,
             ];
@@ -1673,7 +1673,7 @@ class M3uProxyService
                 'playlist_uuid' => $playlist->uuid,
                 'strict_live_ts' => $playlist->strict_live_ts ?? false,
                 'use_sticky_session' => $playlist->use_sticky_session ?? false,
-                'original_channel_id' => $originalEpisodeId,           // Enables findExistingPooledStream reuse
+                'original_episode_id' => $originalEpisodeId,           // Enables findExistingPooledStream reuse
                 'original_playlist_uuid' => $originalPlaylistUuid,
                 'is_failover' => $actualEpisode->id !== $originalEpisodeId,
             ];
@@ -2492,13 +2492,14 @@ class M3uProxyService
      * Supports cross-provider failover pooling by searching based on the ORIGINAL
      * requested channel, not the actual source channel (which may be a failover).
      *
-     * @param  int  $channelId  Original requested channel ID
+     * @param  int  $modelId  Original requested channel ID
      * @param  string  $playlistUuid  Original requested playlist UUID
      * @param  int|null  $profileId  StreamProfile ID (transcoding profile)
      * @param  int|null  $providerProfileId  PlaylistProfile ID (provider profile)
+     * @param  string  $type  The type of model ('channel' or 'episode') for metadata keys
      * @return string|null Stream ID if found, null otherwise
      */
-    protected function findExistingPooledStream(int $channelId, string $playlistUuid, ?int $profileId = null, ?int $providerProfileId = null): ?string
+    protected function findExistingPooledStream(int $modelId, string $playlistUuid, ?int $profileId = null, ?int $providerProfileId = null, string $type = 'channel'): ?string
     {
         try {
             // Query m3u-proxy for streams by ORIGINAL channel ID metadata
@@ -2509,8 +2510,8 @@ class M3uProxyService
                     'X-API-Token' => $this->apiToken,
                 ]))
                 ->get($endpoint, [
-                    'field' => 'original_channel_id',  // Search by original, not actual channel
-                    'value' => (string) $channelId,
+                    'field' => 'original_'.$type.'_id',  // Search by original, not actual model ID to enable cross-provider failover pooling
+                    'value' => (string) $modelId,
                     'active_only' => true,  // Only return active streams
                 ]);
 
@@ -2537,16 +2538,16 @@ class M3uProxyService
                     : ! $isTranscoded;
 
                 if (
-                    ($metadata['original_channel_id'] ?? null) == $channelId &&
+                    ($metadata['original_'.$type.'_id'] ?? null) == $modelId &&
                     ($metadata['original_playlist_uuid'] ?? null) === $playlistUuid &&
                     $transcodingMatch &&
                     ($providerProfileId === null || ($metadata['provider_profile_id'] ?? null) == $providerProfileId)
                 ) {
                     Log::debug('Found existing pooled stream (cross-provider failover support)', [
                         'stream_id' => $stream['stream_id'],
-                        'original_channel_id' => $channelId,
+                        'original_'.$type.'_id' => $modelId,
                         'original_playlist_uuid' => $playlistUuid,
-                        'actual_channel_id' => $metadata['id'] ?? null,
+                        'actual_'.$type.'_id' => $metadata['id'] ?? null,
                         'actual_playlist_uuid' => $metadata['playlist_uuid'] ?? null,
                         'is_failover' => $metadata['is_failover'] ?? false,
                         'is_transcoded' => $isTranscoded,

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -1389,6 +1389,10 @@ class M3uProxyService
 
         // Get episode ID
         $id = $episode->id;
+        $requestedEpisode = $episode;
+        $actualEpisode = $episode;
+        $originalEpisodeId = $id;
+        $originalPlaylistUuid = $playlist->uuid;
 
         // Build client identifier for profile affinity tracking
         $clientIdentifier = ProfileService::buildClientIdentifier($request?->ip(), $username);
@@ -1430,16 +1434,49 @@ class M3uProxyService
                     }
                 }
 
-                // If still at capacity (either setting disabled or stop failed), deny the request
+                // If still at capacity (either setting disabled or stop failed), try episode failovers.
                 if ($activeStreams >= $playlist->available_streams) {
-                    Log::debug('Episode stream request denied - playlist at capacity', [
-                        'episode_id' => $id,
-                        'playlist' => $playlist->uuid,
-                        'limit' => $playlist->available_streams,
-                        'active' => $activeStreams,
-                    ]);
+                    foreach ($requestedEpisode->failoverEpisodes()->with('playlist')->get() as $failoverEpisode) {
+                        $failoverPlaylist = $failoverEpisode->getEffectivePlaylist();
+                        if (! $failoverPlaylist) {
+                            continue;
+                        }
 
-                    abort(503, 'Playlist has reached its maximum stream limit. Please try again later.');
+                        if ($failoverPlaylist->available_streams === 0) {
+                            $playlist = $failoverPlaylist;
+                            $episode = $failoverEpisode;
+                            $actualEpisode = $failoverEpisode;
+                            $id = $episode->id;
+                            break;
+                        }
+
+                        $failoverActiveStreams = self::getActiveStreamsCountByMetadata('playlist_uuid', $failoverPlaylist->uuid);
+                        if ($failoverActiveStreams < $failoverPlaylist->available_streams) {
+                            $playlist = $failoverPlaylist;
+                            $episode = $failoverEpisode;
+                            $actualEpisode = $failoverEpisode;
+                            $id = $episode->id;
+                            break;
+                        }
+                    }
+
+                    if ($actualEpisode->id === $originalEpisodeId) {
+                        Log::debug('Episode stream request denied - all playlists at capacity', [
+                            'episode_id' => $originalEpisodeId,
+                            'playlist' => $playlist->uuid,
+                            'limit' => $playlist->available_streams,
+                            'active' => $activeStreams,
+                        ]);
+
+                        abort(503, 'All playlists have reached their maximum stream limit. Please try again later.');
+                    }
+
+                    $profileSourcePlaylist = null;
+                    if ($playlist instanceof Playlist && $playlist->profiles_enabled) {
+                        $profileSourcePlaylist = $playlist;
+                    } elseif ($episode->playlist instanceof Playlist && $episode->playlist->profiles_enabled) {
+                        $profileSourcePlaylist = $episode->playlist;
+                    }
                 }
             }
         }
@@ -1459,6 +1496,22 @@ class M3uProxyService
         // Get any custom headers for the current playlist
         $headers = $playlist->custom_headers ?? [];
 
+        $episodeFailoverQuery = $requestedEpisode->failoverEpisodes()
+            ->with('playlist')
+            ->where('episodes.id', '!=', $actualEpisode->id);
+
+        $failovers = $this->usingResolver()
+            ? $episodeFailoverQuery->exists()
+            : $episodeFailoverQuery->get()
+                ->map(function ($failoverEpisode) {
+                    $failoverPlaylist = $failoverEpisode->getEffectivePlaylist();
+
+                    return $failoverPlaylist ? PlaylistUrlService::getEpisodeUrl($failoverEpisode, $failoverPlaylist) : null;
+                })
+                ->filter()
+                ->values()
+                ->toArray();
+
         // Provider Profile selection for Xtream playlists with profiles enabled
         // Use profileSourcePlaylist which may be the episode's source playlist when streaming via CustomPlaylist
         // Use selectAndReserveProfile() for atomic select+increment to prevent TOCTOU races
@@ -1466,12 +1519,12 @@ class M3uProxyService
         $reservationId = null;
         if ($profileSourcePlaylist) {
             $forceSelect = $profileSourcePlaylist->bypass_provider_limits ?? false;
-            [$selectedProfile, $reservationId] = ProfileService::selectAndReserveProfile($profileSourcePlaylist, null, $id, $playlist->uuid, $forceSelect, $clientIdentifier, 'episode');
+            [$selectedProfile, $reservationId] = ProfileService::selectAndReserveProfile($profileSourcePlaylist, null, $originalEpisodeId, $originalPlaylistUuid, $forceSelect, $clientIdentifier, 'episode');
 
             if (! $selectedProfile) {
                 // Check if reuse was detected inside the lock (another request is creating this stream).
-                if (ProfileService::isChannelStreamActive($id, $playlist->uuid, 'episode')) {
-                    $existingStreamId = $this->findExistingPooledStream($id, $playlist->uuid, $profile?->id, null);
+                if (ProfileService::isChannelStreamActive($originalEpisodeId, $originalPlaylistUuid, 'episode')) {
+                    $existingStreamId = $this->findExistingPooledStream($originalEpisodeId, $originalPlaylistUuid, $profile?->id, null);
 
                     if ($existingStreamId) {
                         Log::debug('Reusing existing pooled stream for episode', [
@@ -1497,10 +1550,10 @@ class M3uProxyService
                         'episode_id' => $id,
                         'playlist_uuid' => $playlist->uuid,
                     ]);
-                    ProfileService::clearChannelStreamMapping($id, $playlist->uuid, 'episode');
+                    ProfileService::clearChannelStreamMapping($originalEpisodeId, $originalPlaylistUuid, 'episode');
                 }
 
-                [$selectedProfile, $reservationId] = ProfileService::selectAndReserveProfile($profileSourcePlaylist, null, $id, $playlist->uuid, $forceSelect, $clientIdentifier, 'episode');
+                [$selectedProfile, $reservationId] = ProfileService::selectAndReserveProfile($profileSourcePlaylist, null, $originalEpisodeId, $originalPlaylistUuid, $forceSelect, $clientIdentifier, 'episode');
 
                 // No profiles with capacity - try "stop oldest on limit" before giving up
                 if (! $selectedProfile && $this->stopOldestOnLimit) {
@@ -1514,7 +1567,7 @@ class M3uProxyService
                         ]);
 
                         usleep(200000); // 200ms
-                        [$selectedProfile, $reservationId] = ProfileService::selectAndReserveProfile($profileSourcePlaylist, null, $id, $playlist->uuid, $forceSelect, $clientIdentifier, 'episode');
+                        [$selectedProfile, $reservationId] = ProfileService::selectAndReserveProfile($profileSourcePlaylist, null, $originalEpisodeId, $originalPlaylistUuid, $forceSelect, $clientIdentifier, 'episode');
                     }
                 }
 
@@ -1543,7 +1596,7 @@ class M3uProxyService
             // First, check if there's already an active pooled transcoded stream for this episode
             // This allows multiple clients to share the same transcoded stream without consuming
             // additional provider connections
-            $existingStreamId = $this->findExistingPooledStream($id, $playlist->uuid, $profile->id, $selectedProfile?->id);
+            $existingStreamId = $this->findExistingPooledStream($originalEpisodeId, $originalPlaylistUuid, $profile->id, $selectedProfile?->id);
 
             if ($existingStreamId) {
                 Log::debug('Reusing existing pooled transcoded stream', [
@@ -1564,15 +1617,16 @@ class M3uProxyService
 
             // No existing pooled stream found, create a new transcoded stream
             $metadata = [
-                'id' => $id,
-                'episode_id' => (string) $id,  // Searchable by stopPlayerStream
+                'id' => $actualEpisode->id,
+                'episode_id' => (string) $actualEpisode->id,  // Searchable by stopPlayerStream
                 'type' => 'episode',
                 'playlist_uuid' => $playlist->uuid,
                 'profile_id' => $profile->id,
                 'strict_live_ts' => $playlist->strict_live_ts ?? false,
                 'use_sticky_session' => $playlist->use_sticky_session ?? false,
-                'original_channel_id' => $id,           // Enables findExistingPooledStream reuse
-                'original_playlist_uuid' => $playlist->uuid,
+                'original_channel_id' => $originalEpisodeId,           // Enables findExistingPooledStream reuse
+                'original_playlist_uuid' => $originalPlaylistUuid,
+                'is_failover' => $actualEpisode->id !== $originalEpisodeId,
             ];
 
             // Add provider profile ID if using profiles
@@ -1586,7 +1640,7 @@ class M3uProxyService
             }
 
             try {
-                $streamId = $this->createTranscodedStream($url, $profile, false, $userAgent, $headers, $metadata);
+                $streamId = $this->createTranscodedStream($url, $profile, $failovers, $userAgent, $headers, $metadata);
             } catch (Exception $e) {
                 if ($selectedProfile && $reservationId) {
                     ProfileService::cancelReservation($selectedProfile, $reservationId);
@@ -1603,7 +1657,7 @@ class M3uProxyService
 
             // Finalize the reservation with the real stream ID
             if ($selectedProfile && $reservationId) {
-                ProfileService::finalizeReservation($selectedProfile, $reservationId, $streamId, $id, $playlist->uuid, 'episode');
+                ProfileService::finalizeReservation($selectedProfile, $reservationId, $streamId, $originalEpisodeId, $originalPlaylistUuid, 'episode');
             }
 
             // Return transcoded stream URL
@@ -1611,14 +1665,15 @@ class M3uProxyService
         } else {
             // Use direct streaming endpoint
             $metadata = [
-                'id' => $id,
-                'episode_id' => (string) $id,  // Searchable by stopPlayerStream
+                'id' => $actualEpisode->id,
+                'episode_id' => (string) $actualEpisode->id,  // Searchable by stopPlayerStream
                 'type' => 'episode',
                 'playlist_uuid' => $playlist->uuid,
                 'strict_live_ts' => $playlist->strict_live_ts ?? false,
                 'use_sticky_session' => $playlist->use_sticky_session ?? false,
-                'original_channel_id' => $id,           // Enables findExistingPooledStream reuse
-                'original_playlist_uuid' => $playlist->uuid,
+                'original_channel_id' => $originalEpisodeId,           // Enables findExistingPooledStream reuse
+                'original_playlist_uuid' => $originalPlaylistUuid,
+                'is_failover' => $actualEpisode->id !== $originalEpisodeId,
             ];
 
             // Add provider profile ID if using profiles
@@ -1632,7 +1687,7 @@ class M3uProxyService
             }
 
             try {
-                $streamId = $this->createStream($url, false, $userAgent, $headers, $metadata);
+                $streamId = $this->createStream($url, $failovers, $userAgent, $headers, $metadata);
             } catch (Exception $e) {
                 if ($selectedProfile && $reservationId) {
                     ProfileService::cancelReservation($selectedProfile, $reservationId);
@@ -1648,7 +1703,7 @@ class M3uProxyService
 
             // Finalize the reservation with the real stream ID
             if ($selectedProfile && $reservationId) {
-                ProfileService::finalizeReservation($selectedProfile, $reservationId, $streamId, $id, $playlist->uuid, 'episode');
+                ProfileService::finalizeReservation($selectedProfile, $reservationId, $streamId, $originalEpisodeId, $originalPlaylistUuid, 'episode');
             }
 
             // For direct (non-transcoded) streams, always use the /stream/ endpoint.

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -945,8 +945,11 @@ class PlaylistService
 
         $behaviorSchema = [
             Toggle::make('deactivate_failover_channels')
-                ->label('Deactivate Failover Channels')
-                ->helperText('When enabled, channels that become failovers will be automatically disabled.')
+                ->label($isSeries ? 'Deactivate Failover Episodes' : 'Deactivate Failover Channels')
+                ->helperText($isSeries
+                    ? 'When enabled, episodes that become failovers will be automatically disabled.'
+                    : 'When enabled, channels that become failovers will be automatically disabled.'
+                )
                 ->default(false),
             Toggle::make('force_complete_remerge')
                 ->label('Force complete re-merge')
@@ -1195,7 +1198,7 @@ class PlaylistService
     public static function getMergeAction(bool $groupScoped = false, string $contentType = 'live'): Action
     {
         $action = Action::make('merge')
-            ->label('Merge Same ID')
+            ->label($contentType === 'series' ? 'Merge Episodes' : 'Merge Same ID')
             ->schema(self::getMergeFormSchema($contentType))
             ->requiresConfirmation()
             ->icon('heroicon-o-arrows-pointing-in')
@@ -1225,7 +1228,10 @@ class PlaylistService
                 });
         } else {
             $action
-                ->modalDescription('Merge all channels with the same ID into a single channel with failover.')
+                ->modalDescription($contentType === 'series'
+                    ? 'Merge all episodes with the same TMDB ID across playlists into a single episode with failover.'
+                    : 'Merge all channels with the same ID into a single channel with failover.'
+                )
                 ->action(function (array $data) use ($contentType): void {
                     $job = $contentType === 'series'
                         ? new MergeEpisodes(

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -895,67 +895,94 @@ class PlaylistService
     /**
      * Get the form schema for the "Merge Same ID" action.
      */
-    public static function getMergeFormSchema(): array
+    public static function getMergeFormSchema(string $contentType = 'live'): array
     {
-        return [
-            Fieldset::make('Merge source configuration')
-                ->schema([
-                    Select::make('playlist_id')
-                        ->required()
-                        ->columnSpanFull()
-                        ->label('Preferred Playlist')
+        $isVod = $contentType === 'vod';
+
+        $sourceSchema = [
+            Select::make('playlist_id')
+                ->required()
+                ->columnSpanFull()
+                ->label('Preferred Playlist')
+                ->options(Playlist::where('user_id', auth()->id())->pluck('name', 'id'))
+                ->live()
+                ->searchable()
+                ->helperText('Select a playlist to prioritize as the master during the merge process.'),
+            Repeater::make('failover_playlists')
+                ->label('')
+                ->helperText('Select one or more playlists use as failover source(s).')
+                ->reorderable()
+                ->reorderableWithButtons()
+                ->orderColumn('sort')
+                ->simple(
+                    Select::make('playlist_failover_id')
+                        ->label('Failover Playlists')
                         ->options(Playlist::where('user_id', auth()->id())->pluck('name', 'id'))
-                        ->live()
                         ->searchable()
-                        ->helperText('Select a playlist to prioritize as the master during the merge process.'),
-                    Repeater::make('failover_playlists')
-                        ->label('')
-                        ->helperText('Select one or more playlists use as failover source(s).')
-                        ->reorderable()
-                        ->reorderableWithButtons()
-                        ->orderColumn('sort')
-                        ->simple(
-                            Select::make('playlist_failover_id')
-                                ->label('Failover Playlists')
-                                ->options(Playlist::where('user_id', auth()->id())->pluck('name', 'id'))
-                                ->searchable()
-                                ->required()
-                        )
-                        ->distinct()
-                        ->columns(1)
-                        ->addActionLabel('Add failover playlist')
-                        ->columnSpanFull()
-                        ->minItems(1)
-                        ->defaultItems(1),
+                        ->required()
+                )
+                ->distinct()
+                ->columns(1)
+                ->addActionLabel('Add failover playlist')
+                ->columnSpanFull()
+                ->minItems(1)
+                ->defaultItems(1),
+        ];
+
+        if ($isVod) {
+            $sourceSchema[] = Select::make('merge_key')
+                ->label('Merge key')
+                ->options([
+                    'stream_id' => 'Stream ID',
+                    'tmdb_id' => 'TMDB ID',
                 ])
+                ->default('stream_id')
+                ->required()
+                ->helperText('Use TMDB ID to merge the same movie across providers when stream IDs differ. Entries without a TMDB ID are skipped.');
+        }
+
+        $behaviorSchema = [
+            Toggle::make('deactivate_failover_channels')
+                ->label('Deactivate Failover Channels')
+                ->helperText('When enabled, channels that become failovers will be automatically disabled.')
+                ->default(false),
+            Toggle::make('force_complete_remerge')
+                ->label('Force complete re-merge')
+                ->helperText('Re-evaluate ALL existing failover relationships, not just unmerged channels.')
+                ->default(false),
+        ];
+
+        if (! $isVod) {
+            array_splice($behaviorSchema, 0, 0, [
+                Toggle::make('by_resolution')
+                    ->label('Order by Resolution')
+                    ->live()
+                    ->helperText('⚠️ IPTV WARNING: This will analyze each stream to determine resolution, which may cause rate limiting or blocking with IPTV providers. Only enable if your provider allows stream analysis.')
+                    ->default(false),
+            ]);
+
+            $behaviorSchema[] = Toggle::make('prefer_catchup_as_primary')
+                ->label('Prefer catch-up channels as primary')
+                ->helperText('When enabled, catch-up channels will be selected as the master when available.')
+                ->default(false);
+            $behaviorSchema[] = Toggle::make('exclude_disabled_groups')
+                ->label('Exclude disabled groups from master selection')
+                ->helperText('Channels from disabled groups will never be selected as master.')
+                ->default(false);
+        }
+
+        $schema = [
+            Fieldset::make('Merge source configuration')
+                ->schema($sourceSchema)
                 ->columnSpanFull(),
             Fieldset::make('Merge behavior')
-                ->schema([
-                    Toggle::make('by_resolution')
-                        ->label('Order by Resolution')
-                        ->live()
-                        ->helperText('⚠️ IPTV WARNING: This will analyze each stream to determine resolution, which may cause rate limiting or blocking with IPTV providers. Only enable if your provider allows stream analysis.')
-                        ->default(false),
-                    Toggle::make('deactivate_failover_channels')
-                        ->label('Deactivate Failover Channels')
-                        ->helperText('When enabled, channels that become failovers will be automatically disabled.')
-                        ->default(false),
-                    Toggle::make('prefer_catchup_as_primary')
-                        ->label('Prefer catch-up channels as primary')
-                        ->helperText('When enabled, catch-up channels will be selected as the master when available.')
-                        ->default(false),
-                    Toggle::make('exclude_disabled_groups')
-                        ->label('Exclude disabled groups from master selection')
-                        ->helperText('Channels from disabled groups will never be selected as master.')
-                        ->default(false),
-                    Toggle::make('force_complete_remerge')
-                        ->label('Force complete re-merge')
-                        ->helperText('Re-evaluate ALL existing failover relationships, not just unmerged channels.')
-                        ->default(false),
-                ])
+                ->schema($behaviorSchema)
                 ->columns(2)
                 ->columnSpanFull(),
-            Fieldset::make(__('Fallback matching for channels without IDs'))
+        ];
+
+        if (! $isVod) {
+            $schema[] = Fieldset::make(__('Fallback matching for channels without IDs'))
                 ->schema([
                     Toggle::make('fallback_name_matching_enabled')
                         ->label(__('Enable name or alias fallback'))
@@ -990,113 +1017,127 @@ class PlaylistService
                         ->visible(fn (Get $get): bool => (bool) $get('fallback_name_matching_enabled')),
                 ])
                 ->columns(2)
-                ->columnSpanFull(),
-            Fieldset::make('Advanced Priority Scoring (optional)')
-                ->schema([
-                    Select::make('prefer_codec')
-                        ->label('Preferred Codec')
-                        ->options([
-                            'hevc' => 'HEVC / H.265 (smaller file size)',
-                            'h264' => 'H.264 / AVC (better compatibility)',
-                        ])
-                        ->placeholder('No preference')
-                        ->helperText('Prioritize channels with a specific video codec.'),
-                    TagsInput::make('priority_keywords')
-                        ->label('Priority Keywords')
-                        ->placeholder('Add keyword...')
-                        ->helperText('Channels with these keywords in their name will be prioritized (e.g., "RAW", "LOCAL", "HD").')
-                        ->splitKeys(['Tab', 'Return']),
-                    Repeater::make('group_priorities')
-                        ->label('Group Priority Weights')
-                        ->helperText('Assign priority weights to specific groups. Higher weight = more preferred as master. Leave empty for default behavior.')
-                        ->columnSpanFull()
-                        ->columns(2)
-                        ->schema([
-                            Select::make('group_id')
-                                ->label('Group')
-                                ->options(fn () => Group::query()
-                                    ->with(['playlist'])
-                                    ->where(['user_id' => auth()->id(), 'type' => 'live'])
-                                    ->get(['name', 'id', 'playlist_id'])
-                                    ->transform(fn ($group) => [
-                                        'id' => $group->id,
-                                        'name' => $group->name.' ('.$group->playlist->name.')',
-                                    ])->pluck('name', 'id')
-                                )
-                                ->searchable()
-                                ->required(),
-                            TextInput::make('weight')
-                                ->label('Weight')
-                                ->numeric()
-                                ->default(100)
-                                ->minValue(1)
-                                ->maxValue(1000)
-                                ->helperText('1-1000, higher = more preferred')
-                                ->required(),
-                        ])
-                        ->reorderable()
-                        ->reorderableWithButtons()
-                        ->addActionLabel('Add group priority')
-                        ->defaultItems(0)
-                        ->dehydrateStateUsing(function ($state) {
-                            if (is_array($state) && ! empty($state)) {
-                                $formatted = [];
-                                foreach ($state as $item) {
-                                    if (is_array($item) && isset($item['weight'])) {
-                                        $groupId = $item['group_id'] ?? null;
-                                        if (! $groupId) {
-                                            continue;
-                                        }
-                                        $formatted[] = [
-                                            'group_id' => $groupId,
-                                            'weight' => (int) $item['weight'],
-                                        ];
-                                    }
-                                }
+                ->columnSpanFull();
+        }
 
-                                return $formatted;
-                            }
+        $priorityAttributeOptions = $isVod
+            ? [
+                'playlist_priority' => '📋 Playlist Priority (from failover list order)',
+                'codec' => '🎬 Codec Preference (HEVC/H264)',
+                'keyword_match' => '🏷️ Keyword Match',
+            ]
+            : [
+                'playlist_priority' => '📋 Playlist Priority (from failover list order)',
+                'group_priority' => '📁 Group Priority (from weights above)',
+                'catchup_support' => '⏪ Catch-up/Replay Support',
+                'resolution' => '📺 Resolution (requires stream analysis)',
+                'codec' => '🎬 Codec Preference (HEVC/H264)',
+                'keyword_match' => '🏷️ Keyword Match',
+            ];
 
-                            return [];
-                        }),
-                    Repeater::make('priority_attributes')
-                        ->label('Priority Order')
-                        ->helperText('Drag to reorder priority attributes. First attribute has highest priority. Leave empty for default order.')
-                        ->columnSpanFull()
-                        ->simple(
-                            Select::make('attribute')
-                                ->options([
-                                    'playlist_priority' => '📋 Playlist Priority (from failover list order)',
-                                    'group_priority' => '📁 Group Priority (from weights above)',
-                                    'catchup_support' => '⏪ Catch-up/Replay Support',
-                                    'resolution' => '📺 Resolution (requires stream analysis)',
-                                    'codec' => '🎬 Codec Preference (HEVC/H264)',
-                                    'keyword_match' => '🏷️ Keyword Match',
-                                ])
-                                ->required()
-                        )
-                        ->reorderable()
-                        ->reorderableWithDragAndDrop()
-                        ->distinct()
-                        ->addActionLabel('Add priority attribute')
-                        ->defaultItems(0)
-                        ->afterStateHydrated(function ($component, $state) {
-                            if (is_array($state) && ! empty($state)) {
-                                $formatted = [];
-                                foreach ($state as $item) {
-                                    if (is_string($item)) {
-                                        $formatted[] = ['attribute' => $item];
-                                    } elseif (is_array($item) && isset($item['attribute'])) {
-                                        $formatted[] = $item;
-                                    }
-                                }
-                                $component->state($formatted);
-                            }
-                        }),
+        $advancedSchema = [
+            Select::make('prefer_codec')
+                ->label('Preferred Codec')
+                ->options([
+                    'hevc' => 'HEVC / H.265 (smaller file size)',
+                    'h264' => 'H.264 / AVC (better compatibility)',
                 ])
+                ->placeholder('No preference')
+                ->helperText('Prioritize channels with a specific video codec.'),
+            TagsInput::make('priority_keywords')
+                ->label('Priority Keywords')
+                ->placeholder('Add keyword...')
+                ->helperText('Channels with these keywords in their name will be prioritized (e.g., "RAW", "LOCAL", "HD").')
+                ->splitKeys(['Tab', 'Return']),
+            Repeater::make('group_priorities')
+                ->label('Group Priority Weights')
+                ->helperText('Assign priority weights to specific groups. Higher weight = more preferred as master. Leave empty for default behavior.')
+                ->visible(! $isVod)
+                ->columnSpanFull()
                 ->columns(2)
-                ->columnSpanFull(),
+                ->schema([
+                    Select::make('group_id')
+                        ->label('Group')
+                        ->options(fn () => Group::query()
+                            ->with(['playlist'])
+                            ->where(['user_id' => auth()->id(), 'type' => 'live'])
+                            ->get(['name', 'id', 'playlist_id'])
+                            ->transform(fn ($group) => [
+                                'id' => $group->id,
+                                'name' => $group->name.' ('.$group->playlist->name.')',
+                            ])->pluck('name', 'id')
+                        )
+                        ->searchable()
+                        ->required(),
+                    TextInput::make('weight')
+                        ->label('Weight')
+                        ->numeric()
+                        ->default(100)
+                        ->minValue(1)
+                        ->maxValue(1000)
+                        ->helperText('1-1000, higher = more preferred')
+                        ->required(),
+                ])
+                ->reorderable()
+                ->reorderableWithButtons()
+                ->addActionLabel('Add group priority')
+                ->defaultItems(0)
+                ->dehydrateStateUsing(function ($state) {
+                    if (is_array($state) && ! empty($state)) {
+                        $formatted = [];
+                        foreach ($state as $item) {
+                            if (is_array($item) && isset($item['weight'])) {
+                                $groupId = $item['group_id'] ?? null;
+                                if (! $groupId) {
+                                    continue;
+                                }
+                                $formatted[] = [
+                                    'group_id' => $groupId,
+                                    'weight' => (int) $item['weight'],
+                                ];
+                            }
+                        }
+
+                        return $formatted;
+                    }
+
+                    return [];
+                }),
+            Repeater::make('priority_attributes')
+                ->label('Priority Order')
+                ->helperText('Drag to reorder priority attributes. First attribute has highest priority. Leave empty for default order.')
+                ->columnSpanFull()
+                ->simple(
+                    Select::make('attribute')
+                        ->options($priorityAttributeOptions)
+                        ->required()
+                )
+                ->reorderable()
+                ->reorderableWithDragAndDrop()
+                ->distinct()
+                ->addActionLabel('Add priority attribute')
+                ->defaultItems(0)
+                ->afterStateHydrated(function ($component, $state) {
+                    if (is_array($state) && ! empty($state)) {
+                        $formatted = [];
+                        foreach ($state as $item) {
+                            if (is_string($item)) {
+                                $formatted[] = ['attribute' => $item];
+                            } elseif (is_array($item) && isset($item['attribute'])) {
+                                $formatted[] = $item;
+                            }
+                        }
+                        $component->state($formatted);
+                    }
+                }),
         ];
+
+        $schema[] = Fieldset::make('Advanced Priority Scoring (optional)')
+            ->schema($advancedSchema)
+            ->columns(2)
+            ->columnSpanFull();
+
+        return $schema;
     }
 
     /**
@@ -1147,11 +1188,11 @@ class PlaylistService
      *
      * @param  bool  $groupScoped  Whether this action operates on a single group (receives $record as Group)
      */
-    public static function getMergeAction(bool $groupScoped = false): Action
+    public static function getMergeAction(bool $groupScoped = false, string $contentType = 'live'): Action
     {
         $action = Action::make('merge')
             ->label('Merge Same ID')
-            ->schema(self::getMergeFormSchema())
+            ->schema(self::getMergeFormSchema($contentType))
             ->requiresConfirmation()
             ->icon('heroicon-o-arrows-pointing-in')
             ->modalIcon('heroicon-o-arrows-pointing-in')
@@ -1161,7 +1202,7 @@ class PlaylistService
         if ($groupScoped) {
             $action
                 ->modalDescription('Merge all channels with the same ID in this group into a single channel with failover.')
-                ->action(function (Group $record, array $data): void {
+                ->action(function (Group $record, array $data) use ($contentType): void {
                     app('Illuminate\Contracts\Bus\Dispatcher')
                         ->dispatch(new MergeChannels(
                             user: auth()->user(),
@@ -1174,12 +1215,14 @@ class PlaylistService
                             groupId: $record->id,
                             weightedConfig: self::buildMergeWeightedConfig($data),
                             fallbackMergeConfig: self::buildMergeFallbackConfig($data),
+                            contentType: $contentType,
+                            mergeKey: $data['merge_key'] ?? 'stream_id',
                         ));
                 });
         } else {
             $action
                 ->modalDescription('Merge all channels with the same ID into a single channel with failover.')
-                ->action(function (array $data): void {
+                ->action(function (array $data) use ($contentType): void {
                     app('Illuminate\Contracts\Bus\Dispatcher')
                         ->dispatch(new MergeChannels(
                             user: auth()->user(),
@@ -1191,6 +1234,8 @@ class PlaylistService
                             preferCatchupAsPrimary: $data['prefer_catchup_as_primary'] ?? false,
                             weightedConfig: self::buildMergeWeightedConfig($data),
                             fallbackMergeConfig: self::buildMergeFallbackConfig($data),
+                            contentType: $contentType,
+                            mergeKey: $data['merge_key'] ?? 'stream_id',
                         ));
                 });
         }

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -912,7 +912,7 @@ class PlaylistService
                 ->helperText('Select a playlist to prioritize as the master during the merge process.'),
             Repeater::make('failover_playlists')
                 ->label('')
-                ->helperText('Select one or more playlists use as failover source(s).')
+                ->helperText('Select one or more playlists to use as failover source(s).')
                 ->reorderable()
                 ->reorderableWithButtons()
                 ->orderColumn('sort')
@@ -1229,7 +1229,7 @@ class PlaylistService
         } else {
             $action
                 ->modalDescription($contentType === 'series'
-                    ? 'Merge all episodes with the same TMDB ID across playlists into a single episode with failover.'
+                    ? 'Merge all episodes with the same TMDB ID across playlists into a single episode with failover. Episodes without a TMDB ID are matched by series TMDB ID, season, and episode number.'
                     : 'Merge all channels with the same ID into a single channel with failover.'
                 )
                 ->action(function (array $data) use ($contentType): void {

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Jobs\AddGroupsToCustomPlaylist;
 use App\Jobs\MergeChannels;
+use App\Jobs\MergeEpisodes;
 use App\Jobs\UnmergeChannels;
 use App\Models\CustomPlaylist;
 use App\Models\Group;
@@ -898,6 +899,7 @@ class PlaylistService
     public static function getMergeFormSchema(string $contentType = 'live'): array
     {
         $isVod = $contentType === 'vod';
+        $isSeries = $contentType === 'series';
 
         $sourceSchema = [
             Select::make('playlist_id')
@@ -952,7 +954,7 @@ class PlaylistService
                 ->default(false),
         ];
 
-        if (! $isVod) {
+        if (! $isVod && ! $isSeries) {
             array_splice($behaviorSchema, 0, 0, [
                 Toggle::make('by_resolution')
                     ->label('Order by Resolution')
@@ -981,7 +983,7 @@ class PlaylistService
                 ->columnSpanFull(),
         ];
 
-        if (! $isVod) {
+        if (! $isVod && ! $isSeries) {
             $schema[] = Fieldset::make(__('Fallback matching for channels without IDs'))
                 ->schema([
                     Toggle::make('fallback_name_matching_enabled')
@@ -1132,10 +1134,12 @@ class PlaylistService
                 }),
         ];
 
-        $schema[] = Fieldset::make('Advanced Priority Scoring (optional)')
-            ->schema($advancedSchema)
-            ->columns(2)
-            ->columnSpanFull();
+        if (! $isSeries) {
+            $schema[] = Fieldset::make('Advanced Priority Scoring (optional)')
+                ->schema($advancedSchema)
+                ->columns(2)
+                ->columnSpanFull();
+        }
 
         return $schema;
     }
@@ -1223,8 +1227,15 @@ class PlaylistService
             $action
                 ->modalDescription('Merge all channels with the same ID into a single channel with failover.')
                 ->action(function (array $data) use ($contentType): void {
-                    app('Illuminate\Contracts\Bus\Dispatcher')
-                        ->dispatch(new MergeChannels(
+                    $job = $contentType === 'series'
+                        ? new MergeEpisodes(
+                            user: auth()->user(),
+                            playlists: collect($data['failover_playlists']),
+                            playlistId: $data['playlist_id'],
+                            deactivateFailoverEpisodes: $data['deactivate_failover_channels'] ?? false,
+                            forceCompleteRemerge: $data['force_complete_remerge'] ?? false,
+                        )
+                        : new MergeChannels(
                             user: auth()->user(),
                             playlists: collect($data['failover_playlists']),
                             playlistId: $data['playlist_id'],
@@ -1236,7 +1247,9 @@ class PlaylistService
                             fallbackMergeConfig: self::buildMergeFallbackConfig($data),
                             contentType: $contentType,
                             mergeKey: $data['merge_key'] ?? 'stream_id',
-                        ));
+                        );
+
+                    app('Illuminate\Contracts\Bus\Dispatcher')->dispatch($job);
                 });
         }
 

--- a/database/migrations/2026_06_07_000000_create_episode_failovers_table.php
+++ b/database/migrations/2026_06_07_000000_create_episode_failovers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::disableForeignKeyConstraints();
+
+        Schema::create('episode_failovers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('episode_id')->constrained()->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('episode_failover_id')->constrained('episodes')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->unsignedInteger('sort')->nullable()->default(0);
+            $table->jsonb('metadata')->nullable();
+            $table->timestamps();
+
+            $table->unique(['episode_id', 'episode_failover_id']);
+        });
+
+        Schema::enableForeignKeyConstraints();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('episode_failovers');
+    }
+};

--- a/tests/Feature/DirectStreamPoolReuseTest.php
+++ b/tests/Feature/DirectStreamPoolReuseTest.php
@@ -397,7 +397,7 @@ test('getEpisodeUrl uses first available episode failover when primary playlist 
             && ($metadata['id'] ?? null) === $failover->id
             && ($metadata['episode_id'] ?? null) === (string) $failover->id
             && ($metadata['playlist_uuid'] ?? null) === $playlistB->uuid
-            && ($metadata['original_channel_id'] ?? null) === $master->id
+            && ($metadata['original_episode_id'] ?? null) === $master->id
             && ($metadata['original_playlist_uuid'] ?? null) === $playlistA->uuid
             && ($metadata['is_failover'] ?? null) === true;
     });

--- a/tests/Feature/DirectStreamPoolReuseTest.php
+++ b/tests/Feature/DirectStreamPoolReuseTest.php
@@ -18,8 +18,11 @@
  */
 
 use App\Models\Channel;
+use App\Models\Episode;
+use App\Models\EpisodeFailover;
 use App\Models\Playlist;
 use App\Models\PlaylistProfile;
+use App\Models\Series;
 use App\Models\User;
 use App\Services\M3uProxyService;
 use App\Services\ProfileService;
@@ -324,4 +327,78 @@ test('getChannelUrl clears stale channel stream key when proxy has no matching n
 
     // After stale key cleared, a new stream is created and its URL is returned
     expect($url)->toContain('stream/new-stream-xyz');
+});
+
+test('getEpisodeUrl uses first available episode failover when primary playlist is at capacity', function () {
+    $playlistA = Playlist::factory()->for($this->user)->create([
+        'profiles_enabled' => false,
+        'enable_proxy' => true,
+        'available_streams' => 1,
+        'xtream' => false,
+    ]);
+    $playlistB = Playlist::factory()->for($this->user)->create([
+        'profiles_enabled' => false,
+        'enable_proxy' => true,
+        'available_streams' => 2,
+        'xtream' => false,
+    ]);
+
+    $seriesA = Series::factory()->for($this->user)->for($playlistA)->create();
+    $seriesB = Series::factory()->for($this->user)->for($playlistB)->create();
+
+    $master = Episode::factory()->for($this->user)->for($playlistA)->for($seriesA)->create([
+        'url' => 'http://provider-a.example/series/user/pass/1001.mkv',
+        'container_extension' => 'mkv',
+    ]);
+    $failover = Episode::factory()->for($this->user)->for($playlistB)->for($seriesB)->create([
+        'url' => 'http://provider-b.example/series/user/pass/2001.mkv',
+        'container_extension' => 'mkv',
+    ]);
+
+    EpisodeFailover::create([
+        'user_id' => $this->user->id,
+        'episode_id' => $master->id,
+        'episode_failover_id' => $failover->id,
+        'sort' => 1,
+    ]);
+
+    Http::fake(function ($request) use ($playlistA) {
+        if (str_contains($request->url(), '/streams/by-metadata')) {
+            $value = $request['value'] ?? null;
+
+            return Http::response([
+                'matching_streams' => [],
+                'total_matching' => $value === $playlistA->uuid ? 1 : 0,
+                'total_clients' => $value === $playlistA->uuid ? 1 : 0,
+            ]);
+        }
+
+        if ($request->method() === 'POST' && str_ends_with($request->url(), '/streams')) {
+            return Http::response(['stream_id' => 'episode-failover-stream']);
+        }
+
+        return Http::response([], 404);
+    });
+
+    $service = app(M3uProxyService::class);
+    $url = $service->getEpisodeUrl($playlistA, $master);
+
+    expect($url)->toContain('stream/episode-failover-stream');
+
+    Http::assertSent(function ($request) use ($playlistA, $playlistB, $master, $failover) {
+        if ($request->method() !== 'POST' || ! str_ends_with($request->url(), '/streams')) {
+            return false;
+        }
+
+        $body = $request->data();
+        $metadata = $body['metadata'] ?? [];
+
+        return ($body['url'] ?? null) === 'http://provider-b.example/series/user/pass/2001.mkv'
+            && ($metadata['id'] ?? null) === $failover->id
+            && ($metadata['episode_id'] ?? null) === (string) $failover->id
+            && ($metadata['playlist_uuid'] ?? null) === $playlistB->uuid
+            && ($metadata['original_channel_id'] ?? null) === $master->id
+            && ($metadata['original_playlist_uuid'] ?? null) === $playlistA->uuid
+            && ($metadata['is_failover'] ?? null) === true;
+    });
 });

--- a/tests/Unit/MergeChannelsTest.php
+++ b/tests/Unit/MergeChannelsTest.php
@@ -9,49 +9,157 @@ use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Notification;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class MergeChannelsTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Notification::fake();
+    }
+
+    private function runMergeChannels(...$arguments): void
+    {
+        Channel::withoutEvents(fn () => (new MergeChannels(...$arguments))->handle());
+    }
+
+    #[Test]
     public function it_does_not_merge_channels_with_empty_stream_ids()
     {
         // Create a user and playlist
         $user = User::factory()->create();
-        $playlist = Playlist::factory()->for($user)->create();
+        $playlist = Playlist::factory()->for($user)->createQuietly();
 
         // Create channels for the playlist with same stream_id
-        $channel1 = Channel::factory()->create(['stream_id' => 'stream1', 'user_id' => $user->id, 'playlist_id' => $playlist->id]);
-        $channel2 = Channel::factory()->create(['stream_id' => 'stream1', 'user_id' => $user->id, 'playlist_id' => $playlist->id]);
+        $channel1 = Channel::factory()->create(['stream_id' => 'stream1', 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null]);
+        $channel2 = Channel::factory()->create(['stream_id' => 'stream1', 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null]);
         // Channels with empty stream_ids should not be merged
-        $channel3 = Channel::factory()->create(['stream_id' => '', 'user_id' => $user->id, 'playlist_id' => $playlist->id]);
-        $channel4 = Channel::factory()->create(['stream_id' => null, 'user_id' => $user->id, 'playlist_id' => $playlist->id]);
+        $channel3 = Channel::factory()->create(['stream_id' => '', 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null]);
+        $channel4 = Channel::factory()->create(['stream_id' => null, 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null]);
 
         // Create playlists collection as expected by MergeChannels constructor
         $playlists = collect([['playlist_failover_id' => $playlist->id]]);
 
         // Run the job synchronously (dispatchSync instead of dispatch)
-        MergeChannels::dispatchSync($user, $playlists, $playlist->id);
+        $this->runMergeChannels($user, $playlists, $playlist->id);
 
         // Assert that only the channels with the same non-empty stream_id were merged
         // channel1 and channel2 have same stream_id, so there should be 1 failover entry
         $this->assertDatabaseCount('channel_failovers', 1);
     }
 
-    /** @test */
+    #[Test]
+    public function it_merges_vod_channels_by_tmdb_id_when_requested()
+    {
+        $user = User::factory()->create();
+        $playlist1 = Playlist::factory()->for($user)->createQuietly();
+        $playlist2 = Playlist::factory()->for($user)->createQuietly();
+
+        $master = Channel::factory()->create([
+            'is_vod' => true,
+            'tmdb_id' => 12345,
+            'stream_id' => 'provider-a-100',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist1->id,
+            'group_id' => null,
+        ]);
+
+        $failover = Channel::factory()->create([
+            'is_vod' => true,
+            'tmdb_id' => 12345,
+            'stream_id' => 'provider-b-999',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'group_id' => null,
+        ]);
+
+        $unrelatedLive = Channel::factory()->create([
+            'is_vod' => false,
+            'tmdb_id' => 12345,
+            'stream_id' => 'live-provider-999',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'group_id' => null,
+        ]);
+
+        $this->runMergeChannels(
+            user: $user,
+            playlists: collect([
+                ['playlist_failover_id' => $playlist1->id],
+                ['playlist_failover_id' => $playlist2->id],
+            ]),
+            playlistId: $playlist1->id,
+            contentType: 'vod',
+            mergeKey: 'tmdb_id',
+        );
+
+        $this->assertDatabaseHas('channel_failovers', [
+            'channel_id' => $master->id,
+            'channel_failover_id' => $failover->id,
+        ]);
+        $this->assertDatabaseMissing('channel_failovers', [
+            'channel_id' => $master->id,
+            'channel_failover_id' => $unrelatedLive->id,
+        ]);
+    }
+
+    #[Test]
+    public function vod_merge_keeps_stream_id_matching_by_default()
+    {
+        $user = User::factory()->create();
+        $playlist1 = Playlist::factory()->for($user)->createQuietly();
+        $playlist2 = Playlist::factory()->for($user)->createQuietly();
+
+        Channel::factory()->create([
+            'is_vod' => true,
+            'tmdb_id' => 12345,
+            'stream_id' => 'provider-a-100',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist1->id,
+            'group_id' => null,
+        ]);
+
+        Channel::factory()->create([
+            'is_vod' => true,
+            'tmdb_id' => 12345,
+            'stream_id' => 'provider-b-999',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'group_id' => null,
+        ]);
+
+        $this->runMergeChannels(
+            user: $user,
+            playlists: collect([
+                ['playlist_failover_id' => $playlist1->id],
+                ['playlist_failover_id' => $playlist2->id],
+            ]),
+            playlistId: $playlist1->id,
+            contentType: 'vod',
+        );
+
+        $this->assertDatabaseCount('channel_failovers', 0);
+    }
+
+    #[Test]
     public function promoted_master_is_enabled_and_old_master_is_deactivated_when_failovers_are_deactivated()
     {
         $user = User::factory()->create();
-        $playlist1 = Playlist::factory()->for($user)->create();
-        $playlist2 = Playlist::factory()->for($user)->create();
+        $playlist1 = Playlist::factory()->for($user)->createQuietly();
+        $playlist2 = Playlist::factory()->for($user)->createQuietly();
 
         // Create channels with same stream id
         $oldMaster = Channel::factory()->create([
             'stream_id' => 'streamX',
             'user_id' => $user->id,
             'playlist_id' => $playlist1->id,
+            'group_id' => null,
             'enabled' => true,
         ]);
 
@@ -59,6 +167,7 @@ class MergeChannelsTest extends TestCase
             'stream_id' => 'streamX',
             'user_id' => $user->id,
             'playlist_id' => $playlist2->id,
+            'group_id' => null,
             'enabled' => false,
         ]);
 
@@ -66,6 +175,7 @@ class MergeChannelsTest extends TestCase
             'stream_id' => 'streamX',
             'user_id' => $user->id,
             'playlist_id' => $playlist1->id,
+            'group_id' => null,
             'enabled' => true,
         ]);
 
@@ -82,7 +192,7 @@ class MergeChannelsTest extends TestCase
         ]);
 
         // Run job preferring playlist2 as primary and deactivating failovers
-        MergeChannels::dispatchSync($user, $playlists, $playlist2->id, false, true);
+        $this->runMergeChannels($user, $playlists, $playlist2->id, false, true);
 
         // Reload models from DB
         $oldMaster->refresh();

--- a/tests/Unit/MergeEpisodesTest.php
+++ b/tests/Unit/MergeEpisodesTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Events\PlaylistCreated;
+use App\Events\PlaylistDeleted;
+use App\Events\PlaylistUpdated;
+use App\Jobs\MergeEpisodes;
+use App\Models\Episode;
+use App\Models\EpisodeFailover;
+use App\Models\Playlist;
+use App\Models\Series;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MergeEpisodesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Event::fake([
+            PlaylistCreated::class,
+            PlaylistUpdated::class,
+            PlaylistDeleted::class,
+        ]);
+        Notification::fake();
+    }
+
+    private function runMergeEpisodes(...$arguments): void
+    {
+        Episode::withoutEvents(fn () => (new MergeEpisodes(...$arguments))->handle());
+    }
+
+    #[Test]
+    public function it_merges_episodes_by_episode_tmdb_id_when_present(): void
+    {
+        $user = User::factory()->create();
+        $playlist1 = Playlist::factory()->for($user)->createQuietly();
+        $playlist2 = Playlist::factory()->for($user)->createQuietly();
+
+        $seriesA = Series::factory()->for($user)->createQuietly([
+            'playlist_id' => $playlist1->id,
+            'tmdb_id' => 111,
+        ]);
+        $seriesB = Series::factory()->for($user)->createQuietly([
+            'playlist_id' => $playlist2->id,
+            'tmdb_id' => 222,
+        ]);
+
+        $master = Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist1->id,
+            'series_id' => $seriesA->id,
+            'tmdb_id' => 9001,
+            'season' => 1,
+            'episode_num' => 1,
+        ]);
+        $failover = Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'series_id' => $seriesB->id,
+            'tmdb_id' => 9001,
+            'season' => 9,
+            'episode_num' => 9,
+        ]);
+
+        $this->runMergeEpisodes(
+            user: $user,
+            playlists: collect([
+                ['playlist_failover_id' => $playlist1->id],
+                ['playlist_failover_id' => $playlist2->id],
+            ]),
+            playlistId: $playlist1->id,
+        );
+
+        $this->assertDatabaseHas('episode_failovers', [
+            'episode_id' => $master->id,
+            'episode_failover_id' => $failover->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_falls_back_to_series_tmdb_id_season_and_episode_number(): void
+    {
+        $user = User::factory()->create();
+        $playlist1 = Playlist::factory()->for($user)->createQuietly();
+        $playlist2 = Playlist::factory()->for($user)->createQuietly();
+
+        $seriesA = Series::factory()->for($user)->createQuietly([
+            'playlist_id' => $playlist1->id,
+            'tmdb_id' => 333,
+        ]);
+        $seriesB = Series::factory()->for($user)->createQuietly([
+            'playlist_id' => $playlist2->id,
+            'tmdb_id' => 333,
+        ]);
+
+        $master = Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist1->id,
+            'series_id' => $seriesA->id,
+            'tmdb_id' => null,
+            'season' => 1,
+            'episode_num' => 1,
+        ]);
+        $failover = Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'series_id' => $seriesB->id,
+            'tmdb_id' => null,
+            'season' => 1,
+            'episode_num' => 1,
+        ]);
+        $differentEpisode = Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'series_id' => $seriesB->id,
+            'tmdb_id' => null,
+            'season' => 1,
+            'episode_num' => 2,
+        ]);
+
+        $this->runMergeEpisodes(
+            user: $user,
+            playlists: collect([
+                ['playlist_failover_id' => $playlist1->id],
+                ['playlist_failover_id' => $playlist2->id],
+            ]),
+            playlistId: $playlist1->id,
+        );
+
+        $this->assertDatabaseHas('episode_failovers', [
+            'episode_id' => $master->id,
+            'episode_failover_id' => $failover->id,
+        ]);
+        $this->assertDatabaseMissing('episode_failovers', [
+            'episode_id' => $master->id,
+            'episode_failover_id' => $differentEpisode->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_does_not_merge_by_series_tmdb_id_alone(): void
+    {
+        $user = User::factory()->create();
+        $playlist1 = Playlist::factory()->for($user)->createQuietly();
+        $playlist2 = Playlist::factory()->for($user)->createQuietly();
+
+        $seriesA = Series::factory()->for($user)->createQuietly([
+            'playlist_id' => $playlist1->id,
+            'tmdb_id' => 444,
+        ]);
+        $seriesB = Series::factory()->for($user)->createQuietly([
+            'playlist_id' => $playlist2->id,
+            'tmdb_id' => 444,
+        ]);
+
+        Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist1->id,
+            'series_id' => $seriesA->id,
+            'tmdb_id' => null,
+            'season' => 1,
+            'episode_num' => 1,
+        ]);
+        Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'series_id' => $seriesB->id,
+            'tmdb_id' => null,
+            'season' => 1,
+            'episode_num' => 2,
+        ]);
+
+        $this->runMergeEpisodes(
+            user: $user,
+            playlists: collect([
+                ['playlist_failover_id' => $playlist1->id],
+                ['playlist_failover_id' => $playlist2->id],
+            ]),
+            playlistId: $playlist1->id,
+        );
+
+        $this->assertDatabaseCount('episode_failovers', 0);
+    }
+
+    #[Test]
+    public function episode_model_exposes_ordered_failover_episodes(): void
+    {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->createQuietly();
+        $series = Series::factory()->for($user)->createQuietly([
+            'playlist_id' => $playlist->id,
+            'tmdb_id' => 555,
+        ]);
+
+        $master = Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'series_id' => $series->id,
+        ]);
+        $late = Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'series_id' => $series->id,
+        ]);
+        $early = Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'series_id' => $series->id,
+        ]);
+
+        EpisodeFailover::create([
+            'user_id' => $user->id,
+            'episode_id' => $master->id,
+            'episode_failover_id' => $late->id,
+            'sort' => 2,
+        ]);
+        EpisodeFailover::create([
+            'user_id' => $user->id,
+            'episode_id' => $master->id,
+            'episode_failover_id' => $early->id,
+            'sort' => 1,
+        ]);
+
+        $this->assertSame([$early->id, $late->id], $master->failoverEpisodes()->pluck('episodes.id')->all());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an opt-in TMDB merge key for VOD failover merging, while keeping stream ID matching as the default.
- Adds episode-level failover support for series, backed by a new `episode_failovers` table and model.
- Merges duplicate series episodes by episode TMDB ID, or by series TMDB ID plus season and episode number when the episode TMDB ID is missing.
- Updates episode playback so `getEpisodeUrl()` can select the first failover episode whose playlist still has capacity.

## Test Plan
- `docker compose -f docker-compose.dev.yml --profile test run --rm --build m3u-editor-dev-test tests/Feature/RegexMergeTest.php tests/Unit/MergeChannelsTest.php`
- `docker compose -f docker-compose.dev.yml --profile test run --rm --build m3u-editor-dev-test tests/Feature/DirectStreamPoolReuseTest.php --filter 'getEpisodeUrl uses first available episode failover when primary playlist is at capacity'`
- `docker run --rm -v "$PWD":/var/www/html -w /var/www/html --entrypoint /bin/bash m3u-editor-m3u-editor-dev-test -lc 'php -l app/Jobs/MergeEpisodes.php && php -l app/Models/EpisodeFailover.php && php -l app/Models/Episode.php && php -l app/Services/M3uProxyService.php && php -l app/Services/PlaylistService.php && php -l app/Filament/Resources/Series/Pages/ListSeries.php && php -l tests/Unit/MergeEpisodesTest.php && php -l tests/Feature/DirectStreamPoolReuseTest.php && vendor/bin/pint --test app/Jobs/MergeEpisodes.php app/Models/EpisodeFailover.php app/Models/Episode.php app/Services/M3uProxyService.php app/Services/PlaylistService.php app/Filament/Resources/Series/Pages/ListSeries.php tests/Unit/MergeEpisodesTest.php tests/Feature/DirectStreamPoolReuseTest.php'`
- `docker compose -f docker-compose.dev.yml --profile test run --rm m3u-editor-dev-test tests/Feature/DirectStreamPoolReuseTest.php tests/Unit/MergeEpisodesTest.php tests/Unit/MergeChannelsTest.php`
- `git diff --check`
