### PR TITLE
FetchTmdbIds: prefix-aware VOD matching + chunkById to stop dropped matches

### DIFF
--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -1423,6 +1423,42 @@ class Preferences extends SettingsPage
                                             ->maxValue(100)
                                             ->default(80)
                                             ->helperText(__('Minimum title similarity percentage (50-100) required to accept a match. Higher values = stricter matching.')),
+                                        Fieldset::make(__('Title Cleaning for TMDB Lookup'))
+                                            ->columnSpanFull()
+                                            ->schema([
+                                                Grid::make()
+                                                    ->columnSpanFull()
+                                                    ->columns(2)
+                                                    ->schema([
+                                                        Toggle::make('vod_stream_file_sync_name_filter_enabled')
+                                                            ->label(__('Strip provider prefixes from VOD titles before matching'))
+                                                            ->helperText(__('Remove prefix patterns from VOD titles before searching TMDB (e.g. "EN - ", "4K-EN - ", "NF - ").'))
+                                                            ->live()
+                                                            ->inline(false)
+                                                            ->default(false),
+                                                        TagsInput::make('vod_stream_file_sync_name_filter_patterns')
+                                                            ->label(__('VOD title prefix patterns'))
+                                                            ->placeholder(__('EN - '))
+                                                            ->helperText(__('Strings to strip from VOD titles before TMDB lookup. Press [tab] or [return] to add each pattern.'))
+                                                            ->hidden(fn (Get $get): bool => ! (bool) $get('vod_stream_file_sync_name_filter_enabled')),
+                                                    ]),
+                                                Grid::make()
+                                                    ->columnSpanFull()
+                                                    ->columns(2)
+                                                    ->schema([
+                                                        Toggle::make('stream_file_sync_name_filter_enabled')
+                                                            ->label(__('Strip provider prefixes from Series titles before matching'))
+                                                            ->helperText(__('Remove prefix patterns from Series titles before searching TMDB.'))
+                                                            ->live()
+                                                            ->inline(false)
+                                                            ->default(false),
+                                                        TagsInput::make('stream_file_sync_name_filter_patterns')
+                                                            ->label(__('Series title prefix patterns'))
+                                                            ->placeholder(__('EN - '))
+                                                            ->helperText(__('Strings to strip from Series titles before TMDB lookup. Press [tab] or [return] to add each pattern.'))
+                                                            ->hidden(fn (Get $get): bool => ! (bool) $get('stream_file_sync_name_filter_enabled')),
+                                                    ]),
+                                            ]),
                                     ]),
 
                                 Section::make(__('MediaFlow Proxy'))

--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -1424,7 +1424,10 @@ class Preferences extends SettingsPage
                                             ->maxValue(100)
                                             ->default(80)
                                             ->helperText(__('Minimum title similarity percentage (50-100) required to accept a match. Higher values = stricter matching.')),
-                                        Fieldset::make(__('Title Cleaning for TMDB Lookup'))
+                                        Section::make(__('Title Cleaning for TMDB Lookup'))
+                                            ->icon('heroicon-m-scissors')
+                                            ->description(__('Strip provider prefixes from VOD and Series titles before matching with TMDB. This helps improve matching accuracy by removing common prefixes like "EN - ", "4K-EN - ", "NF - ", etc.'))
+                                            ->compact()
                                             ->columnSpanFull()
                                             ->schema([
                                                 Grid::make()
@@ -1433,7 +1436,7 @@ class Preferences extends SettingsPage
                                                     ->schema([
                                                         Toggle::make('vod_stream_file_sync_name_filter_enabled')
                                                             ->label(__('Strip provider prefixes from VOD titles before matching'))
-                                                            ->helperText(__('Remove prefix patterns from VOD titles before searching TMDB (e.g. "EN - ", "4K-EN - ", "NF - ").'))
+                                                            ->helperText(__('Remove prefix patterns from VOD titles before searching TMDB.'))
                                                             ->live()
                                                             ->inline(false)
                                                             ->default(false),

--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Filament\Actions\CronHelperAction;
+use App\Filament\Actions\RegexTesterAction;
 use App\Filament\CopilotTools\EpgChannelMatcherTool;
 use App\Filament\CopilotTools\EpgMappingApplyTool;
 use App\Filament\CopilotTools\EpgMappingStateTool;
@@ -1440,6 +1441,9 @@ class Preferences extends SettingsPage
                                                             ->label(__('VOD title prefix patterns'))
                                                             ->placeholder(__('EN - '))
                                                             ->helperText(__('Strings to strip from VOD titles before TMDB lookup. Press [tab] or [return] to add each pattern.'))
+                                                            ->hintAction(
+                                                                RegexTesterAction::make(name: 'test-vod-name-filter', flags: 'u', samplesContext: 'vod_channels')
+                                                            )
                                                             ->hidden(fn (Get $get): bool => ! (bool) $get('vod_stream_file_sync_name_filter_enabled')),
                                                     ]),
                                                 Grid::make()
@@ -1456,6 +1460,9 @@ class Preferences extends SettingsPage
                                                             ->label(__('Series title prefix patterns'))
                                                             ->placeholder(__('EN - '))
                                                             ->helperText(__('Strings to strip from Series titles before TMDB lookup. Press [tab] or [return] to add each pattern.'))
+                                                            ->hintAction(
+                                                                RegexTesterAction::make(name: 'test-series-name-filter', flags: 'u', samplesContext: 'series')
+                                                            )
                                                             ->hidden(fn (Get $get): bool => ! (bool) $get('stream_file_sync_name_filter_enabled')),
                                                     ]),
                                             ]),

