### PR TITLE
feat: exclude probe-disabled channels from probed filters

### DIFF
--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -426,20 +426,23 @@ class ChannelResource extends Resource implements CopilotResource
                 ->toggle()
                 ->query(function ($query) {
                     return $query->whereNotNull('stream_stats_probed_at')
-                        ->whereNotNull('stream_stats')->whereRaw("CAST(stream_stats AS TEXT) != '[]'");
+                        ->whereNotNull('stream_stats')->whereRaw("CAST(stream_stats AS TEXT) != '[]'")
+                        ->where('probe_enabled', true);
                 }),
             Filter::make('probe_failed')
                 ->label(__('Probe failed'))
                 ->toggle()
                 ->query(function ($query) {
                     return $query->whereNotNull('stream_stats_probed_at')
-                        ->where(fn ($q) => $q->whereNull('stream_stats')->orWhereRaw("CAST(stream_stats AS TEXT) = '[]'"));
+                        ->where(fn ($q) => $q->whereNull('stream_stats')->orWhereRaw("CAST(stream_stats AS TEXT) = '[]'"))
+                        ->where('probe_enabled', true);
                 }),
             Filter::make('not_probed')
                 ->label(__('Not probed'))
                 ->toggle()
                 ->query(function ($query) {
-                    return $query->whereNull('stream_stats_probed_at');
+                    return $query->whereNull('stream_stats_probed_at')
+                        ->where('probe_enabled', true);
                 }),
         ];
     }

--- a/tests/Feature/ChannelProbedFilterExcludesDisabledTest.php
+++ b/tests/Feature/ChannelProbedFilterExcludesDisabledTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Events\PlaylistCreated;
+use App\Events\PlaylistUpdated;
+use App\Filament\Resources\Channels\Pages\ListChannels;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Event::fake([PlaylistCreated::class, PlaylistUpdated::class]);
+
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    $this->playlist = Playlist::factory()->for($this->user)->createQuietly();
+});
+
+it('probed filter excludes channels where probing is disabled', function () {
+    $probedEnabled = Channel::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'is_vod' => false,
+        'probe_enabled' => true,
+        'stream_stats_probed_at' => now()->subHour(),
+        'stream_stats' => [['stream' => ['codec_type' => 'video', 'codec_name' => 'h264']]],
+    ]);
+
+    $probedDisabled = Channel::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'is_vod' => false,
+        'probe_enabled' => false,
+        'stream_stats_probed_at' => now()->subHour(),
+        'stream_stats' => [['stream' => ['codec_type' => 'video', 'codec_name' => 'h264']]],
+    ]);
+
+    Livewire::test(ListChannels::class)
+        ->assertOk()
+        ->loadTable()
+        ->filterTable('probed')
+        ->assertCanSeeTableRecords([$probedEnabled])
+        ->assertCanNotSeeTableRecords([$probedDisabled]);
+});
+
+it('not_probed filter excludes channels where probing is disabled', function () {
+    $notProbedEnabled = Channel::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'is_vod' => false,
+        'probe_enabled' => true,
+        'stream_stats_probed_at' => null,
+    ]);
+
+    $notProbedDisabled = Channel::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'is_vod' => false,
+        'probe_enabled' => false,
+        'stream_stats_probed_at' => null,
+    ]);
+
+    Livewire::test(ListChannels::class)
+        ->assertOk()
+        ->loadTable()
+        ->filterTable('not_probed')
+        ->assertCanSeeTableRecords([$notProbedEnabled])
+        ->assertCanNotSeeTableRecords([$notProbedDisabled]);
+});
+
+it('probe_failed filter excludes channels where probing is disabled', function () {
+    $probeFailedEnabled = Channel::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'is_vod' => false,
+        'probe_enabled' => true,
+        'stream_stats_probed_at' => now()->subHour(),
+        'stream_stats' => [],
+    ]);
+
+    $probeFailedDisabled = Channel::factory()->for($this->playlist)->create([
+        'user_id' => $this->user->id,
+        'is_vod' => false,
+        'probe_enabled' => false,
+        'stream_stats_probed_at' => now()->subHour(),
+        'stream_stats' => [],
+    ]);
+
+    Livewire::test(ListChannels::class)
+        ->assertOk()
+        ->loadTable()
+        ->filterTable('probe_failed')
+        ->assertCanSeeTableRecords([$probeFailedEnabled])
+        ->assertCanNotSeeTableRecords([$probeFailedDisabled]);
+});


### PR DESCRIPTION
## Summary
- Exclude channels with disabled probing from the Probed, Probe failed, and Not probed channel table filters.
- Add focused Livewire coverage for all three probed-related filters.
- Fake playlist events in the test to avoid unrelated Redis-backed import listener side effects.

## Testing
- `docker compose -f docker-compose.dev.yml --profile test run --rm m3u-editor-dev-test tests/Feature/ChannelProbedFilterExcludesDisabledTest.php`
- `docker compose -f docker-compose.dev.yml --profile test run --rm --entrypoint /bin/bash m3u-editor-dev-test -lc 'vendor/bin/pint --test app/Filament/Resources/Channels/ChannelResource.php tests/Feature/ChannelProbedFilterExcludesDisabledTest.php'`
- `git diff --check HEAD^..HEAD`

Note: the focused test command exits 0 with 3 warnings from the existing test environment, and 12 assertions pass.
