### PR TITLE
fix: harden sync against malformed UTF-8 JSON

### DIFF
--- a/app/Jobs/ProcessM3uImportSeriesChunk.php
+++ b/app/Jobs/ProcessM3uImportSeriesChunk.php
@@ -6,6 +6,7 @@ use App\Enums\Status;
 use App\Models\Category;
 use App\Models\Playlist;
 use App\Models\Series;
+use App\Services\Utf8StringService;
 use App\Traits\ProviderRequestDelay;
 use Carbon\Carbon;
 use Filament\Notifications\Notification;
@@ -109,15 +110,45 @@ class ProcessM3uImportSeriesChunk implements ShouldQueue
             return; // skip this category if there's an error
         }
 
+        $seriesStreamsBody = $seriesStreamsResponse->body();
+
         // Guard against providers that return a non-JSON body (e.g. a PNG error image)
         // with a 200 OK status. JsonMachine will throw a SyntaxError on the first byte
         // if the body is not JSON, which would crash the entire import chain.
-        $firstChar = ltrim($seriesStreamsResponse->body())[0] ?? '';
+        $firstChar = ltrim($seriesStreamsBody)[0] ?? '';
         if ($firstChar !== '[' && $firstChar !== '{') {
             Log::warning('ProcessM3uImportSeriesChunk: Non-JSON response for series category, skipping', [
                 'source_category_id' => $sourceCategoryId,
+                'source_category_name' => $sourceCategoryName,
                 'playlist_id' => $playlistId,
-                'content_preview' => substr($seriesStreamsResponse->body(), 0, 12),
+                'phase' => 'series_category_streams',
+                'content_preview' => Utf8StringService::preview($seriesStreamsBody, 12),
+            ]);
+
+            return;
+        }
+
+        if (! Utf8StringService::isValid($seriesStreamsBody)) {
+            Log::warning('ProcessM3uImportSeriesChunk: Malformed JSON response for series category, skipping', [
+                'source_category_id' => $sourceCategoryId,
+                'source_category_name' => $sourceCategoryName,
+                'playlist_id' => $playlistId,
+                'phase' => 'series_category_streams',
+                'error' => 'Response body is not valid UTF-8.',
+                'content_preview' => Utf8StringService::preview($seriesStreamsBody),
+            ]);
+
+            return;
+        }
+
+        if (! json_validate($seriesStreamsBody)) {
+            Log::warning('ProcessM3uImportSeriesChunk: Malformed JSON response for series category, skipping', [
+                'source_category_id' => $sourceCategoryId,
+                'source_category_name' => $sourceCategoryName,
+                'playlist_id' => $playlistId,
+                'phase' => 'series_category_streams',
+                'error' => json_last_error_msg(),
+                'content_preview' => Utf8StringService::preview($seriesStreamsBody),
             ]);
 
             return;
@@ -125,7 +156,7 @@ class ProcessM3uImportSeriesChunk implements ShouldQueue
 
         // Single-pass stream: pluck existing rows once for O(1) lookup, then iterate
         // the JSON stream and immediately route each item to an update or a rolling
-        // insert buffer — never accumulating more than 100 rows at a time.
+        // insert buffer, never accumulating more than 100 rows at a time.
         //
         // Keyed by source_series_id → last_modified. Use has() (not get()) for the
         // existence check so that series whose last_modified is NULL are not mistakenly
@@ -137,7 +168,7 @@ class ProcessM3uImportSeriesChunk implements ShouldQueue
 
         $insertBuffer = [];
 
-        foreach (Items::fromString($seriesStreamsResponse->body()) as $item) {
+        foreach (Items::fromString($seriesStreamsBody) as $item) {
             $itemName = trim((string) ($item->name ?? $item->title ?? ''));
             if ($itemName === '') {
                 continue;
@@ -148,7 +179,7 @@ class ProcessM3uImportSeriesChunk implements ShouldQueue
                 : null;
 
             if ($existingSeriesIds->has($item->series_id)) {
-                // Already in DB — only update last_modified if it changed
+                // Already in DB, only update last_modified if it changed
                 $storedModified = $existingSeriesIds->get($item->series_id);
                 if ($lastModified && $lastModified !== $storedModified) {
                     $playlist->series()
@@ -241,7 +272,7 @@ class ProcessM3uImportSeriesChunk implements ShouldQueue
         } catch (QueryException $e) {
             // SQLSTATE 23503 = foreign_key_violation (PostgreSQL).
             // Occurs when a concurrent sync's seriesCleanup deletes the category between
-            // transaction retries. Log and skip — series are re-imported on next sync.
+            // transaction retries. Log and skip because series are re-imported on next sync.
             if ($e->getCode() === '23503') {
                 Log::warning('Series insert skipped: category deleted by concurrent sync', [
                     'source_category_id' => $sourceCategoryId,

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -352,6 +352,8 @@ class PlaylistService
 
     public static function makeFilesystemSafe(string $name, $replaceWith = ' '): string
     {
+        $name = Utf8StringService::clean($name);
+
         switch ($replaceWith) {
             case 'space':
                 $replaceWith = ' ';

--- a/app/Services/Utf8StringService.php
+++ b/app/Services/Utf8StringService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Services;
+
+class Utf8StringService
+{
+    public static function isValid(string $value): bool
+    {
+        return mb_check_encoding($value, 'UTF-8');
+    }
+
+    public static function clean(string $value): string
+    {
+        if (self::isValid($value)) {
+            return $value;
+        }
+
+        $substituteCharacter = mb_substitute_character();
+        mb_substitute_character('none');
+
+        try {
+            return mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+        } finally {
+            mb_substitute_character($substituteCharacter);
+        }
+    }
+
+    public static function preview(string $value, int $length = 120): string
+    {
+        return substr(self::clean($value), 0, $length);
+    }
+}

--- a/tests/Feature/SeriesChunkImportBatchRegressionTest.php
+++ b/tests/Feature/SeriesChunkImportBatchRegressionTest.php
@@ -20,6 +20,7 @@ use App\Models\Series;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 uses(RefreshDatabase::class);
 
@@ -43,9 +44,9 @@ function runChunk(Playlist $playlist, int $categoryId, string $categoryName, arr
 
     (new ProcessM3uImportSeriesChunk(
         payload: ['playlistId' => $playlist->id, 'categoryId' => $categoryId, 'categoryName' => $categoryName],
-        batchCount: 1,
+        batchCount: 2,
         batchNo: $batchNo,
-        index: 0,
+        index: 1,
     ))->handle();
 }
 
@@ -55,14 +56,14 @@ beforeEach(function () {
 });
 
 it('does not re-insert a series whose last_modified is NULL on subsequent syncs', function () {
-    // First sync — series inserted with no last_modified (null)
+    // First sync: series inserted with no last_modified (null)
     runChunk($this->playlist, 1, 'Drama', [
         ['series_id' => 200, 'name' => 'Null Date Show'],
     ], 'batch-1');
 
     $this->assertDatabaseCount('series', 1);
 
-    // Second sync — same item still has no last_modified
+    // Second sync: same item still has no last_modified
     runChunk($this->playlist, 1, 'Drama', [
         ['series_id' => 200, 'name' => 'Null Date Show'],
     ], 'batch-2');
@@ -99,4 +100,56 @@ it('imports new series and links them to the correct category', function () {
 
     $category = Category::first();
     expect(Series::where('category_id', $category->id)->count())->toBe(2);
+});
+
+it('skips a series category when the provider returns malformed utf-8 json', function () {
+    Log::spy();
+
+    Http::fake([
+        'xtream.test/player_api.php*' => Http::response("[{\"series_id\":400,\"name\":\"Bad \xB1 Name\"}]", 200),
+    ]);
+
+    (new ProcessM3uImportSeriesChunk(
+        payload: ['playlistId' => $this->playlist->id, 'categoryId' => 9, 'categoryName' => 'Bad Data'],
+        batchCount: 2,
+        batchNo: 'bad-utf8-batch',
+        index: 1,
+    ))->handle();
+
+    $this->assertDatabaseCount('series', 0);
+
+    Log::shouldHaveReceived('warning')
+        ->with('ProcessM3uImportSeriesChunk: Malformed JSON response for series category, skipping', Mockery::on(
+            fn (array $context): bool => $context['playlist_id'] === $this->playlist->id
+                && $context['source_category_id'] === 9
+                && $context['source_category_name'] === 'Bad Data'
+                && $context['phase'] === 'series_category_streams'
+        ))
+        ->once();
+});
+
+it('skips a series category when the provider returns malformed json', function () {
+    Log::spy();
+
+    Http::fake([
+        'xtream.test/player_api.php*' => Http::response('[}', 200),
+    ]);
+
+    (new ProcessM3uImportSeriesChunk(
+        payload: ['playlistId' => $this->playlist->id, 'categoryId' => 10, 'categoryName' => 'Malformed Data'],
+        batchCount: 2,
+        batchNo: 'bad-json-batch',
+        index: 1,
+    ))->handle();
+
+    $this->assertDatabaseCount('series', 0);
+
+    Log::shouldHaveReceived('warning')
+        ->with('ProcessM3uImportSeriesChunk: Malformed JSON response for series category, skipping', Mockery::on(
+            fn (array $context): bool => $context['playlist_id'] === $this->playlist->id
+                && $context['source_category_id'] === 10
+                && $context['source_category_name'] === 'Malformed Data'
+                && $context['phase'] === 'series_category_streams'
+        ))
+        ->once();
 });

--- a/tests/Unit/PlaylistServiceTest.php
+++ b/tests/Unit/PlaylistServiceTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Services\PlaylistService;
+
+it('strips malformed utf-8 bytes before making filesystem safe paths', function () {
+    $safe = PlaylistService::makeFilesystemSafe("Movie \xB1: Name", 'dash');
+
+    expect($safe)
+        ->toBe('Movie - Name')
+        ->and(mb_check_encoding($safe, 'UTF-8'))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Add a small UTF-8 string helper for validating, cleaning, and safely previewing provider text.
- Skip malformed series category JSON responses before JsonMachine can abort the whole sync chain.
- Clean malformed UTF-8 bytes before building filesystem-safe STRM path components.
- Add regression coverage for malformed UTF-8 provider JSON, malformed JSON provider responses, and malformed UTF-8 path input.

## Why
Issue #1164 reports sync failures after enabling STRM file sync with errors like `Malformed UTF-8 characters, possibly incorrectly encoded` wrapped as `Error processing "playlist"`. A malformed provider body or persisted malformed text should not permanently break the playlist sync state when a single series category can be skipped safely.

## Testing
- `docker compose -f docker-compose.dev.yml --profile test run --rm --entrypoint vendor/bin/pint m3u-editor-dev-test --dirty --format agent`
- `docker compose -f docker-compose.dev.yml --profile test run --rm m3u-editor-dev-test tests/Feature/SeriesChunkImportBatchRegressionTest.php tests/Unit/PlaylistServiceTest.php`

Note: the focused test run passed with 6 warnings from the existing Docker test harness missing `/var/www/html/.env`, not from the changed code.

Fixes #1164