--- a/app/Jobs/FetchTmdbIds.php
+++ b/app/Jobs/FetchTmdbIds.php
@@ -1195,7 +1195,8 @@ class FetchTmdbIds implements ShouldQueue
         }
 
         // Strip leading numbering ("123. " / "123) ") that remains after prefix removal.
-        $title = preg_replace('/^\s*\d+[\.\)]\s*/', '', $title) ?? $title;
+        // Requires whitespace after the separator so "3.10 to Yuma" is not mangled.
+        $title = preg_replace('/^\s*\d+[\.\)]\s+/', '', $title) ?? $title;
 
         return trim($title);
     }

--- a/app/Jobs/FetchTmdbIds.php
+++ b/app/Jobs/FetchTmdbIds.php
@@ -452,29 +452,6 @@ class FetchTmdbIds implements ShouldQueue
         });
     }
 
-    protected function cleanTitleForSearch(?string $title, bool $isSeries = false): string
-    {
-        $title = $title ?? '';
-
-        $enabled = $isSeries
-            ? ($this->settings->stream_file_sync_name_filter_enabled ?? false)
-            : ($this->settings->vod_stream_file_sync_name_filter_enabled ?? false);
-        $patterns = $isSeries
-            ? ($this->settings->stream_file_sync_name_filter_patterns ?? [])
-            : ($this->settings->vod_stream_file_sync_name_filter_patterns ?? []);
-
-        if ($enabled && ! empty($patterns)) {
-            foreach ($patterns as $pattern) {
-                $title = str_replace($pattern, '', $title);
-            }
-        }
-
-        // Strip leading numbering ("123. " / "123) ") that remains after prefix removal.
-        $title = preg_replace('/^\s*\d+[\.\)]\s*/', '', $title) ?? $title;
-
-        return trim($title);
-    }
-
     /**
      * Process a single VOD channel.
      */
@@ -1195,6 +1172,32 @@ class FetchTmdbIds implements ShouldQueue
             'tmdb_id' => $tmdbId,
             'episodes_updated' => $episodeCount,
         ]);
