### PR TITLE
Delete comskip sidecar files when recording is deleted

### DIFF
--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -2,6 +2,8 @@
 
 namespace App\Filament\Pages;
 
+use App\Filament\CopilotTools\DvrOverviewTool;
+use App\Filament\CopilotTools\DvrScheduleTool;
 use App\Filament\CopilotTools\EpgChannelMatcherTool;
 use App\Filament\CopilotTools\EpgMappingApplyTool;
 use App\Filament\CopilotTools\EpgMappingStateTool;
@@ -1485,6 +1487,8 @@ class Preferences extends SettingsPage
                                             ->bulkToggleable()
                                             ->options([
                                                 SearchDocsTool::class => __('Search Documentation'),
+                                                DvrOverviewTool::class => __('DVR: Recording Overview'),
+                                                DvrScheduleTool::class => __('DVR: Schedule Recording'),
                                                 EpgMappingStateTool::class => __('EPG Mapper: Mapping State'),
                                                 EpgChannelMatcherTool::class => __('EPG Mapper: Channel Matcher'),
                                                 EpgMappingApplyTool::class => __('EPG Mapper: Apply Mappings'),
@@ -1506,6 +1510,8 @@ class Preferences extends SettingsPage
                                             ->columns(2)
                                             ->default([
                                                 SearchDocsTool::class,
+                                                DvrOverviewTool::class,
+                                                DvrScheduleTool::class,
                                             ])
                                             ->helperText(__('Select which additional tools the AI assistant can use. Core tools (navigation, memory) are always available.')),
                                     ]),

--- a/app/Models/DvrRecording.php
+++ b/app/Models/DvrRecording.php
@@ -62,6 +62,15 @@ class DvrRecording extends Model
                     if (Storage::disk($disk)->exists($recording->file_path)) {
                         Storage::disk($disk)->delete($recording->file_path);
                     }
+
+                    // Delete comskip sidecar files: .edl, .txt, and .logo.txt
+                    $basePath = preg_replace('/\.[^.]+$/', '', $recording->file_path);
+                    foreach (['.edl', '.txt', '.logo.txt'] as $ext) {
+                        $sidecarPath = $basePath . $ext;
+                        if (Storage::disk($disk)->exists($sidecarPath)) {
+                            Storage::disk($disk)->delete($sidecarPath);
+                        }
+                    }
                 } catch (\Throwable $e) {
                     Log::warning("DvrRecording deleting hook: could not delete file {$recording->file_path}: {$e->getMessage()}", [
                         'recording_id' => $recording->id,

--- a/database/migrations/2026_05_13_131401_add_include_disabled_channels_to_dvr_settings_table.php
+++ b/database/migrations/2026_05_13_131401_add_include_disabled_channels_to_dvr_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dvr_settings', function (Blueprint $table) {
+            $table->boolean('include_disabled_channels')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dvr_settings', function (Blueprint $table) {
+            $table->dropColumn('include_disabled_channels');
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -86,6 +86,11 @@
     overflow-y: auto;
 } */
 
+/* Copilot Chat — widen the slide-over drawer from max-w-md to max-w-2xl */
+.copilot-chat-widget {
+    max-width: 42rem !important;
+}
+
 /* DVR Status Animations */
 @keyframes dvr-status-spin {
     0% { transform: rotate(0deg); }


### PR DESCRIPTION
When a DVR recording is deleted, the associated comskip sidecar files (.edl, .txt, .logo.txt) are now also removed from disk.