### PR TITLE
fix: plugin schema foreign key delete actions

### DIFF
--- a/app/Plugins/PluginSchemaManager.php
+++ b/app/Plugins/PluginSchemaManager.php
@@ -155,10 +155,10 @@ class PluginSchemaManager
             }
 
             if ($type === 'foreignId' && filled($column['references'] ?? null)) {
-                $definition->constrained((string) $column['references']);
+                $constraint = $definition->constrained((string) $column['references']);
                 match ($column['on_delete'] ?? null) {
-                    'cascade' => $definition->cascadeOnDelete(),
-                    'null' => $definition->nullOnDelete(),
+                    'cascade' => $constraint->cascadeOnDelete(),
+                    'null' => $constraint->nullOnDelete(),
                     default => null,
                 };
             }

--- a/tests/Feature/PluginDeclaredTableUiTest.php
+++ b/tests/Feature/PluginDeclaredTableUiTest.php
@@ -222,6 +222,17 @@ it('renders plugin-declared table UIs through the generic plugin table page', fu
         ->assertSee('Native Playlist');
 });
 
+it('applies declared cascade actions to plugin table foreign keys', function () {
+    $plugin = declaredTableUiPlugin();
+    $tableName = 'plugin_declared_table_ui_profiles';
+
+    expect(DB::table($tableName)->count())->toBe(1);
+
+    $plugin->delete();
+
+    expect(DB::table($tableName)->count())->toBe(0);
+});
+
 it('prefills plugin-declared table rows from an owned source table', function () {
     $user = User::factory()->admin()->create();
     $otherUser = User::factory()->create();


### PR DESCRIPTION
Apply manifest on_delete options to the generated foreign key constraint rather than the foreignId column definition. This ensures plugin-declared cascade and set-null actions are enforced by the database.

Add a regression test covering cascade behaviour for plugin-declared tables.