+    }
+
+    /**
+     * Clean title for TMDB search by applying user-defined patterns and stripping common prefixes.
+     */
+    protected function cleanTitleForSearch(?string $title, bool $isSeries = false): string
+    {
+        $title = $title ?? '';
+
+        $enabled = $isSeries
+            ? ($this->settings->stream_file_sync_name_filter_enabled ?? false)
+            : ($this->settings->vod_stream_file_sync_name_filter_enabled ?? false);
+        $patterns = $isSeries
+            ? ($this->settings->stream_file_sync_name_filter_patterns ?? [])
+            : ($this->settings->vod_stream_file_sync_name_filter_patterns ?? []);
+
+        if ($enabled && ! empty($patterns)) {
+            foreach ($patterns as $pattern) {
+                $title = str_replace($pattern, '', $title);
+            }
+        }
+
+        // Strip leading numbering ("123. " / "123) ") that remains after prefix removal.
+        $title = preg_replace('/^\s*\d+[\.\)]\s*/', '', $title) ?? $title;
+
+        return trim($title);
     }
 
     /**

--- a/app/Jobs/FetchTmdbIds.php
+++ b/app/Jobs/FetchTmdbIds.php
@@ -428,22 +428,57 @@ class FetchTmdbIds implements ShouldQueue
             'count' => $count,
         ]);
 
-        // Use cursor for memory-efficient iteration
-        foreach ($query->cursor() as $channel) {
-            if (! $channel instanceof Channel) {
-                continue;
-            }
+        // Iterate in buffered chunks (chunkById), NOT cursor(): cursor() keeps an
+        // unbuffered read statement open on the same SQLite connection, so the
+        // per-row update() inside processVodChannel() cannot upgrade to a writer
+        // and fails with "database is locked" — silently dropping the match.
+        // chunkById() closes each page's statement before we write. Pages by the
+        // primary key, which our updates never change, so it is safe.
+        $query->chunkById(100, function ($channels) use ($tmdb) {
+            foreach ($channels as $channel) {
+                if (! $channel instanceof Channel) {
+                    continue;
+                }
 
-            try {
-                $this->processVodChannel($tmdb, $channel);
-            } catch (\Exception $e) {
-                $this->errorCount++;
-                Log::error('FetchTmdbIds: Error processing VOD channel', [
-                    'channel_id' => $channel->id,
-                    'error' => $e->getMessage(),
-                ]);
+                try {
+                    $this->processVodChannel($tmdb, $channel);
+                } catch (\Exception $e) {
+                    $this->errorCount++;
+                    Log::error('FetchTmdbIds: Error processing VOD channel', [
+                        'channel_id' => $channel->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+        });
+    }
+
+    /**
+     * Build the title used for the TMDB lookup.
+     *
+     * Providers prefix VOD names with category labels ("EN - ", "4K-EN - ",
+     * "D+ - ", "NF - ", "EN-TOP - 123. ", …) that wreck the search. We reuse the
+     * configured VOD name-filter patterns (the same ones the .strm sync applies to
+     * file names) and additionally drop any leading "123. " numbering, so a single
+     * setting cleans both the on-disk name and the match query. Display fields
+     * (title_custom) are left untouched.
+     */
+    protected function cleanTitleForSearch(?string $title): string
+    {
+        $title = $title ?? '';
+
+        $settings = app(GeneralSettings::class);
+        if (($settings->vod_stream_file_sync_name_filter_enabled ?? false)
+            && ! empty($settings->vod_stream_file_sync_name_filter_patterns)) {
+            foreach ($settings->vod_stream_file_sync_name_filter_patterns as $pattern) {
+                $title = str_replace($pattern, '', $title);
             }
         }
+
+        // Drop leading provider numbering like "123. " or "123) " left after a prefix.
+        $title = preg_replace('/^\s*\d+[\.\)]\s*/', '', $title);
+
+        return trim($title);
     }
 
     /**
@@ -520,8 +555,12 @@ class FetchTmdbIds implements ShouldQueue
             return;
         }
 
-        // Get title and year for search
-        $title = $channel->title_custom ?? $channel->title ?? $channel->name;
+        // Get title and year for search. Strip provider/category prefixes
+        // ("EN - ", "4K-EN - ", "D+ - ", "NF - ", "123. " numbering, …) BEFORE the
+        // TMDB lookup, otherwise the normalizer turns e.g. "NF - My Hero Academia"
+        // into "NFL …" or leaves "En", poisoning the match. Reuses the same VOD
+        // name-filter the .strm sync uses, so one setting governs both.
+        $title = $this->cleanTitleForSearch($channel->title_custom ?? $channel->title ?? $channel->name);
         $year = $channel->year
             ?? $channel->info['year']
             ?? TmdbService::extractYearFromTitle($title);
@@ -714,22 +753,25 @@ class FetchTmdbIds implements ShouldQueue
             'count' => $count,
         ]);
 
-        // Use cursor for memory-efficient iteration
-        foreach ($query->cursor() as $series) {
-            if (! $series instanceof Series) {
-                continue;
-            }
+        // Buffered chunks (chunkById), NOT cursor(): see processVodChannels() —
+        // cursor() holds an open read statement that blocks the per-row update().
+        $query->chunkById(100, function ($seriesChunk) use ($tmdb) {
+            foreach ($seriesChunk as $series) {
+                if (! $series instanceof Series) {
+                    continue;
+                }
 
-            try {
-                $this->processSingleSeries($tmdb, $series);
-            } catch (\Exception $e) {
-                $this->errorCount++;
-                Log::error('FetchTmdbIds: Error processing series', [
-                    'series_id' => $series->id,
-                    'error' => $e->getMessage(),
-                ]);
+                try {
+                    $this->processSingleSeries($tmdb, $series);
+                } catch (\Exception $e) {
+                    $this->errorCount++;
+                    Log::error('FetchTmdbIds: Error processing series', [
+                        'series_id' => $series->id,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
             }
-        }
+        });
     }
 
     /**

--- a/app/Jobs/FetchTmdbIds.php
+++ b/app/Jobs/FetchTmdbIds.php
@@ -34,6 +34,8 @@ class FetchTmdbIds implements ShouldQueue
 
     protected bool $autoCreateGroups = false;
 
+    protected GeneralSettings $settings;
+
     protected const BATCH_STATS_TTL_HOURS = 6;
 
     public int $batchChunkSize = self::BATCH_CHUNK_SIZE;
@@ -101,7 +103,8 @@ class FetchTmdbIds implements ShouldQueue
             'overwriteExisting' => $this->overwriteExisting,
         ]);
 
-        $this->autoCreateGroups = (bool) app(GeneralSettings::class)->tmdb_auto_create_groups;
+        $this->settings = app(GeneralSettings::class);
+        $this->autoCreateGroups = (bool) $this->settings->tmdb_auto_create_groups;
 
         if (! $tmdb->isConfigured()) {
             Log::warning('FetchTmdbIds: TMDB API key not configured');
@@ -428,12 +431,8 @@ class FetchTmdbIds implements ShouldQueue
             'count' => $count,
         ]);
 
-        // Iterate in buffered chunks (chunkById), NOT cursor(): cursor() keeps an
-        // unbuffered read statement open on the same SQLite connection, so the
-        // per-row update() inside processVodChannel() cannot upgrade to a writer
-        // and fails with "database is locked" — silently dropping the match.
-        // chunkById() closes each page's statement before we write. Pages by the
-        // primary key, which our updates never change, so it is safe.
+        // chunkById() rather than cursor(): cursor() holds an open read statement on
+        // the SQLite connection, blocking the per-row update() with "database is locked".
         $query->chunkById(100, function ($channels) use ($tmdb) {
             foreach ($channels as $channel) {
                 if (! $channel instanceof Channel) {
@@ -453,30 +452,25 @@ class FetchTmdbIds implements ShouldQueue
         });
     }
 
-    /**
-     * Build the title used for the TMDB lookup.
-     *
-     * Providers prefix VOD names with category labels ("EN - ", "4K-EN - ",
-     * "D+ - ", "NF - ", "EN-TOP - 123. ", …) that wreck the search. We reuse the
-     * configured VOD name-filter patterns (the same ones the .strm sync applies to
-     * file names) and additionally drop any leading "123. " numbering, so a single
-     * setting cleans both the on-disk name and the match query. Display fields
-     * (title_custom) are left untouched.
-     */
-    protected function cleanTitleForSearch(?string $title): string
+    protected function cleanTitleForSearch(?string $title, bool $isSeries = false): string
     {
         $title = $title ?? '';
 
-        $settings = app(GeneralSettings::class);
-        if (($settings->vod_stream_file_sync_name_filter_enabled ?? false)
-            && ! empty($settings->vod_stream_file_sync_name_filter_patterns)) {
-            foreach ($settings->vod_stream_file_sync_name_filter_patterns as $pattern) {
+        $enabled = $isSeries
+            ? ($this->settings->stream_file_sync_name_filter_enabled ?? false)
+            : ($this->settings->vod_stream_file_sync_name_filter_enabled ?? false);
+        $patterns = $isSeries
+            ? ($this->settings->stream_file_sync_name_filter_patterns ?? [])
+            : ($this->settings->vod_stream_file_sync_name_filter_patterns ?? []);
+
+        if ($enabled && ! empty($patterns)) {
+            foreach ($patterns as $pattern) {
                 $title = str_replace($pattern, '', $title);
             }
         }
 
-        // Drop leading provider numbering like "123. " or "123) " left after a prefix.
-        $title = preg_replace('/^\s*\d+[\.\)]\s*/', '', $title);
+        // Strip leading numbering ("123. " / "123) ") that remains after prefix removal.
+        $title = preg_replace('/^\s*\d+[\.\)]\s*/', '', $title) ?? $title;
 
         return trim($title);
     }
@@ -555,11 +549,6 @@ class FetchTmdbIds implements ShouldQueue
             return;
         }
 
-        // Get title and year for search. Strip provider/category prefixes
-        // ("EN - ", "4K-EN - ", "D+ - ", "NF - ", "123. " numbering, …) BEFORE the
-        // TMDB lookup, otherwise the normalizer turns e.g. "NF - My Hero Academia"
-        // into "NFL …" or leaves "En", poisoning the match. Reuses the same VOD
-        // name-filter the .strm sync uses, so one setting governs both.
         $title = $this->cleanTitleForSearch($channel->title_custom ?? $channel->title ?? $channel->name);
         $year = $channel->year
             ?? $channel->info['year']
@@ -753,8 +742,7 @@ class FetchTmdbIds implements ShouldQueue
             'count' => $count,
         ]);
 
-        // Buffered chunks (chunkById), NOT cursor(): see processVodChannels() —
-        // cursor() holds an open read statement that blocks the per-row update().
+        // chunkById() rather than cursor(): same reason as processVodChannels().
         $query->chunkById(100, function ($seriesChunk) use ($tmdb) {
             foreach ($seriesChunk as $series) {
                 if (! $series instanceof Series) {
@@ -860,7 +848,7 @@ class FetchTmdbIds implements ShouldQueue
         }
 
         // Get name and year for search
-        $name = $series->name;
+        $name = $this->cleanTitleForSearch($series->name, true);
         $year = null;
 
         if ($series->release_date) {

--- a/app/Jobs/SyncSeriesStrmFiles.php
+++ b/app/Jobs/SyncSeriesStrmFiles.php
@@ -865,8 +865,8 @@ class SyncSeriesStrmFiles implements ShouldQueue
             'clean_special_chars' => $settings->stream_file_sync_clean_special_chars ?? false,
             'remove_consecutive_chars' => $settings->stream_file_sync_remove_consecutive_chars ?? false,
             'replace_char' => $settings->stream_file_sync_replace_char ?? 'space',
-            'name_filter_enabled' => $settings->stream_file_sync_name_filter_enabled ?? false,
-            'name_filter_patterns' => $settings->stream_file_sync_name_filter_patterns ?? [],
+            'name_filter_enabled' => false, // Use Stream File Setting for name filtering configuration; legacy settings do not support name filtering
+            'name_filter_patterns' => [], // Use Stream File Setting for name filtering configuration; legacy settings do not support name filtering
             'generate_nfo' => $settings->stream_file_sync_generate_nfo ?? false,
         ];
 

--- a/app/Jobs/SyncVodStrmFiles.php
+++ b/app/Jobs/SyncVodStrmFiles.php
@@ -816,8 +816,8 @@ class SyncVodStrmFiles implements ShouldQueue
             'clean_special_chars' => $settings->vod_stream_file_sync_clean_special_chars ?? false,
             'remove_consecutive_chars' => $settings->vod_stream_file_sync_remove_consecutive_chars ?? false,
             'replace_char' => $settings->vod_stream_file_sync_replace_char ?? 'space',
-            'name_filter_enabled' => $settings->vod_stream_file_sync_name_filter_enabled ?? false,
-            'name_filter_patterns' => $settings->vod_stream_file_sync_name_filter_patterns ?? [],
+            'name_filter_enabled' => false, // Use Stream File Setting for name filtering configuration; legacy settings do not support name filtering
+            'name_filter_patterns' => [], // Use Stream File Setting for name filtering configuration; legacy settings do not support name filtering
             'generate_nfo' => $settings->vod_stream_file_sync_generate_nfo ?? false,
         ];
 

--- a/tests/Feature/FetchTmdbIdsTest.php
+++ b/tests/Feature/FetchTmdbIdsTest.php
@@ -1586,9 +1586,270 @@ it('advances the sync pipeline when TMDB is not configured', function () {
     $job->handle($tmdb);
 });
 
+// ---------------------------------------------------------------------------
+// Helper: build a GeneralSettings mock with name-filter settings wired up.
+// ---------------------------------------------------------------------------
+function mockTmdbSettingsWithNameFilter(
+    array $vodPatterns = [],
+    bool $vodEnabled = true,
+    array $seriesPatterns = [],
+    bool $seriesEnabled = true,
+    bool $autoCreateGroups = false,
+): void {
+    test()->mock(GeneralSettings::class, function ($mock) use (
+        $vodPatterns,
+        $vodEnabled,
+        $seriesPatterns,
+        $seriesEnabled,
+        $autoCreateGroups,
+    ) {
+        $mock->shouldReceive('getAttribute')->with('tmdb_api_key')->andReturn('fake-api-key');
+        $mock->shouldReceive('getAttribute')->with('tmdb_language')->andReturn('en-US');
+        $mock->shouldReceive('getAttribute')->with('tmdb_rate_limit')->andReturn(40);
+        $mock->shouldReceive('getAttribute')->with('tmdb_confidence_threshold')->andReturn(80);
+        $mock->shouldReceive('getAttribute')->with('tmdb_auto_create_groups')->andReturn($autoCreateGroups);
+        $mock->tmdb_api_key = 'fake-api-key';
+        $mock->tmdb_language = 'en-US';
+        $mock->tmdb_rate_limit = 40;
+        $mock->tmdb_confidence_threshold = 80;
+        $mock->tmdb_auto_create_groups = $autoCreateGroups;
+        $mock->vod_stream_file_sync_name_filter_enabled = $vodEnabled;
+        $mock->vod_stream_file_sync_name_filter_patterns = $vodPatterns;
+        $mock->stream_file_sync_name_filter_enabled = $seriesEnabled;
+        $mock->stream_file_sync_name_filter_patterns = $seriesPatterns;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// cleanTitleForSearch — unit tests
+// ---------------------------------------------------------------------------
+
+describe('cleanTitleForSearch', function () {
+    beforeEach(function () {
+        $this->job = new TestableFetchTmdbIds(vodChannelIds: []);
+    });
+
+    it('returns an empty string for null input', function () {
+        $this->job->initSettings(app(GeneralSettings::class));
+        expect($this->job->callCleanTitle(null))->toBe('');
+    });
+
+    it('returns the title unchanged when the VOD filter is disabled', function () {
+        $settings = app(GeneralSettings::class);
+        $settings->vod_stream_file_sync_name_filter_enabled = false;
+        $settings->vod_stream_file_sync_name_filter_patterns = ['EN - '];
+        $this->job->initSettings($settings);
+
+        expect($this->job->callCleanTitle('EN - The Matrix'))->toBe('EN - The Matrix');
+    });
+
+    it('strips a single VOD prefix pattern', function () {
+        $settings = app(GeneralSettings::class);
+        $settings->vod_stream_file_sync_name_filter_enabled = true;
+        $settings->vod_stream_file_sync_name_filter_patterns = ['EN - '];
+        $this->job->initSettings($settings);
+
+        expect($this->job->callCleanTitle('EN - The Matrix'))->toBe('The Matrix');
+    });
+
+    it('strips multiple VOD patterns in sequence', function () {
+        $settings = app(GeneralSettings::class);
+        $settings->vod_stream_file_sync_name_filter_enabled = true;
+        $settings->vod_stream_file_sync_name_filter_patterns = ['4K-EN - ', 'NF - '];
+        $this->job->initSettings($settings);
+
+        expect($this->job->callCleanTitle('4K-EN - The Conjuring'))->toBe('The Conjuring')
+            ->and($this->job->callCleanTitle('NF - My Hero Academia'))->toBe('My Hero Academia');
+    });
+
+    it('strips leading numbering left after prefix removal', function () {
+        $settings = app(GeneralSettings::class);
+        $settings->vod_stream_file_sync_name_filter_enabled = true;
+        $settings->vod_stream_file_sync_name_filter_patterns = ['EN-TOP - '];
+        $this->job->initSettings($settings);
+
+        expect($this->job->callCleanTitle('EN-TOP - 42. Interstellar'))->toBe('Interstellar')
+            ->and($this->job->callCleanTitle('EN-TOP - 7) Dune'))->toBe('Dune');
+    });
+
+    it('strips leading numbering even when no patterns are configured', function () {
+        $settings = app(GeneralSettings::class);
+        $settings->vod_stream_file_sync_name_filter_enabled = false;
+        $settings->vod_stream_file_sync_name_filter_patterns = [];
+        $this->job->initSettings($settings);
+
+        expect($this->job->callCleanTitle('123. Inception'))->toBe('Inception');
+    });
+
+    it('does not strip numeric movie titles without a separator', function () {
+        $settings = app(GeneralSettings::class);
+        $settings->vod_stream_file_sync_name_filter_enabled = false;
+        $settings->vod_stream_file_sync_name_filter_patterns = [];
+        $this->job->initSettings($settings);
+
+        expect($this->job->callCleanTitle('1917'))->toBe('1917')
+            ->and($this->job->callCleanTitle('65'))->toBe('65')
+            ->and($this->job->callCleanTitle('10 Cloverfield Lane'))->toBe('10 Cloverfield Lane')
+            ->and($this->job->callCleanTitle('2001: A Space Odyssey'))->toBe('2001: A Space Odyssey')
+            ->and($this->job->callCleanTitle('3.10 to Yuma'))->toBe('3.10 to Yuma');
+    });
+
+    it('trims surrounding whitespace after stripping', function () {
+        $settings = app(GeneralSettings::class);
+        $settings->vod_stream_file_sync_name_filter_enabled = true;
+        $settings->vod_stream_file_sync_name_filter_patterns = ['D+ - '];
+        $this->job->initSettings($settings);
+
+        expect($this->job->callCleanTitle('D+ - Avengers: Endgame'))->toBe('Avengers: Endgame');
+    });
+
+    it('uses series patterns (not VOD patterns) when isSeries is true', function () {
+        $settings = app(GeneralSettings::class);
+        $settings->vod_stream_file_sync_name_filter_enabled = true;
+        $settings->vod_stream_file_sync_name_filter_patterns = ['VOD-PREFIX - '];
+        $settings->stream_file_sync_name_filter_enabled = true;
+        $settings->stream_file_sync_name_filter_patterns = ['NF - '];
+        $this->job->initSettings($settings);
+
+        expect($this->job->callCleanTitle('NF - Breaking Bad', isSeries: true))->toBe('Breaking Bad')
+            ->and($this->job->callCleanTitle('VOD-PREFIX - The Matrix', isSeries: true))->toBe('VOD-PREFIX - The Matrix');
+    });
+
+    it('does not apply series patterns to VOD titles', function () {
+        $settings = app(GeneralSettings::class);
+        $settings->vod_stream_file_sync_name_filter_enabled = true;
+        $settings->vod_stream_file_sync_name_filter_patterns = ['EN - '];
+        $settings->stream_file_sync_name_filter_enabled = true;
+        $settings->stream_file_sync_name_filter_patterns = ['SERIES-PREFIX - '];
+        $this->job->initSettings($settings);
+
+        expect($this->job->callCleanTitle('EN - The Matrix', isSeries: false))->toBe('The Matrix')
+            ->and($this->job->callCleanTitle('SERIES-PREFIX - The Matrix', isSeries: false))->toBe('SERIES-PREFIX - The Matrix');
+    });
+
+    it('returns the title unchanged when no patterns are provided', function () {
+        $settings = app(GeneralSettings::class);
+        $settings->vod_stream_file_sync_name_filter_enabled = true;
+        $settings->vod_stream_file_sync_name_filter_patterns = [];
+        $this->job->initSettings($settings);
+
+        expect($this->job->callCleanTitle('EN - The Matrix'))->toBe('EN - The Matrix');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Name-filter integration — TMDB is called with the cleaned title
+// ---------------------------------------------------------------------------
+
+it('searches TMDB with cleaned VOD title when name filter is enabled', function () {
+    mockTmdbSettingsWithNameFilter(vodPatterns: ['EN - '], vodEnabled: true);
+
+    $channel = Channel::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'is_vod' => true,
+        'title' => 'EN - The Matrix',
+        'tmdb_id' => null,
+        'last_metadata_fetch' => null,
+        'info' => [],
+    ]);
+
+    $tmdb = Mockery::mock(TmdbService::class);
+    $tmdb->shouldReceive('isConfigured')->andReturn(true);
+    $tmdb->shouldReceive('searchMovie')
+        ->once()
+        ->with('The Matrix', Mockery::any())
+        ->andReturn(['tmdb_id' => 603, 'imdb_id' => 'tt0133093']);
+    $tmdb->shouldReceive('getMovieDetails')->andReturn(null);
+
+    $job = new TestableFetchTmdbIds(vodChannelIds: [$channel->id], user: $this->user);
+    $job->handle($tmdb);
+});
+
+it('searches TMDB with raw VOD title when name filter is disabled', function () {
+    mockTmdbSettingsWithNameFilter(vodPatterns: ['EN - '], vodEnabled: false);
+
+    $channel = Channel::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'is_vod' => true,
+        'title' => 'EN - The Matrix',
+        'tmdb_id' => null,
+        'last_metadata_fetch' => null,
+        'info' => [],
+    ]);
+
+    $tmdb = Mockery::mock(TmdbService::class);
+    $tmdb->shouldReceive('isConfigured')->andReturn(true);
+    $tmdb->shouldReceive('searchMovie')
+        ->once()
+        ->with('EN - The Matrix', Mockery::any())
+        ->andReturn(null);
+
+    $job = new TestableFetchTmdbIds(vodChannelIds: [$channel->id], user: $this->user);
+    $job->handle($tmdb);
+});
+
+it('searches TMDB with cleaned series title when series name filter is enabled', function () {
+    mockTmdbSettingsWithNameFilter(seriesPatterns: ['NF - '], seriesEnabled: true);
+
+    $series = Series::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'name' => 'NF - Breaking Bad',
+        'tmdb_id' => null,
+        'last_metadata_fetch' => null,
+        'metadata' => [],
+    ]);
+
+    $tmdb = Mockery::mock(TmdbService::class);
+    $tmdb->shouldReceive('isConfigured')->andReturn(true);
+    $tmdb->shouldReceive('searchTvSeries')
+        ->once()
+        ->with('Breaking Bad', Mockery::any())
+        ->andReturn(null);
+
+    $job = new TestableFetchTmdbIds(seriesIds: [$series->id], user: $this->user);
+    $job->handle($tmdb);
+});
+
+it('strips numbering from VOD title even without prefix patterns', function () {
+    mockTmdbSettingsWithNameFilter(vodPatterns: [], vodEnabled: false);
+
+    $channel = Channel::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->user->id,
+        'is_vod' => true,
+        'title' => '42. Interstellar',
+        'tmdb_id' => null,
+        'last_metadata_fetch' => null,
+        'info' => [],
+    ]);
+
+    $tmdb = Mockery::mock(TmdbService::class);
+    $tmdb->shouldReceive('isConfigured')->andReturn(true);
+    $tmdb->shouldReceive('searchMovie')
+        ->once()
+        ->with('Interstellar', Mockery::any())
+        ->andReturn(null);
+
+    $job = new TestableFetchTmdbIds(vodChannelIds: [$channel->id], user: $this->user);
+    $job->handle($tmdb);
+});
+
 class TestableFetchTmdbIds extends FetchTmdbIds
 {
     protected function sendCompletionNotification(): void {}
 
     protected function notifyUser(string $title, string $body, string $type = 'success'): void {}
+
+    public function callCleanTitle(?string $title, bool $isSeries = false): string
+    {
+        return $this->cleanTitleForSearch($title, $isSeries);
+    }
+
+    public function initSettings(GeneralSettings $settings): void
+    {
+        $this->settings = $settings;
+    }
 }


### PR DESCRIPTION
## Problem

Two issues cause wrong or missing TMDB matches for VOD on Xtream providers that prefix stream names with category labels (`EN - `, `4K-EN - `, `D+ - `, `NF - `, `EN-TOP - 123. `, …):

1. **Prefixes poison the search.** `searchMovie()` receives the raw prefixed title and `normalizeTitle()` mangles it — e.g. `NF - My Hero Academia` searches as *NFL …*, `4K-EN - The Conjuring` collapses to *En* — yielding confident-but-wrong matches.
2. **Matches silently dropped under SQLite lock.** `processVodChannels()`/`processSeries()` iterate with `cursor()`, which holds an unbuffered read statement open on the same SQLite connection. The per-row `update()` inside the loop then can't upgrade to a writer and throws `database is locked` under any concurrency (queue workers, parallel jobs). The exception is swallowed per-row, leaving a stale/empty `tmdb_id`.

In a ~1800-title library this produced dozens of titles all stuck on one wrong id and ~150 unmatched.

## Changes

- **Prefix-aware lookup:** new `cleanTitleForSearch()` strips the configured VOD name-filter patterns (the same `vod_stream_file_sync_name_filter_patterns` the .strm sync already applies to file names) plus any leading `123. ` numbering, *before* the TMDB search. One setting now cleans both the on-disk name and the match query. Display fields (`title_custom`) are untouched.
- **`cursor()` → `chunkById()`** for VOD and series. Buffered pages close their statement before writes; paging is by primary key, which the updates never change.

## Testing

Built and deployed on a live ~1800-title library. Fresh-import titles that previously mis-matched now resolve correctly (`4K-EN - Tom Clancy's Without Remorse (2021)` → 567189, `NF - My Hero Academia: You're Next` → 1159311, `D+ - Avengers: Endgame` → 299534, `4K-EN - The Conjuring` → 138843). No more dropped-write `database is locked` errors during bulk fetch.

Both changes are behind existing behavior when no name-filter patterns are configured (only the `cursor()`→`chunkById()` swap applies, which is a pure reliability fix).