### PR TITLE
feat: media request integration — browse pagination + automatic search feedback

### DIFF
--- a/app/Events/ArrQueueUpdated.php
+++ b/app/Events/ArrQueueUpdated.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ArrQueueUpdated implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public readonly int $userId) {}
+
+    public function broadcastOn(): PrivateChannel
+    {
+        return new PrivateChannel('arr-queue.'.$this->userId);
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'queue.updated';
+    }
+
+    /**
+     * No payload needed — the Livewire component re-fetches on receipt.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/GuestPanel/Pages/GuestRequestContent.php
+++ b/app/Filament/GuestPanel/Pages/GuestRequestContent.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Filament\GuestPanel\Pages;
+
+use App\Facades\PlaylistFacade;
+use App\Filament\GuestPanel\Pages\Concerns\HasGuestAuth;
+use App\Models\ArrIntegration;
+use App\Models\Playlist;
+use App\Models\PlaylistAlias;
+use Filament\Pages\Page;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Collection;
+
+class GuestRequestContent extends Page
+{
+    use HasGuestAuth;
+
+    protected string $view = 'filament.guest-panel.pages.request-content';
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-magnifying-glass-circle';
+
+    protected static ?int $navigationSort = 7;
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Request Content');
+    }
+
+    public function getTitle(): string|Htmlable
+    {
+        return __('Request Content');
+    }
+
+    protected static ?string $slug = 'request-content';
+
+    /**
+     * Only show the page if the guest is authenticated AND their playlist has at
+     * least one enabled Sonarr/Radarr integration with guest_enabled = true.
+     */
+    public static function canAccess(): bool
+    {
+        if (! static::isSessionAuthenticated()) {
+            return false;
+        }
+
+        $uuid = static::getCurrentUuid();
+        if (! $uuid) {
+            return false;
+        }
+
+        $playlist = PlaylistFacade::resolvePlaylistByUuid($uuid);
+        if (! $playlist) {
+            return false;
+        }
+
+        $playlistId = $playlist instanceof PlaylistAlias ? $playlist->playlist_id : $playlist->id;
+        if (! $playlistId) {
+            return false;
+        }
+
+        return ArrIntegration::query()
+            ->where('playlist_id', $playlistId)
+            ->enabled()
+            ->guestEnabled()
+            ->exists();
+    }
+
+    public static function getUrl(
+        array $parameters = [],
+        bool $isAbsolute = true,
+        ?string $panel = null,
+        $tenant = null,
+        bool $shouldGuessMissingParameters = false,
+        ?string $configuration = null
+    ): string {
+        $parameters['uuid'] = static::getCurrentUuid();
+
+        return route(static::getRouteName($panel), $parameters, $isAbsolute);
+    }
+
+    /**
+     * Resolve the first guest-enabled integration for the current playlist.
+     */
+    public function getIntegrationProperty(): ?ArrIntegration
+    {
+        $uuid = static::getCurrentUuid();
+        if (! $uuid) {
+            return null;
+        }
+
+        $playlist = PlaylistFacade::resolvePlaylistByUuid($uuid);
+        $playlistId = $playlist instanceof PlaylistAlias ? $playlist->playlist_id : $playlist?->id;
+        if (! $playlistId) {
+            return null;
+        }
+
+        return ArrIntegration::query()
+            ->where('playlist_id', $playlistId)
+            ->enabled()
+            ->guestEnabled()
+            ->orderBy('name')
+            ->first();
+    }
+
+    /**
+     * All guest-enabled integrations for the playlist (when more than one exists,
+     * a tab/select UI can be added in the future).
+     *
+     * @return Collection<int, ArrIntegration>
+     */
+    public function getIntegrationsProperty()
+    {
+        $uuid = static::getCurrentUuid();
+        if (! $uuid) {
+            return collect();
+        }
+
+        $playlist = PlaylistFacade::resolvePlaylistByUuid($uuid);
+        $playlistId = $playlist instanceof PlaylistAlias ? $playlist->playlist_id : $playlist?->id;
+        if (! $playlistId) {
+            return collect();
+        }
+
+        return ArrIntegration::query()
+            ->where('playlist_id', $playlistId)
+            ->enabled()
+            ->guestEnabled()
+            ->orderBy('name')
+            ->get();
+    }
+}

--- a/app/Filament/GuestPanel/Pages/GuestRequestContent.php
+++ b/app/Filament/GuestPanel/Pages/GuestRequestContent.php
@@ -7,6 +7,7 @@ use App\Filament\GuestPanel\Pages\Concerns\HasGuestAuth;
 use App\Models\ArrIntegration;
 use App\Models\Playlist;
 use App\Models\PlaylistAlias;
+use App\Models\PlaylistRequestSetting;
 use Filament\Pages\Page;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Collection;
@@ -34,8 +35,9 @@ class GuestRequestContent extends Page
     protected static ?string $slug = 'request-content';
 
     /**
-     * Only show the page if the guest is authenticated AND their playlist has at
-     * least one enabled Sonarr/Radarr integration with guest_enabled = true.
+     * Only show the page if the guest is authenticated, the playlist has content
+     * requests enabled, and the playlist owner has at least one enabled, guest-enabled
+     * Sonarr/Radarr integration.
      */
     public static function canAccess(): bool
     {
@@ -58,8 +60,21 @@ class GuestRequestContent extends Page
             return false;
         }
 
+        $requestSetting = PlaylistRequestSetting::where('playlist_id', $playlistId)->first();
+        if (! $requestSetting?->enabled) {
+            return false;
+        }
+
+        $actualPlaylist = $playlist instanceof PlaylistAlias
+            ? Playlist::find($playlistId)
+            : $playlist;
+
+        if (! $actualPlaylist) {
+            return false;
+        }
+
         return ArrIntegration::query()
-            ->where('playlist_id', $playlistId)
+            ->where('user_id', $actualPlaylist->user_id)
             ->enabled()
             ->guestEnabled()
             ->exists();
@@ -79,23 +94,17 @@ class GuestRequestContent extends Page
     }
 
     /**
-     * Resolve the first guest-enabled integration for the current playlist.
+     * Resolve the first guest-enabled integration for the playlist owner.
      */
     public function getIntegrationProperty(): ?ArrIntegration
     {
-        $uuid = static::getCurrentUuid();
-        if (! $uuid) {
-            return null;
-        }
-
-        $playlist = PlaylistFacade::resolvePlaylistByUuid($uuid);
-        $playlistId = $playlist instanceof PlaylistAlias ? $playlist->playlist_id : $playlist?->id;
-        if (! $playlistId) {
+        $userId = $this->resolvePlaylistOwnerId();
+        if (! $userId) {
             return null;
         }
 
         return ArrIntegration::query()
-            ->where('playlist_id', $playlistId)
+            ->where('user_id', $userId)
             ->enabled()
             ->guestEnabled()
             ->orderBy('name')
@@ -103,29 +112,46 @@ class GuestRequestContent extends Page
     }
 
     /**
-     * All guest-enabled integrations for the playlist (when more than one exists,
-     * a tab/select UI can be added in the future).
+     * All guest-enabled integrations for the playlist owner.
      *
      * @return Collection<int, ArrIntegration>
      */
-    public function getIntegrationsProperty()
+    public function getIntegrationsProperty(): Collection
     {
-        $uuid = static::getCurrentUuid();
-        if (! $uuid) {
-            return collect();
-        }
-
-        $playlist = PlaylistFacade::resolvePlaylistByUuid($uuid);
-        $playlistId = $playlist instanceof PlaylistAlias ? $playlist->playlist_id : $playlist?->id;
-        if (! $playlistId) {
+        $userId = $this->resolvePlaylistOwnerId();
+        if (! $userId) {
             return collect();
         }
 
         return ArrIntegration::query()
-            ->where('playlist_id', $playlistId)
+            ->where('user_id', $userId)
             ->enabled()
             ->guestEnabled()
             ->orderBy('name')
             ->get();
+    }
+
+    /**
+     * Resolve the user_id of the playlist owner from the current guest session UUID.
+     */
+    private function resolvePlaylistOwnerId(): ?int
+    {
+        $uuid = static::getCurrentUuid();
+        if (! $uuid) {
+            return null;
+        }
+
+        $playlist = PlaylistFacade::resolvePlaylistByUuid($uuid);
+        if (! $playlist) {
+            return null;
+        }
+
+        if ($playlist instanceof PlaylistAlias) {
+            $actual = Playlist::find($playlist->playlist_id);
+
+            return $actual?->user_id;
+        }
+
+        return $playlist->user_id;
     }
 }

--- a/app/Filament/Pages/DownloadQueue.php
+++ b/app/Filament/Pages/DownloadQueue.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use Filament\Pages\Page;
+use Illuminate\Contracts\Support\Htmlable;
+
+class DownloadQueue extends Page
+{
+    protected string $view = 'filament.pages.download-queue';
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-arrow-down-tray';
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Download Queue');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('Integrations');
+    }
+
+    protected static ?int $navigationSort = 107;
+
+    public function getTitle(): string|Htmlable
+    {
+        return __('Download Queue');
+    }
+
+    public function getHeading(): string|Htmlable
+    {
+        return __('Download Queue');
+    }
+
+    public function getSubheading(): string|Htmlable|null
+    {
+        return __('Live status of active downloads across all your Sonarr and Radarr servers. Refreshes every 10 seconds.');
+    }
+
+    public static function canAccess(): bool
+    {
+        return auth()->check() && auth()->user()->canUseIntegrations();
+    }
+}

--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -2,6 +2,8 @@
 
 namespace App\Filament\Pages;
 
+use App\Filament\CopilotTools\DvrOverviewTool;
+use App\Filament\CopilotTools\DvrScheduleTool;
 use App\Filament\CopilotTools\EpgChannelMatcherTool;
 use App\Filament\CopilotTools\EpgMappingApplyTool;
 use App\Filament\CopilotTools\EpgMappingStateTool;
@@ -1485,6 +1487,8 @@ class Preferences extends SettingsPage
                                             ->bulkToggleable()
                                             ->options([
                                                 SearchDocsTool::class => __('Search Documentation'),
+                                                DvrOverviewTool::class => __('DVR: Recording Overview'),
+                                                DvrScheduleTool::class => __('DVR: Schedule Recording'),
                                                 EpgMappingStateTool::class => __('EPG Mapper: Mapping State'),
                                                 EpgChannelMatcherTool::class => __('EPG Mapper: Channel Matcher'),
                                                 EpgMappingApplyTool::class => __('EPG Mapper: Apply Mappings'),
@@ -1506,6 +1510,8 @@ class Preferences extends SettingsPage
                                             ->columns(2)
                                             ->default([
                                                 SearchDocsTool::class,
+                                                DvrOverviewTool::class,
+                                                DvrScheduleTool::class,
                                             ])
                                             ->helperText(__('Select which additional tools the AI assistant can use. Core tools (navigation, memory) are always available.')),
                                     ]),

--- a/app/Filament/Pages/RequestContent.php
+++ b/app/Filament/Pages/RequestContent.php
@@ -9,8 +9,6 @@ class RequestContent extends Page
 {
     protected string $view = 'filament.pages.request-content';
 
-    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-magnifying-glass-circle';
-
     public static function getNavigationLabel(): string
     {
         return __('Request Content');

--- a/app/Filament/Pages/RequestContent.php
+++ b/app/Filament/Pages/RequestContent.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Models\ArrIntegration;
+use Filament\Pages\Page;
+use Illuminate\Contracts\Support\Htmlable;
+
+class RequestContent extends Page
+{
+    protected string $view = 'filament.pages.request-content';
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-magnifying-glass-circle';
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Request Content');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('Integrations');
+    }
+
+    protected static ?int $navigationSort = 106;
+
+    public function getTitle(): string|Htmlable
+    {
+        return __('Request Content');
+    }
+
+    public static function canAccess(): bool
+    {
+        return auth()->check() && auth()->user()->canUseIntegrations();
+    }
+
+    public function getHeading(): string|Htmlable
+    {
+        return __('Search & Request Movies / TV Shows');
+    }
+
+    public function getSubheading(): string|Htmlable|null
+    {
+        return __('Search your Sonarr (TV) and Radarr (Movies) servers and submit download requests for content not already in your library.');
+    }
+
+    public function mount(): void
+    {
+        // Pre-select the first enabled integration so the page is useful on first load
+        $first = ArrIntegration::query()
+            ->where('user_id', auth()->id())
+            ->where('enabled', true)
+            ->orderBy('name')
+            ->first();
+
+        if ($first) {
+            $this->dispatch('set-arr-integration', integrationId: $first->id);
+        }
+    }
+}

--- a/app/Filament/Pages/RequestContent.php
+++ b/app/Filament/Pages/RequestContent.php
@@ -2,7 +2,6 @@
 
 namespace App\Filament\Pages;
 
-use App\Models\ArrIntegration;
 use Filament\Pages\Page;
 use Illuminate\Contracts\Support\Htmlable;
 
@@ -42,19 +41,5 @@ class RequestContent extends Page
     public function getSubheading(): string|Htmlable|null
     {
         return __('Search your Sonarr (TV) and Radarr (Movies) servers and submit download requests for content not already in your library.');
-    }
-
-    public function mount(): void
-    {
-        // Pre-select the first enabled integration so the page is useful on first load
-        $first = ArrIntegration::query()
-            ->where('user_id', auth()->id())
-            ->where('enabled', true)
-            ->orderBy('name')
-            ->first();
-
-        if ($first) {
-            $this->dispatch('set-arr-integration', integrationId: $first->id);
-        }
     }
 }

--- a/app/Filament/Resources/ArrIntegrations/ArrIntegrationResource.php
+++ b/app/Filament/Resources/ArrIntegrations/ArrIntegrationResource.php
@@ -8,6 +8,7 @@ use App\Filament\Resources\ArrIntegrations\Pages\ListArrIntegrations;
 use App\Models\ArrIntegration;
 use App\Services\Arr\ArrService;
 use App\Traits\HasUserFiltering;
+use Carbon\Carbon;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkActionGroup;
@@ -61,6 +62,8 @@ class ArrIntegrationResource extends Resource
         return __('Integrations');
     }
 
+    protected static bool $shouldRegisterNavigation = false;
+
     protected static ?int $navigationSort = 105;
 
     /**
@@ -104,27 +107,12 @@ class ArrIntegrationResource extends Resource
                                 ->disabledOn('edit'),
                         ]),
 
-                        Grid::make(2)->schema([
-                            Select::make('playlist_id')
-                                ->label(__('Playlist'))
-                                ->relationship(
-                                    'playlist',
-                                    'name',
-                                    fn (Builder $query): Builder => $query->where('user_id', Auth::id())
-                                )
-                                ->required()
-                                ->searchable()
-                                ->preload()
-                                ->native(false)
-                                ->helperText(__('Content added via this integration will be requested in the context of this playlist.')),
-
-                            TextInput::make('url')
-                                ->label(__('Server URL'))
-                                ->placeholder('http://192.168.1.42:8989')
-                                ->required()
-                                ->url()
-                                ->maxLength(255),
-                        ]),
+                        TextInput::make('url')
+                            ->label(__('Server URL'))
+                            ->placeholder('http://192.168.1.42:8989')
+                            ->required()
+                            ->url()
+                            ->maxLength(255),
 
                         TextInput::make('api_key')
                             ->label(__('API Key'))
@@ -139,10 +127,7 @@ class ArrIntegrationResource extends Resource
                         Actions::make(self::getDiscoverActions())
                             ->fullWidth(),
 
-                        // Hidden fields populated by the Discover action
-                        Hidden::make('quality_profile_id'),
                         Hidden::make('quality_profile_name'),
-                        Hidden::make('root_folder_path'),
 
                         Grid::make(2)->schema([
                             Select::make('quality_profile_id')
@@ -157,6 +142,15 @@ class ArrIntegrationResource extends Resource
                                 })
                                 ->helperText(__('Discovered from the server — click "Test Connection & Discover" above to populate.'))
                                 ->visible(fn (Get $get): bool => filled($get('quality_profiles_options')))
+                                ->live()
+                                ->afterStateUpdated(function (Get $get, Set $set, $state): void {
+                                    $raw = $get('quality_profiles_options') ?? '[]';
+                                    $profiles = json_decode($raw, true) ?: [];
+                                    $profile = collect($profiles)->firstWhere('id', $state);
+                                    if ($profile) {
+                                        $set('quality_profile_name', $profile['name']);
+                                    }
+                                })
                                 ->native(false),
 
                             Select::make('root_folder_path')
@@ -192,9 +186,22 @@ class ArrIntegrationResource extends Resource
 
                         Toggle::make('guest_enabled')
                             ->label(__('Allow Guest Requests'))
-                            ->helperText(__('Allow guests on this playlist to request content via this integration.'))
+                            ->helperText(__('Allow guests to request content via this integration on any playlist that has content requests enabled.'))
                             ->default(false),
                     ]),
+
+                Section::make(__('Webhook'))
+                    ->description(__('Add this URL as a notification in Radarr/Sonarr (Settings → Connect → Webhook) for real-time queue updates.'))
+                    ->schema([
+                        TextInput::make('webhook_url')
+                            ->label(__('Webhook URL'))
+                            ->disabled()
+                            ->dehydrated(false)
+                            ->copyable()
+                            ->extraAttributes(['class' => 'font-mono text-xs'])
+                            ->helperText(__('Set "On Grab", "On Download", "On Movie Added", and "On Manual Interaction Required" triggers in Radarr/Sonarr.')),
+                    ])
+                    ->visible(fn (string $operation): bool => $operation === 'edit'),
 
                 Section::make(__('Status'))
                     ->schema([
@@ -203,7 +210,7 @@ class ArrIntegrationResource extends Resource
                                 ->label(__('Last Tested'))
                                 ->disabled()
                                 ->dehydrated(false)
-                                ->formatStateUsing(fn ($state) => $state ? $state->diffForHumans() : 'Never'),
+                                ->formatStateUsing(fn ($state) => $state ? Carbon::parse($state)->diffForHumans() : 'Never'),
 
                             TextInput::make('quality_profile_name')
                                 ->label(__('Active Quality Profile'))
@@ -229,12 +236,6 @@ class ArrIntegrationResource extends Resource
                     ->color(fn (string $state): string => $state === 'sonarr' ? 'info' : 'purple')
                     ->formatStateUsing(fn (string $state): string => ucfirst($state))
                     ->sortable(),
-
-                TextColumn::make('playlist.name')
-                    ->label(__('Playlist'))
-                    ->searchable()
-                    ->sortable()
-                    ->placeholder('—'),
 
                 TextColumn::make('url')
                     ->label(__('URL'))

--- a/app/Filament/Resources/ArrIntegrations/ArrIntegrationResource.php
+++ b/app/Filament/Resources/ArrIntegrations/ArrIntegrationResource.php
@@ -1,0 +1,428 @@
+<?php
+
+namespace App\Filament\Resources\ArrIntegrations;
+
+use App\Filament\Resources\ArrIntegrations\Pages\CreateArrIntegration;
+use App\Filament\Resources\ArrIntegrations\Pages\EditArrIntegration;
+use App\Filament\Resources\ArrIntegrations\Pages\ListArrIntegrations;
+use App\Models\ArrIntegration;
+use App\Services\Arr\ArrService;
+use App\Traits\HasUserFiltering;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Actions;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use Filament\Tables;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class ArrIntegrationResource extends Resource
+{
+    use HasUserFiltering;
+
+    protected static ?string $model = ArrIntegration::class;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Sonarr & Radarr');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('Sonarr/Radarr');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('Sonarr & Radarr');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('Integrations');
+    }
+
+    protected static ?int $navigationSort = 105;
+
+    /**
+     * Restrict the resource to integrations owned by the current user.
+     */
+    public static function canAccess(): bool
+    {
+        return auth()->check() && auth()->user()->canUseIntegrations();
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('user_id', Auth::id());
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make(__('Connection'))
+                    ->description(__('Connect to your Sonarr or Radarr server.'))
+                    ->collapsible()
+                    ->schema([
+                        Grid::make(2)->schema([
+                            TextInput::make('name')
+                                ->label(__('Display Name'))
+                                ->placeholder(fn (Get $get): string => $get('type') === 'radarr' ? 'e.g., Radarr - 4K Movies' : 'e.g., Sonarr - 1080p TV')
+                                ->required()
+                                ->maxLength(255),
+
+                            Select::make('type')
+                                ->label(__('Type'))
+                                ->options([
+                                    'sonarr' => 'Sonarr',
+                                    'radarr' => 'Radarr',
+                                ])
+                                ->required()
+                                ->live()
+                                ->native(false)
+                                ->disabledOn('edit'),
+                        ]),
+
+                        Grid::make(2)->schema([
+                            Select::make('playlist_id')
+                                ->label(__('Playlist'))
+                                ->relationship(
+                                    'playlist',
+                                    'name',
+                                    fn (Builder $query): Builder => $query->where('user_id', Auth::id())
+                                )
+                                ->required()
+                                ->searchable()
+                                ->preload()
+                                ->native(false)
+                                ->helperText(__('Content added via this integration will be requested in the context of this playlist.')),
+
+                            TextInput::make('url')
+                                ->label(__('Server URL'))
+                                ->placeholder('http://192.168.1.42:8989')
+                                ->required()
+                                ->url()
+                                ->maxLength(255),
+                        ]),
+
+                        TextInput::make('api_key')
+                            ->label(__('API Key'))
+                            ->password()
+                            ->revealable()
+                            ->required(fn (string $operation): bool => $operation === 'create')
+                            ->dehydrateStateUsing(fn ($state, ?ArrIntegration $record) => filled($state) ? $state : $record?->api_key)
+                            ->helperText(fn (string $operation): string => $operation === 'edit'
+                                ? 'Leave blank to keep the existing API key.'
+                                : 'Found in Sonarr/Radarr under Settings → General → API Key.'),
+
+                        Actions::make(self::getDiscoverActions())
+                            ->fullWidth(),
+
+                        // Hidden fields populated by the Discover action
+                        Hidden::make('quality_profile_id'),
+                        Hidden::make('quality_profile_name'),
+                        Hidden::make('root_folder_path'),
+
+                        Grid::make(2)->schema([
+                            Select::make('quality_profile_id')
+                                ->label(__('Quality Profile'))
+                                ->options(function (Get $get) {
+                                    $raw = $get('quality_profiles_options') ?? '[]';
+                                    $profiles = json_decode($raw, true) ?: [];
+
+                                    return collect($profiles)
+                                        ->mapWithKeys(fn (array $p) => [$p['id'] => $p['name']])
+                                        ->all();
+                                })
+                                ->helperText(__('Discovered from the server — click "Test Connection & Discover" above to populate.'))
+                                ->visible(fn (Get $get): bool => filled($get('quality_profiles_options')))
+                                ->native(false),
+
+                            Select::make('root_folder_path')
+                                ->label(__('Root Folder'))
+                                ->options(function (Get $get) {
+                                    $raw = $get('root_folders_options') ?? '[]';
+                                    $folders = json_decode($raw, true) ?: [];
+
+                                    return collect($folders)
+                                        ->mapWithKeys(fn (array $f) => [$f['path'] => $f['path']])
+                                        ->all();
+                                })
+                                ->helperText(__('Discovered from the server — click "Test Connection & Discover" above to populate.'))
+                                ->visible(fn (Get $get): bool => filled($get('root_folders_options')))
+                                ->native(false),
+                        ]),
+
+                        // Stash the discovered lists as hidden JSON so they're available
+                        // to the visible Selects above (Filament option callbacks need access).
+                        // These are form-only state — never written to the DB.
+                        Hidden::make('quality_profiles_options')
+                            ->dehydrated(false),
+                        Hidden::make('root_folders_options')
+                            ->dehydrated(false),
+                    ]),
+
+                Section::make(__('Options'))
+                    ->schema([
+                        Toggle::make('enabled')
+                            ->label(__('Enabled'))
+                            ->helperText(__('Disable to pause use of this integration without deleting it.'))
+                            ->default(true),
+
+                        Toggle::make('guest_enabled')
+                            ->label(__('Allow Guest Requests'))
+                            ->helperText(__('Allow guests on this playlist to request content via this integration.'))
+                            ->default(false),
+                    ]),
+
+                Section::make(__('Status'))
+                    ->schema([
+                        Grid::make(2)->schema([
+                            TextInput::make('last_test_at')
+                                ->label(__('Last Tested'))
+                                ->disabled()
+                                ->dehydrated(false)
+                                ->formatStateUsing(fn ($state) => $state ? $state->diffForHumans() : 'Never'),
+
+                            TextInput::make('quality_profile_name')
+                                ->label(__('Active Quality Profile'))
+                                ->disabled()
+                                ->dehydrated(false)
+                                ->placeholder('—'),
+                        ]),
+                    ])
+                    ->visible(fn (string $operation): bool => $operation === 'edit'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('type')
+                    ->badge()
+                    ->color(fn (string $state): string => $state === 'sonarr' ? 'info' : 'purple')
+                    ->formatStateUsing(fn (string $state): string => ucfirst($state))
+                    ->sortable(),
+
+                TextColumn::make('playlist.name')
+                    ->label(__('Playlist'))
+                    ->searchable()
+                    ->sortable()
+                    ->placeholder('—'),
+
+                TextColumn::make('url')
+                    ->label(__('URL'))
+                    ->searchable()
+                    ->copyable()
+                    ->limit(40),
+
+                TextColumn::make('quality_profile_name')
+                    ->label(__('Quality Profile'))
+                    ->placeholder('—')
+                    ->toggleable(),
+
+                IconColumn::make('enabled')
+                    ->label(__('Enabled'))
+                    ->boolean()
+                    ->sortable(),
+
+                IconColumn::make('guest_enabled')
+                    ->label(__('Guest'))
+                    ->boolean()
+                    ->sortable(),
+
+                TextColumn::make('last_test_at')
+                    ->label(__('Last Tested'))
+                    ->dateTime()
+                    ->placeholder('Never')
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('type')
+                    ->options([
+                        'sonarr' => 'Sonarr',
+                        'radarr' => 'Radarr',
+                    ]),
+            ])
+            ->actions([
+                ActionGroup::make([
+                    EditAction::make(),
+                    Action::make('test')
+                        ->label(__('Test Connection'))
+                        ->icon('heroicon-o-signal')
+                        ->action(function (ArrIntegration $record) {
+                            $service = ArrService::make($record);
+                            $result = $service->testConnection();
+
+                            if ($result['ok']) {
+                                $record->forceFill(['last_test_at' => now()])->save();
+
+                                Notification::make()
+                                    ->success()
+                                    ->title(__('Connection Successful'))
+                                    ->body(__('Connected to :name (v:version)', [
+                                        'name' => $record->name,
+                                        'version' => $result['version'] ?? 'unknown',
+                                    ]))
+                                    ->send();
+                            } else {
+                                Notification::make()
+                                    ->danger()
+                                    ->title(__('Connection Failed'))
+                                    ->body($result['error'] ?? 'Unknown error')
+                                    ->send();
+                            }
+                        }),
+                    Action::make('syncProfiles')
+                        ->label(__('Sync Profiles & Folders'))
+                        ->icon('heroicon-o-arrow-path')
+                        ->action(function (ArrIntegration $record) {
+                            $service = ArrService::make($record);
+                            $profiles = $service->fetchQualityProfiles();
+                            $folders = $service->fetchRootFolders();
+
+                            // Cache first as defaults on the model if not already set
+                            $update = [];
+                            if (! empty($profiles) && ! $record->quality_profile_id) {
+                                $update['quality_profile_id'] = $profiles[0]['id'];
+                                $update['quality_profile_name'] = $profiles[0]['name'];
+                            }
+                            if (! empty($folders) && ! $record->root_folder_path) {
+                                $update['root_folder_path'] = $folders[0]['path'];
+                            }
+
+                            if (! empty($update)) {
+                                $record->forceFill($update)->save();
+                            }
+
+                            Notification::make()
+                                ->success()
+                                ->title(__('Synced'))
+                                ->body(__('Found :profiles profiles and :folders root folders.', [
+                                    'profiles' => count($profiles),
+                                    'folders' => count($folders),
+                                ]))
+                                ->send();
+                        }),
+                    DeleteAction::make(),
+                ])->button(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('name');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListArrIntegrations::route('/'),
+            'create' => CreateArrIntegration::route('/create'),
+            'edit' => EditArrIntegration::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * Build the in-form "Test Connection & Discover" action. Runs against the
+     * current form state, populates profile/folder hidden state, and surfaces
+     * a Filament notification.
+     *
+     * @return array<int, Action>
+     */
+    private static function getDiscoverActions(): array
+    {
+        return [
+            Action::make('testAndDiscover')
+                ->label(__('Test Connection & Discover'))
+                ->icon('heroicon-o-signal')
+                ->action(function (Get $get, Set $set, $livewire) {
+                    $apiKey = $get('api_key') ?: $livewire->record?->api_key;
+
+                    if (! $get('type') || ! $get('url') || ! $apiKey) {
+                        Notification::make()
+                            ->danger()
+                            ->title(__('Validation Error'))
+                            ->body(__('Please fill in Type, URL, and API Key before testing.'))
+                            ->send();
+
+                        return;
+                    }
+
+                    $temp = new ArrIntegration([
+                        'type' => $get('type'),
+                        'url' => $get('url'),
+                        'api_key' => $apiKey,
+                    ]);
+
+                    $service = ArrService::make($temp);
+                    $test = $service->testConnection();
+
+                    if (! $test['ok']) {
+                        Notification::make()
+                            ->danger()
+                            ->title(__('Connection Failed'))
+                            ->body($test['error'] ?? 'Unknown error')
+                            ->send();
+
+                        return;
+                    }
+
+                    $profiles = $service->fetchQualityProfiles();
+                    $folders = $service->fetchRootFolders();
+
+                    $set('quality_profiles_options', json_encode($profiles));
+                    $set('root_folders_options', json_encode($folders));
+
+                    // Pre-select the first option if nothing is set yet
+                    if (! $get('quality_profile_id') && ! empty($profiles)) {
+                        $set('quality_profile_id', $profiles[0]['id']);
+                        $set('quality_profile_name', $profiles[0]['name']);
+                    }
+                    if (! $get('root_folder_path') && ! empty($folders)) {
+                        $set('root_folder_path', $folders[0]['path']);
+                    }
+
+                    $livewire->record?->forceFill(['last_test_at' => now()])->save();
+
+                    Notification::make()
+                        ->success()
+                        ->title(__('Connection Successful'))
+                        ->body(__('Connected to v:version — found :p profiles, :f folders.', [
+                            'version' => $test['version'] ?? 'unknown',
+                            'p' => count($profiles),
+                            'f' => count($folders),
+                        ]))
+                        ->send();
+                }),
+        ];
+    }
+}

--- a/app/Filament/Resources/ArrIntegrations/Pages/CreateArrIntegration.php
+++ b/app/Filament/Resources/ArrIntegrations/Pages/CreateArrIntegration.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Resources\ArrIntegrations\Pages;
+
+use App\Filament\Resources\ArrIntegrations\ArrIntegrationResource;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Support\Facades\Auth;
+
+class CreateArrIntegration extends CreateRecord
+{
+    protected static string $resource = ArrIntegrationResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['user_id'] = Auth::id();
+
+        return $data;
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/ArrIntegrations/Pages/CreateArrIntegration.php
+++ b/app/Filament/Resources/ArrIntegrations/Pages/CreateArrIntegration.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\ArrIntegrations\Pages;
 
 use App\Filament\Resources\ArrIntegrations\ArrIntegrationResource;
+use App\Filament\Resources\MediaServerIntegrations\MediaServerIntegrationResource;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Support\Facades\Auth;
 
@@ -19,6 +20,6 @@ class CreateArrIntegration extends CreateRecord
 
     protected function getRedirectUrl(): string
     {
-        return $this->getResource()::getUrl('index');
+        return MediaServerIntegrationResource::getUrl('index');
     }
 }

--- a/app/Filament/Resources/ArrIntegrations/Pages/EditArrIntegration.php
+++ b/app/Filament/Resources/ArrIntegrations/Pages/EditArrIntegration.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\ArrIntegrations\Pages;
 
 use App\Filament\Resources\ArrIntegrations\ArrIntegrationResource;
+use App\Filament\Resources\MediaServerIntegrations\MediaServerIntegrationResource;
 use App\Models\ArrIntegration;
 use App\Services\Arr\ArrService;
 use Filament\Actions\Action;
@@ -84,6 +85,6 @@ class EditArrIntegration extends EditRecord
 
     protected function getRedirectUrl(): string
     {
-        return $this->getResource()::getUrl('index');
+        return MediaServerIntegrationResource::getUrl('index');
     }
 }

--- a/app/Filament/Resources/ArrIntegrations/Pages/EditArrIntegration.php
+++ b/app/Filament/Resources/ArrIntegrations/Pages/EditArrIntegration.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Filament\Resources\ArrIntegrations\Pages;
+
+use App\Filament\Resources\ArrIntegrations\ArrIntegrationResource;
+use App\Models\ArrIntegration;
+use App\Services\Arr\ArrService;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\EditRecord;
+
+class EditArrIntegration extends EditRecord
+{
+    protected static string $resource = ArrIntegrationResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ActionGroup::make([
+                Action::make('test')
+                    ->label(__('Test Connection'))
+                    ->icon('heroicon-o-signal')
+                    ->action(function () {
+                        $service = ArrService::make($this->record);
+                        $result = $service->testConnection();
+
+                        if ($result['ok']) {
+                            $this->record->forceFill(['last_test_at' => now()])->save();
+
+                            Notification::make()
+                                ->success()
+                                ->title(__('Connection Successful'))
+                                ->body(__('Connected to :name (v:version)', [
+                                    'name' => $this->record->name,
+                                    'version' => $result['version'] ?? 'unknown',
+                                ]))
+                                ->send();
+                        } else {
+                            Notification::make()
+                                ->danger()
+                                ->title(__('Connection Failed'))
+                                ->body($result['error'] ?? 'Unknown error')
+                                ->send();
+                        }
+                    }),
+
+                Action::make('syncProfiles')
+                    ->label(__('Sync Profiles & Folders'))
+                    ->icon('heroicon-o-arrow-path')
+                    ->action(function (ArrIntegration $record) {
+                        $service = ArrService::make($record);
+                        $profiles = $service->fetchQualityProfiles();
+                        $folders = $service->fetchRootFolders();
+
+                        $update = [];
+                        if (! empty($profiles)) {
+                            $update['quality_profile_id'] = $profiles[0]['id'];
+                            $update['quality_profile_name'] = $profiles[0]['name'];
+                        }
+                        if (! empty($folders)) {
+                            $update['root_folder_path'] = $folders[0]['path'];
+                        }
+
+                        if (! empty($update)) {
+                            $record->forceFill($update)->save();
+                        }
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Synced'))
+                            ->body(__('Cached :profiles profiles and :folders root folders.', [
+                                'profiles' => count($profiles),
+                                'folders' => count($folders),
+                            ]))
+                            ->send();
+                    }),
+
+                DeleteAction::make(),
+            ])->button(),
+        ];
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/ArrIntegrations/Pages/ListArrIntegrations.php
+++ b/app/Filament/Resources/ArrIntegrations/Pages/ListArrIntegrations.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Filament\Resources\ArrIntegrations\Pages;
+
+use App\Filament\Resources\ArrIntegrations\ArrIntegrationResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Support\Htmlable;
+
+class ListArrIntegrations extends ListRecords
+{
+    protected static string $resource = ArrIntegrationResource::class;
+
+    public function getSubheading(): string|Htmlable|null
+    {
+        return __('Connect your existing Sonarr (TV) and Radarr (Movies) servers to search and request content directly from m3u-editor. One integration per (playlist, server) is supported.');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make()
+                ->label(__('Add Sonarr/Radarr')),
+        ];
+    }
+}

--- a/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
+++ b/app/Filament/Resources/MediaServerIntegrations/MediaServerIntegrationResource.php
@@ -30,6 +30,7 @@ use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\BulkAction;
 use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -75,17 +76,17 @@ class MediaServerIntegrationResource extends Resource implements CopilotResource
 
     public static function getNavigationLabel(): string
     {
-        return __('Media Servers');
+        return __('Servers');
     }
 
     public static function getModelLabel(): string
     {
-        return __('Media Server');
+        return __('Server');
     }
 
     public static function getPluralModelLabel(): string
     {
-        return __('Media Servers');
+        return __('Servers');
     }
 
     public static function getNavigationGroup(): ?string
@@ -1130,6 +1131,11 @@ class MediaServerIntegrationResource extends Resource implements CopilotResource
     public static function table(Table $table): Table
     {
         return $table
+            ->heading(__('Media Servers'))
+            ->headerActions([
+                CreateAction::make()
+                    ->label(__('Add Media Server')),
+            ])
             ->filtersTriggerAction(function ($action) {
                 return $action->button()->label(__('Filters'));
             })

--- a/app/Filament/Resources/MediaServerIntegrations/Pages/ListMediaServerIntegrations.php
+++ b/app/Filament/Resources/MediaServerIntegrations/Pages/ListMediaServerIntegrations.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Resources\MediaServerIntegrations\Pages;
 
 use App\Filament\Resources\MediaServerIntegrations\MediaServerIntegrationResource;
-use Filament\Actions\CreateAction;
+use App\Filament\Resources\MediaServerIntegrations\Widgets\ArrIntegrationsWidget;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Contracts\Support\Htmlable;
 
@@ -13,14 +13,13 @@ class ListMediaServerIntegrations extends ListRecords
 
     public function getSubheading(): string|Htmlable|null
     {
-        return __('Access your media server content directly within M3U Editor by integrating with popular media servers like Emby and Jellyfin, or directly via mount points. An associated playlist will be automatically created for each integration to manage content like you would for any other playlist.');
+        return __('Connect media servers (Emby, Jellyfin, Plex), local media libraries, WebDAV shares, and download servers (Sonarr, Radarr) — all from one place.');
     }
 
-    protected function getHeaderActions(): array
+    protected function getFooterWidgets(): array
     {
         return [
-            CreateAction::make()
-                ->label(__('Add Media Server')),
+            ArrIntegrationsWidget::class,
         ];
     }
 }

--- a/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
+++ b/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace App\Filament\Resources\MediaServerIntegrations\Widgets;
+
+use App\Filament\Resources\ArrIntegrations\ArrIntegrationResource;
+use App\Models\ArrIntegration;
+use App\Services\Arr\ArrService;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Actions as FormActions;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Auth;
+
+class ArrIntegrationsWidget extends BaseWidget
+{
+    protected static ?string $heading = 'Sonarr & Radarr';
+
+    protected int|string|array $columnSpan = 'full';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                ArrIntegration::query()
+                    ->where('user_id', Auth::id())
+                    ->orderBy('name')
+            )
+            ->headerActions([
+                Action::make('createArr')
+                    ->label(__('Add Sonarr / Radarr'))
+                    ->modalHeading(__('Add Sonarr / Radarr Integration'))
+                    ->form(self::arrForm())
+                    ->action(function (array $data): void {
+                        ArrIntegration::create(array_merge(
+                            $data,
+                            ['user_id' => Auth::id()]
+                        ));
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Integration Added'))
+                            ->send();
+                    }),
+            ])
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('type')
+                    ->badge()
+                    ->color(fn (string $state): string => $state === 'sonarr' ? 'info' : 'purple')
+                    ->formatStateUsing(fn (string $state): string => ucfirst($state))
+                    ->sortable(),
+
+                TextColumn::make('playlist.name')
+                    ->label(__('Playlist'))
+                    ->searchable()
+                    ->sortable()
+                    ->placeholder('—'),
+
+                TextColumn::make('url')
+                    ->label(__('URL'))
+                    ->searchable()
+                    ->copyable()
+                    ->limit(40),
+
+                TextColumn::make('quality_profile_name')
+                    ->label(__('Quality Profile'))
+                    ->placeholder('—')
+                    ->toggleable(),
+
+                IconColumn::make('enabled')
+                    ->label(__('Enabled'))
+                    ->boolean()
+                    ->sortable(),
+
+                IconColumn::make('guest_enabled')
+                    ->label(__('Guest'))
+                    ->boolean()
+                    ->sortable(),
+
+                TextColumn::make('last_test_at')
+                    ->label(__('Last Tested'))
+                    ->dateTime()
+                    ->placeholder('Never')
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('type')
+                    ->options([
+                        'sonarr' => 'Sonarr',
+                        'radarr' => 'Radarr',
+                    ]),
+            ])
+            ->actions([
+                ActionGroup::make([
+                    Action::make('edit')
+                        ->label(__('Edit'))
+                        ->icon('heroicon-o-pencil')
+                        ->url(fn (ArrIntegration $record): string => ArrIntegrationResource::getUrl('edit', ['record' => $record])),
+
+                    Action::make('test')
+                        ->label(__('Test Connection'))
+                        ->icon('heroicon-o-signal')
+                        ->action(function (ArrIntegration $record): void {
+                            $result = ArrService::make($record)->testConnection();
+
+                            if ($result['ok']) {
+                                $record->forceFill(['last_test_at' => now()])->save();
+
+                                Notification::make()
+                                    ->success()
+                                    ->title(__('Connection Successful'))
+                                    ->body(__('Connected to :name (v:version)', [
+                                        'name' => $record->name,
+                                        'version' => $result['version'] ?? 'unknown',
+                                    ]))
+                                    ->send();
+                            } else {
+                                Notification::make()
+                                    ->danger()
+                                    ->title(__('Connection Failed'))
+                                    ->body($result['error'] ?? 'Unknown error')
+                                    ->send();
+                            }
+                        }),
+
+                    Action::make('syncProfiles')
+                        ->label(__('Sync Profiles & Folders'))
+                        ->icon('heroicon-o-arrow-path')
+                        ->action(function (ArrIntegration $record): void {
+                            $service = ArrService::make($record);
+                            $profiles = $service->fetchQualityProfiles();
+                            $folders = $service->fetchRootFolders();
+
+                            $update = [];
+                            if (! empty($profiles) && ! $record->quality_profile_id) {
+                                $update['quality_profile_id'] = $profiles[0]['id'];
+                                $update['quality_profile_name'] = $profiles[0]['name'];
+                            }
+                            if (! empty($folders) && ! $record->root_folder_path) {
+                                $update['root_folder_path'] = $folders[0]['path'];
+                            }
+
+                            if (! empty($update)) {
+                                $record->forceFill($update)->save();
+                            }
+
+                            Notification::make()
+                                ->success()
+                                ->title(__('Synced'))
+                                ->body(__('Found :profiles profiles and :folders root folders.', [
+                                    'profiles' => count($profiles),
+                                    'folders' => count($folders),
+                                ]))
+                                ->send();
+                        }),
+
+                    DeleteAction::make(),
+                ])->button(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('name')
+            ->emptyStateHeading(__('No Sonarr or Radarr integrations'))
+            ->emptyStateDescription(__('Add a Sonarr or Radarr server to enable content requesting.'))
+            ->emptyStateIcon('heroicon-o-arrow-down-tray');
+    }
+
+    /**
+     * Form schema shared by the Add modal. Edit uses the full resource page.
+     *
+     * @return array<int, mixed>
+     */
+    private static function arrForm(): array
+    {
+        return [
+            Section::make(__('Connection'))
+                ->schema([
+                    Grid::make(2)->schema([
+                        TextInput::make('name')
+                            ->label(__('Display Name'))
+                            ->placeholder(fn (Get $get): string => $get('type') === 'radarr' ? 'e.g., Radarr - 4K Movies' : 'e.g., Sonarr - 1080p TV')
+                            ->required()
+                            ->maxLength(255),
+
+                        Select::make('type')
+                            ->label(__('Type'))
+                            ->options([
+                                'sonarr' => 'Sonarr',
+                                'radarr' => 'Radarr',
+                            ])
+                            ->required()
+                            ->live()
+                            ->native(false),
+                    ]),
+
+                    Grid::make(2)->schema([
+                        Select::make('playlist_id')
+                            ->label(__('Playlist'))
+                            ->relationship(
+                                'playlist',
+                                'name',
+                                fn (Builder $query): Builder => $query->where('user_id', Auth::id())
+                            )
+                            ->required()
+                            ->searchable()
+                            ->preload()
+                            ->native(false)
+                            ->helperText(__('Content added via this integration will be requested in the context of this playlist.')),
+
+                        TextInput::make('url')
+                            ->label(__('Server URL'))
+                            ->placeholder('http://192.168.1.42:8989')
+                            ->required()
+                            ->url()
+                            ->maxLength(255),
+                    ]),
+
+                    TextInput::make('api_key')
+                        ->label(__('API Key'))
+                        ->password()
+                        ->revealable()
+                        ->required()
+                        ->helperText(__('Found in Sonarr/Radarr under Settings → General → API Key.')),
+
+                    FormActions::make([
+                        Action::make('testAndDiscover')
+                            ->label(__('Test Connection & Discover'))
+                            ->icon('heroicon-o-signal')
+                            ->action(function (Get $get, Set $set, $livewire): void {
+                                $apiKey = $get('api_key');
+
+                                if (! $get('type') || ! $get('url') || ! $apiKey) {
+                                    Notification::make()
+                                        ->danger()
+                                        ->title(__('Validation Error'))
+                                        ->body(__('Please fill in Type, URL, and API Key before testing.'))
+                                        ->send();
+
+                                    return;
+                                }
+
+                                $temp = new ArrIntegration([
+                                    'type' => $get('type'),
+                                    'url' => $get('url'),
+                                    'api_key' => $apiKey,
+                                ]);
+
+                                $service = ArrService::make($temp);
+                                $test = $service->testConnection();
+
+                                if (! $test['ok']) {
+                                    Notification::make()
+                                        ->danger()
+                                        ->title(__('Connection Failed'))
+                                        ->body($test['error'] ?? 'Unknown error')
+                                        ->send();
+
+                                    return;
+                                }
+
+                                $profiles = $service->fetchQualityProfiles();
+                                $folders = $service->fetchRootFolders();
+
+                                $set('quality_profiles_options', json_encode($profiles));
+                                $set('root_folders_options', json_encode($folders));
+
+                                if (! $get('quality_profile_id') && ! empty($profiles)) {
+                                    $set('quality_profile_id', $profiles[0]['id']);
+                                    $set('quality_profile_name', $profiles[0]['name']);
+                                }
+                                if (! $get('root_folder_path') && ! empty($folders)) {
+                                    $set('root_folder_path', $folders[0]['path']);
+                                }
+
+                                Notification::make()
+                                    ->success()
+                                    ->title(__('Connection Successful'))
+                                    ->body(__('Connected to v:version — found :p profiles, :f folders.', [
+                                        'version' => $test['version'] ?? 'unknown',
+                                        'p' => count($profiles),
+                                        'f' => count($folders),
+                                    ]))
+                                    ->send();
+                            }),
+                    ])->fullWidth(),
+
+                    Hidden::make('quality_profile_id'),
+                    Hidden::make('quality_profile_name'),
+                    Hidden::make('root_folder_path'),
+
+                    Grid::make(2)->schema([
+                        Select::make('quality_profile_id')
+                            ->label(__('Quality Profile'))
+                            ->options(function (Get $get): array {
+                                $raw = $get('quality_profiles_options') ?? '[]';
+                                $profiles = json_decode($raw, true) ?: [];
+
+                                return collect($profiles)
+                                    ->mapWithKeys(fn (array $p) => [$p['id'] => $p['name']])
+                                    ->all();
+                            })
+                            ->helperText(__('Discovered from the server — click "Test Connection & Discover" above to populate.'))
+                            ->visible(fn (Get $get): bool => filled($get('quality_profiles_options')))
+                            ->native(false),
+
+                        Select::make('root_folder_path')
+                            ->label(__('Root Folder'))
+                            ->options(function (Get $get): array {
+                                $raw = $get('root_folders_options') ?? '[]';
+                                $folders = json_decode($raw, true) ?: [];
+
+                                return collect($folders)
+                                    ->mapWithKeys(fn (array $f) => [$f['path'] => $f['path']])
+                                    ->all();
+                            })
+                            ->helperText(__('Discovered from the server — click "Test Connection & Discover" above to populate.'))
+                            ->visible(fn (Get $get): bool => filled($get('root_folders_options')))
+                            ->native(false),
+                    ]),
+
+                    Hidden::make('quality_profiles_options')->dehydrated(false),
+                    Hidden::make('root_folders_options')->dehydrated(false),
+                ]),
+
+            Section::make(__('Options'))
+                ->schema([
+                    Toggle::make('enabled')
+                        ->label(__('Enabled'))
+                        ->helperText(__('Disable to pause use of this integration without deleting it.'))
+                        ->default(true),
+
+                    Toggle::make('guest_enabled')
+                        ->label(__('Allow Guest Requests'))
+                        ->helperText(__('Allow guests on this playlist to request content via this integration.'))
+                        ->default(false),
+                ]),
+        ];
+    }
+}

--- a/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
+++ b/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\MediaServerIntegrations\Widgets;
 
+use App\Filament\Pages\RequestContent;
 use App\Filament\Resources\ArrIntegrations\ArrIntegrationResource;
 use App\Models\ArrIntegration;
 use App\Services\Arr\ArrService;
@@ -46,6 +47,11 @@ class ArrIntegrationsWidget extends BaseWidget
                     ->orderBy('name')
             )
             ->headerActions([
+                Action::make('request')
+                    ->label(__('Request Content'))
+                    ->url(RequestContent::getUrl())
+                    ->color('gray')
+                    ->button(),
                 Action::make('createArr')
                     ->label(__('Add Sonarr / Radarr'))
                     ->modalHeading(__('Add Sonarr / Radarr Integration'))

--- a/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
+++ b/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
@@ -77,7 +77,7 @@ class ArrIntegrationsWidget extends BaseWidget
 
                 TextColumn::make('type')
                     ->badge()
-                    ->color(fn (string $state): string => $state === 'sonarr' ? 'info' : 'purple')
+                    ->color(fn (string $state): string => $state === 'sonarr' ? 'info' : 'warning')
                     ->formatStateUsing(fn (string $state): string => ucfirst($state))
                     ->sortable(),
 

--- a/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
+++ b/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
@@ -25,7 +25,6 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget as BaseWidget;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 
 class ArrIntegrationsWidget extends BaseWidget
@@ -37,7 +36,7 @@ class ArrIntegrationsWidget extends BaseWidget
     public function table(Table $table): Table
     {
         return $table
-        ->filtersTriggerAction(function ($action) {
+            ->filtersTriggerAction(function ($action) {
                 return $action->button()->label(__('Filters'));
             })
             ->query(
@@ -72,12 +71,6 @@ class ArrIntegrationsWidget extends BaseWidget
                     ->color(fn (string $state): string => $state === 'sonarr' ? 'info' : 'purple')
                     ->formatStateUsing(fn (string $state): string => ucfirst($state))
                     ->sortable(),
-
-                TextColumn::make('playlist.name')
-                    ->label(__('Playlist'))
-                    ->searchable()
-                    ->sortable()
-                    ->placeholder('—'),
 
                 TextColumn::make('url')
                     ->label(__('URL'))
@@ -221,19 +214,6 @@ class ArrIntegrationsWidget extends BaseWidget
                     ]),
 
                     Grid::make(2)->schema([
-                        Select::make('playlist_id')
-                            ->label(__('Playlist'))
-                            ->relationship(
-                                'playlist',
-                                'name',
-                                fn (Builder $query): Builder => $query->where('user_id', Auth::id())
-                            )
-                            ->required()
-                            ->searchable()
-                            ->preload()
-                            ->native(false)
-                            ->helperText(__('Content added via this integration will be requested in the context of this playlist.')),
-
                         TextInput::make('url')
                             ->label(__('Server URL'))
                             ->placeholder('http://192.168.1.42:8989')

--- a/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
+++ b/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
@@ -20,8 +20,9 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
-use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\ToggleColumn;
+use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget as BaseWidget;
@@ -66,6 +67,14 @@ class ArrIntegrationsWidget extends BaseWidget
                     ->searchable()
                     ->sortable(),
 
+                ToggleColumn::make('enabled')
+                    ->label(__('Enabled'))
+                    ->sortable(),
+
+                ToggleColumn::make('guest_enabled')
+                    ->label(__('Guest'))
+                    ->sortable(),
+
                 TextColumn::make('type')
                     ->badge()
                     ->color(fn (string $state): string => $state === 'sonarr' ? 'info' : 'purple')
@@ -83,16 +92,6 @@ class ArrIntegrationsWidget extends BaseWidget
                     ->placeholder('—')
                     ->toggleable(),
 
-                IconColumn::make('enabled')
-                    ->label(__('Enabled'))
-                    ->boolean()
-                    ->sortable(),
-
-                IconColumn::make('guest_enabled')
-                    ->label(__('Guest'))
-                    ->boolean()
-                    ->sortable(),
-
                 TextColumn::make('last_test_at')
                     ->label(__('Last Tested'))
                     ->dateTime()
@@ -107,13 +106,8 @@ class ArrIntegrationsWidget extends BaseWidget
                         'radarr' => 'Radarr',
                     ]),
             ])
-            ->actions([
+            ->recordActions([
                 ActionGroup::make([
-                    Action::make('edit')
-                        ->label(__('Edit'))
-                        ->icon('heroicon-o-pencil')
-                        ->url(fn (ArrIntegration $record): string => ArrIntegrationResource::getUrl('edit', ['record' => $record])),
-
                     Action::make('test')
                         ->label(__('Test Connection'))
                         ->icon('heroicon-o-signal')
@@ -172,9 +166,14 @@ class ArrIntegrationsWidget extends BaseWidget
                         }),
 
                     DeleteAction::make(),
-                ])->button(),
-            ])
-            ->bulkActions([
+                ])->button()->hiddenLabel()->size('sm'),
+                Action::make('edit')
+                    ->label(__('Edit'))
+                    ->icon('heroicon-s-pencil-square')
+                    ->url(fn (ArrIntegration $record): string => ArrIntegrationResource::getUrl('edit', ['record' => $record]))
+                    ->button()->hiddenLabel()->size('sm'),
+            ], RecordActionsPosition::BeforeCells)
+            ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),
                 ]),

--- a/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
+++ b/app/Filament/Resources/MediaServerIntegrations/Widgets/ArrIntegrationsWidget.php
@@ -37,6 +37,9 @@ class ArrIntegrationsWidget extends BaseWidget
     public function table(Table $table): Table
     {
         return $table
+        ->filtersTriggerAction(function ($action) {
+                return $action->button()->label(__('Filters'));
+            })
             ->query(
                 ArrIntegration::query()
                     ->where('user_id', Auth::id())

--- a/app/Filament/Resources/Playlists/Pages/EditPlaylist.php
+++ b/app/Filament/Resources/Playlists/Pages/EditPlaylist.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\Playlists\PlaylistResource;
 use App\Filament\Resources\Playlists\Widgets\ImportProgress;
 use App\Models\DvrSetting;
 use App\Models\Playlist;
+use App\Models\PlaylistRequestSetting;
 use Filament\Actions\ViewAction;
 use Filament\Resources\Pages\EditRecord;
 
@@ -108,6 +109,8 @@ class EditPlaylist extends EditRecord
             $data['dvr_default_series_keep_last'] = null;
         }
 
+        $data['request_enabled'] = $record->requestSetting?->enabled ?? false;
+
         return $data;
     }
 
@@ -120,7 +123,7 @@ class EditPlaylist extends EditRecord
     protected function mutateFormDataBeforeSave(array $data): array
     {
         foreach (array_keys($data) as $key) {
-            if (str_starts_with($key, 'dvr_')) {
+            if (str_starts_with($key, 'dvr_') || str_starts_with($key, 'request_')) {
                 unset($data[$key]);
             }
         }
@@ -129,7 +132,7 @@ class EditPlaylist extends EditRecord
     }
 
     /**
-     * Save dvr_ prefixed fields back to the dvrSetting HasOne relationship.
+     * Save dvr_ and request_ prefixed fields back to their respective HasOne relationships.
      */
     protected function afterSave(): void
     {
@@ -137,29 +140,37 @@ class EditPlaylist extends EditRecord
         $record = $this->getRecord();
         $data = $this->form->getRawState();
 
-        if (! isset($data['dvr_enabled'])) {
-            return;
+        if (isset($data['dvr_enabled'])) {
+            DvrSetting::updateOrCreate(
+                ['playlist_id' => $record->id],
+                [
+                    'user_id' => $record->user_id,
+                    'enabled' => $data['dvr_enabled'] ?? false,
+                    'use_proxy' => true,
+                    'dvr_output_format' => $data['dvr_output_format'] ?? 'ts',
+                    'max_concurrent_recordings' => $data['dvr_max_concurrent_recordings'] ?? 2,
+                    'default_start_early_seconds' => $data['dvr_default_start_early_seconds'] ?? 30,
+                    'default_end_late_seconds' => $data['dvr_default_end_late_seconds'] ?? 60,
+                    'retention_days' => $data['dvr_retention_days'] ?? 0,
+                    'global_disk_quota_gb' => $data['dvr_global_disk_quota_gb'] ?? 0,
+                    'enable_metadata_enrichment' => $data['dvr_enable_metadata_enrichment'] ?? true,
+                    'generate_nfo_files' => $data['dvr_generate_nfo_files'] ?? false,
+                    'enable_comskip' => $data['dvr_enable_comskip'] ?? false,
+                    'include_disabled_channels' => $data['dvr_include_disabled_channels'] ?? false,
+                    'default_series_mode' => $data['dvr_default_series_mode'] ?? DvrSeriesMode::UniqueSe->value,
+                    'default_series_keep_last' => ($data['dvr_default_series_keep_last'] > 0) ? $data['dvr_default_series_keep_last'] : null,
+                ]
+            );
         }
 
-        DvrSetting::updateOrCreate(
-            ['playlist_id' => $record->id],
-            [
-                'user_id' => $record->user_id,
-                'enabled' => $data['dvr_enabled'] ?? false,
-                'use_proxy' => true,
-                'dvr_output_format' => $data['dvr_output_format'] ?? 'ts',
-                'max_concurrent_recordings' => $data['dvr_max_concurrent_recordings'] ?? 2,
-                'default_start_early_seconds' => $data['dvr_default_start_early_seconds'] ?? 30,
-                'default_end_late_seconds' => $data['dvr_default_end_late_seconds'] ?? 60,
-                'retention_days' => $data['dvr_retention_days'] ?? 0,
-                'global_disk_quota_gb' => $data['dvr_global_disk_quota_gb'] ?? 0,
-                'enable_metadata_enrichment' => $data['dvr_enable_metadata_enrichment'] ?? true,
-                'generate_nfo_files' => $data['dvr_generate_nfo_files'] ?? false,
-                'enable_comskip' => $data['dvr_enable_comskip'] ?? false,
-                'include_disabled_channels' => $data['dvr_include_disabled_channels'] ?? false,
-                'default_series_mode' => $data['dvr_default_series_mode'] ?? DvrSeriesMode::UniqueSe->value,
-                'default_series_keep_last' => ($data['dvr_default_series_keep_last'] > 0) ? $data['dvr_default_series_keep_last'] : null,
-            ]
-        );
+        if (isset($data['request_enabled'])) {
+            PlaylistRequestSetting::updateOrCreate(
+                ['playlist_id' => $record->id],
+                [
+                    'user_id' => $record->user_id,
+                    'enabled' => $data['request_enabled'] ?? false,
+                ]
+            );
+        }
     }
 }

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -3300,6 +3300,25 @@ class PlaylistResource extends Resource implements CopilotResource
                 ->hiddenOn('create');
         }
 
+        // Requests tab — per-playlist opt-in for content requests via Sonarr/Radarr.
+        // Fields are prefixed with request_ and hydrated/dehydrated via EditPlaylist hooks.
+        $tabs[] = Tab::make(__('Requests'))
+            ->icon('heroicon-m-magnifying-glass-circle')
+            ->hidden(fn () => ! auth()->user()->canUseIntegrations())
+            ->schema([
+                Section::make(__('Content Requests'))
+                    ->icon('heroicon-m-magnifying-glass-circle')
+                    ->description(__('Allow guests to browse and request content from your Sonarr and Radarr servers on this playlist.'))
+                    ->schema([
+                        Toggle::make('request_enabled')
+                            ->label(__('Enable Content Requests'))
+                            ->helperText(__('When enabled, guests on this playlist will see the Request Content page and can submit requests to your configured Sonarr/Radarr integrations.'))
+                            ->default(false)
+                            ->inline(false),
+                    ]),
+            ])
+            ->hiddenOn('create');
+
         // Compose the form with tabs and sections
         return [
             Grid::make()

--- a/app/Http/Controllers/ArrWebhookController.php
+++ b/app/Http/Controllers/ArrWebhookController.php
@@ -43,7 +43,10 @@ class ArrWebhookController extends Controller
             'Grab' => $this->handleGrab($integration, $payload),
             'Download' => $this->handleDownload($integration, $payload),
             'ManualInteractionRequired' => $this->handleManualRequired($integration, $payload),
-            default => null,
+            default => Log::debug('ArrWebhook: unhandled event type', [
+                'integration_id' => $integration->id,
+                'event_type' => $eventType,
+            ]),
         };
     }
 

--- a/app/Http/Controllers/ArrWebhookController.php
+++ b/app/Http/Controllers/ArrWebhookController.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\ArrQueueUpdated;
+use App\Models\ArrIntegration;
+use App\Models\ArrQueueEvent;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+
+class ArrWebhookController extends Controller
+{
+    public function receive(ArrIntegration $integration, Request $request): Response
+    {
+        $eventType = $request->input('eventType', 'Unknown');
+
+        if ($eventType === 'Test') {
+            return response()->noContent();
+        }
+
+        $payload = $request->all();
+
+        try {
+            $this->processEvent($integration, $eventType, $payload);
+        } catch (\Throwable $e) {
+            Log::warning('ArrWebhook: failed to process event', [
+                'integration_id' => $integration->id,
+                'event_type' => $eventType,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        ArrQueueUpdated::dispatch($integration->user_id);
+
+        return response()->noContent();
+    }
+
+    private function processEvent(ArrIntegration $integration, string $eventType, array $payload): void
+    {
+        match ($eventType) {
+            'MovieAdded', 'SeriesAdd' => $this->handleAdded($integration, $payload),
+            'Grab' => $this->handleGrab($integration, $payload),
+            'Download' => $this->handleDownload($integration, $payload),
+            'ManualInteractionRequired' => $this->handleManualRequired($integration, $payload),
+            default => null,
+        };
+    }
+
+    private function handleAdded(ArrIntegration $integration, array $payload): void
+    {
+        $title = $this->extractTitle($integration, $payload);
+        $externalId = $this->extractExternalId($integration, $payload);
+
+        if (! $title || ! $externalId) {
+            return;
+        }
+
+        ArrQueueEvent::updateOrCreate(
+            ['arr_integration_id' => $integration->id, 'external_id' => $externalId, 'download_id' => null],
+            [
+                'user_id' => $integration->user_id,
+                'title' => $title,
+                'event_type' => $integration->isRadarr() ? 'MovieAdded' : 'SeriesAdd',
+                'status' => 'monitored',
+                'quality' => null,
+                'release_title' => null,
+                'size' => 0,
+                'progress' => 0,
+                'last_event_at' => now(),
+            ]
+        );
+    }
+
+    private function handleGrab(ArrIntegration $integration, array $payload): void
+    {
+        $downloadId = $payload['downloadId'] ?? null;
+        $title = $this->extractTitle($integration, $payload);
+        $externalId = $this->extractExternalId($integration, $payload);
+        $release = $payload['release'] ?? [];
+        $quality = $release['quality']['quality']['name'] ?? $release['qualityVersion'] ?? null;
+        $releaseTitle = $release['releaseTitle'] ?? null;
+        $size = (int) ($release['size'] ?? 0);
+
+        if (! $title) {
+            return;
+        }
+
+        $attributes = [
+            'arr_integration_id' => $integration->id,
+            'download_id' => $downloadId,
+        ];
+
+        // If we have a prior "monitored" event for this external ID, update it to grabbing.
+        if ($externalId) {
+            ArrQueueEvent::where('arr_integration_id', $integration->id)
+                ->where('external_id', $externalId)
+                ->where('status', 'monitored')
+                ->delete();
+        }
+
+        ArrQueueEvent::updateOrCreate($attributes, [
+            'user_id' => $integration->user_id,
+            'external_id' => $externalId,
+            'title' => $title,
+            'event_type' => 'Grab',
+            'status' => 'grabbing',
+            'quality' => $quality,
+            'release_title' => $releaseTitle,
+            'size' => $size,
+            'progress' => 0,
+            'last_event_at' => now(),
+        ]);
+    }
+
+    private function handleDownload(ArrIntegration $integration, array $payload): void
+    {
+        $downloadId = $payload['downloadId'] ?? null;
+        $title = $this->extractTitle($integration, $payload);
+        $externalId = $this->extractExternalId($integration, $payload);
+
+        if (! $title) {
+            return;
+        }
+
+        $quality = null;
+        if ($integration->isRadarr()) {
+            $quality = $payload['movieFile']['quality']['quality']['name'] ?? null;
+        } else {
+            $quality = $payload['episodeFile']['quality']['quality']['name'] ?? null;
+        }
+
+        $attributes = $downloadId
+            ? ['arr_integration_id' => $integration->id, 'download_id' => $downloadId]
+            : ['arr_integration_id' => $integration->id, 'external_id' => $externalId];
+
+        ArrQueueEvent::updateOrCreate($attributes, [
+            'user_id' => $integration->user_id,
+            'external_id' => $externalId,
+            'title' => $title,
+            'event_type' => 'Download',
+            'status' => 'imported',
+            'quality' => $quality,
+            'size' => 0,
+            'progress' => 100,
+            'last_event_at' => now(),
+        ]);
+    }
+
+    private function handleManualRequired(ArrIntegration $integration, array $payload): void
+    {
+        $downloadId = $payload['downloadId'] ?? null;
+        $title = $this->extractTitle($integration, $payload);
+        $externalId = $this->extractExternalId($integration, $payload);
+
+        if (! $title) {
+            return;
+        }
+
+        $attributes = $downloadId
+            ? ['arr_integration_id' => $integration->id, 'download_id' => $downloadId]
+            : ['arr_integration_id' => $integration->id, 'external_id' => $externalId];
+
+        ArrQueueEvent::updateOrCreate($attributes, [
+            'user_id' => $integration->user_id,
+            'external_id' => $externalId,
+            'title' => $title,
+            'event_type' => 'ManualInteractionRequired',
+            'status' => 'manual_required',
+            'last_event_at' => now(),
+        ]);
+    }
+
+    private function extractTitle(ArrIntegration $integration, array $payload): ?string
+    {
+        if ($integration->isRadarr()) {
+            return $payload['movie']['title']
+                ?? $payload['remoteMovie']['title']
+                ?? null;
+        }
+
+        return $payload['series']['title'] ?? null;
+    }
+
+    private function extractExternalId(ArrIntegration $integration, array $payload): ?string
+    {
+        if ($integration->isRadarr()) {
+            $id = $payload['movie']['tmdbId'] ?? null;
+
+            return $id !== null ? (string) $id : null;
+        }
+
+        $id = $payload['series']['tvdbId'] ?? null;
+
+        return $id !== null ? (string) $id : null;
+    }
+}

--- a/app/Jobs/MonitorArrSearch.php
+++ b/app/Jobs/MonitorArrSearch.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\ArrIntegration;
+use App\Models\User;
+use App\Services\Arr\ArrService;
+use Filament\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class MonitorArrSearch implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public int $backoff = 10;
+
+    public function __construct(
+        public int $integrationId,
+        public int $contentId,
+        public string $contentTitle,
+        public int $userId,
+    ) {}
+
+    public function handle(): void
+    {
+        $integration = ArrIntegration::find($this->integrationId);
+        $user = User::find($this->userId);
+
+        if (! $integration || ! $user || ! $integration->isRadarr()) {
+            return;
+        }
+
+        $service = ArrService::make($integration);
+        $releases = $service->fetchReleases($this->contentId);
+
+        $allRejected = empty($releases) || collect($releases)->every(fn ($r) => ! ($r['approved'] ?? false));
+
+        if ($allRejected) {
+            Notification::make()
+                ->warning()
+                ->title(__('No Approved Releases'))
+                ->body(__('All releases found for ":title" are rejected by your quality profile or indexer settings. Try adjusting your settings in Radarr, or use Interactive Search to pick a release manually.', [
+                    'title' => $this->contentTitle,
+                ]))
+                ->broadcast($user)
+                ->sendToDatabase($user);
+        }
+    }
+
+    public function failed(\Throwable $e): void
+    {
+        $user = User::find($this->userId);
+
+        if (! $user) {
+            return;
+        }
+
+        Notification::make()
+            ->warning()
+            ->title(__('Search Check Failed'))
+            ->body(__('Could not verify release availability for ":title". Check Radarr directly.', [
+                'title' => $this->contentTitle,
+            ]))
+            ->broadcast($user)
+            ->sendToDatabase($user);
+    }
+}

--- a/app/Jobs/RequestArrEpisode.php
+++ b/app/Jobs/RequestArrEpisode.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\ArrIntegration;
+use App\Models\User;
+use App\Services\Arr\SonarrService;
+use Filament\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class RequestArrEpisode implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Retry up to 8 times with 5-second gaps (~40s total), giving Sonarr
+     * enough time to finish indexing a freshly-added series.
+     */
+    public int $tries = 8;
+
+    public int $backoff = 5;
+
+    public function __construct(
+        public int $integrationId,
+        public int $sonarrSeriesId,
+        public int $seasonNumber,
+        public int $episodeNumber,
+        public int $userId,
+        public string $showTitle,
+    ) {}
+
+    public function handle(): void
+    {
+        $integration = ArrIntegration::find($this->integrationId);
+        $user = User::find($this->userId);
+
+        if (! $integration || ! $user) {
+            return;
+        }
+
+        /** @var SonarrService $service */
+        $service = new SonarrService($integration);
+        $result = $service->monitorAndSearchEpisode($this->sonarrSeriesId, $this->seasonNumber, $this->episodeNumber);
+
+        if (! $result['ok']) {
+            // Episode not yet indexed by Sonarr — throw to trigger a retry.
+            throw new \RuntimeException($result['error'] ?? 'Episode not yet indexed.');
+        }
+
+        $label = $this->episodeLabel();
+
+        Notification::make()
+            ->success()
+            ->title(__('Episode Queued for Download'))
+            ->body(__(':episode of :title has been queued for download.', [
+                'episode' => $label,
+                'title' => $this->showTitle,
+            ]))
+            ->broadcast($user)
+            ->sendToDatabase($user);
+    }
+
+    public function failed(\Throwable $e): void
+    {
+        $user = User::find($this->userId);
+
+        if (! $user) {
+            return;
+        }
+
+        Notification::make()
+            ->danger()
+            ->title(__('Episode Request Failed'))
+            ->body(__('Could not queue :episode of :title: :error', [
+                'episode' => $this->episodeLabel(),
+                'title' => $this->showTitle,
+                'error' => $e->getMessage(),
+            ]))
+            ->broadcast($user)
+            ->sendToDatabase($user);
+    }
+
+    private function episodeLabel(): string
+    {
+        return 'S'.str_pad((string) $this->seasonNumber, 2, '0', STR_PAD_LEFT)
+            .'E'.str_pad((string) $this->episodeNumber, 2, '0', STR_PAD_LEFT);
+    }
+}

--- a/app/Livewire/ArrQueueMonitor.php
+++ b/app/Livewire/ArrQueueMonitor.php
@@ -5,6 +5,8 @@ namespace App\Livewire;
 use App\Models\ArrIntegration;
 use App\Models\ArrQueueEvent;
 use App\Services\Arr\ArrService;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Support\Facades\Http;
 use Illuminate\View\View;
 use Livewire\Component;
 
@@ -20,10 +22,13 @@ class ArrQueueMonitor extends Component
     /**
      * Completed orphan items (no webhook event) captured between polls.
      * Keyed by "{integrationId}_{downloadId}". Persists until dismissed.
+     * Capped at MAX_SNAPSHOTS_PER_INTEGRATION per integration to prevent unbounded growth.
      *
      * @var array<string, array<string, mixed>>
      */
     public array $completedSnapshots = [];
+
+    protected const MAX_SNAPSHOTS_PER_INTEGRATION = 25;
 
     /** @var array<string, string> */
     protected $listeners = ['refreshArrQueue' => 'loadQueues'];
@@ -57,16 +62,44 @@ class ArrQueueMonitor extends Component
             ->where('user_id', auth()->id())
             ->where('enabled', true)
             ->orderBy('name')
-            ->get();
+            ->get()
+            ->values(); // 0-indexed so pool responses map by position
 
-        foreach ($integrations as $integration) {
+        if ($integrations->isEmpty()) {
+            $this->dispatch('queue-status', count: 0);
+
+            return;
+        }
+
+        // Fire all queue HTTP requests in parallel instead of serially.
+        $services = $integrations->map(fn ($i) => ArrService::make($i));
+
+        $queueResponses = Http::pool(function (Pool $pool) use ($integrations) {
+            return $integrations->map(function ($integration) use ($pool) {
+                $params = $integration->isSonarr()
+                    ? ['includeSeries' => 'true', 'includeEpisode' => 'true']
+                    : ['includeMovie' => 'true'];
+
+                return $pool
+                    ->baseUrl($integration->base_url.'/api/v3')
+                    ->timeout(5)
+                    ->acceptJson()
+                    ->withHeaders(['X-Api-Key' => $integration->api_key])
+                    ->get('/queue', $params);
+            })->all();
+        });
+
+        foreach ($integrations as $index => $integration) {
+            $queueResponse = $queueResponses[$index];
+
             // Live items from the Arr service (actively downloading — have progress).
             $liveItems = collect();
             $liveError = false;
-            try {
-                $liveItems = collect(ArrService::make($integration)->fetchQueue());
-            } catch (\Exception) {
+
+            if ($queueResponse instanceof \Throwable || ! $queueResponse->successful()) {
                 $liveError = true;
+            } else {
+                $liveItems = collect($services[$index]->parseQueueRecords($queueResponse->json()['records'] ?? []));
             }
 
             $liveByDownloadId = $liveItems->keyBy('downloadId')->filter();
@@ -93,6 +126,16 @@ class ArrQueueMonitor extends Component
                         'can_dismiss' => true,
                         'source' => 'snapshot',
                     ]);
+
+                    // Trim oldest snapshots for this integration to enforce the cap.
+                    $integrationSnapshots = array_filter(
+                        $this->completedSnapshots,
+                        fn ($s) => ($s['integration_id'] ?? null) === $integration->id
+                    );
+
+                    if (count($integrationSnapshots) > self::MAX_SNAPSHOTS_PER_INTEGRATION) {
+                        unset($this->completedSnapshots[(string) array_key_first($integrationSnapshots)]);
+                    }
                 }
             }
 

--- a/app/Livewire/ArrQueueMonitor.php
+++ b/app/Livewire/ArrQueueMonitor.php
@@ -17,6 +17,17 @@ class ArrQueueMonitor extends Component
      */
     public array $queues = [];
 
+    /**
+     * Completed orphan items (no webhook event) captured between polls.
+     * Keyed by "{integrationId}_{downloadId}". Persists until dismissed.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    public array $completedSnapshots = [];
+
+    /** @var array<string, string> */
+    protected $listeners = ['refreshArrQueue' => 'loadQueues'];
+
     public function mount(): void
     {
         $this->loadQueues();
@@ -59,6 +70,31 @@ class ArrQueueMonitor extends Component
             }
 
             $liveByDownloadId = $liveItems->keyBy('downloadId')->filter();
+            $currentLiveDownloadIds = $liveItems->pluck('downloadId')->filter()->flip();
+
+            // Snapshot orphan live items that vanished since the last poll.
+            // This lets us show "Completed" even when the item leaves the Arr queue.
+            $prevOrphans = collect($this->queues[$integration->id]['items'] ?? [])
+                ->where('source', 'live')
+                ->filter(fn ($i) => ! empty($i['downloadId']));
+
+            foreach ($prevOrphans as $prevItem) {
+                $downloadId = $prevItem['downloadId'];
+                $key = "{$integration->id}_{$downloadId}";
+
+                if (! isset($currentLiveDownloadIds[$downloadId]) && ! isset($this->completedSnapshots[$key])) {
+                    $this->completedSnapshots[$key] = array_merge($prevItem, [
+                        'status' => 'completed',
+                        'progress' => 100,
+                        'timeLeft' => null,
+                        'integration_id' => $integration->id,
+                        'dismiss_source' => 'snapshot',
+                        'dismiss_key' => $key,
+                        'can_dismiss' => true,
+                        'source' => 'snapshot',
+                    ]);
+                }
+            }
 
             // Webhook-sourced local events for the last 48 h (imported events age out after that).
             $localEvents = ArrQueueEvent::query()
@@ -80,17 +116,32 @@ class ArrQueueMonitor extends Component
                     $seenDownloadIds[] = $event->download_id;
                 }
 
+                $trackedState = $live ? ($live['trackedDownloadState'] ?? null) : null;
+                $effectiveStatus = self::resolveStatus(
+                    $live ? $live['status'] : $event->status,
+                    $trackedState
+                );
+
+                $canDismiss = in_array($effectiveStatus, ['imported', 'completed', 'failed', 'monitored', 'manual_required']);
+
                 return [
                     'title' => $event->title,
-                    'status' => $live ? $live['status'] : $event->status,
+                    'status' => $effectiveStatus,
                     'progress' => $live ? $live['progress'] : $event->progress,
-                    'quality' => $event->quality,
+                    'quality' => $event->quality ?? ($live ? ($live['quality'] ?? null) : null),
+                    'protocol' => $live ? ($live['protocol'] ?? null) : null,
+                    'indexer' => $live ? ($live['indexer'] ?? null) : null,
+                    'episode' => $live ? ($live['episode'] ?? null) : null,
                     'size' => $live ? (int) $live['size'] : (int) $event->size,
                     'timeLeft' => $live ? ($live['timeLeft'] ?? null) : null,
                     'event_type' => $event->event_type,
                     'last_event_at' => $event->last_event_at?->toIso8601String(),
                     'formattedSize' => self::formatBytes($live ? (int) $live['size'] : (int) $event->size),
                     'source' => 'webhook',
+                    'event_db_id' => $event->id,
+                    'dismiss_source' => 'event',
+                    'dismiss_key' => (string) $event->id,
+                    'can_dismiss' => $canDismiss,
                 ];
             });
 
@@ -100,16 +151,26 @@ class ArrQueueMonitor extends Component
                 ->filter(fn ($item) => ! ($item['downloadId'] && in_array($item['downloadId'], $seenDownloadIds)))
                 ->map(fn ($item) => [
                     'title' => $item['title'],
-                    'status' => $item['status'],
+                    'status' => self::resolveStatus($item['status'], $item['trackedDownloadState'] ?? null),
                     'progress' => $item['progress'],
-                    'quality' => null,
+                    'quality' => $item['quality'] ?? null,
+                    'protocol' => $item['protocol'] ?? null,
+                    'indexer' => $item['indexer'] ?? null,
+                    'episode' => $item['episode'] ?? null,
+                    'downloadId' => $item['downloadId'] ?? null,
                     'size' => (int) $item['size'],
                     'timeLeft' => $item['timeLeft'] ?? null,
                     'event_type' => 'live',
                     'last_event_at' => null,
                     'formattedSize' => self::formatBytes((int) $item['size']),
                     'source' => 'live',
+                    'can_dismiss' => false,
                 ]);
+
+            // Merge in completed snapshots that belong to this integration.
+            $snapshotItems = collect($this->completedSnapshots)
+                ->filter(fn ($s) => ($s['integration_id'] ?? null) === $integration->id)
+                ->values();
 
             $this->queues[$integration->id] = [
                 'integration' => [
@@ -117,12 +178,30 @@ class ArrQueueMonitor extends Component
                     'name' => $integration->name,
                     'type' => $integration->type,
                 ],
-                'items' => $items->concat($orphanLive)->values()->all(),
+                'items' => $items->concat($orphanLive)->concat($snapshotItems)->values()->all(),
                 'error' => $liveError && $localEvents->isEmpty(),
             ];
         }
 
         $this->dispatch('queue-status', count: $this->totalCount);
+    }
+
+    /**
+     * Dismiss a queue item from the display.
+     * For webhook events: delete the local ArrQueueEvent record.
+     * For completed snapshots: remove from component state.
+     */
+    public function dismissItem(string $source, string $key): void
+    {
+        if ($source === 'event') {
+            ArrQueueEvent::where('id', (int) $key)
+                ->where('user_id', auth()->id())
+                ->delete();
+        } elseif ($source === 'snapshot') {
+            unset($this->completedSnapshots[$key]);
+        }
+
+        $this->loadQueues();
     }
 
     /**
@@ -153,6 +232,21 @@ class ArrQueueMonitor extends Component
     }
 
     /**
+     * Resolve the display status from the raw Arr status + trackedDownloadState.
+     * trackedDownloadState is more precise once a download completes.
+     */
+    public static function resolveStatus(string $status, ?string $trackedDownloadState): string
+    {
+        return match ($trackedDownloadState) {
+            'importPending' => 'import_pending',
+            'importing' => 'importing',
+            'imported' => 'imported',
+            'failedPending' => 'failed',
+            default => $status,
+        };
+    }
+
+    /**
      * @return array{color: string, label: string}
      */
     public static function statusBadge(string $status): array
@@ -161,6 +255,8 @@ class ArrQueueMonitor extends Component
             'monitored' => ['color' => 'gray', 'label' => 'Monitored'],
             'grabbing' => ['color' => 'warning', 'label' => 'Grabbing'],
             'downloading' => ['color' => 'primary', 'label' => 'Downloading'],
+            'import_pending' => ['color' => 'warning', 'label' => 'Import Pending'],
+            'importing' => ['color' => 'primary', 'label' => 'Importing'],
             'imported' => ['color' => 'success', 'label' => 'Imported'],
             'manual_required' => ['color' => 'danger', 'label' => 'Manual Required'],
             'queued' => ['color' => 'warning', 'label' => 'Queued'],

--- a/app/Livewire/ArrQueueMonitor.php
+++ b/app/Livewire/ArrQueueMonitor.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\ArrIntegration;
+use App\Models\ArrQueueEvent;
+use App\Services\Arr\ArrService;
+use Illuminate\View\View;
+use Livewire\Component;
+
+class ArrQueueMonitor extends Component
+{
+    /**
+     * Keyed by integration ID.
+     *
+     * @var array<int, array{integration: array<string, mixed>, items: array<int, array<string, mixed>>, error: bool}>
+     */
+    public array $queues = [];
+
+    public function mount(): void
+    {
+        $this->loadQueues();
+    }
+
+    /**
+     * Listen for real-time webhook-triggered broadcasts.
+     * Using getListeners() because the channel name contains a runtime value.
+     *
+     * @return array<string, string>
+     */
+    public function getListeners(): array
+    {
+        return [
+            'echo-private:arr-queue.'.auth()->id().',.queue.updated' => 'refresh',
+        ];
+    }
+
+    public function refresh(): void
+    {
+        $this->loadQueues();
+    }
+
+    public function loadQueues(): void
+    {
+        $integrations = ArrIntegration::query()
+            ->where('user_id', auth()->id())
+            ->where('enabled', true)
+            ->orderBy('name')
+            ->get();
+
+        foreach ($integrations as $integration) {
+            // Live items from the Arr service (actively downloading — have progress).
+            $liveItems = collect();
+            $liveError = false;
+            try {
+                $liveItems = collect(ArrService::make($integration)->fetchQueue());
+            } catch (\Exception) {
+                $liveError = true;
+            }
+
+            $liveByDownloadId = $liveItems->keyBy('downloadId')->filter();
+
+            // Webhook-sourced local events for the last 48 h (imported events age out after that).
+            $localEvents = ArrQueueEvent::query()
+                ->where('arr_integration_id', $integration->id)
+                ->where(function ($q) {
+                    $q->where('status', '!=', 'imported')
+                        ->orWhere('last_event_at', '>', now()->subHours(24));
+                })
+                ->orderByDesc('last_event_at')
+                ->get();
+
+            // Build merged item list: local events take precedence (richer status vocabulary).
+            // For items that are actively downloading, enrich with live progress.
+            $seenDownloadIds = [];
+            $items = $localEvents->map(function (ArrQueueEvent $event) use ($liveByDownloadId, &$seenDownloadIds) {
+                $live = $event->download_id ? $liveByDownloadId->get($event->download_id) : null;
+
+                if ($event->download_id) {
+                    $seenDownloadIds[] = $event->download_id;
+                }
+
+                return [
+                    'title' => $event->title,
+                    'status' => $live ? $live['status'] : $event->status,
+                    'progress' => $live ? $live['progress'] : $event->progress,
+                    'quality' => $event->quality,
+                    'size' => $live ? (int) $live['size'] : (int) $event->size,
+                    'timeLeft' => $live ? ($live['timeLeft'] ?? null) : null,
+                    'event_type' => $event->event_type,
+                    'last_event_at' => $event->last_event_at?->toIso8601String(),
+                    'formattedSize' => self::formatBytes($live ? (int) $live['size'] : (int) $event->size),
+                    'source' => 'webhook',
+                ];
+            });
+
+            // Include live items not matched by any local event (e.g., downloads started before
+            // webhooks were configured, or responses without a downloadId).
+            $orphanLive = $liveItems
+                ->filter(fn ($item) => ! ($item['downloadId'] && in_array($item['downloadId'], $seenDownloadIds)))
+                ->map(fn ($item) => [
+                    'title' => $item['title'],
+                    'status' => $item['status'],
+                    'progress' => $item['progress'],
+                    'quality' => null,
+                    'size' => (int) $item['size'],
+                    'timeLeft' => $item['timeLeft'] ?? null,
+                    'event_type' => 'live',
+                    'last_event_at' => null,
+                    'formattedSize' => self::formatBytes((int) $item['size']),
+                    'source' => 'live',
+                ]);
+
+            $this->queues[$integration->id] = [
+                'integration' => [
+                    'id' => $integration->id,
+                    'name' => $integration->name,
+                    'type' => $integration->type,
+                ],
+                'items' => $items->concat($orphanLive)->values()->all(),
+                'error' => $liveError && $localEvents->isEmpty(),
+            ];
+        }
+
+        $this->dispatch('queue-status', count: $this->totalCount);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getSonarrQueuesProperty(): array
+    {
+        return collect($this->queues)
+            ->filter(fn ($q) => $q['integration']['type'] === 'sonarr')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getRadarrQueuesProperty(): array
+    {
+        return collect($this->queues)
+            ->filter(fn ($q) => $q['integration']['type'] === 'radarr')
+            ->values()
+            ->all();
+    }
+
+    public function getTotalCountProperty(): int
+    {
+        return collect($this->queues)->sum(fn ($q) => count($q['items']));
+    }
+
+    /**
+     * @return array{color: string, label: string}
+     */
+    public static function statusBadge(string $status): array
+    {
+        return match (strtolower($status)) {
+            'monitored' => ['color' => 'gray', 'label' => 'Monitored'],
+            'grabbing' => ['color' => 'warning', 'label' => 'Grabbing'],
+            'downloading' => ['color' => 'primary', 'label' => 'Downloading'],
+            'imported' => ['color' => 'success', 'label' => 'Imported'],
+            'manual_required' => ['color' => 'danger', 'label' => 'Manual Required'],
+            'queued' => ['color' => 'warning', 'label' => 'Queued'],
+            'paused' => ['color' => 'gray', 'label' => 'Paused'],
+            'completed' => ['color' => 'success', 'label' => 'Completed'],
+            'failed', 'error' => ['color' => 'danger', 'label' => 'Failed'],
+            default => ['color' => 'gray', 'label' => ucfirst($status)],
+        };
+    }
+
+    public static function formatBytes(int $bytes): string
+    {
+        if ($bytes <= 0) {
+            return '–';
+        }
+
+        if ($bytes >= 1_073_741_824) {
+            return number_format($bytes / 1_073_741_824, 2).' GB';
+        }
+
+        if ($bytes >= 1_048_576) {
+            return number_format($bytes / 1_048_576, 2).' MB';
+        }
+
+        return number_format($bytes / 1_024, 2).' KB';
+    }
+
+    public function render(): View
+    {
+        return view('livewire.arr-queue-monitor');
+    }
+}

--- a/app/Livewire/ArrSearch.php
+++ b/app/Livewire/ArrSearch.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire;
 
+use App\Jobs\MonitorArrSearch;
 use App\Models\ArrIntegration;
 use App\Services\Arr\ArrService;
 use App\Services\Arr\SonarrService;
@@ -11,6 +12,7 @@ use Filament\Notifications\Notification;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Client\Pool;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -141,6 +143,10 @@ class ArrSearch extends Component
     public array $browseResults = [];
 
     public bool $browseLoading = false;
+
+    public int $browsePage = 1;
+
+    public int $browseTotalPages = 0;
 
     // ── Browse Filters ────────────────────────────────────────────────────────
 
@@ -479,14 +485,29 @@ class ArrSearch extends Component
 
         $result = ArrService::make($this->detailIntegration)->triggerAutomaticSearch($libraryId);
 
+        $server = $this->detailIntegration->isSonarr() ? 'Sonarr' : 'Radarr';
+
         if ($result['ok']) {
+            $commandId = $result['data'] ?? 0;
+            $title = $this->detailResult['title'] ?? 'this title';
+
             Notification::make()
                 ->success()
-                ->title(__('Search Triggered'))
-                ->body(__('Sonarr/Radarr is now searching for releases of :title.', [
-                    'title' => $this->detailResult['title'] ?? 'this title',
+                ->title(__('Search Started'))
+                ->body(__(':server is searching for ":title". You\'ll receive a notification when results are in.', [
+                    'server' => $server,
+                    'title' => $title,
                 ]))
                 ->send();
+
+            if ($commandId > 0) {
+                MonitorArrSearch::dispatch(
+                    integrationId: $this->detailIntegration->id,
+                    contentId: $libraryId,
+                    contentTitle: $title,
+                    userId: Auth::id(),
+                );
+            }
         } else {
             Notification::make()
                 ->danger()
@@ -838,17 +859,35 @@ class ArrSearch extends Component
         );
 
         if ($result['ok']) {
-            Notification::make()
-                ->success()
-                ->title(__('Episode Requested'))
-                ->body(__('S:s E:e of :title has been queued for download.', [
-                    's' => str_pad((string) $seasonNumber, 2, '0', STR_PAD_LEFT),
-                    'e' => str_pad((string) $episodeNumber, 2, '0', STR_PAD_LEFT),
-                    'title' => $this->detailResult['title'] ?? 'the show',
-                ]))
-                ->send();
+            $s = str_pad((string) $seasonNumber, 2, '0', STR_PAD_LEFT);
+            $e = str_pad((string) $episodeNumber, 2, '0', STR_PAD_LEFT);
+            $title = $this->detailResult['title'] ?? 'the show';
 
-            $this->loadQueue();
+            if ($result['data']['queued'] ?? false) {
+                // Series was just added to Sonarr and is still indexing — a background
+                // job will monitor and search the episode once it becomes available.
+                Notification::make()
+                    ->info()
+                    ->title(__('Series Added — Episode Queued'))
+                    ->body(__('S:s E:e of :title will be queued for download once Sonarr finishes indexing. You\'ll be notified when it\'s ready.', [
+                        's' => $s,
+                        'e' => $e,
+                        'title' => $title,
+                    ]))
+                    ->send();
+            } else {
+                Notification::make()
+                    ->success()
+                    ->title(__('Episode Requested'))
+                    ->body(__('S:s E:e of :title has been queued for download.', [
+                        's' => $s,
+                        'e' => $e,
+                        'title' => $title,
+                    ]))
+                    ->send();
+
+                $this->loadQueue();
+            }
         } else {
             Notification::make()
                 ->danger()
@@ -1002,6 +1041,8 @@ class ArrSearch extends Component
 
         $this->browseGenreId = $genreId;
         $this->browseGenreType = $type;
+        $this->browsePage = 1;
+        $this->browseHasMore = false;
         $this->browseLoading = true;
         $this->browseResults = [];
 
@@ -1010,9 +1051,9 @@ class ArrSearch extends Component
 
         $this->availableProviders = $tmdb->getWatchProviders($type === 'tv' ? 'tv' : 'movie', $this->watchRegion ?: 'US');
 
-        $params = array_merge(['with_genres' => $genreId], $this->buildFilterParams($type));
+        $params = array_merge(['with_genres' => $genreId, 'page' => 1], $this->buildFilterParams($type));
 
-        $items = $type === 'tv'
+        $response = $type === 'tv'
             ? $tmdb->discoverTv($params)
             : $tmdb->discoverMovies($params);
 
@@ -1022,9 +1063,46 @@ class ArrSearch extends Component
             $item['isDownloaded'] = $libraryIds[$tmdbId] ?? false;
 
             return $item;
-        }, $items);
+        }, $response['results']);
 
+        $this->browseTotalPages = $response['total_pages'];
         $this->browseLoading = false;
+    }
+
+    /**
+     * Navigate to a specific page of the current genre browse results.
+     */
+    public function goToBrowsePage(int $page): void
+    {
+        if (! $this->tmdbConfigured || $this->browseGenreId === null || $this->browseGenreType === null) {
+            return;
+        }
+
+        $page = max(1, min($page, $this->browseTotalPages));
+        $this->browsePage = $page;
+
+        $tmdb = app(TmdbService::class);
+        $libraryIds = $this->loadLibraryTmdbIds();
+        $type = $this->browseGenreType;
+
+        $params = array_merge(
+            ['with_genres' => $this->browseGenreId, 'page' => $this->browsePage],
+            $this->buildFilterParams($type)
+        );
+
+        $response = $type === 'tv'
+            ? $tmdb->discoverTv($params)
+            : $tmdb->discoverMovies($params);
+
+        $this->browseResults = array_map(function ($item) use ($libraryIds) {
+            $tmdbId = (int) ($item['tmdb_id'] ?? 0);
+            $item['existsInLibrary'] = array_key_exists($tmdbId, $libraryIds);
+            $item['isDownloaded'] = $libraryIds[$tmdbId] ?? false;
+
+            return $item;
+        }, $response['results']);
+
+        $this->browseTotalPages = $response['total_pages'];
     }
 
     /**
@@ -1036,6 +1114,8 @@ class ArrSearch extends Component
         $this->browseGenreType = null;
         $this->browseResults = [];
         $this->browseLoading = false;
+        $this->browsePage = 1;
+        $this->browseTotalPages = 0;
     }
 
     /**

--- a/app/Livewire/ArrSearch.php
+++ b/app/Livewire/ArrSearch.php
@@ -386,7 +386,8 @@ class ArrSearch extends Component
             if ($libraryId) {
                 $service = ArrService::make($this->detailIntegration);
 
-                if ($service instanceof SonarrService) {
+                if ($service->supportsEpisodes()) {
+                    /** @var SonarrService $service */
                     try {
                         $this->detailSonarrEpisodeStatus = $service->fetchEpisodes($libraryId);
                     } catch (\Exception) {
@@ -589,7 +590,8 @@ class ArrSearch extends Component
         }
 
         try {
-            $service = new SonarrService($this->detailIntegration);
+            /** @var SonarrService $service */
+            $service = ArrService::make($this->detailIntegration);
             $episodeId = $service->resolveEpisodeId($libraryId, $seasonNumber, $episodeNumber, $seriesJustAdded);
 
             if (! $episodeId) {
@@ -784,7 +786,9 @@ class ArrSearch extends Component
             return;
         }
 
-        $result = ArrService::make($integration)->requestEpisode(
+        /** @var SonarrService $sonarrService */
+        $sonarrService = ArrService::make($integration);
+        $result = $sonarrService->requestEpisode(
             $tvdbId,
             $seasonNumber,
             $episodeNumber,

--- a/app/Livewire/ArrSearch.php
+++ b/app/Livewire/ArrSearch.php
@@ -4,16 +4,29 @@ namespace App\Livewire;
 
 use App\Models\ArrIntegration;
 use App\Services\Arr\ArrService;
+use App\Services\Arr\SonarrService;
+use App\Services\TmdbService;
+use App\Services\TvMazeService;
 use Filament\Notifications\Notification;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Cache;
 use Livewire\Component;
 
 /**
- * Shared Sonarr/Radarr search & request UI for admin and guest panels.
- * Renders a search box, result grid, and queue panel with optional polling.
+ * Unified Sonarr/Radarr search & request UI for admin and guest panels.
+ * Searches all enabled integrations simultaneously; content type (TV/movie)
+ * is derived from the integration that returned each result.
+ *
+ * Also provides a TMDB-powered discover/browse mode when TMDB is configured.
  */
 class ArrSearch extends Component
 {
-    public ?int $integrationId = null;
+    /**
+     * Guest-mode: restrict search to these specific integration IDs.
+     *
+     * @var array<int>
+     */
+    public array $guestIntegrationIds = [];
 
     public string $searchTerm = '';
 
@@ -27,34 +40,161 @@ class ArrSearch extends Component
     /** @var array<int, array<string, mixed>> */
     public array $queue = [];
 
-    public bool $queuePolling = true;
+    public bool $queuePolling = false;
 
-    public function mount(?int $integrationId = null, bool $guestMode = false): void
+    public bool $showDetail = false;
+
+    /** @var array<string, mixed>|null */
+    public ?array $detailResult = null;
+
+    public ?int $detailIndex = null;
+
+    public ?int $detailIntegrationId = null;
+
+    /** @var array<int, bool> keyed by seasonNumber */
+    public array $selectedSeasons = [];
+
+    /**
+     * Episodes fetched from TV Maze, keyed by seasonNumber.
+     *
+     * @var array<int, array<int, array{seasonNumber: int, episodeNumber: int, title: string, airDate: ?string, overview: ?string}>>
+     */
+    public array $detailEpisodes = [];
+
+    /**
+     * Cast fetched from TV Maze.
+     *
+     * @var array<int, array{actor: string, character: string, photo: ?string}>
+     */
+    public array $detailCast = [];
+
+    /**
+     * Interactive search releases for the currently open detail panel.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $detailReleases = [];
+
+    /**
+     * Per-episode hasFile status fetched from Sonarr for an in-library series.
+     * Keyed seasonNumber => [episodeNumber => hasFile].
+     *
+     * @var array<int, array<int, bool>>
+     */
+    public array $detailSonarrEpisodeStatus = [];
+
+    public bool $releasesLoading = false;
+
+    // ── Discover ──────────────────────────────────────────────────────────────
+
+    public bool $tmdbConfigured = false;
+
+    public bool $discoverLoaded = false;
+
+    /** @var array<int, array<string, mixed>> */
+    public array $trendingItems = [];
+
+    /** @var array<int, array<string, mixed>> */
+    public array $popularMovies = [];
+
+    /** @var array<int, array<string, mixed>> */
+    public array $popularTv = [];
+
+    /** @var array<int, array<string, mixed>> */
+    public array $upcomingMovies = [];
+
+    /** @var array<int, array{id: int, name: string}> */
+    public array $movieGenres = [];
+
+    /** @var array<int, array{id: int, name: string}> */
+    public array $tvGenres = [];
+
+    public ?int $browseGenreId = null;
+
+    public ?string $browseGenreType = null;
+
+    /** @var array<int, array<string, mixed>> */
+    public array $browseResults = [];
+
+    public bool $browseLoading = false;
+
+    // ── Browse Filters ────────────────────────────────────────────────────────
+
+    public string $sortBy = 'popularity';
+
+    public ?int $yearFrom = null;
+
+    public ?int $yearTo = null;
+
+    public float $minRating = 0;
+
+    public int $minVoteCount = 0;
+
+    public ?int $minRuntime = null;
+
+    public ?int $maxRuntime = null;
+
+    public string $originalLanguage = '';
+
+    public string $watchRegion = 'US';
+
+    /** @var array<int, int> Selected streaming provider IDs */
+    public array $selectedProviders = [];
+
+    /** @var array<int, int> Selected TV status values (0=Returning, 3=Ended, 4=Canceled, etc.) */
+    public array $tvStatuses = [];
+
+    /** @var array<int, array{id: int, name: string, logo: string|null}> Loaded from TMDB for current region+type */
+    public array $availableProviders = [];
+
+    public function mount(array $guestIntegrationIds = [], bool $guestMode = false): void
     {
-        $this->integrationId = $integrationId;
+        $this->guestIntegrationIds = $guestIntegrationIds;
         $this->guestMode = $guestMode;
+        $this->queuePolling = $guestMode;
+        $this->tmdbConfigured = app(TmdbService::class)->isConfigured();
 
-        $this->loadQueue();
-    }
-
-    public function getIntegrationProperty(): ?ArrIntegration
-    {
-        if (! $this->integrationId) {
-            return null;
+        if ($guestMode) {
+            $this->loadQueue();
         }
-
-        return ArrIntegration::find($this->integrationId);
     }
 
     /**
-     * Re-fetch the queue when the active integration changes.
+     * Integration used by the currently open detail panel.
      */
-    public function updatedIntegrationId(): void
+    public function getDetailIntegrationProperty(): ?ArrIntegration
     {
-        $this->results = [];
-        $this->searchTerm = '';
-        $this->loadQueue();
+        if (! $this->detailIntegrationId) {
+            return null;
+        }
+
+        return ArrIntegration::find($this->detailIntegrationId);
     }
+
+    /**
+     * Integrations to search.
+     * Admin: all enabled integrations for the authenticated user.
+     * Guest: only integrations in $guestIntegrationIds.
+     *
+     * @return Collection<int, ArrIntegration>
+     */
+    public function getIntegrationsForSearchProperty(): Collection
+    {
+        if ($this->guestMode && count($this->guestIntegrationIds) > 0) {
+            return ArrIntegration::whereIn('id', $this->guestIntegrationIds)
+                ->where('enabled', true)
+                ->orderBy('name')
+                ->get();
+        }
+
+        return ArrIntegration::query()
+            ->where('user_id', auth()->id())
+            ->where('enabled', true)
+            ->orderBy('name')
+            ->get();
+    }
+
+    // ── Search ────────────────────────────────────────────────────────────────
 
     /**
      * Debounced search trigger.
@@ -66,59 +206,63 @@ class ArrSearch extends Component
 
     public function search(): void
     {
-        $integration = $this->integration;
-        if (! $integration || strlen(trim($this->searchTerm)) < 2) {
+        if (strlen(trim($this->searchTerm)) < 2) {
             $this->results = [];
 
             return;
         }
 
         $this->isSearching = true;
+        $this->results = [];
 
-        try {
-            $this->results = ArrService::make($integration)->search($this->searchTerm);
-        } catch (\Exception $e) {
-            Notification::make()
-                ->danger()
-                ->title(__('Search Failed'))
-                ->body($e->getMessage())
-                ->send();
+        $integrations = $this->integrationsForSearch;
 
-            $this->results = [];
+        foreach ($integrations as $integration) {
+            try {
+                $items = ArrService::make($integration)->search($this->searchTerm);
+                foreach ($items as $item) {
+                    $this->results[] = array_merge($item, [
+                        'integrationId' => $integration->id,
+                        'integrationName' => $integration->name,
+                        'integrationType' => $integration->type,
+                    ]);
+                }
+            } catch (\Exception) {
+                // Skip failed integrations silently
+            }
         }
 
         $this->isSearching = false;
     }
 
     /**
-     * Request a single result. Honours integration defaults if no override passed.
-     *
-     * @param  int  $index  index into $this->results
+     * Request a single result. Routes to the correct integration based on the result.
      */
     public function request(int $index, ?int $qualityProfileId = null, ?string $rootFolderPath = null): void
     {
-        $integration = $this->integration;
-        if (! $integration) {
-            return;
-        }
-
         if (! isset($this->results[$index])) {
             return;
         }
 
         $item = $this->results[$index];
+        $integration = ArrIntegration::find($item['integrationId'] ?? null);
+
+        if (! $integration) {
+            return;
+        }
+
         $isSonarr = $integration->isSonarr();
 
         $payload = [
             'title' => $item['title'] ?? null,
             'titleSlug' => $item['titleSlug'] ?? null,
+            'images' => $item['images'] ?? [],
             'qualityProfileId' => $qualityProfileId ?? $integration->quality_profile_id,
             'rootFolderPath' => $rootFolderPath ?? $integration->root_folder_path,
             'searchForMissingEpisodes' => true,
             'searchForMovie' => true,
         ];
 
-        // External ID key differs per platform
         $externalKey = $isSonarr ? 'tvdbId' : 'tmdbId';
         $payload[$externalKey] = $item[$externalKey] ?? null;
 
@@ -134,7 +278,378 @@ class ArrSearch extends Component
                 ]))
                 ->send();
 
-            // Refresh queue shortly after to show the new download
+            $this->loadQueue();
+        } else {
+            Notification::make()
+                ->danger()
+                ->title(__('Request Failed'))
+                ->body($result['error'] ?? 'Unknown error')
+                ->send();
+        }
+    }
+
+    public function openDetail(int $index): void
+    {
+        if (! isset($this->results[$index])) {
+            return;
+        }
+
+        $this->detailIndex = $index;
+        $this->detailResult = $this->results[$index];
+        $this->detailIntegrationId = (int) ($this->detailResult['integrationId'] ?? 0) ?: null;
+
+        // Pre-check all seasons except specials (season 0)
+        $this->selectedSeasons = collect($this->detailResult['seasons'] ?? [])
+            ->mapWithKeys(fn ($s) => [(int) $s['seasonNumber'] => (int) $s['seasonNumber'] !== 0])
+            ->all();
+
+        $this->detailEpisodes = [];
+        $this->detailCast = [];
+        $this->showDetail = true;
+    }
+
+    public function closeDetail(): void
+    {
+        $this->showDetail = false;
+        $this->detailResult = null;
+        $this->detailIndex = null;
+        $this->detailIntegrationId = null;
+        $this->selectedSeasons = [];
+        $this->detailEpisodes = [];
+        $this->detailCast = [];
+        $this->detailReleases = [];
+        $this->detailSonarrEpisodeStatus = [];
+        $this->releasesLoading = false;
+    }
+
+    /**
+     * Fetch episode data from TV Maze for the currently open detail panel.
+     * Triggered by Alpine after the panel opens so it doesn't block the slide-over appearing.
+     */
+    public function loadDetailEpisodes(): void
+    {
+        if (! $this->detailResult) {
+            return;
+        }
+
+        if ($this->detailIntegration?->isSonarr()) {
+            $tvdbId = (int) ($this->detailResult['tvdbId'] ?? 0);
+
+            if (! $tvdbId) {
+                return;
+            }
+
+            try {
+                $data = app(TvMazeService::class)->fetchSeriesData($tvdbId);
+                $this->detailEpisodes = $data['episodes'];
+                $this->detailCast = $data['cast'];
+            } catch (\Exception) {
+                $this->detailEpisodes = [];
+                $this->detailCast = [];
+            }
+
+            // Fetch authoritative per-episode hasFile status from Sonarr when the
+            // series is already in the library — this is the reliable source for
+            // download status, not the lookup's statistics fields.
+            $libraryId = (int) ($this->detailResult['libraryId'] ?? 0);
+
+            if ($libraryId) {
+                $service = ArrService::make($this->detailIntegration);
+
+                if ($service instanceof SonarrService) {
+                    try {
+                        $this->detailSonarrEpisodeStatus = $service->fetchEpisodes($libraryId);
+                    } catch (\Exception) {
+                        $this->detailSonarrEpisodeStatus = [];
+                    }
+                }
+            }
+
+            return;
+        }
+
+        if ($this->detailIntegration?->isRadarr()) {
+            $tmdbId = (int) ($this->detailResult['tmdbId'] ?? 0);
+
+            if (! $tmdbId) {
+                return;
+            }
+
+            $this->detailCast = app(TmdbService::class)->getMovieCast($tmdbId);
+        }
+    }
+
+    /**
+     * Trigger an automatic search in Sonarr/Radarr for a library item.
+     * Admin only — not available in guest mode.
+     */
+    public function triggerAutomaticSearch(): void
+    {
+        if ($this->guestMode || ! $this->detailResult || ! $this->detailIntegration) {
+            return;
+        }
+
+        $libraryId = $this->resolveLibraryId();
+
+        if (! $libraryId) {
+            Notification::make()
+                ->warning()
+                ->title(__('Not in Library'))
+                ->body(__('This title must be added to the library before triggering a search.'))
+                ->send();
+
+            return;
+        }
+
+        $result = ArrService::make($this->detailIntegration)->triggerAutomaticSearch($libraryId);
+
+        if ($result['ok']) {
+            Notification::make()
+                ->success()
+                ->title(__('Search Triggered'))
+                ->body(__('Sonarr/Radarr is now searching for releases of :title.', [
+                    'title' => $this->detailResult['title'] ?? 'this title',
+                ]))
+                ->send();
+        } else {
+            Notification::make()
+                ->danger()
+                ->title(__('Search Failed'))
+                ->body($result['error'] ?? 'Unknown error')
+                ->send();
+        }
+    }
+
+    /**
+     * Fetch interactive search releases for the currently open detail panel.
+     * Admin only — not available in guest mode.
+     */
+    public function loadDetailReleases(): void
+    {
+        if ($this->guestMode || ! $this->detailResult || ! $this->detailIntegration) {
+            return;
+        }
+
+        $libraryId = $this->resolveLibraryId();
+
+        if (! $libraryId) {
+            Notification::make()
+                ->warning()
+                ->title(__('Not in Library'))
+                ->body(__('Add this title to the library first to perform an interactive search.'))
+                ->send();
+
+            return;
+        }
+
+        $this->releasesLoading = true;
+        $this->detailReleases = [];
+
+        try {
+            $this->detailReleases = ArrService::make($this->detailIntegration)->fetchReleases($libraryId);
+        } catch (\Exception) {
+            Notification::make()
+                ->danger()
+                ->title(__('Search Failed'))
+                ->body(__('Could not fetch releases from the indexer.'))
+                ->send();
+        }
+
+        $this->releasesLoading = false;
+    }
+
+    /**
+     * Download a specific release selected from the interactive search.
+     * Admin only — not available in guest mode.
+     */
+    public function downloadDetailRelease(string $guid, int $indexerId): void
+    {
+        if ($this->guestMode || ! $this->detailResult || ! $this->detailIntegration) {
+            return;
+        }
+
+        $libraryId = $this->resolveLibraryId();
+
+        if (! $libraryId) {
+            return;
+        }
+
+        $isSonarr = $this->detailIntegration->isSonarr();
+
+        $payload = [
+            'guid' => $guid,
+            'indexerId' => $indexerId,
+            $isSonarr ? 'seriesId' : 'movieId' => $libraryId,
+        ];
+
+        $result = ArrService::make($this->detailIntegration)->downloadRelease($payload);
+
+        if ($result['ok']) {
+            Notification::make()
+                ->success()
+                ->title(__('Download Started'))
+                ->body(__('The release has been sent to your download client.'))
+                ->send();
+
+            $this->detailReleases = [];
+        } else {
+            Notification::make()
+                ->danger()
+                ->title(__('Download Failed'))
+                ->body($result['error'] ?? 'Unknown error')
+                ->send();
+        }
+    }
+
+    /**
+     * Resolve the Sonarr/Radarr internal library ID for the current detail result.
+     * Uses the cached libraryId from the search result, falling back to checkExists().
+     */
+    private function resolveLibraryId(): ?int
+    {
+        if (! $this->detailResult || ! $this->detailIntegration) {
+            return null;
+        }
+
+        $libraryId = $this->detailResult['libraryId'] ?? null;
+
+        if ($libraryId) {
+            return (int) $libraryId;
+        }
+
+        $isSonarr = $this->detailIntegration->isSonarr();
+        $externalId = $isSonarr
+            ? (int) ($this->detailResult['tvdbId'] ?? 0)
+            : (int) ($this->detailResult['tmdbId'] ?? 0);
+
+        if (! $externalId) {
+            return null;
+        }
+
+        try {
+            $check = ArrService::make($this->detailIntegration)->checkExists($externalId);
+
+            return $check['exists'] ? ($check['id'] ?? null) : null;
+        } catch (\Exception) {
+            return null;
+        }
+    }
+
+    public function toggleAllSeasons(bool $checked): void
+    {
+        $this->selectedSeasons = collect($this->selectedSeasons)
+            ->map(fn () => $checked)
+            ->all();
+    }
+
+    /**
+     * Request a single episode from the detail panel (Sonarr only).
+     * Adds the series with all seasons unmonitored if it is not yet in the library,
+     * then monitors and searches the specific episode.
+     */
+    public function requestEpisode(int $seasonNumber, int $episodeNumber): void
+    {
+        $integration = $this->detailIntegration;
+
+        if (! $integration || ! $this->detailResult || ! $integration->isSonarr()) {
+            return;
+        }
+
+        $tvdbId = (int) ($this->detailResult['tvdbId'] ?? 0);
+
+        if (! $tvdbId) {
+            return;
+        }
+
+        $result = ArrService::make($integration)->requestEpisode(
+            $tvdbId,
+            $seasonNumber,
+            $episodeNumber,
+            [
+                'qualityProfileId' => $integration->quality_profile_id,
+                'rootFolderPath' => $integration->root_folder_path,
+            ]
+        );
+
+        if ($result['ok']) {
+            Notification::make()
+                ->success()
+                ->title(__('Episode Requested'))
+                ->body(__('S:s E:e of :title has been queued for download.', [
+                    's' => str_pad((string) $seasonNumber, 2, '0', STR_PAD_LEFT),
+                    'e' => str_pad((string) $episodeNumber, 2, '0', STR_PAD_LEFT),
+                    'title' => $this->detailResult['title'] ?? 'the show',
+                ]))
+                ->send();
+
+            $this->loadQueue();
+        } else {
+            Notification::make()
+                ->danger()
+                ->title(__('Request Failed'))
+                ->body($result['error'] ?? 'Unknown error')
+                ->send();
+        }
+    }
+
+    /**
+     * Request a Sonarr series from the detail panel with season-level granularity.
+     * Sends all seasons from the lookup result, each with an explicit monitored flag.
+     */
+    public function requestDetail(): void
+    {
+        $integration = $this->detailIntegration;
+        if (! $integration || ! $this->detailResult || ! $integration->isSonarr()) {
+            return;
+        }
+
+        // Build full seasons array with explicit monitored flag per season
+        $seasons = collect($this->detailResult['seasons'] ?? [])
+            ->map(fn ($s) => [
+                'seasonNumber' => (int) $s['seasonNumber'],
+                'monitored' => (bool) ($this->selectedSeasons[(int) $s['seasonNumber']] ?? false),
+            ])
+            ->values()
+            ->all();
+
+        $monitoredCount = collect($seasons)->where('monitored', true)->count();
+
+        if ($monitoredCount === 0) {
+            Notification::make()
+                ->warning()
+                ->title(__('No Seasons Selected'))
+                ->body(__('Please select at least one season to request.'))
+                ->send();
+
+            return;
+        }
+
+        $item = $this->detailResult;
+
+        $payload = [
+            'tvdbId' => $item['tvdbId'] ?? null,
+            'title' => $item['title'] ?? null,
+            'titleSlug' => $item['titleSlug'] ?? null,
+            'qualityProfileId' => $integration->quality_profile_id,
+            'rootFolderPath' => $integration->root_folder_path,
+            'seasons' => $seasons,
+            'searchForMissingEpisodes' => true,
+        ];
+
+        $result = ArrService::make($integration)->add($payload);
+
+        if ($result['ok']) {
+            Notification::make()
+                ->success()
+                ->title(__('Request Submitted'))
+                ->body(__(':title has been added to :server and will begin searching for :count selected season(s).', [
+                    'title' => $item['title'] ?? 'Content',
+                    'server' => $integration->name,
+                    'count' => $monitoredCount,
+                ]))
+                ->send();
+
+            $this->closeDetail();
             $this->loadQueue();
         } else {
             Notification::make()
@@ -147,23 +662,382 @@ class ArrSearch extends Component
 
     public function loadQueue(): void
     {
-        $integration = $this->integration;
-        if (! $integration) {
+        if (! $this->guestMode) {
             $this->queue = [];
 
             return;
         }
 
-        try {
-            $this->queue = ArrService::make($integration)->fetchQueue();
-        } catch (\Exception $e) {
-            $this->queue = [];
+        $allItems = [];
+
+        foreach ($this->integrationsForSearch as $integration) {
+            try {
+                $items = ArrService::make($integration)->fetchQueue();
+                foreach ($items as $item) {
+                    $allItems[] = array_merge($item, ['server' => $integration->name]);
+                }
+            } catch (\Exception) {
+                // Skip failed integrations silently
+            }
         }
+
+        $this->queue = $allItems;
     }
 
     public function getQueuePollIntervalProperty(): int
     {
         return $this->queuePolling ? 5 : 0;
+    }
+
+    // ── Discover ──────────────────────────────────────────────────────────────
+
+    /**
+     * Load discover data (trending, popular, genres). Called via wire:init on the root element.
+     * All sections are cached at the TMDB service layer; this method just assembles them.
+     */
+    public function loadDiscover(): void
+    {
+        if ($this->discoverLoaded || ! $this->tmdbConfigured) {
+            $this->discoverLoaded = true;
+
+            return;
+        }
+
+        $tmdb = app(TmdbService::class);
+        $libraryIds = $this->loadLibraryTmdbIds();
+
+        $crossRef = function (array $items) use ($libraryIds): array {
+            return array_map(function ($item) use ($libraryIds) {
+                $tmdbId = (int) ($item['tmdb_id'] ?? 0);
+                $item['existsInLibrary'] = array_key_exists($tmdbId, $libraryIds);
+                $item['isDownloaded'] = $libraryIds[$tmdbId] ?? false;
+
+                return $item;
+            }, $items);
+        };
+
+        $this->trendingItems = $crossRef($tmdb->getTrending());
+        $this->popularMovies = $crossRef($tmdb->getPopularMovies());
+        $this->popularTv = $crossRef($tmdb->getPopularTv());
+        $this->upcomingMovies = $crossRef($tmdb->getUpcomingMovies());
+        $this->movieGenres = $tmdb->getMovieGenres();
+        $this->tvGenres = $tmdb->getTvGenres();
+        $this->discoverLoaded = true;
+    }
+
+    /**
+     * Browse content by genre. Replaces the carousel view with a filtered grid.
+     */
+    public function browseGenre(int $genreId, string $type): void
+    {
+        if (! $this->tmdbConfigured) {
+            return;
+        }
+
+        $this->browseGenreId = $genreId;
+        $this->browseGenreType = $type;
+        $this->browseLoading = true;
+        $this->browseResults = [];
+
+        $tmdb = app(TmdbService::class);
+        $libraryIds = $this->loadLibraryTmdbIds();
+
+        $this->availableProviders = $tmdb->getWatchProviders($type === 'tv' ? 'tv' : 'movie', $this->watchRegion ?: 'US');
+
+        $params = array_merge(['with_genres' => $genreId], $this->buildFilterParams($type));
+
+        $items = $type === 'tv'
+            ? $tmdb->discoverTv($params)
+            : $tmdb->discoverMovies($params);
+
+        $this->browseResults = array_map(function ($item) use ($libraryIds) {
+            $tmdbId = (int) ($item['tmdb_id'] ?? 0);
+            $item['existsInLibrary'] = array_key_exists($tmdbId, $libraryIds);
+            $item['isDownloaded'] = $libraryIds[$tmdbId] ?? false;
+
+            return $item;
+        }, $items);
+
+        $this->browseLoading = false;
+    }
+
+    /**
+     * Clear the genre browse view and return to carousels.
+     */
+    public function clearBrowse(): void
+    {
+        $this->browseGenreId = null;
+        $this->browseGenreType = null;
+        $this->browseResults = [];
+        $this->browseLoading = false;
+    }
+
+    /**
+     * Re-run the current genre browse with updated filter state.
+     */
+    public function reloadBrowse(): void
+    {
+        if ($this->browseGenreId !== null && $this->browseGenreType !== null) {
+            $this->browseGenre($this->browseGenreId, $this->browseGenreType);
+        }
+    }
+
+    /**
+     * Reset all browse filters and reload.
+     */
+    public function resetFilters(): void
+    {
+        $this->sortBy = 'popularity';
+        $this->yearFrom = null;
+        $this->yearTo = null;
+        $this->minRating = 0;
+        $this->minVoteCount = 0;
+        $this->minRuntime = null;
+        $this->maxRuntime = null;
+        $this->originalLanguage = '';
+        $this->selectedProviders = [];
+        $this->tvStatuses = [];
+        $this->reloadBrowse();
+    }
+
+    /**
+     * Toggle a streaming provider in/out of the selected set.
+     */
+    public function toggleProvider(int $providerId): void
+    {
+        $key = array_search($providerId, $this->selectedProviders);
+
+        if ($key !== false) {
+            array_splice($this->selectedProviders, $key, 1);
+        } else {
+            $this->selectedProviders[] = $providerId;
+        }
+    }
+
+    /**
+     * Toggle a TV status value in/out of the selected set.
+     */
+    public function toggleTvStatus(int $status): void
+    {
+        $key = array_search($status, $this->tvStatuses);
+
+        if ($key !== false) {
+            array_splice($this->tvStatuses, $key, 1);
+        } else {
+            $this->tvStatuses[] = $status;
+        }
+    }
+
+    /**
+     * Auto-reload when sort order changes.
+     */
+    public function updatedSortBy(): void
+    {
+        $this->reloadBrowse();
+    }
+
+    /**
+     * Auto-reload when language filter changes.
+     */
+    public function updatedOriginalLanguage(): void
+    {
+        $this->reloadBrowse();
+    }
+
+    /**
+     * Reload providers and results when region changes.
+     */
+    public function updatedWatchRegion(): void
+    {
+        if ($this->browseGenreId !== null && $this->browseGenreType !== null) {
+            $tmdb = app(TmdbService::class);
+            $this->availableProviders = $tmdb->getWatchProviders(
+                $this->browseGenreType === 'tv' ? 'tv' : 'movie',
+                $this->watchRegion ?: 'US'
+            );
+        }
+
+        $this->reloadBrowse();
+    }
+
+    /**
+     * Build TMDB /discover query params from current filter state.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildFilterParams(string $type): array
+    {
+        $params = [];
+
+        // Sort order — map generic keys to type-aware TMDB sort_by values
+        $sortMap = [
+            'popularity' => 'popularity.desc',
+            'rating' => 'vote_average.desc',
+            'votes' => 'vote_count.desc',
+            'newest' => $type === 'tv' ? 'first_air_date.desc' : 'primary_release_date.desc',
+            'oldest' => $type === 'tv' ? 'first_air_date.asc' : 'primary_release_date.asc',
+            'revenue' => 'revenue.desc',
+        ];
+        $params['sort_by'] = $sortMap[$this->sortBy] ?? 'popularity.desc';
+
+        // Year range — map to type-aware date fields
+        if ($this->yearFrom) {
+            $params[$type === 'tv' ? 'first_air_date.gte' : 'primary_release_date.gte'] = $this->yearFrom.'-01-01';
+        }
+
+        if ($this->yearTo) {
+            $params[$type === 'tv' ? 'first_air_date.lte' : 'primary_release_date.lte'] = $this->yearTo.'-12-31';
+        }
+
+        // Rating + vote count floor
+        if ($this->minRating > 0) {
+            $params['vote_average.gte'] = $this->minRating;
+        }
+
+        $voteCountFloor = $this->minVoteCount > 0 ? $this->minVoteCount : ($this->minRating > 0 ? 50 : 0);
+
+        if ($voteCountFloor > 0) {
+            $params['vote_count.gte'] = $voteCountFloor;
+        }
+
+        // Runtime range (minutes)
+        if ($this->minRuntime !== null && $this->minRuntime > 0) {
+            $params['with_runtime.gte'] = $this->minRuntime;
+        }
+
+        if ($this->maxRuntime !== null && $this->maxRuntime > 0) {
+            $params['with_runtime.lte'] = $this->maxRuntime;
+        }
+
+        // Original language
+        if ($this->originalLanguage !== '') {
+            $params['with_original_language'] = $this->originalLanguage;
+        }
+
+        // Watch providers (pipe-separated IDs, requires watch_region)
+        if (! empty($this->selectedProviders)) {
+            $params['with_watch_providers'] = implode('|', $this->selectedProviders);
+            $params['watch_region'] = $this->watchRegion ?: 'US';
+        }
+
+        // TV show status (pipe-separated values)
+        if ($type === 'tv' && ! empty($this->tvStatuses)) {
+            $params['with_status'] = implode('|', $this->tvStatuses);
+        }
+
+        return $params;
+    }
+
+    /**
+     * Handle a click on a TMDB discover card.
+     * Resolves the TMDB card to an Arr-native result shape and opens the detail panel.
+     * For movies this also enables direct requesting from the panel.
+     */
+    public function requestFromDiscover(int $tmdbId, string $mediaType): void
+    {
+        $resolved = $this->resolveDiscoverToArrResult($tmdbId, $mediaType);
+
+        if (! $resolved) {
+            Notification::make()
+                ->warning()
+                ->title(__('Not Found'))
+                ->body(__('Could not find this title on your Sonarr/Radarr servers. Try searching for it directly.'))
+                ->send();
+
+            return;
+        }
+
+        // Append to results so the existing openDetail()/request() machinery can use the index
+        $idx = count($this->results);
+        $this->results[$idx] = $resolved;
+        $this->openDetail($idx);
+    }
+
+    /**
+     * Resolve a TMDB discover item to an Arr-native result shape.
+     * Movies go through Radarr's tmdb: lookup; TV goes through TMDB external IDs → Sonarr tvdb: lookup.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function resolveDiscoverToArrResult(int $tmdbId, string $mediaType): ?array
+    {
+        $integrations = $this->integrationsForSearch;
+
+        if ($mediaType === 'movie') {
+            $radarr = $integrations->first(fn ($i) => $i->isRadarr());
+
+            if (! $radarr) {
+                return null;
+            }
+
+            $items = ArrService::make($radarr)->search("tmdb:{$tmdbId}");
+            $item = $items[0] ?? null;
+
+            if (! $item) {
+                return null;
+            }
+
+            return array_merge($item, [
+                'integrationId' => $radarr->id,
+                'integrationName' => $radarr->name,
+                'integrationType' => 'radarr',
+            ]);
+        }
+
+        // TV: TMDB → TVDB → Sonarr
+        $sonarr = $integrations->first(fn ($i) => $i->isSonarr());
+
+        if (! $sonarr) {
+            return null;
+        }
+
+        $externalIds = app(TmdbService::class)->getTvExternalIds($tmdbId);
+        $tvdbId = $externalIds['tvdb_id'] ?? null;
+
+        if (! $tvdbId) {
+            return null;
+        }
+
+        $items = ArrService::make($sonarr)->search("tvdb:{$tvdbId}");
+        $item = $items[0] ?? null;
+
+        if (! $item) {
+            return null;
+        }
+
+        return array_merge($item, [
+            'integrationId' => $sonarr->id,
+            'integrationName' => $sonarr->name,
+            'integrationType' => 'sonarr',
+        ]);
+    }
+
+    /**
+     * Fetch all TMDB IDs currently in library across all accessible integrations.
+     * Cached per integration for 5 minutes to avoid hammering Sonarr/Radarr on every page view.
+     *
+     * @return array<int, bool> tmdbId => isDownloaded
+     */
+    private function loadLibraryTmdbIds(): array
+    {
+        $map = [];
+
+        foreach ($this->integrationsForSearch as $integration) {
+            $cacheKey = "arr_library_tmdb_ids_{$integration->id}";
+            $integrationMap = Cache::remember($cacheKey, now()->addMinutes(5), function () use ($integration) {
+                try {
+                    return ArrService::make($integration)->fetchLibraryTmdbIds();
+                } catch (\Exception) {
+                    return [];
+                }
+            });
+
+            foreach ($integrationMap as $tmdbId => $isDownloaded) {
+                $map[$tmdbId] = ($map[$tmdbId] ?? false) || $isDownloaded;
+            }
+        }
+
+        return $map;
     }
 
     public function render()

--- a/app/Livewire/ArrSearch.php
+++ b/app/Livewire/ArrSearch.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\ArrIntegration;
+use App\Services\Arr\ArrService;
+use Filament\Notifications\Notification;
+use Livewire\Component;
+
+/**
+ * Shared Sonarr/Radarr search & request UI for admin and guest panels.
+ * Renders a search box, result grid, and queue panel with optional polling.
+ */
+class ArrSearch extends Component
+{
+    public ?int $integrationId = null;
+
+    public string $searchTerm = '';
+
+    /** @var array<int, array<string, mixed>> */
+    public array $results = [];
+
+    public bool $isSearching = false;
+
+    public bool $guestMode = false;
+
+    /** @var array<int, array<string, mixed>> */
+    public array $queue = [];
+
+    public bool $queuePolling = true;
+
+    public function mount(?int $integrationId = null, bool $guestMode = false): void
+    {
+        $this->integrationId = $integrationId;
+        $this->guestMode = $guestMode;
+
+        $this->loadQueue();
+    }
+
+    public function getIntegrationProperty(): ?ArrIntegration
+    {
+        if (! $this->integrationId) {
+            return null;
+        }
+
+        return ArrIntegration::find($this->integrationId);
+    }
+
+    /**
+     * Re-fetch the queue when the active integration changes.
+     */
+    public function updatedIntegrationId(): void
+    {
+        $this->results = [];
+        $this->searchTerm = '';
+        $this->loadQueue();
+    }
+
+    /**
+     * Debounced search trigger.
+     */
+    public function updatedSearchTerm(): void
+    {
+        $this->search();
+    }
+
+    public function search(): void
+    {
+        $integration = $this->integration;
+        if (! $integration || strlen(trim($this->searchTerm)) < 2) {
+            $this->results = [];
+
+            return;
+        }
+
+        $this->isSearching = true;
+
+        try {
+            $this->results = ArrService::make($integration)->search($this->searchTerm);
+        } catch (\Exception $e) {
+            Notification::make()
+                ->danger()
+                ->title(__('Search Failed'))
+                ->body($e->getMessage())
+                ->send();
+
+            $this->results = [];
+        }
+
+        $this->isSearching = false;
+    }
+
+    /**
+     * Request a single result. Honours integration defaults if no override passed.
+     *
+     * @param  int  $index  index into $this->results
+     */
+    public function request(int $index, ?int $qualityProfileId = null, ?string $rootFolderPath = null): void
+    {
+        $integration = $this->integration;
+        if (! $integration) {
+            return;
+        }
+
+        if (! isset($this->results[$index])) {
+            return;
+        }
+
+        $item = $this->results[$index];
+        $isSonarr = $integration->isSonarr();
+
+        $payload = [
+            'title' => $item['title'] ?? null,
+            'titleSlug' => $item['titleSlug'] ?? null,
+            'qualityProfileId' => $qualityProfileId ?? $integration->quality_profile_id,
+            'rootFolderPath' => $rootFolderPath ?? $integration->root_folder_path,
+            'searchForMissingEpisodes' => true,
+            'searchForMovie' => true,
+        ];
+
+        // External ID key differs per platform
+        $externalKey = $isSonarr ? 'tvdbId' : 'tmdbId';
+        $payload[$externalKey] = $item[$externalKey] ?? null;
+
+        $result = ArrService::make($integration)->add($payload);
+
+        if ($result['ok']) {
+            Notification::make()
+                ->success()
+                ->title(__('Request Submitted'))
+                ->body(__(':title has been added to :server and will search for releases.', [
+                    'title' => $item['title'] ?? 'Content',
+                    'server' => $integration->name,
+                ]))
+                ->send();
+
+            // Refresh queue shortly after to show the new download
+            $this->loadQueue();
+        } else {
+            Notification::make()
+                ->danger()
+                ->title(__('Request Failed'))
+                ->body($result['error'] ?? 'Unknown error')
+                ->send();
+        }
+    }
+
+    public function loadQueue(): void
+    {
+        $integration = $this->integration;
+        if (! $integration) {
+            $this->queue = [];
+
+            return;
+        }
+
+        try {
+            $this->queue = ArrService::make($integration)->fetchQueue();
+        } catch (\Exception $e) {
+            $this->queue = [];
+        }
+    }
+
+    public function getQueuePollIntervalProperty(): int
+    {
+        return $this->queuePolling ? 5 : 0;
+    }
+
+    public function render()
+    {
+        return view('livewire.arr-search');
+    }
+}

--- a/app/Livewire/ArrSearch.php
+++ b/app/Livewire/ArrSearch.php
@@ -83,7 +83,27 @@ class ArrSearch extends Component
      */
     public array $detailSonarrEpisodeStatus = [];
 
+    /**
+     * Per-episode file quality and size, keyed seasonNumber => [episodeNumber => {quality, size}].
+     * Only populated for episodes that have a file and Sonarr embeds episodeFile in the response.
+     *
+     * @var array<int, array<int, array{quality: ?string, size: ?int}>>
+     */
+    public array $detailSonarrEpisodeFileInfo = [];
+
     public bool $releasesLoading = false;
+
+    /** Sonarr episode ID when the interactive search accordion is showing episode-level results. */
+    public ?int $detailEpisodeId = null;
+
+    /** Season number for the episode-level search context, used to re-run on Refresh. */
+    public ?int $detailEpisodeSeason = null;
+
+    /** Episode number for the episode-level search context, used to re-run on Refresh. */
+    public ?int $detailEpisodeNumber = null;
+
+    /** Human-readable label shown in the accordion header when in episode context, e.g. "S01E05". */
+    public ?string $detailReleasesLabel = null;
 
     // ── Discover ──────────────────────────────────────────────────────────────
 
@@ -305,6 +325,11 @@ class ArrSearch extends Component
 
         $this->detailEpisodes = [];
         $this->detailCast = [];
+        $this->detailReleases = [];
+        $this->detailEpisodeId = null;
+        $this->detailEpisodeSeason = null;
+        $this->detailEpisodeNumber = null;
+        $this->detailReleasesLabel = null;
         $this->showDetail = true;
     }
 
@@ -319,7 +344,12 @@ class ArrSearch extends Component
         $this->detailCast = [];
         $this->detailReleases = [];
         $this->detailSonarrEpisodeStatus = [];
+        $this->detailSonarrEpisodeFileInfo = [];
         $this->releasesLoading = false;
+        $this->detailEpisodeId = null;
+        $this->detailEpisodeSeason = null;
+        $this->detailEpisodeNumber = null;
+        $this->detailReleasesLabel = null;
     }
 
     /**
@@ -361,6 +391,12 @@ class ArrSearch extends Component
                         $this->detailSonarrEpisodeStatus = $service->fetchEpisodes($libraryId);
                     } catch (\Exception) {
                         $this->detailSonarrEpisodeStatus = [];
+                    }
+
+                    try {
+                        $this->detailSonarrEpisodeFileInfo = $service->fetchEpisodeFileInfo($libraryId);
+                    } catch (\Exception) {
+                        $this->detailSonarrEpisodeFileInfo = [];
                     }
                 }
             }
@@ -430,6 +466,19 @@ class ArrSearch extends Component
             return;
         }
 
+        // If in episode context, refresh the episode-specific releases instead.
+        if ($this->detailEpisodeSeason !== null && $this->detailEpisodeNumber !== null) {
+            $this->loadEpisodeReleases($this->detailEpisodeSeason, $this->detailEpisodeNumber);
+
+            return;
+        }
+
+        // Series/movie level search — clear any stale episode context.
+        $this->detailEpisodeId = null;
+        $this->detailEpisodeSeason = null;
+        $this->detailEpisodeNumber = null;
+        $this->detailReleasesLabel = null;
+
         $libraryId = $this->resolveLibraryId();
 
         if (! $libraryId) {
@@ -459,6 +508,176 @@ class ArrSearch extends Component
     }
 
     /**
+     * Load interactive search releases for a specific episode (Sonarr only).
+     * Adds the series to Sonarr without searching if it is not yet in the library,
+     * then fetches episode-level releases via /release?seriesId=X&episodeId=Y.
+     * Admin only — not available in guest mode.
+     */
+    public function loadEpisodeReleases(int $seasonNumber, int $episodeNumber): void
+    {
+        if ($this->guestMode || ! $this->detailResult || ! $this->detailIntegration) {
+            return;
+        }
+
+        if (! $this->detailIntegration->isSonarr()) {
+            return;
+        }
+
+        $tvdbId = (int) ($this->detailResult['tvdbId'] ?? 0);
+
+        if (! $tvdbId) {
+            return;
+        }
+
+        $this->releasesLoading = true;
+        $this->detailReleases = [];
+        $this->detailEpisodeId = null;
+
+        $libraryId = $this->resolveLibraryId();
+        $seriesJustAdded = false;
+
+        if (! $libraryId) {
+            $item = $this->detailResult;
+            $seasons = collect($item['seasons'] ?? [])
+                ->map(fn ($s) => ['seasonNumber' => (int) $s['seasonNumber'], 'monitored' => false])
+                ->all();
+
+            $result = ArrService::make($this->detailIntegration)->add([
+                'tvdbId' => $tvdbId,
+                'title' => $item['title'] ?? null,
+                'titleSlug' => $item['titleSlug'] ?? null,
+                'seasons' => $seasons,
+                'searchForMissingEpisodes' => false,
+            ]);
+
+            if (! $result['ok']) {
+                Notification::make()
+                    ->danger()
+                    ->title(__('Failed to Add Series'))
+                    ->body($result['error'] ?? 'Unknown error')
+                    ->send();
+
+                $this->releasesLoading = false;
+
+                return;
+            }
+
+            $libraryId = (int) ($result['data']['id'] ?? 0);
+            $seriesJustAdded = true;
+
+            if ($libraryId) {
+                $this->detailResult['libraryId'] = $libraryId;
+                $this->detailResult['existsInLibrary'] = true;
+
+                if ($this->detailIndex !== null && isset($this->results[$this->detailIndex])) {
+                    $this->results[$this->detailIndex]['libraryId'] = $libraryId;
+                    $this->results[$this->detailIndex]['existsInLibrary'] = true;
+                }
+            }
+        }
+
+        if (! $libraryId) {
+            Notification::make()
+                ->danger()
+                ->title(__('Could Not Add Series'))
+                ->body(__('Unable to resolve the series in Sonarr.'))
+                ->send();
+
+            $this->releasesLoading = false;
+
+            return;
+        }
+
+        try {
+            $service = new SonarrService($this->detailIntegration);
+            $episodeId = $service->resolveEpisodeId($libraryId, $seasonNumber, $episodeNumber, $seriesJustAdded);
+
+            if (! $episodeId) {
+                Notification::make()
+                    ->warning()
+                    ->title(__('Episode Not Ready'))
+                    ->body(__('Sonarr is still indexing the series. Please try again in a moment.'))
+                    ->send();
+
+                $this->releasesLoading = false;
+
+                return;
+            }
+
+            $this->detailEpisodeId = $episodeId;
+            $this->detailEpisodeSeason = $seasonNumber;
+            $this->detailEpisodeNumber = $episodeNumber;
+            $s = str_pad((string) $seasonNumber, 2, '0', STR_PAD_LEFT);
+            $e = str_pad((string) $episodeNumber, 2, '0', STR_PAD_LEFT);
+            $this->detailReleasesLabel = "S{$s}E{$e}";
+
+            $this->detailReleases = $service->fetchEpisodeReleases($libraryId, $episodeId);
+        } catch (\Exception) {
+            Notification::make()
+                ->danger()
+                ->title(__('Search Failed'))
+                ->body(__('Could not fetch episode releases from the indexer.'))
+                ->send();
+        }
+
+        $this->releasesLoading = false;
+    }
+
+    /**
+     * Add a Radarr movie to the library without triggering an automatic search,
+     * then immediately open the interactive search so the user can pick a specific release.
+     * Admin only — not available in guest mode.
+     */
+    public function addForInteractiveSearch(): void
+    {
+        if ($this->guestMode || ! $this->detailResult || ! $this->detailIntegration) {
+            return;
+        }
+
+        if (! $this->detailIntegration->isRadarr()) {
+            return;
+        }
+
+        $item = $this->detailResult;
+
+        $result = ArrService::make($this->detailIntegration)->add([
+            'tmdbId' => $item['tmdbId'] ?? null,
+            'title' => $item['title'] ?? null,
+            'titleSlug' => $item['titleSlug'] ?? null,
+            'images' => $item['images'] ?? [],
+            'qualityProfileId' => $this->detailIntegration->quality_profile_id,
+            'rootFolderPath' => $this->detailIntegration->root_folder_path,
+            'minimumAvailability' => 'released',
+            'searchForMovie' => false,
+        ]);
+
+        if (! $result['ok']) {
+            Notification::make()
+                ->danger()
+                ->title(__('Failed to Add Movie'))
+                ->body($result['error'] ?? 'Unknown error')
+                ->send();
+
+            return;
+        }
+
+        // Update local state so resolveLibraryId() finds the new ID without a round-trip
+        $newId = $result['data']['id'] ?? null;
+
+        if ($newId) {
+            $this->detailResult['libraryId'] = (int) $newId;
+            $this->detailResult['existsInLibrary'] = true;
+
+            if ($this->detailIndex !== null && isset($this->results[$this->detailIndex])) {
+                $this->results[$this->detailIndex]['libraryId'] = (int) $newId;
+                $this->results[$this->detailIndex]['existsInLibrary'] = true;
+            }
+        }
+
+        $this->loadDetailReleases();
+    }
+
+    /**
      * Download a specific release selected from the interactive search.
      * Admin only — not available in guest mode.
      */
@@ -481,6 +700,10 @@ class ArrSearch extends Component
             'indexerId' => $indexerId,
             $isSonarr ? 'seriesId' : 'movieId' => $libraryId,
         ];
+
+        if ($isSonarr && $this->detailEpisodeId !== null) {
+            $payload['episodeId'] = $this->detailEpisodeId;
+        }
 
         $result = ArrService::make($this->detailIntegration)->downloadRelease($payload);
 
@@ -663,7 +886,7 @@ class ArrSearch extends Component
     public function loadQueue(): void
     {
         if (! $this->guestMode) {
-            $this->queue = [];
+            $this->dispatch('refreshArrQueue');
 
             return;
         }

--- a/app/Livewire/ArrSearch.php
+++ b/app/Livewire/ArrSearch.php
@@ -9,7 +9,11 @@ use App\Services\TmdbService;
 use App\Services\TvMazeService;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Livewire\Component;
 
 /**
@@ -200,7 +204,11 @@ class ArrSearch extends Component
      */
     public function getIntegrationsForSearchProperty(): Collection
     {
-        if ($this->guestMode && count($this->guestIntegrationIds) > 0) {
+        if ($this->guestMode) {
+            if (empty($this->guestIntegrationIds)) {
+                return collect();
+            }
+
             return ArrIntegration::whereIn('id', $this->guestIntegrationIds)
                 ->where('enabled', true)
                 ->orderBy('name')
@@ -237,18 +245,52 @@ class ArrSearch extends Component
 
         $integrations = $this->integrationsForSearch;
 
-        foreach ($integrations as $integration) {
-            try {
-                $items = ArrService::make($integration)->search($this->searchTerm);
-                foreach ($items as $item) {
-                    $this->results[] = array_merge($item, [
-                        'integrationId' => $integration->id,
-                        'integrationName' => $integration->name,
-                        'integrationType' => $integration->type,
-                    ]);
+        if ($integrations->isEmpty()) {
+            $this->isSearching = false;
+
+            return;
+        }
+
+        $services = $integrations->mapWithKeys(
+            fn ($i) => [(string) $i->id => ArrService::make($i)]
+        );
+
+        try {
+            $responses = Http::pool(function (Pool $pool) use ($integrations, $services) {
+                foreach ($integrations as $integration) {
+                    $pool->as((string) $integration->id)
+                        ->withHeaders(['X-Api-Key' => $integration->api_key])
+                        ->timeout(15)
+                        ->get(
+                            rtrim($integration->base_url, '/').'/api/v3'.$services[(string) $integration->id]->getSearchEndpoint(),
+                            ['term' => $this->searchTerm]
+                        );
                 }
-            } catch (\Exception) {
-                // Skip failed integrations silently
+            });
+        } catch (\Exception $e) {
+            Log::warning('ArrSearch: pool request failed', ['error' => $e->getMessage()]);
+            $this->isSearching = false;
+
+            return;
+        }
+
+        foreach ($integrations as $integration) {
+            $response = $responses[(string) $integration->id] ?? null;
+
+            if (! $response instanceof Response || ! $response->successful()) {
+                Log::warning('ArrSearch: integration search failed', ['integration_id' => $integration->id]);
+
+                continue;
+            }
+
+            $items = $services[(string) $integration->id]->parseSearchResponse($response);
+
+            foreach ($items as $item) {
+                $this->results[] = array_merge($item, [
+                    'integrationId' => $integration->id,
+                    'integrationName' => $integration->name,
+                    'integrationType' => $integration->type,
+                ]);
             }
         }
 
@@ -389,14 +431,11 @@ class ArrSearch extends Component
                 if ($service->supportsEpisodes()) {
                     /** @var SonarrService $service */
                     try {
-                        $this->detailSonarrEpisodeStatus = $service->fetchEpisodes($libraryId);
+                        $episodeData = $service->fetchEpisodeData($libraryId);
+                        $this->detailSonarrEpisodeStatus = $episodeData['status'];
+                        $this->detailSonarrEpisodeFileInfo = $episodeData['fileInfo'];
                     } catch (\Exception) {
                         $this->detailSonarrEpisodeStatus = [];
-                    }
-
-                    try {
-                        $this->detailSonarrEpisodeFileInfo = $service->fetchEpisodeFileInfo($libraryId);
-                    } catch (\Exception) {
                         $this->detailSonarrEpisodeFileInfo = [];
                     }
                 }

--- a/app/Models/ArrIntegration.php
+++ b/app/Models/ArrIntegration.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
 
 class ArrIntegration extends Model
 {
@@ -31,14 +32,18 @@ class ArrIntegration extends Model
         'api_key',
     ];
 
+    protected static function booted(): void
+    {
+        static::creating(function (self $model) {
+            if (empty($model->webhook_secret)) {
+                $model->webhook_secret = (string) Str::uuid();
+            }
+        });
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
-    }
-
-    public function playlist(): BelongsTo
-    {
-        return $this->belongsTo(Playlist::class);
     }
 
     public function isSonarr(): bool
@@ -49,6 +54,18 @@ class ArrIntegration extends Model
     public function isRadarr(): bool
     {
         return $this->type === 'radarr';
+    }
+
+    /**
+     * Full webhook URL to paste into Radarr/Sonarr notification settings.
+     */
+    public function getWebhookUrlAttribute(): ?string
+    {
+        if (! $this->webhook_secret) {
+            return null;
+        }
+
+        return url('/api/webhooks/arr/'.$this->webhook_secret);
     }
 
     /**

--- a/app/Models/ArrIntegration.php
+++ b/app/Models/ArrIntegration.php
@@ -12,6 +12,24 @@ class ArrIntegration extends Model
     use HasFactory;
 
     /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'type',
+        'url',
+        'api_key',
+        'quality_profile_id',
+        'quality_profile_name',
+        'root_folder_path',
+        'enabled',
+        'guest_enabled',
+        'last_test_at',
+        'webhook_secret',
+        'user_id',
+    ];
+
+    /**
      * @return array<string, string>
      */
     protected function casts(): array

--- a/app/Models/ArrIntegration.php
+++ b/app/Models/ArrIntegration.php
@@ -12,24 +12,6 @@ class ArrIntegration extends Model
     use HasFactory;
 
     /**
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'name',
-        'type',
-        'url',
-        'api_key',
-        'quality_profile_id',
-        'quality_profile_name',
-        'root_folder_path',
-        'enabled',
-        'guest_enabled',
-        'last_test_at',
-        'webhook_secret',
-        'user_id',
-    ];
-
-    /**
      * @return array<string, string>
      */
     protected function casts(): array

--- a/app/Models/ArrIntegration.php
+++ b/app/Models/ArrIntegration.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ArrIntegration extends Model
+{
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+            'guest_enabled' => 'boolean',
+            'api_key' => 'encrypted',
+            'last_test_at' => 'datetime',
+            'quality_profile_id' => 'integer',
+        ];
+    }
+
+    /**
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'api_key',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function playlist(): BelongsTo
+    {
+        return $this->belongsTo(Playlist::class);
+    }
+
+    public function isSonarr(): bool
+    {
+        return $this->type === 'sonarr';
+    }
+
+    public function isRadarr(): bool
+    {
+        return $this->type === 'radarr';
+    }
+
+    /**
+     * Base URL with trailing slash stripped.
+     */
+    public function getBaseUrlAttribute(): string
+    {
+        return rtrim($this->url, '/');
+    }
+
+    public function scopeEnabled($query)
+    {
+        return $query->where('enabled', true);
+    }
+
+    public function scopeGuestEnabled($query)
+    {
+        return $query->where('guest_enabled', true);
+    }
+}

--- a/app/Models/ArrQueueEvent.php
+++ b/app/Models/ArrQueueEvent.php
@@ -2,13 +2,21 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ArrQueueEvent extends Model
 {
     use HasFactory;
+    use MassPrunable;
+
+    public function prunable(): Builder
+    {
+        return static::query()->where('last_event_at', '<', now()->subDays(30));
+    }
 
     /**
      * @return array<string, string>

--- a/app/Models/ArrQueueEvent.php
+++ b/app/Models/ArrQueueEvent.php
@@ -11,24 +11,6 @@ class ArrQueueEvent extends Model
     use HasFactory;
 
     /**
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'arr_integration_id',
-        'user_id',
-        'download_id',
-        'external_id',
-        'title',
-        'event_type',
-        'status',
-        'quality',
-        'release_title',
-        'size',
-        'progress',
-        'last_event_at',
-    ];
-
-    /**
      * @return array<string, string>
      */
     protected function casts(): array

--- a/app/Models/ArrQueueEvent.php
+++ b/app/Models/ArrQueueEvent.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ArrQueueEvent extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'arr_integration_id',
+        'user_id',
+        'download_id',
+        'external_id',
+        'title',
+        'event_type',
+        'status',
+        'quality',
+        'release_title',
+        'size',
+        'progress',
+        'last_event_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'last_event_at' => 'datetime',
+            'size' => 'integer',
+            'progress' => 'integer',
+        ];
+    }
+
+    public function arrIntegration(): BelongsTo
+    {
+        return $this->belongsTo(ArrIntegration::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -261,6 +261,11 @@ class Playlist extends Model
         return $this->hasOne(DvrSetting::class);
     }
 
+    public function requestSetting(): HasOne
+    {
+        return $this->hasOne(PlaylistRequestSetting::class);
+    }
+
     public function channelScrubbers(): HasMany
     {
         return $this->hasMany(ChannelScrubber::class);

--- a/app/Models/PlaylistRequestSetting.php
+++ b/app/Models/PlaylistRequestSetting.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PlaylistRequestSetting extends Model
+{
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+        ];
+    }
+
+    public function playlist(): BelongsTo
+    {
+        return $this->belongsTo(Playlist::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/PlaylistRequestSetting.php
+++ b/app/Models/PlaylistRequestSetting.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PlaylistRequestSetting extends Model
 {
+    use HasFactory;
+
     /**
      * @var array<int, string>
      */

--- a/app/Models/PlaylistRequestSetting.php
+++ b/app/Models/PlaylistRequestSetting.php
@@ -7,6 +7,15 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PlaylistRequestSetting extends Model
 {
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'playlist_id',
+        'user_id',
+        'enabled',
+    ];
+
     protected function casts(): array
     {
         return [

--- a/app/Models/PlaylistRequestSetting.php
+++ b/app/Models/PlaylistRequestSetting.php
@@ -10,15 +10,6 @@ class PlaylistRequestSetting extends Model
 {
     use HasFactory;
 
-    /**
-     * @var array<int, string>
-     */
-    protected $fillable = [
-        'playlist_id',
-        'user_id',
-        'enabled',
-    ];
-
     protected function casts(): array
     {
         return [

--- a/app/Models/QueueMonitor.php
+++ b/app/Models/QueueMonitor.php
@@ -15,20 +15,6 @@ class QueueMonitor extends Model
 
     protected $table = 'queue_monitor';
 
-    protected $fillable = [
-        'job_id',
-        'name',
-        'queue',
-        'batch_id',
-        'batch_name',
-        'started_at',
-        'finished_at',
-        'failed',
-        'attempt',
-        'progress',
-        'exception_message',
-    ];
-
     protected $casts = [
         'failed' => 'boolean',
         'started_at' => 'datetime',

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -14,6 +14,8 @@ use App\Filament\Pages\M3uProxyStreamMonitor;
 use App\Filament\Pages\PluginsDashboard;
 use App\Filament\Pages\Preferences;
 use App\Filament\Pages\ReleaseLogs;
+use App\Filament\Pages\RequestContent;
+use App\Filament\Resources\ArrIntegrations\ArrIntegrationResource;
 use App\Filament\Resources\Assets\AssetResource;
 use App\Filament\Resources\Categories\CategoryResource;
 use App\Filament\Resources\Channels\ChannelResource;
@@ -214,6 +216,8 @@ class AdminPanelProvider extends PanelProvider
                             ->icon('heroicon-m-server-stack')
                             ->items([
                                 ...MediaServerIntegrationResource::getNavigationItems(),
+                                ...ArrIntegrationResource::getNavigationItems(),
+                                ...RequestContent::getNavigationItems(),
                                 ...(config('proxy.proxy_integration_enabled', true) ? NetworkResource::getNavigationItems() : []),
                             ]),
                         NavigationGroup::make(fn () => __('Live Channels'))

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -15,7 +15,6 @@ use App\Filament\Pages\PluginsDashboard;
 use App\Filament\Pages\Preferences;
 use App\Filament\Pages\ReleaseLogs;
 use App\Filament\Pages\RequestContent;
-use App\Filament\Resources\ArrIntegrations\ArrIntegrationResource;
 use App\Filament\Resources\Assets\AssetResource;
 use App\Filament\Resources\Categories\CategoryResource;
 use App\Filament\Resources\Channels\ChannelResource;
@@ -216,7 +215,6 @@ class AdminPanelProvider extends PanelProvider
                             ->icon('heroicon-m-server-stack')
                             ->items([
                                 ...MediaServerIntegrationResource::getNavigationItems(),
-                                ...ArrIntegrationResource::getNavigationItems(),
                                 ...RequestContent::getNavigationItems(),
                                 ...(config('proxy.proxy_integration_enabled', true) ? NetworkResource::getNavigationItems() : []),
                             ]),

--- a/app/Services/Arr/ArrService.php
+++ b/app/Services/Arr/ArrService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\Arr;
+
+use App\Models\ArrIntegration;
+use App\Services\Arr\Contracts\ArrIntegrationInterface;
+use InvalidArgumentException;
+
+class ArrService
+{
+    /**
+     * Resolve an ArrIntegration into a concrete service instance.
+     */
+    public static function make(ArrIntegration $integration): ArrIntegrationInterface
+    {
+        return match ($integration->type) {
+            'sonarr' => new SonarrService($integration),
+            'radarr' => new RadarrService($integration),
+            default => throw new InvalidArgumentException("Unsupported arr type: {$integration->type}"),
+        };
+    }
+}

--- a/app/Services/Arr/BaseArrService.php
+++ b/app/Services/Arr/BaseArrService.php
@@ -51,6 +51,21 @@ abstract class BaseArrService implements ArrIntegrationInterface
             ]);
     }
 
+    public function getCommandStatus(int $commandId): string
+    {
+        $response = $this->client()->get("/command/{$commandId}");
+
+        if ($response->status() === 404) {
+            return 'completed';
+        }
+
+        if (! $response->successful()) {
+            return 'failed';
+        }
+
+        return $response->json('status') ?? 'failed';
+    }
+
     /**
      * Wrap a request in a try/catch and return a uniform {ok, data, error} shape.
      *

--- a/app/Services/Arr/BaseArrService.php
+++ b/app/Services/Arr/BaseArrService.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Services\Arr;
+
+use App\Models\ArrIntegration;
+use App\Services\Arr\Contracts\ArrIntegrationInterface;
+use Exception;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Base class for Sonarr/Radarr services — handles the shared X-Api-Key client
+ * and common request/response plumbing. Subclasses implement the per-platform
+ * endpoints and payload shapes.
+ */
+abstract class BaseArrService implements ArrIntegrationInterface
+{
+    public function __construct(protected ArrIntegration $integration) {}
+
+    public function getIntegration(): ArrIntegration
+    {
+        return $this->integration;
+    }
+
+    /**
+     * Configured HTTP client (X-Api-Key auth, /api/v3 base path).
+     */
+    protected function client(): PendingRequest
+    {
+        return Http::baseUrl($this->integration->base_url.'/api/v3')
+            ->timeout(30)
+            ->retry(2, 1000)
+            ->acceptJson()
+            ->withHeaders([
+                'X-Api-Key' => $this->integration->api_key,
+            ]);
+    }
+
+    /**
+     * Wrap a request in a try/catch and return a uniform {ok, data, error} shape.
+     *
+     * @template T
+     *
+     * @param  callable(): T  $callback
+     * @return array{ok: bool, data?: T, error?: string}
+     */
+    protected function safeCall(callable $callback, string $op): array
+    {
+        try {
+            $data = $callback();
+
+            return ['ok' => true, 'data' => $data];
+        } catch (Exception $e) {
+            Log::warning("ArrService: {$op} failed", [
+                'integration_id' => $this->integration->id,
+                'type' => $this->integration->type,
+                'error' => $e->getMessage(),
+            ]);
+
+            return ['ok' => false, 'error' => $e->getMessage()];
+        }
+    }
+}

--- a/app/Services/Arr/BaseArrService.php
+++ b/app/Services/Arr/BaseArrService.php
@@ -6,6 +6,7 @@ use App\Models\ArrIntegration;
 use App\Services\Arr\Contracts\ArrIntegrationInterface;
 use Exception;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
@@ -38,6 +39,19 @@ abstract class BaseArrService implements ArrIntegrationInterface
     }
 
     /**
+     * Short-lived client for queue polling — avoids a dead server hanging the page for 60s.
+     */
+    protected function queueClient(): PendingRequest
+    {
+        return Http::baseUrl($this->integration->base_url.'/api/v3')
+            ->timeout(5)
+            ->acceptJson()
+            ->withHeaders([
+                'X-Api-Key' => $this->integration->api_key,
+            ]);
+    }
+
+    /**
      * Wrap a request in a try/catch and return a uniform {ok, data, error} shape.
      *
      * @template T
@@ -51,6 +65,28 @@ abstract class BaseArrService implements ArrIntegrationInterface
             $data = $callback();
 
             return ['ok' => true, 'data' => $data];
+        } catch (RequestException $e) {
+            $body = $e->response->body();
+            $decoded = json_decode($body, true);
+            $errors = $decoded['errors'] ?? null;
+
+            Log::warning("ArrService: {$op} failed", [
+                'integration_id' => $this->integration->id,
+                'type' => $this->integration->type,
+                'status' => $e->response->status(),
+                'errors' => $errors,
+                'body' => $body,
+            ]);
+
+            $message = $errors
+                ? implode(' ', array_map(
+                    fn ($field, $msgs) => "{$field}: ".implode(', ', (array) $msgs),
+                    array_keys($errors),
+                    $errors
+                ))
+                : ($decoded['title'] ?? $e->getMessage());
+
+            return ['ok' => false, 'error' => $message];
         } catch (Exception $e) {
             Log::warning("ArrService: {$op} failed", [
                 'integration_id' => $this->integration->id,

--- a/app/Services/Arr/Contracts/ArrIntegrationInterface.php
+++ b/app/Services/Arr/Contracts/ArrIntegrationInterface.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services\Arr\Contracts;
+
+use App\Models\ArrIntegration;
+
+interface ArrIntegrationInterface
+{
+    /**
+     * Test connection to the Sonarr/Radarr server.
+     *
+     * @return array{ok: bool, version?: string, error?: string}
+     */
+    public function testConnection(): array;
+
+    /**
+     * Fetch available quality profiles.
+     *
+     * @return array<int, array{id: int, name: string}>
+     */
+    public function fetchQualityProfiles(): array;
+
+    /**
+     * Fetch available root folders.
+     *
+     * @return array<int, array{id: int, path: string, freeSpace?: int}>
+     */
+    public function fetchRootFolders(): array;
+
+    /**
+     * Search the catalogue for a term.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function search(string $term): array;
+
+    /**
+     * Add content to the library and trigger a search.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array{ok: bool, data?: array<string, mixed>, error?: string}
+     */
+    public function add(array $payload): array;
+
+    /**
+     * Check whether an external ID already exists in the library.
+     *
+     * @return array{exists: bool, id?: int}
+     */
+    public function checkExists(int $externalId): array;
+
+    /**
+     * Fetch interactive search releases for content already in the library.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchReleases(int $contentId): array;
+
+    /**
+     * Trigger a download of a specific release.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array{ok: bool, error?: string}
+     */
+    public function downloadRelease(array $payload): array;
+
+    /**
+     * Fetch the current download queue.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchQueue(): array;
+
+    /**
+     * The integration this service was constructed for.
+     */
+    public function getIntegration(): ArrIntegration;
+}

--- a/app/Services/Arr/Contracts/ArrIntegrationInterface.php
+++ b/app/Services/Arr/Contracts/ArrIntegrationInterface.php
@@ -89,4 +89,19 @@ interface ArrIntegrationInterface
      * @return array<int>
      */
     public function fetchLibraryTmdbIds(): array;
+
+    /**
+     * Whether this integration supports episode-level operations (Sonarr only).
+     * Use this instead of instanceof checks to keep components decoupled from concrete types.
+     */
+    public function supportsEpisodes(): bool;
+
+    /**
+     * Parse raw /queue API records into the normalized queue item shape.
+     * Separated from fetchQueue() to allow parallel HTTP fetching via Http::pool().
+     *
+     * @param  array<int, array<string, mixed>>  $records
+     * @return array<int, array<string, mixed>>
+     */
+    public function parseQueueRecords(array $records): array;
 }

--- a/app/Services/Arr/Contracts/ArrIntegrationInterface.php
+++ b/app/Services/Arr/Contracts/ArrIntegrationInterface.php
@@ -3,6 +3,7 @@
 namespace App\Services\Arr\Contracts;
 
 use App\Models\ArrIntegration;
+use Carbon\Carbon;
 use Illuminate\Http\Client\Response;
 
 interface ArrIntegrationInterface
@@ -82,9 +83,20 @@ interface ArrIntegrationInterface
     /**
      * Trigger an automatic search for content already in the library.
      *
-     * @return array{ok: bool, error?: string}
+     * @return array{ok: bool, data?: int, error?: string}
      */
     public function triggerAutomaticSearch(int $contentId): array;
+
+    /**
+     * Get the status of a command by its ID ('queued', 'started', 'completed', 'failed', etc.).
+     * Returns 'completed' if the command has aged out (404).
+     */
+    public function getCommandStatus(int $commandId): string;
+
+    /**
+     * Count history records of type 'grabbed' for the given content since a timestamp.
+     */
+    public function fetchRecentGrabCount(int $contentId, Carbon $since): int;
 
     /**
      * Fetch the current download queue.

--- a/app/Services/Arr/Contracts/ArrIntegrationInterface.php
+++ b/app/Services/Arr/Contracts/ArrIntegrationInterface.php
@@ -65,6 +65,13 @@ interface ArrIntegrationInterface
     public function downloadRelease(array $payload): array;
 
     /**
+     * Trigger an automatic search for content already in the library.
+     *
+     * @return array{ok: bool, error?: string}
+     */
+    public function triggerAutomaticSearch(int $contentId): array;
+
+    /**
      * Fetch the current download queue.
      *
      * @return array<int, array<string, mixed>>
@@ -75,4 +82,11 @@ interface ArrIntegrationInterface
      * The integration this service was constructed for.
      */
     public function getIntegration(): ArrIntegration;
+
+    /**
+     * Fetch all TMDB IDs currently in the library (for library cross-reference).
+     *
+     * @return array<int>
+     */
+    public function fetchLibraryTmdbIds(): array;
 }

--- a/app/Services/Arr/Contracts/ArrIntegrationInterface.php
+++ b/app/Services/Arr/Contracts/ArrIntegrationInterface.php
@@ -3,6 +3,7 @@
 namespace App\Services\Arr\Contracts;
 
 use App\Models\ArrIntegration;
+use Illuminate\Http\Client\Response;
 
 interface ArrIntegrationInterface
 {
@@ -33,6 +34,20 @@ interface ArrIntegrationInterface
      * @return array<int, array<string, mixed>>
      */
     public function search(string $term): array;
+
+    /**
+     * The /lookup endpoint path for this integration (e.g. /movie/lookup or /series/lookup).
+     * Used by ArrSearch to build parallel pool requests.
+     */
+    public function getSearchEndpoint(): string;
+
+    /**
+     * Parse a raw /lookup HTTP response into the normalized search result shape.
+     * Separated from search() to allow parallel fetching via Http::pool() in ArrSearch.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function parseSearchResponse(Response $response): array;
 
     /**
      * Add content to the library and trigger a search.

--- a/app/Services/Arr/RadarrService.php
+++ b/app/Services/Arr/RadarrService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Arr;
 
+use Illuminate\Http\Client\Response;
+
 class RadarrService extends BaseArrService
 {
     /**
@@ -72,10 +74,20 @@ class RadarrService extends BaseArrService
     /**
      * @return array<int, array<string, mixed>>
      */
+    public function getSearchEndpoint(): string
+    {
+        return '/movie/lookup';
+    }
+
     public function search(string $term): array
     {
         $response = $this->client()->get('/movie/lookup', ['term' => $term]);
 
+        return $this->parseSearchResponse($response);
+    }
+
+    public function parseSearchResponse(Response $response): array
+    {
         if (! $response->successful()) {
             return [];
         }

--- a/app/Services/Arr/RadarrService.php
+++ b/app/Services/Arr/RadarrService.php
@@ -81,17 +81,43 @@ class RadarrService extends BaseArrService
         }
 
         return collect($response->json() ?? [])
-            ->map(fn ($item) => [
-                'tmdbId' => $item['tmdbId'] ?? null,
-                'title' => $item['title'] ?? 'Unknown',
-                'titleSlug' => $item['titleSlug'] ?? null,
-                'year' => $item['year'] ?? null,
-                'overview' => $item['overview'] ?? null,
-                'poster' => $item['remotePoster'] ?? null,
-                'runtime' => $item['runtime'] ?? null,
-                'genres' => $item['genres'] ?? [],
-                'status' => $item['status'] ?? null,
-            ])
+            ->map(function ($item) {
+                $fanart = collect($item['images'] ?? [])->firstWhere('coverType', 'fanart');
+                $ratings = $item['ratings'] ?? [];
+                $rating = null;
+                if (! empty($ratings['imdb']['value'])) {
+                    $rating = [
+                        'value' => round((float) $ratings['imdb']['value'], 1),
+                        'votes' => (int) ($ratings['imdb']['votes'] ?? 0),
+                        'source' => 'imdb',
+                    ];
+                } elseif (! empty($ratings['tmdb']['value'])) {
+                    $rating = [
+                        'value' => round((float) $ratings['tmdb']['value'], 1),
+                        'votes' => (int) ($ratings['tmdb']['votes'] ?? 0),
+                        'source' => 'tmdb',
+                    ];
+                }
+
+                return [
+                    'tmdbId' => $item['tmdbId'] ?? null,
+                    'title' => $item['title'] ?? 'Unknown',
+                    'titleSlug' => $item['titleSlug'] ?? null,
+                    'year' => $item['year'] ?? null,
+                    'overview' => $item['overview'] ?? null,
+                    'poster' => $item['remotePoster'] ?? null,
+                    'fanart' => $fanart ? ($fanart['remoteUrl'] ?? null) : null,
+                    'runtime' => $item['runtime'] ?? null,
+                    'genres' => $item['genres'] ?? [],
+                    'status' => $item['status'] ?? null,
+                    'certification' => $item['certification'] ?? null,
+                    'rating' => $rating,
+                    'existsInLibrary' => isset($item['id']),
+                    'libraryId' => isset($item['id']) ? (int) $item['id'] : null,
+                    'hasFile' => ($item['hasFile'] ?? false) === true,
+                    'images' => $item['images'] ?? [],
+                ];
+            })
             ->all();
     }
 
@@ -101,11 +127,26 @@ class RadarrService extends BaseArrService
      */
     public function add(array $payload): array
     {
+        $qualityProfileId = (int) ($payload['qualityProfileId'] ?? $this->integration->quality_profile_id);
+        $rootFolderPath = $payload['rootFolderPath'] ?? $this->integration->root_folder_path;
+
+        if (! $qualityProfileId || ! $rootFolderPath) {
+            return [
+                'ok' => false,
+                'error' => __('Radarr integration ":name" is missing a quality profile or root folder. Please configure it in Settings → Integrations.', [
+                    'name' => $this->integration->name,
+                ]),
+            ];
+        }
+
         $body = [
             'tmdbId' => $payload['tmdbId'] ?? null,
             'title' => $payload['title'] ?? null,
-            'qualityProfileId' => $payload['qualityProfileId'] ?? $this->integration->quality_profile_id,
-            'rootFolderPath' => $payload['rootFolderPath'] ?? $this->integration->root_folder_path,
+            'titleSlug' => $payload['titleSlug'] ?? null,
+            'images' => $payload['images'] ?? [],
+            'qualityProfileId' => $qualityProfileId,
+            'rootFolderPath' => $rootFolderPath,
+            'minimumAvailability' => $payload['minimumAvailability'] ?? 'released',
             'monitored' => true,
             'addOptions' => [
                 'searchForMovie' => $payload['searchForMovie'] ?? true,
@@ -161,6 +202,7 @@ class RadarrService extends BaseArrService
                 'rejections' => $release['rejections'] ?? [],
                 'approved' => empty($release['rejections']),
             ])
+            ->sortByDesc('approved')
             ->values()
             ->all();
     }
@@ -188,11 +230,45 @@ class RadarrService extends BaseArrService
     }
 
     /**
+     * @return array{ok: bool, error?: string}
+     */
+    public function triggerAutomaticSearch(int $contentId): array
+    {
+        return $this->safeCall(
+            function () use ($contentId) {
+                $this->client()
+                    ->post('/command', ['name' => 'MoviesSearch', 'movieIds' => [$contentId]])
+                    ->throw();
+
+                return true;
+            },
+            'trigger automatic search'
+        );
+    }
+
+    /**
+     * @return array<int, bool> tmdbId => isDownloaded
+     */
+    public function fetchLibraryTmdbIds(): array
+    {
+        $response = $this->client()->get('/movie');
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->filter(fn ($m) => ! empty($m['tmdbId']))
+            ->mapWithKeys(fn ($m) => [(int) $m['tmdbId'] => ($m['hasFile'] ?? false) === true])
+            ->all();
+    }
+
+    /**
      * @return array<int, array<string, mixed>>
      */
     public function fetchQueue(): array
     {
-        $response = $this->client()->get('/queue', ['includeMovie' => 'true']);
+        $response = $this->queueClient()->get('/queue', ['includeMovie' => 'true']);
 
         if (! $response->successful()) {
             return [];
@@ -208,6 +284,7 @@ class RadarrService extends BaseArrService
 
                 return [
                     'id' => $item['id'] ?? null,
+                    'downloadId' => $item['downloadId'] ?? null,
                     'title' => $movie['title'] ?? $item['title'] ?? 'Unknown',
                     'status' => $item['status'] ?? 'unknown',
                     'progress' => max(0, min(100, $progress)),

--- a/app/Services/Arr/RadarrService.php
+++ b/app/Services/Arr/RadarrService.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace App\Services\Arr;
+
+class RadarrService extends BaseArrService
+{
+    /**
+     * @return array{ok: bool, version?: string, error?: string}
+     */
+    public function testConnection(): array
+    {
+        try {
+            $response = $this->client()->get('/system/status');
+
+            if (! $response->successful()) {
+                return [
+                    'ok' => false,
+                    'error' => 'Server returned status: '.$response->status(),
+                ];
+            }
+
+            $data = $response->json();
+
+            return [
+                'ok' => true,
+                'version' => $data['version'] ?? 'unknown',
+            ];
+        } catch (\Exception $e) {
+            return ['ok' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * @return array<int, array{id: int, name: string}>
+     */
+    public function fetchQualityProfiles(): array
+    {
+        $response = $this->client()->get('/qualityprofile');
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->map(fn ($profile) => [
+                'id' => (int) ($profile['id'] ?? 0),
+                'name' => $profile['name'] ?? 'Unnamed',
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<int, array{id: int, path: string, freeSpace?: int}>
+     */
+    public function fetchRootFolders(): array
+    {
+        $response = $this->client()->get('/rootfolder');
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->map(fn ($folder) => [
+                'id' => (int) ($folder['id'] ?? 0),
+                'path' => $folder['path'] ?? '',
+                'freeSpace' => isset($folder['freeSpace']) ? (int) $folder['freeSpace'] : null,
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function search(string $term): array
+    {
+        $response = $this->client()->get('/movie/lookup', ['term' => $term]);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->map(fn ($item) => [
+                'tmdbId' => $item['tmdbId'] ?? null,
+                'title' => $item['title'] ?? 'Unknown',
+                'titleSlug' => $item['titleSlug'] ?? null,
+                'year' => $item['year'] ?? null,
+                'overview' => $item['overview'] ?? null,
+                'poster' => $item['remotePoster'] ?? null,
+                'runtime' => $item['runtime'] ?? null,
+                'genres' => $item['genres'] ?? [],
+                'status' => $item['status'] ?? null,
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{ok: bool, data?: array<string, mixed>, error?: string}
+     */
+    public function add(array $payload): array
+    {
+        $body = [
+            'tmdbId' => $payload['tmdbId'] ?? null,
+            'title' => $payload['title'] ?? null,
+            'qualityProfileId' => $payload['qualityProfileId'] ?? $this->integration->quality_profile_id,
+            'rootFolderPath' => $payload['rootFolderPath'] ?? $this->integration->root_folder_path,
+            'monitored' => true,
+            'addOptions' => [
+                'searchForMovie' => $payload['searchForMovie'] ?? true,
+            ],
+        ];
+
+        return $this->safeCall(
+            fn () => $this->client()->post('/movie', $body)->throw()->json(),
+            'add movie'
+        );
+    }
+
+    /**
+     * @return array{exists: bool, id?: int}
+     */
+    public function checkExists(int $externalId): array
+    {
+        $response = $this->client()->get('/movie', ['tmdbId' => $externalId]);
+
+        if (! $response->successful()) {
+            return ['exists' => false];
+        }
+
+        $items = $response->json() ?? [];
+        $first = $items[0] ?? null;
+
+        if (! $first || ! isset($first['id'])) {
+            return ['exists' => false];
+        }
+
+        return ['exists' => true, 'id' => (int) $first['id']];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchReleases(int $contentId): array
+    {
+        $response = $this->client()->get('/release', ['movieId' => $contentId]);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->map(fn ($release) => [
+                'guid' => $release['guid'] ?? null,
+                'title' => $release['title'] ?? 'Unknown',
+                'indexerId' => $release['indexerId'] ?? null,
+                'size' => $release['size'] ?? 0,
+                'quality' => $release['quality']['quality']['name'] ?? 'Unknown',
+                'protocol' => $release['protocol'] ?? 'unknown',
+                'rejections' => $release['rejections'] ?? [],
+                'approved' => empty($release['rejections']),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{ok: bool, error?: string}
+     */
+    public function downloadRelease(array $payload): array
+    {
+        return $this->safeCall(
+            function () use ($payload) {
+                $this->client()
+                    ->post('/release', [
+                        'guid' => $payload['guid'] ?? null,
+                        'indexerId' => $payload['indexerId'] ?? null,
+                        'movieId' => $payload['movieId'] ?? null,
+                    ])
+                    ->throw();
+
+                return true;
+            },
+            'download release'
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchQueue(): array
+    {
+        $response = $this->client()->get('/queue', ['includeMovie' => 'true']);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json()['records'] ?? [])
+            ->map(function ($item) {
+                $size = (int) ($item['size'] ?? 0);
+                $sizeLeft = (int) ($item['sizeleft'] ?? 0);
+                $progress = $size > 0 ? (int) round((1 - ($sizeLeft / $size)) * 100) : 0;
+
+                $movie = $item['movie'] ?? null;
+
+                return [
+                    'id' => $item['id'] ?? null,
+                    'title' => $movie['title'] ?? $item['title'] ?? 'Unknown',
+                    'status' => $item['status'] ?? 'unknown',
+                    'progress' => max(0, min(100, $progress)),
+                    'size' => $size,
+                    'sizeLeft' => $sizeLeft,
+                    'timeLeft' => $item['timeleft'] ?? null,
+                ];
+            })
+            ->values()
+            ->all();
+    }
+}

--- a/app/Services/Arr/RadarrService.php
+++ b/app/Services/Arr/RadarrService.php
@@ -265,6 +265,11 @@ class RadarrService extends BaseArrService
             ->all();
     }
 
+    public function supportsEpisodes(): bool
+    {
+        return false;
+    }
+
     /**
      * @return array<int, array<string, mixed>>
      */
@@ -276,7 +281,16 @@ class RadarrService extends BaseArrService
             return [];
         }
 
-        return collect($response->json()['records'] ?? [])
+        return $this->parseQueueRecords($response->json()['records'] ?? []);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $records
+     * @return array<int, array<string, mixed>>
+     */
+    public function parseQueueRecords(array $records): array
+    {
+        return collect($records)
             ->map(function ($item) {
                 $size = (int) ($item['size'] ?? 0);
                 $sizeLeft = (int) ($item['sizeleft'] ?? 0);

--- a/app/Services/Arr/RadarrService.php
+++ b/app/Services/Arr/RadarrService.php
@@ -114,7 +114,9 @@ class RadarrService extends BaseArrService
                     'rating' => $rating,
                     'existsInLibrary' => isset($item['id']),
                     'libraryId' => isset($item['id']) ? (int) $item['id'] : null,
-                    'hasFile' => ($item['hasFile'] ?? false) === true,
+                    'hasFile' => ($item['hasFile'] ?? false) === true || isset($item['movieFile']),
+                    'fileQuality' => isset($item['movieFile']) ? ($item['movieFile']['quality']['quality']['name'] ?? null) : null,
+                    'fileSize' => isset($item['movieFile']) ? ($item['movieFile']['size'] ?? null) : null,
                     'images' => $item['images'] ?? [],
                 ];
             })
@@ -291,6 +293,11 @@ class RadarrService extends BaseArrService
                     'size' => $size,
                     'sizeLeft' => $sizeLeft,
                     'timeLeft' => $item['timeleft'] ?? null,
+                    'quality' => $item['quality']['quality']['name'] ?? null,
+                    'protocol' => $item['protocol'] ?? null,
+                    'indexer' => $item['indexer'] ?? null,
+                    'episode' => null,
+                    'trackedDownloadState' => $item['trackedDownloadState'] ?? null,
                 ];
             })
             ->values()

--- a/app/Services/Arr/RadarrService.php
+++ b/app/Services/Arr/RadarrService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Arr;
 
+use Carbon\Carbon;
 use Illuminate\Http\Client\Response;
 
 class RadarrService extends BaseArrService
@@ -244,20 +245,40 @@ class RadarrService extends BaseArrService
     }
 
     /**
-     * @return array{ok: bool, error?: string}
+     * @return array{ok: bool, data?: int, error?: string}
      */
     public function triggerAutomaticSearch(int $contentId): array
     {
         return $this->safeCall(
             function () use ($contentId) {
-                $this->client()
+                $response = $this->client()
                     ->post('/command', ['name' => 'MoviesSearch', 'movieIds' => [$contentId]])
                     ->throw();
 
-                return true;
+                return (int) $response->json('id');
             },
             'trigger automatic search'
         );
+    }
+
+    public function fetchRecentGrabCount(int $contentId, Carbon $since): int
+    {
+        $response = $this->client()->get('/history', [
+            'movieId' => $contentId,
+            'pageSize' => 50,
+            'page' => 1,
+            'sortKey' => 'date',
+            'sortDirection' => 'descending',
+        ]);
+
+        if (! $response->successful()) {
+            return 0;
+        }
+
+        return collect($response->json('records') ?? [])
+            ->filter(fn ($r) => ($r['eventType'] ?? '') === 'grabbed'
+                && Carbon::parse($r['date'])->isAfter($since))
+            ->count();
     }
 
     /**

--- a/app/Services/Arr/SonarrService.php
+++ b/app/Services/Arr/SonarrService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Arr;
 
+use Illuminate\Http\Client\Response;
+
 class SonarrService extends BaseArrService
 {
     /**
@@ -75,6 +77,11 @@ class SonarrService extends BaseArrService
             ->all();
     }
 
+    public function getSearchEndpoint(): string
+    {
+        return '/series/lookup';
+    }
+
     /**
      * @return array<int, array<string, mixed>>
      */
@@ -82,6 +89,11 @@ class SonarrService extends BaseArrService
     {
         $response = $this->client()->get('/series/lookup', ['term' => $term]);
 
+        return $this->parseSearchResponse($response);
+    }
+
+    public function parseSearchResponse(Response $response): array
+    {
         if (! $response->successful()) {
             return [];
         }
@@ -218,53 +230,54 @@ class SonarrService extends BaseArrService
      *
      * @return array<int, array<int, bool>> seasonNumber => [episodeNumber => hasFile]
      */
-    public function fetchEpisodes(int $seriesId): array
+    /**
+     * Fetch episode status and file info for a library series in a single API call.
+     *
+     * @return array{
+     *     status: array<int, array<int, bool>>,
+     *     fileInfo: array<int, array<int, array{quality: ?string, size: ?int}>>
+     * }
+     */
+    public function fetchEpisodeData(int $seriesId): array
     {
         $response = $this->client()->get('/episode', ['seriesId' => $seriesId]);
 
         if (! $response->successful()) {
-            return [];
+            return ['status' => [], 'fileInfo' => []];
         }
 
         $status = [];
+        $fileInfo = [];
+
         foreach ($response->json() ?? [] as $episode) {
             $season = (int) ($episode['seasonNumber'] ?? 0);
             $epNum = (int) ($episode['episodeNumber'] ?? 0);
-            $status[$season][$epNum] = ($episode['hasFile'] ?? false) === true;
+            $hasFile = ($episode['hasFile'] ?? false) === true;
+
+            $status[$season][$epNum] = $hasFile;
+
+            if ($hasFile) {
+                $fileInfo[$season][$epNum] = [
+                    'quality' => $episode['episodeFile']['quality']['quality']['name'] ?? null,
+                    'size' => isset($episode['episodeFile']['size']) ? (int) $episode['episodeFile']['size'] : null,
+                ];
+            }
         }
 
-        return $status;
+        return ['status' => $status, 'fileInfo' => $fileInfo];
+    }
+
+    public function fetchEpisodes(int $seriesId): array
+    {
+        return $this->fetchEpisodeData($seriesId)['status'];
     }
 
     /**
-     * Fetch per-episode file quality and size for a series in the Sonarr library.
-     * Only populated when the episode has a file and Sonarr embeds episodeFile.
-     *
-     * @return array<int, array<int, array{quality: ?string, size: ?int}>> seasonNumber => [episodeNumber => {quality, size}]
+     * @return array<int, array<int, array{quality: ?string, size: ?int}>>
      */
     public function fetchEpisodeFileInfo(int $seriesId): array
     {
-        $response = $this->client()->get('/episode', ['seriesId' => $seriesId]);
-
-        if (! $response->successful()) {
-            return [];
-        }
-
-        $info = [];
-        foreach ($response->json() ?? [] as $episode) {
-            if (! ($episode['hasFile'] ?? false)) {
-                continue;
-            }
-
-            $season = (int) ($episode['seasonNumber'] ?? 0);
-            $epNum = (int) ($episode['episodeNumber'] ?? 0);
-            $info[$season][$epNum] = [
-                'quality' => $episode['episodeFile']['quality']['quality']['name'] ?? null,
-                'size' => isset($episode['episodeFile']['size']) ? (int) $episode['episodeFile']['size'] : null,
-            ];
-        }
-
-        return $info;
+        return $this->fetchEpisodeData($seriesId)['fileInfo'];
     }
 
     /**

--- a/app/Services/Arr/SonarrService.php
+++ b/app/Services/Arr/SonarrService.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace App\Services\Arr;
+
+class SonarrService extends BaseArrService
+{
+    /**
+     * @return array{ok: bool, version?: string, error?: string}
+     */
+    public function testConnection(): array
+    {
+        try {
+            $response = $this->client()->get('/system/status');
+
+            if (! $response->successful()) {
+                return [
+                    'ok' => false,
+                    'error' => 'Server returned status: '.$response->status(),
+                ];
+            }
+
+            $data = $response->json();
+
+            return [
+                'ok' => true,
+                'version' => $data['version'] ?? 'unknown',
+            ];
+        } catch (\Exception $e) {
+            return ['ok' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * @return array<int, array{id: int, name: string}>
+     */
+    public function fetchQualityProfiles(): array
+    {
+        $response = $this->client()->get('/qualityprofile');
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->map(fn ($profile) => [
+                'id' => (int) ($profile['id'] ?? 0),
+                'name' => $profile['name'] ?? 'Unnamed',
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<int, array{id: int, path: string, freeSpace?: int}>
+     */
+    public function fetchRootFolders(): array
+    {
+        $response = $this->client()->get('/rootfolder');
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->map(fn ($folder) => [
+                'id' => (int) ($folder['id'] ?? 0),
+                'path' => $folder['path'] ?? '',
+                'freeSpace' => isset($folder['freeSpace']) ? (int) $folder['freeSpace'] : null,
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function search(string $term): array
+    {
+        $response = $this->client()->get('/series/lookup', ['term' => $term]);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->map(fn ($item) => [
+                'tvdbId' => $item['tvdbId'] ?? null,
+                'title' => $item['title'] ?? 'Unknown',
+                'titleSlug' => $item['titleSlug'] ?? null,
+                'year' => $item['year'] ?? null,
+                'overview' => $item['overview'] ?? null,
+                'poster' => $item['remotePoster'] ?? null,
+                'seasons' => $item['seasons'] ?? [],
+                'status' => $item['status'] ?? null,
+                'network' => $item['network'] ?? null,
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{ok: bool, data?: array<string, mixed>, error?: string}
+     */
+    public function add(array $payload): array
+    {
+        $body = [
+            'tvdbId' => $payload['tvdbId'] ?? null,
+            'title' => $payload['title'] ?? null,
+            'titleSlug' => $payload['titleSlug'] ?? null,
+            'qualityProfileId' => $payload['qualityProfileId'] ?? $this->integration->quality_profile_id,
+            'rootFolderPath' => $payload['rootFolderPath'] ?? $this->integration->root_folder_path,
+            'monitored' => true,
+            'addOptions' => [
+                'searchForMissingEpisodes' => $payload['searchForMissingEpisodes'] ?? true,
+            ],
+        ];
+
+        // Optionally restrict to specific seasons when provided
+        if (! empty($payload['seasons'])) {
+            $body['seasons'] = $payload['seasons'];
+        }
+
+        return $this->safeCall(
+            fn () => $this->client()->post('/series', $body)->throw()->json(),
+            'add series'
+        );
+    }
+
+    /**
+     * @return array{exists: bool, id?: int}
+     */
+    public function checkExists(int $externalId): array
+    {
+        $response = $this->client()->get('/series/lookup', ['term' => 'tvdb:'.$externalId]);
+
+        if (! $response->successful()) {
+            return ['exists' => false];
+        }
+
+        $items = $response->json() ?? [];
+        $first = $items[0] ?? null;
+
+        if (! $first || ! isset($first['id'])) {
+            return ['exists' => false];
+        }
+
+        return ['exists' => true, 'id' => (int) $first['id']];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchReleases(int $contentId): array
+    {
+        $response = $this->client()->get('/release', ['seriesId' => $contentId]);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->map(fn ($release) => [
+                'guid' => $release['guid'] ?? null,
+                'title' => $release['title'] ?? 'Unknown',
+                'indexerId' => $release['indexerId'] ?? null,
+                'size' => $release['size'] ?? 0,
+                'quality' => $release['quality']['quality']['name'] ?? 'Unknown',
+                'protocol' => $release['protocol'] ?? 'unknown',
+                'rejections' => $release['rejections'] ?? [],
+                'approved' => empty($release['rejections']),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{ok: bool, error?: string}
+     */
+    public function downloadRelease(array $payload): array
+    {
+        return $this->safeCall(
+            function () use ($payload) {
+                $this->client()
+                    ->post('/release', [
+                        'guid' => $payload['guid'] ?? null,
+                        'indexerId' => $payload['indexerId'] ?? null,
+                        'seriesId' => $payload['seriesId'] ?? null,
+                    ])
+                    ->throw();
+
+                return true;
+            },
+            'download release'
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchQueue(): array
+    {
+        $response = $this->client()->get('/queue', ['includeSeries' => 'true']);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json()['records'] ?? [])
+            ->map(function ($item) {
+                $size = (int) ($item['size'] ?? 0);
+                $sizeLeft = (int) ($item['sizeleft'] ?? 0);
+                $progress = $size > 0 ? (int) round((1 - ($sizeLeft / $size)) * 100) : 0;
+
+                $series = $item['series'] ?? null;
+
+                return [
+                    'id' => $item['id'] ?? null,
+                    'title' => $series['title'] ?? $item['title'] ?? 'Unknown',
+                    'status' => $item['status'] ?? 'unknown',
+                    'progress' => max(0, min(100, $progress)),
+                    'size' => $size,
+                    'sizeLeft' => $sizeLeft,
+                    'timeLeft' => $item['timeleft'] ?? null,
+                ];
+            })
+            ->values()
+            ->all();
+    }
+}

--- a/app/Services/Arr/SonarrService.php
+++ b/app/Services/Arr/SonarrService.php
@@ -5,6 +5,12 @@ namespace App\Services\Arr;
 class SonarrService extends BaseArrService
 {
     /**
+     * Microseconds to wait between episode-fetch retry attempts after adding a new series.
+     * Sonarr indexes episodes asynchronously — zero in tests to avoid sleeping.
+     */
+    public static int $episodeRetryDelayUs = 500_000;
+
+    /**
      * @return array{ok: bool, version?: string, error?: string}
      */
     public function testConnection(): array
@@ -112,6 +118,7 @@ class SonarrService extends BaseArrService
                     'libraryId' => isset($item['id']) ? (int) $item['id'] : null,
                     'episodeFileCount' => (int) ($item['statistics']['episodeFileCount'] ?? 0),
                     'totalEpisodeCount' => (int) ($item['statistics']['totalEpisodeCount'] ?? 0),
+                    'sizeOnDisk' => (int) ($item['statistics']['sizeOnDisk'] ?? 0),
                 ];
             })
             ->all();
@@ -230,6 +237,37 @@ class SonarrService extends BaseArrService
     }
 
     /**
+     * Fetch per-episode file quality and size for a series in the Sonarr library.
+     * Only populated when the episode has a file and Sonarr embeds episodeFile.
+     *
+     * @return array<int, array<int, array{quality: ?string, size: ?int}>> seasonNumber => [episodeNumber => {quality, size}]
+     */
+    public function fetchEpisodeFileInfo(int $seriesId): array
+    {
+        $response = $this->client()->get('/episode', ['seriesId' => $seriesId]);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        $info = [];
+        foreach ($response->json() ?? [] as $episode) {
+            if (! ($episode['hasFile'] ?? false)) {
+                continue;
+            }
+
+            $season = (int) ($episode['seasonNumber'] ?? 0);
+            $epNum = (int) ($episode['episodeNumber'] ?? 0);
+            $info[$season][$epNum] = [
+                'quality' => $episode['episodeFile']['quality']['quality']['name'] ?? null,
+                'size' => isset($episode['episodeFile']['size']) ? (int) $episode['episodeFile']['size'] : null,
+            ];
+        }
+
+        return $info;
+    }
+
+    /**
      * @param  array<string, mixed>  $payload
      * @return array{ok: bool, error?: string}
      */
@@ -237,13 +275,17 @@ class SonarrService extends BaseArrService
     {
         return $this->safeCall(
             function () use ($payload) {
-                $this->client()
-                    ->post('/release', [
-                        'guid' => $payload['guid'] ?? null,
-                        'indexerId' => $payload['indexerId'] ?? null,
-                        'seriesId' => $payload['seriesId'] ?? null,
-                    ])
-                    ->throw();
+                $body = [
+                    'guid' => $payload['guid'] ?? null,
+                    'indexerId' => $payload['indexerId'] ?? null,
+                    'seriesId' => $payload['seriesId'] ?? null,
+                ];
+
+                if (isset($payload['episodeId'])) {
+                    $body['episodeId'] = (int) $payload['episodeId'];
+                }
+
+                $this->client()->post('/release', $body)->throw();
 
                 return true;
             },
@@ -274,6 +316,7 @@ class SonarrService extends BaseArrService
             }
 
             $sonarrId = $series['id'] ?? null;
+            $seriesJustAdded = false;
 
             if (! $sonarrId) {
                 // Add the series with every season unmonitored so nothing bulk-downloads
@@ -296,21 +339,19 @@ class SonarrService extends BaseArrService
                     ->json();
 
                 $sonarrId = $added['id'];
+                $seriesJustAdded = true;
             }
 
-            // Find the target episode by season + episode number
-            $episodes = $this->client()
-                ->get('/episode', ['seriesId' => $sonarrId, 'seasonNumber' => $seasonNumber])
-                ->throw()
-                ->json();
+            // Find the target episode — retry when the series was just added because Sonarr
+            // indexes episodes asynchronously and the first fetch may return an empty list.
+            $episodeId = $this->resolveEpisodeId($sonarrId, $seasonNumber, $episodeNumber, $seriesJustAdded);
 
-            $episode = collect($episodes ?? [])->firstWhere('episodeNumber', $episodeNumber);
-
-            if (! $episode) {
-                throw new \RuntimeException("Episode S{$seasonNumber}E{$episodeNumber} not found in Sonarr.");
+            if (! $episodeId) {
+                throw new \RuntimeException(
+                    "Episode S{$seasonNumber}E{$episodeNumber} not found in Sonarr. ".
+                    'Sonarr may still be indexing the series — please try again in a moment.'
+                );
             }
-
-            $episodeId = (int) $episode['id'];
 
             // Monitor the episode then trigger an immediate search
             $this->client()
@@ -323,6 +364,71 @@ class SonarrService extends BaseArrService
 
             return $episodeId;
         }, "request episode S{$seasonNumber}E{$episodeNumber}");
+    }
+
+    /**
+     * Resolve the Sonarr-internal episode ID for a given season + episode number.
+     * When $retryIfEmpty is true, retries up to 5 times to handle the delay between
+     * a series being added via POST /series and its episodes becoming available.
+     */
+    public function resolveEpisodeId(int $seriesId, int $seasonNumber, int $episodeNumber, bool $retryIfEmpty = false): ?int
+    {
+        $maxAttempts = $retryIfEmpty ? 5 : 1;
+
+        for ($attempt = 0; $attempt < $maxAttempts; $attempt++) {
+            if ($attempt > 0 && static::$episodeRetryDelayUs > 0) {
+                usleep(static::$episodeRetryDelayUs);
+            }
+
+            $response = $this->client()->get('/episode', [
+                'seriesId' => $seriesId,
+                'seasonNumber' => $seasonNumber,
+            ]);
+
+            if (! $response->successful()) {
+                return null;
+            }
+
+            $episode = collect($response->json() ?? [])->firstWhere('episodeNumber', $episodeNumber);
+
+            if ($episode) {
+                return (int) $episode['id'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Fetch releases for a specific episode via Sonarr's indexer search.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchEpisodeReleases(int $seriesId, int $episodeId): array
+    {
+        $response = $this->client()->get('/release', [
+            'seriesId' => $seriesId,
+            'episodeId' => $episodeId,
+        ]);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->map(fn ($release) => [
+                'guid' => $release['guid'] ?? null,
+                'title' => $release['title'] ?? 'Unknown',
+                'indexerId' => $release['indexerId'] ?? null,
+                'size' => $release['size'] ?? 0,
+                'quality' => $release['quality']['quality']['name'] ?? 'Unknown',
+                'protocol' => $release['protocol'] ?? 'unknown',
+                'rejections' => $release['rejections'] ?? [],
+                'approved' => empty($release['rejections']),
+            ])
+            ->sortByDesc('approved')
+            ->values()
+            ->all();
     }
 
     /**
@@ -364,7 +470,7 @@ class SonarrService extends BaseArrService
      */
     public function fetchQueue(): array
     {
-        $response = $this->queueClient()->get('/queue', ['includeSeries' => 'true']);
+        $response = $this->queueClient()->get('/queue', ['includeSeries' => 'true', 'includeEpisode' => 'true']);
 
         if (! $response->successful()) {
             return [];
@@ -377,6 +483,13 @@ class SonarrService extends BaseArrService
                 $progress = $size > 0 ? (int) round((1 - ($sizeLeft / $size)) * 100) : 0;
 
                 $series = $item['series'] ?? null;
+                $episode = $item['episode'] ?? null;
+                $episodeLabel = null;
+                if ($episode) {
+                    $s = str_pad((string) ($episode['seasonNumber'] ?? 0), 2, '0', STR_PAD_LEFT);
+                    $e = str_pad((string) ($episode['episodeNumber'] ?? 0), 2, '0', STR_PAD_LEFT);
+                    $episodeLabel = "S{$s}E{$e}".($episode['title'] ? ' · '.$episode['title'] : '');
+                }
 
                 return [
                     'id' => $item['id'] ?? null,
@@ -387,6 +500,11 @@ class SonarrService extends BaseArrService
                     'size' => $size,
                     'sizeLeft' => $sizeLeft,
                     'timeLeft' => $item['timeleft'] ?? null,
+                    'quality' => $item['quality']['quality']['name'] ?? null,
+                    'protocol' => $item['protocol'] ?? null,
+                    'indexer' => $item['indexer'] ?? null,
+                    'episode' => $episodeLabel,
+                    'trackedDownloadState' => $item['trackedDownloadState'] ?? null,
                 ];
             })
             ->values()

--- a/app/Services/Arr/SonarrService.php
+++ b/app/Services/Arr/SonarrService.php
@@ -370,6 +370,10 @@ class SonarrService extends BaseArrService
      * Resolve the Sonarr-internal episode ID for a given season + episode number.
      * When $retryIfEmpty is true, retries up to 5 times to handle the delay between
      * a series being added via POST /series and its episodes becoming available.
+     *
+     * NOTE: Retries use usleep() which blocks the PHP worker for up to 2.5 s total.
+     * This is intentional for a single-user self-hosted setup; do not call from a
+     * high-concurrency context without moving to a queued job first.
      */
     public function resolveEpisodeId(int $seriesId, int $seasonNumber, int $episodeNumber, bool $retryIfEmpty = false): ?int
     {
@@ -465,6 +469,11 @@ class SonarrService extends BaseArrService
             ->all();
     }
 
+    public function supportsEpisodes(): bool
+    {
+        return true;
+    }
+
     /**
      * @return array<int, array<string, mixed>>
      */
@@ -476,7 +485,16 @@ class SonarrService extends BaseArrService
             return [];
         }
 
-        return collect($response->json()['records'] ?? [])
+        return $this->parseQueueRecords($response->json()['records'] ?? []);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $records
+     * @return array<int, array<string, mixed>>
+     */
+    public function parseQueueRecords(array $records): array
+    {
+        return collect($records)
             ->map(function ($item) {
                 $size = (int) ($item['size'] ?? 0);
                 $sizeLeft = (int) ($item['sizeleft'] ?? 0);

--- a/app/Services/Arr/SonarrService.php
+++ b/app/Services/Arr/SonarrService.php
@@ -81,17 +81,39 @@ class SonarrService extends BaseArrService
         }
 
         return collect($response->json() ?? [])
-            ->map(fn ($item) => [
-                'tvdbId' => $item['tvdbId'] ?? null,
-                'title' => $item['title'] ?? 'Unknown',
-                'titleSlug' => $item['titleSlug'] ?? null,
-                'year' => $item['year'] ?? null,
-                'overview' => $item['overview'] ?? null,
-                'poster' => $item['remotePoster'] ?? null,
-                'seasons' => $item['seasons'] ?? [],
-                'status' => $item['status'] ?? null,
-                'network' => $item['network'] ?? null,
-            ])
+            ->map(function ($item) {
+                $fanart = collect($item['images'] ?? [])->firstWhere('coverType', 'fanart');
+                $ratings = $item['ratings'] ?? [];
+                $rating = null;
+                if (! empty($ratings['value'])) {
+                    $rating = [
+                        'value' => round((float) $ratings['value'], 1),
+                        'votes' => (int) ($ratings['votes'] ?? 0),
+                        'source' => 'tvdb',
+                    ];
+                }
+
+                return [
+                    'tvdbId' => $item['tvdbId'] ?? null,
+                    'title' => $item['title'] ?? 'Unknown',
+                    'titleSlug' => $item['titleSlug'] ?? null,
+                    'year' => $item['year'] ?? null,
+                    'overview' => $item['overview'] ?? null,
+                    'poster' => $item['remotePoster'] ?? null,
+                    'fanart' => $fanart ? ($fanart['remoteUrl'] ?? null) : null,
+                    'seasons' => $item['seasons'] ?? [],
+                    'status' => $item['status'] ?? null,
+                    'network' => $item['network'] ?? null,
+                    'genres' => $item['genres'] ?? [],
+                    'runtime' => $item['runtime'] ?? null,
+                    'certification' => $item['certification'] ?? null,
+                    'rating' => $rating,
+                    'existsInLibrary' => isset($item['id']),
+                    'libraryId' => isset($item['id']) ? (int) $item['id'] : null,
+                    'episodeFileCount' => (int) ($item['statistics']['episodeFileCount'] ?? 0),
+                    'totalEpisodeCount' => (int) ($item['statistics']['totalEpisodeCount'] ?? 0),
+                ];
+            })
             ->all();
     }
 
@@ -101,12 +123,24 @@ class SonarrService extends BaseArrService
      */
     public function add(array $payload): array
     {
+        $qualityProfileId = (int) ($payload['qualityProfileId'] ?? $this->integration->quality_profile_id);
+        $rootFolderPath = $payload['rootFolderPath'] ?? $this->integration->root_folder_path;
+
+        if (! $qualityProfileId || ! $rootFolderPath) {
+            return [
+                'ok' => false,
+                'error' => __('Sonarr integration ":name" is missing a quality profile or root folder. Please configure it in Settings → Integrations.', [
+                    'name' => $this->integration->name,
+                ]),
+            ];
+        }
+
         $body = [
             'tvdbId' => $payload['tvdbId'] ?? null,
             'title' => $payload['title'] ?? null,
             'titleSlug' => $payload['titleSlug'] ?? null,
-            'qualityProfileId' => $payload['qualityProfileId'] ?? $this->integration->quality_profile_id,
-            'rootFolderPath' => $payload['rootFolderPath'] ?? $this->integration->root_folder_path,
+            'qualityProfileId' => $qualityProfileId,
+            'rootFolderPath' => $rootFolderPath,
             'monitored' => true,
             'addOptions' => [
                 'searchForMissingEpisodes' => $payload['searchForMissingEpisodes'] ?? true,
@@ -167,8 +201,32 @@ class SonarrService extends BaseArrService
                 'rejections' => $release['rejections'] ?? [],
                 'approved' => empty($release['rejections']),
             ])
+            ->sortByDesc('approved')
             ->values()
             ->all();
+    }
+
+    /**
+     * Fetch per-episode hasFile status for a series already in the Sonarr library.
+     *
+     * @return array<int, array<int, bool>> seasonNumber => [episodeNumber => hasFile]
+     */
+    public function fetchEpisodes(int $seriesId): array
+    {
+        $response = $this->client()->get('/episode', ['seriesId' => $seriesId]);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        $status = [];
+        foreach ($response->json() ?? [] as $episode) {
+            $season = (int) ($episode['seasonNumber'] ?? 0);
+            $epNum = (int) ($episode['episodeNumber'] ?? 0);
+            $status[$season][$epNum] = ($episode['hasFile'] ?? false) === true;
+        }
+
+        return $status;
     }
 
     /**
@@ -194,11 +252,119 @@ class SonarrService extends BaseArrService
     }
 
     /**
+     * Request a single episode. Adds the series (all seasons unmonitored) if it is
+     * not yet in the library, then monitors and searches the specific episode.
+     *
+     * @param  array{qualityProfileId?: int, rootFolderPath?: string}  $defaults
+     * @return array{ok: bool, data?: mixed, error?: string}
+     */
+    public function requestEpisode(int $tvdbId, int $seasonNumber, int $episodeNumber, array $defaults = []): array
+    {
+        return $this->safeCall(function () use ($tvdbId, $seasonNumber, $episodeNumber, $defaults) {
+            // Resolve the Sonarr series ID, adding the series if necessary
+            $lookup = $this->client()
+                ->get('/series/lookup', ['term' => 'tvdb:'.$tvdbId])
+                ->throw()
+                ->json();
+
+            $series = $lookup[0] ?? null;
+
+            if (! $series) {
+                throw new \RuntimeException('Series not found via TVDB lookup.');
+            }
+
+            $sonarrId = $series['id'] ?? null;
+
+            if (! $sonarrId) {
+                // Add the series with every season unmonitored so nothing bulk-downloads
+                $seasons = collect($series['seasons'] ?? [])
+                    ->map(fn ($s) => ['seasonNumber' => (int) $s['seasonNumber'], 'monitored' => false])
+                    ->all();
+
+                $added = $this->client()
+                    ->post('/series', [
+                        'tvdbId' => $tvdbId,
+                        'title' => $series['title'],
+                        'titleSlug' => $series['titleSlug'],
+                        'qualityProfileId' => $defaults['qualityProfileId'] ?? $this->integration->quality_profile_id,
+                        'rootFolderPath' => $defaults['rootFolderPath'] ?? $this->integration->root_folder_path,
+                        'monitored' => true,
+                        'seasons' => $seasons,
+                        'addOptions' => ['searchForMissingEpisodes' => false],
+                    ])
+                    ->throw()
+                    ->json();
+
+                $sonarrId = $added['id'];
+            }
+
+            // Find the target episode by season + episode number
+            $episodes = $this->client()
+                ->get('/episode', ['seriesId' => $sonarrId, 'seasonNumber' => $seasonNumber])
+                ->throw()
+                ->json();
+
+            $episode = collect($episodes ?? [])->firstWhere('episodeNumber', $episodeNumber);
+
+            if (! $episode) {
+                throw new \RuntimeException("Episode S{$seasonNumber}E{$episodeNumber} not found in Sonarr.");
+            }
+
+            $episodeId = (int) $episode['id'];
+
+            // Monitor the episode then trigger an immediate search
+            $this->client()
+                ->put('/episode/monitor', ['episodeIds' => [$episodeId], 'monitored' => true])
+                ->throw();
+
+            $this->client()
+                ->post('/command', ['name' => 'EpisodeSearch', 'episodeIds' => [$episodeId]])
+                ->throw();
+
+            return $episodeId;
+        }, "request episode S{$seasonNumber}E{$episodeNumber}");
+    }
+
+    /**
+     * @return array{ok: bool, error?: string}
+     */
+    public function triggerAutomaticSearch(int $contentId): array
+    {
+        return $this->safeCall(
+            function () use ($contentId) {
+                $this->client()
+                    ->post('/command', ['name' => 'SeriesSearch', 'seriesId' => $contentId])
+                    ->throw();
+
+                return true;
+            },
+            'trigger automatic search'
+        );
+    }
+
+    /**
+     * @return array<int, bool> tmdbId => isDownloaded
+     */
+    public function fetchLibraryTmdbIds(): array
+    {
+        $response = $this->client()->get('/series');
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->filter(fn ($s) => ! empty($s['tmdbId']))
+            ->mapWithKeys(fn ($s) => [(int) $s['tmdbId'] => (int) ($s['statistics']['episodeFileCount'] ?? 0) > 0])
+            ->all();
+    }
+
+    /**
      * @return array<int, array<string, mixed>>
      */
     public function fetchQueue(): array
     {
-        $response = $this->client()->get('/queue', ['includeSeries' => 'true']);
+        $response = $this->queueClient()->get('/queue', ['includeSeries' => 'true']);
 
         if (! $response->successful()) {
             return [];
@@ -214,6 +380,7 @@ class SonarrService extends BaseArrService
 
                 return [
                     'id' => $item['id'] ?? null,
+                    'downloadId' => $item['downloadId'] ?? null,
                     'title' => $series['title'] ?? $item['title'] ?? 'Unknown',
                     'status' => $item['status'] ?? 'unknown',
                     'progress' => max(0, min(100, $progress)),

--- a/app/Services/Arr/SonarrService.php
+++ b/app/Services/Arr/SonarrService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Arr;
 
+use App\Jobs\RequestArrEpisode;
+use Carbon\Carbon;
 use Illuminate\Http\Client\Response;
 
 class SonarrService extends BaseArrService
@@ -355,18 +357,50 @@ class SonarrService extends BaseArrService
                 $seriesJustAdded = true;
             }
 
-            // Find the target episode — retry when the series was just added because Sonarr
-            // indexes episodes asynchronously and the first fetch may return an empty list.
-            $episodeId = $this->resolveEpisodeId($sonarrId, $seasonNumber, $episodeNumber, $seriesJustAdded);
+            if ($seriesJustAdded) {
+                // Sonarr indexes episodes asynchronously after a POST /series, so the episode
+                // list may be empty for several seconds. Hand off to a queued job that retries
+                // with backoff rather than blocking the web worker with usleep().
+                RequestArrEpisode::dispatch(
+                    $this->integration->id,
+                    $sonarrId,
+                    $seasonNumber,
+                    $episodeNumber,
+                    $this->integration->user_id,
+                    $series['title'] ?? 'Unknown',
+                );
+
+                return ['queued' => true];
+            }
+
+            $result = $this->monitorAndSearchEpisode($sonarrId, $seasonNumber, $episodeNumber);
+
+            if (! $result['ok']) {
+                throw new \RuntimeException($result['error'] ?? 'Failed to monitor and search episode.');
+            }
+
+            return $result['data'];
+        }, "request episode S{$seasonNumber}E{$episodeNumber}");
+    }
+
+    /**
+     * Monitor a specific episode and trigger an immediate search.
+     * Returns ok=false (without throwing) when the episode is not yet indexed,
+     * so the caller (e.g. RequestArrEpisode job) can decide whether to retry.
+     *
+     * @return array{ok: bool, data?: mixed, error?: string}
+     */
+    public function monitorAndSearchEpisode(int $sonarrSeriesId, int $seasonNumber, int $episodeNumber): array
+    {
+        return $this->safeCall(function () use ($sonarrSeriesId, $seasonNumber, $episodeNumber) {
+            $episodeId = $this->resolveEpisodeId($sonarrSeriesId, $seasonNumber, $episodeNumber);
 
             if (! $episodeId) {
                 throw new \RuntimeException(
-                    "Episode S{$seasonNumber}E{$episodeNumber} not found in Sonarr. ".
-                    'Sonarr may still be indexing the series — please try again in a moment.'
+                    "Episode S{$seasonNumber}E{$episodeNumber} not yet indexed by Sonarr."
                 );
             }
 
-            // Monitor the episode then trigger an immediate search
             $this->client()
                 ->put('/episode/monitor', ['episodeIds' => [$episodeId], 'monitored' => true])
                 ->throw();
@@ -376,17 +410,13 @@ class SonarrService extends BaseArrService
                 ->throw();
 
             return $episodeId;
-        }, "request episode S{$seasonNumber}E{$episodeNumber}");
+        }, "monitor and search episode S{$seasonNumber}E{$episodeNumber}");
     }
 
     /**
      * Resolve the Sonarr-internal episode ID for a given season + episode number.
      * When $retryIfEmpty is true, retries up to 5 times to handle the delay between
      * a series being added via POST /series and its episodes becoming available.
-     *
-     * NOTE: Retries use usleep() which blocks the PHP worker for up to 2.5 s total.
-     * This is intentional for a single-user self-hosted setup; do not call from a
-     * high-concurrency context without moving to a queued job first.
      */
     public function resolveEpisodeId(int $seriesId, int $seasonNumber, int $episodeNumber, bool $retryIfEmpty = false): ?int
     {
@@ -449,20 +479,40 @@ class SonarrService extends BaseArrService
     }
 
     /**
-     * @return array{ok: bool, error?: string}
+     * @return array{ok: bool, data?: int, error?: string}
      */
     public function triggerAutomaticSearch(int $contentId): array
     {
         return $this->safeCall(
             function () use ($contentId) {
-                $this->client()
+                $response = $this->client()
                     ->post('/command', ['name' => 'SeriesSearch', 'seriesId' => $contentId])
                     ->throw();
 
-                return true;
+                return (int) $response->json('id');
             },
             'trigger automatic search'
         );
+    }
+
+    public function fetchRecentGrabCount(int $contentId, Carbon $since): int
+    {
+        $response = $this->client()->get('/history', [
+            'seriesId' => $contentId,
+            'pageSize' => 50,
+            'page' => 1,
+            'sortKey' => 'date',
+            'sortDirection' => 'descending',
+        ]);
+
+        if (! $response->successful()) {
+            return 0;
+        }
+
+        return collect($response->json('records') ?? [])
+            ->filter(fn ($r) => ($r['eventType'] ?? '') === 'grabbed'
+                && Carbon::parse($r['date'])->isAfter($since))
+            ->count();
     }
 
     /**

--- a/app/Services/TmdbService.php
+++ b/app/Services/TmdbService.php
@@ -960,6 +960,49 @@ class TmdbService
     }
 
     /**
+     * Fetch cast for a movie from TMDB credits endpoint.
+     *
+     * @return array<int, array{actor: string, character: string, photo: ?string}>
+     */
+    public function getMovieCast(int $tmdbId): array
+    {
+        if (! $this->isConfigured()) {
+            return [];
+        }
+
+        $cacheKey = "tmdb_movie_cast_{$tmdbId}_{$this->language}";
+
+        return Cache::remember($cacheKey, now()->addMinutes(60), function () use ($tmdbId) {
+            $this->waitForRateLimit();
+
+            try {
+                $response = Http::timeout(15)->get(
+                    self::BASE_URL."/movie/{$tmdbId}/credits",
+                    ['api_key' => $this->apiKey, 'language' => $this->language]
+                );
+
+                if (! $response->successful()) {
+                    return [];
+                }
+
+                return collect($response->json()['cast'] ?? [])
+                    ->take(15)
+                    ->map(fn ($p) => [
+                        'actor' => $p['name'] ?? '',
+                        'character' => $p['character'] ?? '',
+                        'photo' => ! empty($p['profile_path'])
+                            ? 'https://image.tmdb.org/t/p/w185'.$p['profile_path']
+                            : null,
+                    ])
+                    ->values()
+                    ->all();
+            } catch (\Exception) {
+                return [];
+            }
+        });
+    }
+
+    /**
      * Get alternative titles for a TV series.
      * Returns titles in different languages/regions.
      *
@@ -1744,6 +1787,394 @@ class TmdbService
 
             return null;
         }
+    }
+
+    /**
+     * Fetch trending content (movies + TV or a specific type).
+     *
+     * @param  string  $mediaType  'all', 'movie', or 'tv'
+     * @param  string  $timeWindow  'day' or 'week'
+     * @return array<int, array<string, mixed>>
+     */
+    public function getTrending(string $mediaType = 'all', string $timeWindow = 'week'): array
+    {
+        if (! $this->isConfigured()) {
+            return [];
+        }
+
+        $cacheKey = "tmdb_trending_{$mediaType}_{$timeWindow}_{$this->language}";
+
+        return Cache::remember($cacheKey, now()->addMinutes(30), function () use ($mediaType, $timeWindow) {
+            $this->waitForRateLimit();
+
+            try {
+                $response = Http::timeout(15)->get(
+                    self::BASE_URL."/trending/{$mediaType}/{$timeWindow}",
+                    ['api_key' => $this->apiKey, 'language' => $this->language]
+                );
+
+                if (! $response->successful()) {
+                    return [];
+                }
+
+                return collect($response->json()['results'] ?? [])
+                    ->map(fn ($item) => $this->normalizeDiscoverResult($item, $item['media_type'] ?? $mediaType))
+                    ->filter(fn ($item) => $item['tmdb_id'] > 0 && in_array($item['media_type'], ['movie', 'tv'], true))
+                    ->values()
+                    ->all();
+            } catch (\Exception $e) {
+                Log::error('TMDB: getTrending error', ['error' => $e->getMessage()]);
+
+                return [];
+            }
+        });
+    }
+
+    /**
+     * Fetch popular movies.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getPopularMovies(int $page = 1): array
+    {
+        if (! $this->isConfigured()) {
+            return [];
+        }
+
+        $cacheKey = "tmdb_popular_movies_{$page}_{$this->language}";
+
+        return Cache::remember($cacheKey, now()->addMinutes(30), function () use ($page) {
+            $this->waitForRateLimit();
+
+            try {
+                $response = Http::timeout(15)->get(self::BASE_URL.'/movie/popular', [
+                    'api_key' => $this->apiKey,
+                    'language' => $this->language,
+                    'page' => $page,
+                ]);
+
+                if (! $response->successful()) {
+                    return [];
+                }
+
+                return collect($response->json()['results'] ?? [])
+                    ->map(fn ($item) => $this->normalizeDiscoverResult($item, 'movie'))
+                    ->filter(fn ($item) => $item['tmdb_id'] > 0)
+                    ->values()
+                    ->all();
+            } catch (\Exception $e) {
+                Log::error('TMDB: getPopularMovies error', ['error' => $e->getMessage()]);
+
+                return [];
+            }
+        });
+    }
+
+    /**
+     * Fetch popular TV series.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getPopularTv(int $page = 1): array
+    {
+        if (! $this->isConfigured()) {
+            return [];
+        }
+
+        $cacheKey = "tmdb_popular_tv_{$page}_{$this->language}";
+
+        return Cache::remember($cacheKey, now()->addMinutes(30), function () use ($page) {
+            $this->waitForRateLimit();
+
+            try {
+                $response = Http::timeout(15)->get(self::BASE_URL.'/tv/popular', [
+                    'api_key' => $this->apiKey,
+                    'language' => $this->language,
+                    'page' => $page,
+                ]);
+
+                if (! $response->successful()) {
+                    return [];
+                }
+
+                return collect($response->json()['results'] ?? [])
+                    ->map(fn ($item) => $this->normalizeDiscoverResult($item, 'tv'))
+                    ->filter(fn ($item) => $item['tmdb_id'] > 0)
+                    ->values()
+                    ->all();
+            } catch (\Exception $e) {
+                Log::error('TMDB: getPopularTv error', ['error' => $e->getMessage()]);
+
+                return [];
+            }
+        });
+    }
+
+    /**
+     * Fetch upcoming movies.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getUpcomingMovies(int $page = 1): array
+    {
+        if (! $this->isConfigured()) {
+            return [];
+        }
+
+        $cacheKey = "tmdb_upcoming_movies_{$page}_{$this->language}";
+
+        return Cache::remember($cacheKey, now()->addHours(1), function () use ($page) {
+            $this->waitForRateLimit();
+
+            try {
+                $response = Http::timeout(15)->get(self::BASE_URL.'/movie/upcoming', [
+                    'api_key' => $this->apiKey,
+                    'language' => $this->language,
+                    'page' => $page,
+                ]);
+
+                if (! $response->successful()) {
+                    return [];
+                }
+
+                return collect($response->json()['results'] ?? [])
+                    ->map(fn ($item) => $this->normalizeDiscoverResult($item, 'movie'))
+                    ->filter(fn ($item) => $item['tmdb_id'] > 0)
+                    ->values()
+                    ->all();
+            } catch (\Exception $e) {
+                Log::error('TMDB: getUpcomingMovies error', ['error' => $e->getMessage()]);
+
+                return [];
+            }
+        });
+    }
+
+    /**
+     * Fetch movie genre list.
+     *
+     * @return array<int, array{id: int, name: string}>
+     */
+    public function getMovieGenres(): array
+    {
+        if (! $this->isConfigured()) {
+            return [];
+        }
+
+        return Cache::remember('tmdb_genres_movie_'.$this->language, now()->addHours(24), function () {
+            $this->waitForRateLimit();
+
+            try {
+                $response = Http::timeout(15)->get(self::BASE_URL.'/genre/movie/list', [
+                    'api_key' => $this->apiKey,
+                    'language' => $this->language,
+                ]);
+
+                if (! $response->successful()) {
+                    return [];
+                }
+
+                return collect($response->json()['genres'] ?? [])
+                    ->map(fn ($g) => ['id' => (int) $g['id'], 'name' => $g['name']])
+                    ->all();
+            } catch (\Exception $e) {
+                Log::error('TMDB: getMovieGenres error', ['error' => $e->getMessage()]);
+
+                return [];
+            }
+        });
+    }
+
+    /**
+     * Fetch TV genre list.
+     *
+     * @return array<int, array{id: int, name: string}>
+     */
+    public function getTvGenres(): array
+    {
+        if (! $this->isConfigured()) {
+            return [];
+        }
+
+        return Cache::remember('tmdb_genres_tv_'.$this->language, now()->addHours(24), function () {
+            $this->waitForRateLimit();
+
+            try {
+                $response = Http::timeout(15)->get(self::BASE_URL.'/genre/tv/list', [
+                    'api_key' => $this->apiKey,
+                    'language' => $this->language,
+                ]);
+
+                if (! $response->successful()) {
+                    return [];
+                }
+
+                return collect($response->json()['genres'] ?? [])
+                    ->map(fn ($g) => ['id' => (int) $g['id'], 'name' => $g['name']])
+                    ->all();
+            } catch (\Exception $e) {
+                Log::error('TMDB: getTvGenres error', ['error' => $e->getMessage()]);
+
+                return [];
+            }
+        });
+    }
+
+    /**
+     * Discover movies with optional filters.
+     *
+     * @param  array<string, mixed>  $params  TMDB /discover/movie query params
+     * @return array<int, array<string, mixed>>
+     */
+    public function discoverMovies(array $params = []): array
+    {
+        if (! $this->isConfigured()) {
+            return [];
+        }
+
+        $cacheKey = 'tmdb_discover_movie_'.md5(serialize($params)).'_'.$this->language;
+
+        return Cache::remember($cacheKey, now()->addMinutes(30), function () use ($params) {
+            $this->waitForRateLimit();
+
+            try {
+                $response = Http::timeout(15)->get(self::BASE_URL.'/discover/movie', array_merge([
+                    'api_key' => $this->apiKey,
+                    'language' => $this->language,
+                    'sort_by' => 'popularity.desc',
+                ], $params));
+
+                if (! $response->successful()) {
+                    return [];
+                }
+
+                return collect($response->json()['results'] ?? [])
+                    ->map(fn ($item) => $this->normalizeDiscoverResult($item, 'movie'))
+                    ->filter(fn ($item) => $item['tmdb_id'] > 0)
+                    ->values()
+                    ->all();
+            } catch (\Exception $e) {
+                Log::error('TMDB: discoverMovies error', ['error' => $e->getMessage()]);
+
+                return [];
+            }
+        });
+    }
+
+    /**
+     * Discover TV series with optional filters.
+     *
+     * @param  array<string, mixed>  $params  TMDB /discover/tv query params
+     * @return array<int, array<string, mixed>>
+     */
+    public function discoverTv(array $params = []): array
+    {
+        if (! $this->isConfigured()) {
+            return [];
+        }
+
+        $cacheKey = 'tmdb_discover_tv_'.md5(serialize($params)).'_'.$this->language;
+
+        return Cache::remember($cacheKey, now()->addMinutes(30), function () use ($params) {
+            $this->waitForRateLimit();
+
+            try {
+                $response = Http::timeout(15)->get(self::BASE_URL.'/discover/tv', array_merge([
+                    'api_key' => $this->apiKey,
+                    'language' => $this->language,
+                    'sort_by' => 'popularity.desc',
+                ], $params));
+
+                if (! $response->successful()) {
+                    return [];
+                }
+
+                return collect($response->json()['results'] ?? [])
+                    ->map(fn ($item) => $this->normalizeDiscoverResult($item, 'tv'))
+                    ->filter(fn ($item) => $item['tmdb_id'] > 0)
+                    ->values()
+                    ->all();
+            } catch (\Exception $e) {
+                Log::error('TMDB: discoverTv error', ['error' => $e->getMessage()]);
+
+                return [];
+            }
+        });
+    }
+
+    /**
+     * Fetch available streaming providers for a media type + region, sorted by display priority.
+     *
+     * @return array<int, array{id: int, name: string, logo: string|null}>
+     */
+    public function getWatchProviders(string $mediaType = 'movie', string $region = 'US'): array
+    {
+        if (! $this->isConfigured()) {
+            return [];
+        }
+
+        $cacheKey = "tmdb_watch_providers_{$mediaType}_{$region}";
+
+        return Cache::remember($cacheKey, now()->addDay(), function () use ($mediaType, $region) {
+            try {
+                $response = Http::timeout(15)->get(self::BASE_URL."/watch/providers/{$mediaType}", [
+                    'api_key' => $this->apiKey,
+                    'watch_region' => $region,
+                    'language' => $this->language,
+                ]);
+
+                if (! $response->successful()) {
+                    return [];
+                }
+
+                return collect($response->json()['results'] ?? [])
+                    ->sortBy('display_priority')
+                    ->map(fn ($p) => [
+                        'id' => $p['provider_id'],
+                        'name' => $p['provider_name'],
+                        'logo' => ! empty($p['logo_path'])
+                            ? 'https://image.tmdb.org/t/p/w45'.$p['logo_path']
+                            : null,
+                    ])
+                    ->values()
+                    ->all();
+            } catch (\Exception $e) {
+                Log::error('TMDB: getWatchProviders error', ['error' => $e->getMessage()]);
+
+                return [];
+            }
+        });
+    }
+
+    /**
+     * Normalize a single TMDB discover/trending result to the standard discover card shape.
+     *
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function normalizeDiscoverResult(array $item, string $mediaType = 'movie'): array
+    {
+        $title = $mediaType === 'tv'
+            ? ($item['name'] ?? $item['title'] ?? 'Unknown')
+            : ($item['title'] ?? $item['name'] ?? 'Unknown');
+
+        $date = $mediaType === 'tv'
+            ? ($item['first_air_date'] ?? null)
+            : ($item['release_date'] ?? null);
+
+        return [
+            'tmdb_id' => (int) ($item['id'] ?? 0),
+            'title' => $title,
+            'media_type' => $mediaType,
+            'year' => $date ? substr((string) $date, 0, 4) : null,
+            'overview' => $item['overview'] ?? null,
+            'poster_url' => ! empty($item['poster_path']) ? 'https://image.tmdb.org/t/p/w500'.$item['poster_path'] : null,
+            'backdrop_url' => ! empty($item['backdrop_path']) ? 'https://image.tmdb.org/t/p/original'.$item['backdrop_path'] : null,
+            'vote_average' => isset($item['vote_average']) && $item['vote_average'] > 0
+                ? round((float) $item['vote_average'], 1)
+                : null,
+            'genre_ids' => $item['genre_ids'] ?? [],
+        ];
     }
 
     /**

--- a/app/Services/TmdbService.php
+++ b/app/Services/TmdbService.php
@@ -2026,10 +2026,16 @@ class TmdbService
      * @param  array<string, mixed>  $params  TMDB /discover/movie query params
      * @return array<int, array<string, mixed>>
      */
+    /**
+     * Discover movies with optional filters.
+     *
+     * @param  array<string, mixed>  $params  TMDB /discover/movie query params (include 'page' for pagination)
+     * @return array{results: array<int, array<string, mixed>>, total_pages: int}
+     */
     public function discoverMovies(array $params = []): array
     {
         if (! $this->isConfigured()) {
-            return [];
+            return ['results' => [], 'total_pages' => 0];
         }
 
         $cacheKey = 'tmdb_discover_movie_'.md5(serialize($params)).'_'.$this->language;
@@ -2045,18 +2051,23 @@ class TmdbService
                 ], $params));
 
                 if (! $response->successful()) {
-                    return [];
+                    return ['results' => [], 'total_pages' => 0];
                 }
 
-                return collect($response->json()['results'] ?? [])
-                    ->map(fn ($item) => $this->normalizeDiscoverResult($item, 'movie'))
-                    ->filter(fn ($item) => $item['tmdb_id'] > 0)
-                    ->values()
-                    ->all();
+                $json = $response->json();
+
+                return [
+                    'results' => collect($json['results'] ?? [])
+                        ->map(fn ($item) => $this->normalizeDiscoverResult($item, 'movie'))
+                        ->filter(fn ($item) => $item['tmdb_id'] > 0)
+                        ->values()
+                        ->all(),
+                    'total_pages' => (int) ($json['total_pages'] ?? 1),
+                ];
             } catch (\Exception $e) {
                 Log::error('TMDB: discoverMovies error', ['error' => $e->getMessage()]);
 
-                return [];
+                return ['results' => [], 'total_pages' => 0];
             }
         });
     }
@@ -2064,13 +2075,13 @@ class TmdbService
     /**
      * Discover TV series with optional filters.
      *
-     * @param  array<string, mixed>  $params  TMDB /discover/tv query params
-     * @return array<int, array<string, mixed>>
+     * @param  array<string, mixed>  $params  TMDB /discover/tv query params (include 'page' for pagination)
+     * @return array{results: array<int, array<string, mixed>>, total_pages: int}
      */
     public function discoverTv(array $params = []): array
     {
         if (! $this->isConfigured()) {
-            return [];
+            return ['results' => [], 'total_pages' => 0];
         }
 
         $cacheKey = 'tmdb_discover_tv_'.md5(serialize($params)).'_'.$this->language;
@@ -2086,18 +2097,23 @@ class TmdbService
                 ], $params));
 
                 if (! $response->successful()) {
-                    return [];
+                    return ['results' => [], 'total_pages' => 0];
                 }
 
-                return collect($response->json()['results'] ?? [])
-                    ->map(fn ($item) => $this->normalizeDiscoverResult($item, 'tv'))
-                    ->filter(fn ($item) => $item['tmdb_id'] > 0)
-                    ->values()
-                    ->all();
+                $json = $response->json();
+
+                return [
+                    'results' => collect($json['results'] ?? [])
+                        ->map(fn ($item) => $this->normalizeDiscoverResult($item, 'tv'))
+                        ->filter(fn ($item) => $item['tmdb_id'] > 0)
+                        ->values()
+                        ->all(),
+                    'total_pages' => (int) ($json['total_pages'] ?? 1),
+                ];
             } catch (\Exception $e) {
                 Log::error('TMDB: discoverTv error', ['error' => $e->getMessage()]);
 
-                return [];
+                return ['results' => [], 'total_pages' => 0];
             }
         });
     }

--- a/app/Services/TvMazeService.php
+++ b/app/Services/TvMazeService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
@@ -10,8 +11,9 @@ class TvMazeService
     protected const BASE_URL = 'https://api.tvmaze.com';
 
     /**
-     * Fetch episodes and cast for a TV series by its TVDB ID in one session.
-     * Shares the TV Maze lookup call so only one /lookup/shows request is made.
+     * Fetch episodes and cast for a TV series by its TVDB ID.
+     * Episodes and cast are fetched concurrently when the cache is cold,
+     * reducing worst-case latency from ~28s sequential to ~18s.
      *
      * @return array{
      *     episodes: array<int, array<int, array{seasonNumber: int, episodeNumber: int, title: string, airDate: ?string, overview: ?string}>>,
@@ -26,10 +28,37 @@ class TvMazeService
             return ['episodes' => [], 'cast' => []];
         }
 
-        return [
-            'episodes' => $this->fetchEpisodes($tvMazeId),
-            'cast' => $this->fetchCast($tvMazeId),
-        ];
+        $episodesKey = "tvmaze_episodes_{$tvMazeId}";
+        $castKey = "tvmaze_cast_{$tvMazeId}";
+
+        $episodes = Cache::get($episodesKey);
+        $cast = Cache::get($castKey);
+
+        if ($episodes !== null && $cast !== null) {
+            return ['episodes' => $episodes, 'cast' => $cast];
+        }
+
+        // Fetch whichever are missing in parallel rather than sequentially.
+        try {
+            [$episodesResponse, $castResponse] = Http::pool(fn ($pool) => [
+                $pool->timeout(10)->get(self::BASE_URL."/shows/{$tvMazeId}/episodes", ['specials' => 1]),
+                $pool->timeout(10)->get(self::BASE_URL."/shows/{$tvMazeId}/cast"),
+            ]);
+        } catch (\Exception) {
+            return ['episodes' => $episodes ?? [], 'cast' => $cast ?? []];
+        }
+
+        if ($episodes === null) {
+            $episodes = $this->parseEpisodes($episodesResponse);
+            Cache::put($episodesKey, $episodes, now()->addHours(24));
+        }
+
+        if ($cast === null) {
+            $cast = $this->parseCast($castResponse);
+            Cache::put($castKey, $cast, now()->addHours(24));
+        }
+
+        return ['episodes' => $episodes, 'cast' => $cast];
     }
 
     /**
@@ -43,7 +72,13 @@ class TvMazeService
             return [];
         }
 
-        return $this->fetchEpisodes($tvMazeId);
+        return Cache::remember("tvmaze_episodes_{$tvMazeId}", now()->addHours(24), function () use ($tvMazeId) {
+            $response = Http::baseUrl(self::BASE_URL)
+                ->timeout(10)
+                ->get("/shows/{$tvMazeId}/episodes", ['specials' => 1]);
+
+            return $this->parseEpisodes($response);
+        });
     }
 
     private function lookupTvMazeId(int $tvdbId): ?int
@@ -66,54 +101,42 @@ class TvMazeService
     /**
      * @return array<int, array<int, array{seasonNumber: int, episodeNumber: int, title: string, airDate: ?string, overview: ?string}>>
      */
-    private function fetchEpisodes(int $tvMazeId): array
+    private function parseEpisodes(mixed $response): array
     {
-        return Cache::remember("tvmaze_episodes_{$tvMazeId}", now()->addHours(24), function () use ($tvMazeId) {
-            $response = Http::baseUrl(self::BASE_URL)
-                ->timeout(10)
-                ->get("/shows/{$tvMazeId}/episodes", ['specials' => 1]);
+        if (! $response instanceof Response || ! $response->successful()) {
+            return [];
+        }
 
-            if (! $response->successful()) {
-                return [];
-            }
-
-            return collect($response->json() ?? [])
-                ->map(fn ($ep) => [
-                    'seasonNumber' => (int) ($ep['season'] ?? 0),
-                    'episodeNumber' => (int) ($ep['number'] ?? 0),
-                    'title' => $ep['name'] ?? 'Unknown',
-                    'airDate' => $ep['airdate'] ?? null,
-                    'overview' => isset($ep['summary']) ? strip_tags((string) $ep['summary']) : null,
-                ])
-                ->groupBy('seasonNumber')
-                ->map(fn ($eps) => $eps->values()->all())
-                ->all();
-        });
+        return collect($response->json() ?? [])
+            ->map(fn ($ep) => [
+                'seasonNumber' => (int) ($ep['season'] ?? 0),
+                'episodeNumber' => (int) ($ep['number'] ?? 0),
+                'title' => $ep['name'] ?? 'Unknown',
+                'airDate' => $ep['airdate'] ?? null,
+                'overview' => isset($ep['summary']) ? strip_tags((string) $ep['summary']) : null,
+            ])
+            ->groupBy('seasonNumber')
+            ->map(fn ($eps) => $eps->values()->all())
+            ->all();
     }
 
     /**
      * @return array<int, array{actor: string, character: string, photo: ?string}>
      */
-    private function fetchCast(int $tvMazeId): array
+    private function parseCast(mixed $response): array
     {
-        return Cache::remember("tvmaze_cast_{$tvMazeId}", now()->addHours(24), function () use ($tvMazeId) {
-            $response = Http::baseUrl(self::BASE_URL)
-                ->timeout(10)
-                ->get("/shows/{$tvMazeId}/cast");
+        if (! $response instanceof Response || ! $response->successful()) {
+            return [];
+        }
 
-            if (! $response->successful()) {
-                return [];
-            }
-
-            return collect($response->json() ?? [])
-                ->filter(fn ($m) => ! ($m['voice'] ?? false) && ! ($m['self'] ?? false))
-                ->map(fn ($m) => [
-                    'actor' => $m['person']['name'] ?? 'Unknown',
-                    'character' => $m['character']['name'] ?? '',
-                    'photo' => $m['person']['image']['medium'] ?? null,
-                ])
-                ->values()
-                ->all();
-        });
+        return collect($response->json() ?? [])
+            ->filter(fn ($m) => ! ($m['voice'] ?? false) && ! ($m['self'] ?? false))
+            ->map(fn ($m) => [
+                'actor' => $m['person']['name'] ?? 'Unknown',
+                'character' => $m['character']['name'] ?? '',
+                'photo' => $m['person']['image']['medium'] ?? null,
+            ])
+            ->values()
+            ->all();
     }
 }

--- a/app/Services/TvMazeService.php
+++ b/app/Services/TvMazeService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
 class TvMazeService
@@ -47,17 +48,19 @@ class TvMazeService
 
     private function lookupTvMazeId(int $tvdbId): ?int
     {
-        $response = Http::baseUrl(self::BASE_URL)
-            ->timeout(8)
-            ->get('/lookup/shows', ['thetvdb' => $tvdbId]);
+        return Cache::remember("tvmaze_lookup_{$tvdbId}", now()->addHours(12), function () use ($tvdbId) {
+            $response = Http::baseUrl(self::BASE_URL)
+                ->timeout(8)
+                ->get('/lookup/shows', ['thetvdb' => $tvdbId]);
 
-        if (! $response->successful()) {
-            return null;
-        }
+            if (! $response->successful()) {
+                return null;
+            }
 
-        $id = $response->json('id');
+            $id = $response->json('id');
 
-        return $id ? (int) $id : null;
+            return $id ? (int) $id : null;
+        });
     }
 
     /**
@@ -65,25 +68,27 @@ class TvMazeService
      */
     private function fetchEpisodes(int $tvMazeId): array
     {
-        $response = Http::baseUrl(self::BASE_URL)
-            ->timeout(10)
-            ->get("/shows/{$tvMazeId}/episodes", ['specials' => 1]);
+        return Cache::remember("tvmaze_episodes_{$tvMazeId}", now()->addHours(24), function () use ($tvMazeId) {
+            $response = Http::baseUrl(self::BASE_URL)
+                ->timeout(10)
+                ->get("/shows/{$tvMazeId}/episodes", ['specials' => 1]);
 
-        if (! $response->successful()) {
-            return [];
-        }
+            if (! $response->successful()) {
+                return [];
+            }
 
-        return collect($response->json() ?? [])
-            ->map(fn ($ep) => [
-                'seasonNumber' => (int) ($ep['season'] ?? 0),
-                'episodeNumber' => (int) ($ep['number'] ?? 0),
-                'title' => $ep['name'] ?? 'Unknown',
-                'airDate' => $ep['airdate'] ?? null,
-                'overview' => isset($ep['summary']) ? strip_tags((string) $ep['summary']) : null,
-            ])
-            ->groupBy('seasonNumber')
-            ->map(fn ($eps) => $eps->values()->all())
-            ->all();
+            return collect($response->json() ?? [])
+                ->map(fn ($ep) => [
+                    'seasonNumber' => (int) ($ep['season'] ?? 0),
+                    'episodeNumber' => (int) ($ep['number'] ?? 0),
+                    'title' => $ep['name'] ?? 'Unknown',
+                    'airDate' => $ep['airdate'] ?? null,
+                    'overview' => isset($ep['summary']) ? strip_tags((string) $ep['summary']) : null,
+                ])
+                ->groupBy('seasonNumber')
+                ->map(fn ($eps) => $eps->values()->all())
+                ->all();
+        });
     }
 
     /**
@@ -91,22 +96,24 @@ class TvMazeService
      */
     private function fetchCast(int $tvMazeId): array
     {
-        $response = Http::baseUrl(self::BASE_URL)
-            ->timeout(10)
-            ->get("/shows/{$tvMazeId}/cast");
+        return Cache::remember("tvmaze_cast_{$tvMazeId}", now()->addHours(24), function () use ($tvMazeId) {
+            $response = Http::baseUrl(self::BASE_URL)
+                ->timeout(10)
+                ->get("/shows/{$tvMazeId}/cast");
 
-        if (! $response->successful()) {
-            return [];
-        }
+            if (! $response->successful()) {
+                return [];
+            }
 
-        return collect($response->json() ?? [])
-            ->filter(fn ($m) => ! ($m['voice'] ?? false) && ! ($m['self'] ?? false))
-            ->map(fn ($m) => [
-                'actor' => $m['person']['name'] ?? 'Unknown',
-                'character' => $m['character']['name'] ?? '',
-                'photo' => $m['person']['image']['medium'] ?? null,
-            ])
-            ->values()
-            ->all();
+            return collect($response->json() ?? [])
+                ->filter(fn ($m) => ! ($m['voice'] ?? false) && ! ($m['self'] ?? false))
+                ->map(fn ($m) => [
+                    'actor' => $m['person']['name'] ?? 'Unknown',
+                    'character' => $m['character']['name'] ?? '',
+                    'photo' => $m['person']['image']['medium'] ?? null,
+                ])
+                ->values()
+                ->all();
+        });
     }
 }

--- a/app/Services/TvMazeService.php
+++ b/app/Services/TvMazeService.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class TvMazeService
+{
+    protected const BASE_URL = 'https://api.tvmaze.com';
+
+    /**
+     * Fetch episodes and cast for a TV series by its TVDB ID in one session.
+     * Shares the TV Maze lookup call so only one /lookup/shows request is made.
+     *
+     * @return array{
+     *     episodes: array<int, array<int, array{seasonNumber: int, episodeNumber: int, title: string, airDate: ?string, overview: ?string}>>,
+     *     cast: array<int, array{actor: string, character: string, photo: ?string}>
+     * }
+     */
+    public function fetchSeriesData(int $tvdbId): array
+    {
+        $tvMazeId = $this->lookupTvMazeId($tvdbId);
+
+        if (! $tvMazeId) {
+            return ['episodes' => [], 'cast' => []];
+        }
+
+        return [
+            'episodes' => $this->fetchEpisodes($tvMazeId),
+            'cast' => $this->fetchCast($tvMazeId),
+        ];
+    }
+
+    /**
+     * @return array<int, array<int, array{seasonNumber: int, episodeNumber: int, title: string, airDate: ?string, overview: ?string}>>
+     */
+    public function fetchEpisodesByTvdbId(int $tvdbId): array
+    {
+        $tvMazeId = $this->lookupTvMazeId($tvdbId);
+
+        if (! $tvMazeId) {
+            return [];
+        }
+
+        return $this->fetchEpisodes($tvMazeId);
+    }
+
+    private function lookupTvMazeId(int $tvdbId): ?int
+    {
+        $response = Http::baseUrl(self::BASE_URL)
+            ->timeout(8)
+            ->get('/lookup/shows', ['thetvdb' => $tvdbId]);
+
+        if (! $response->successful()) {
+            return null;
+        }
+
+        $id = $response->json('id');
+
+        return $id ? (int) $id : null;
+    }
+
+    /**
+     * @return array<int, array<int, array{seasonNumber: int, episodeNumber: int, title: string, airDate: ?string, overview: ?string}>>
+     */
+    private function fetchEpisodes(int $tvMazeId): array
+    {
+        $response = Http::baseUrl(self::BASE_URL)
+            ->timeout(10)
+            ->get("/shows/{$tvMazeId}/episodes", ['specials' => 1]);
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->map(fn ($ep) => [
+                'seasonNumber' => (int) ($ep['season'] ?? 0),
+                'episodeNumber' => (int) ($ep['number'] ?? 0),
+                'title' => $ep['name'] ?? 'Unknown',
+                'airDate' => $ep['airdate'] ?? null,
+                'overview' => isset($ep['summary']) ? strip_tags((string) $ep['summary']) : null,
+            ])
+            ->groupBy('seasonNumber')
+            ->map(fn ($eps) => $eps->values()->all())
+            ->all();
+    }
+
+    /**
+     * @return array<int, array{actor: string, character: string, photo: ?string}>
+     */
+    private function fetchCast(int $tvMazeId): array
+    {
+        $response = Http::baseUrl(self::BASE_URL)
+            ->timeout(10)
+            ->get("/shows/{$tvMazeId}/cast");
+
+        if (! $response->successful()) {
+            return [];
+        }
+
+        return collect($response->json() ?? [])
+            ->filter(fn ($m) => ! ($m['voice'] ?? false) && ! ($m['self'] ?? false))
+            ->map(fn ($m) => [
+                'actor' => $m['person']['name'] ?? 'Unknown',
+                'character' => $m['character']['name'] ?? '',
+                'photo' => $m['person']['image']['medium'] ?? null,
+            ])
+            ->values()
+            ->all();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=${APP_HOST:-127.0.0.1} --port=${APP_PORT:-8000}\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
         ],
         "security:scan": [
             "composer audit --format=summary",

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         ],
         "dev": [
             "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=${APP_HOST:-127.0.0.1} --port=${APP_PORT:-8000}\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve --host=${APP_HOST:-127.0.0.1} --port=${APP_PORT:-8000}\" \"php artisan horizon\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,horizon,logs,vite"
         ],
         "security:scan": [
             "composer audit --format=summary",

--- a/config/checkpoint.php
+++ b/config/checkpoint.php
@@ -134,6 +134,10 @@ return [
         // not a credential.
         '3d9d85f224d4',
 
+        // ArrIntegration: 'api_key' => 'encrypted' is a Laravel Eloquent cast
+        // declaration, not a hardcoded credential.
+        'acca5cf068e1',
+
         // GenerateTranslations: "{PH{$index}}" is a placeholder token template,
         // not a secret.
         '2a3eaf0a6403',

--- a/config/checkpoint.php
+++ b/config/checkpoint.php
@@ -338,6 +338,13 @@ return [
         '6903bd970c3a', // StreamFileSetting
         '2dce3e94d599', // EpgProgramme
         '16a8d1dc6e60', // DvrRecordingRule
+
+        // Arr integration models — managed via Filament form schemas and explicit
+        // service-layer assignments. Model::unguard() is called in AppServiceProvider.
+        '0f3dc97aaced', // ArrIntegration
+        'f19a8a24ad42', // ArrQueueEvent
+        '057e992825e3', // PlaylistRequestSetting
+        '9a065d722be9', // QueueMonitor
     ],
 
     /*

--- a/database/factories/ArrIntegrationFactory.php
+++ b/database/factories/ArrIntegrationFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ArrIntegration;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ArrIntegration>
+ */
+class ArrIntegrationFactory extends Factory
+{
+    protected $model = ArrIntegration::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'playlist_id' => Playlist::factory(),
+            'name' => fake()->company().' Arr',
+            'type' => fake()->randomElement(['sonarr', 'radarr']),
+            'url' => 'http://'.fake()->ipv4().':8989',
+            'api_key' => fake()->uuid(),
+            'enabled' => true,
+            'guest_enabled' => false,
+        ];
+    }
+
+    public function sonarr(): static
+    {
+        return $this->state(fn (): array => [
+            'type' => 'sonarr',
+            'name' => 'Sonarr',
+        ]);
+    }
+
+    public function radarr(): static
+    {
+        return $this->state(fn (): array => [
+            'type' => 'radarr',
+            'name' => 'Radarr',
+        ]);
+    }
+
+    public function guestEnabled(): static
+    {
+        return $this->state(fn (): array => [
+            'guest_enabled' => true,
+        ]);
+    }
+}

--- a/database/factories/ArrIntegrationFactory.php
+++ b/database/factories/ArrIntegrationFactory.php
@@ -3,7 +3,6 @@
 namespace Database\Factories;
 
 use App\Models\ArrIntegration;
-use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -21,7 +20,6 @@ class ArrIntegrationFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
-            'playlist_id' => Playlist::factory(),
             'name' => fake()->company().' Arr',
             'type' => fake()->randomElement(['sonarr', 'radarr']),
             'url' => 'http://'.fake()->ipv4().':8989',

--- a/database/factories/ArrQueueEventFactory.php
+++ b/database/factories/ArrQueueEventFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ArrIntegration;
+use App\Models\ArrQueueEvent;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ArrQueueEvent>
+ */
+class ArrQueueEventFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'arr_integration_id' => ArrIntegration::factory(),
+            'user_id' => User::factory(),
+            'download_id' => null,
+            'external_id' => (string) fake()->randomNumber(6),
+            'title' => fake()->words(3, true),
+            'event_type' => fake()->randomElement(['MovieAdded', 'SeriesAdd', 'Grab', 'Download']),
+            'status' => 'monitored',
+            'quality' => null,
+            'release_title' => null,
+            'size' => 0,
+            'progress' => 0,
+            'last_event_at' => now(),
+        ];
+    }
+}

--- a/database/factories/PlaylistRequestSettingFactory.php
+++ b/database/factories/PlaylistRequestSettingFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Playlist;
+use App\Models\PlaylistRequestSetting;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PlaylistRequestSetting>
+ */
+class PlaylistRequestSettingFactory extends Factory
+{
+    protected $model = PlaylistRequestSetting::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'playlist_id' => Playlist::factory(),
+            'user_id' => User::factory(),
+            'enabled' => true,
+        ];
+    }
+
+    public function disabled(): static
+    {
+        return $this->state(fn (): array => ['enabled' => false]);
+    }
+}

--- a/database/migrations/2026_05_13_131401_add_include_disabled_channels_to_dvr_settings_table.php
+++ b/database/migrations/2026_05_13_131401_add_include_disabled_channels_to_dvr_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dvr_settings', function (Blueprint $table) {
+            $table->boolean('include_disabled_channels')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dvr_settings', function (Blueprint $table) {
+            $table->dropColumn('include_disabled_channels');
+        });
+    }
+};

--- a/database/migrations/2026_06_16_181252_create_arr_integrations_table.php
+++ b/database/migrations/2026_06_16_181252_create_arr_integrations_table.php
@@ -6,12 +6,6 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     *
-     * Sonarr/Radarr content request integrations.
-     * One record per (user, playlist, server) — mirrors the DvrSetting per-playlist pattern.
-     */
     public function up(): void
     {
         Schema::create('arr_integrations', function (Blueprint $table) {
@@ -27,11 +21,9 @@ return new class extends Migration
             $table->boolean('guest_enabled')->default(false);
             $table->timestamp('last_test_at')->nullable();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('playlist_id')->constrained()->cascadeOnDelete();
             $table->timestamps();
 
             $table->index(['user_id', 'enabled']);
-            $table->index(['playlist_id', 'enabled', 'guest_enabled']);
         });
     }
 

--- a/database/migrations/2026_06_16_181252_create_arr_integrations_table.php
+++ b/database/migrations/2026_06_16_181252_create_arr_integrations_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Sonarr/Radarr content request integrations.
+     * One record per (user, playlist, server) — mirrors the DvrSetting per-playlist pattern.
+     */
+    public function up(): void
+    {
+        Schema::create('arr_integrations', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('type'); // 'sonarr' | 'radarr'
+            $table->string('url');
+            $table->text('api_key'); // encrypted at app layer via Eloquent cast
+            $table->integer('quality_profile_id')->nullable();
+            $table->string('quality_profile_name')->nullable();
+            $table->string('root_folder_path')->nullable();
+            $table->boolean('enabled')->default(true);
+            $table->boolean('guest_enabled')->default(false);
+            $table->timestamp('last_test_at')->nullable();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('playlist_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->index(['user_id', 'enabled']);
+            $table->index(['playlist_id', 'enabled', 'guest_enabled']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('arr_integrations');
+    }
+};

--- a/database/migrations/2026_06_17_234855_add_webhook_secret_to_arr_integrations_table.php
+++ b/database/migrations/2026_06_17_234855_add_webhook_secret_to_arr_integrations_table.php
@@ -2,9 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
 
 return new class extends Migration
 {
@@ -12,13 +10,6 @@ return new class extends Migration
     {
         Schema::table('arr_integrations', function (Blueprint $table) {
             $table->string('webhook_secret')->unique()->nullable()->after('guest_enabled');
-        });
-
-        // Backfill existing rows so every integration immediately has a usable webhook URL.
-        DB::table('arr_integrations')->lazyById()->each(function (object $row) {
-            DB::table('arr_integrations')
-                ->where('id', $row->id)
-                ->update(['webhook_secret' => (string) Str::uuid()]);
         });
     }
 

--- a/database/migrations/2026_06_17_234855_add_webhook_secret_to_arr_integrations_table.php
+++ b/database/migrations/2026_06_17_234855_add_webhook_secret_to_arr_integrations_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('arr_integrations', function (Blueprint $table) {
+            $table->string('webhook_secret')->unique()->nullable()->after('guest_enabled');
+        });
+
+        // Backfill existing rows so every integration immediately has a usable webhook URL.
+        DB::table('arr_integrations')->lazyById()->each(function (object $row) {
+            DB::table('arr_integrations')
+                ->where('id', $row->id)
+                ->update(['webhook_secret' => (string) Str::uuid()]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('arr_integrations', function (Blueprint $table) {
+            $table->dropColumn('webhook_secret');
+        });
+    }
+};

--- a/database/migrations/2026_06_17_234856_create_arr_queue_events_table.php
+++ b/database/migrations/2026_06_17_234856_create_arr_queue_events_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('arr_queue_events', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('arr_integration_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('download_id')->nullable();
+            $table->string('external_id')->nullable();   // tmdb_id or tvdb_id
+            $table->string('title');
+            $table->string('event_type');                // Grab | Download | MovieAdded | SeriesAdd | ManualInteractionRequired
+            $table->string('status');                    // monitored | grabbing | downloading | imported | manual_required
+            $table->string('quality')->nullable();
+            $table->string('release_title')->nullable();
+            $table->unsignedBigInteger('size')->default(0);
+            $table->unsignedSmallInteger('progress')->default(0);
+            $table->timestamp('last_event_at');
+            $table->timestamps();
+
+            $table->index(['arr_integration_id', 'download_id']);
+            $table->index(['arr_integration_id', 'external_id']);
+            $table->index(['user_id', 'last_event_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('arr_queue_events');
+    }
+};

--- a/database/migrations/2026_06_18_143851_create_playlist_request_settings_and_migrate_arr_integrations.php
+++ b/database/migrations/2026_06_18_143851_create_playlist_request_settings_and_migrate_arr_integrations.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -16,40 +15,10 @@ return new class extends Migration
             $table->boolean('enabled')->default(false);
             $table->timestamps();
         });
-
-        // Backfill: any playlist that already had an arr_integration pointing at it
-        // gets a request setting with enabled = true so existing behaviour is preserved.
-        $rows = DB::table('arr_integrations')
-            ->select('playlist_id', 'user_id')
-            ->whereNotNull('playlist_id')
-            ->distinct()
-            ->get();
-
-        foreach ($rows as $row) {
-            DB::table('playlist_request_settings')->insertOrIgnore([
-                'playlist_id' => $row->playlist_id,
-                'user_id' => $row->user_id,
-                'enabled' => true,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]);
-        }
-
-        // Drop the playlist_id FK, index, and column from arr_integrations.
-        Schema::table('arr_integrations', function (Blueprint $table) {
-            $table->dropForeign(['playlist_id']);
-            $table->dropIndex(['playlist_id', 'enabled', 'guest_enabled']);
-            $table->dropColumn('playlist_id');
-        });
     }
 
     public function down(): void
     {
-        Schema::table('arr_integrations', function (Blueprint $table) {
-            $table->foreignId('playlist_id')->nullable()->constrained()->cascadeOnDelete();
-            $table->index(['playlist_id', 'enabled', 'guest_enabled']);
-        });
-
         Schema::dropIfExists('playlist_request_settings');
     }
 };

--- a/database/migrations/2026_06_18_143851_create_playlist_request_settings_and_migrate_arr_integrations.php
+++ b/database/migrations/2026_06_18_143851_create_playlist_request_settings_and_migrate_arr_integrations.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('playlist_request_settings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('playlist_id')->unique()->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->boolean('enabled')->default(false);
+            $table->timestamps();
+        });
+
+        // Backfill: any playlist that already had an arr_integration pointing at it
+        // gets a request setting with enabled = true so existing behaviour is preserved.
+        $rows = DB::table('arr_integrations')
+            ->select('playlist_id', 'user_id')
+            ->whereNotNull('playlist_id')
+            ->distinct()
+            ->get();
+
+        foreach ($rows as $row) {
+            DB::table('playlist_request_settings')->insertOrIgnore([
+                'playlist_id' => $row->playlist_id,
+                'user_id' => $row->user_id,
+                'enabled' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        // Drop the playlist_id FK, index, and column from arr_integrations.
+        Schema::table('arr_integrations', function (Blueprint $table) {
+            $table->dropForeign(['playlist_id']);
+            $table->dropIndex(['playlist_id', 'enabled', 'guest_enabled']);
+            $table->dropColumn('playlist_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('arr_integrations', function (Blueprint $table) {
+            $table->foreignId('playlist_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->index(['playlist_id', 'enabled', 'guest_enabled']);
+        });
+
+        Schema::dropIfExists('playlist_request_settings');
+    }
+};

--- a/docs/plans/sonarr-radarr-integration.md
+++ b/docs/plans/sonarr-radarr-integration.md
@@ -1,0 +1,423 @@
+# Sonarr/Radarr Content Request Integration Plan
+
+## Overview
+
+New media integration for searching and requesting content via Sonarr (TV) and Radarr (Movies) APIs. Users integrate their existing Sonarr/Radarr configurations, search for content, and request downloads — all within m3u-editor.
+
+### Key Design Decisions
+
+- **Multi-instance model** — per-playlist `ArrIntegration` records (not single global settings)
+- **`playlist_id` required** — mirrors DVR's `DvrSetting` per-playlist pattern
+- **Guest access** — guests authenticate via playlist UUID, only see integrations with `guest_enabled = true`
+- **Follows existing `MediaServerIntegration` pattern** — model, resource, service factory
+- **Does NOT use the `MediaServerIntegration` model** — Sonarr/Radarr are content acquisition tools, not media servers
+
+---
+
+## Phase 1: Database & Model
+
+### Migration: `create_arr_integrations_table`
+
+```php
+Schema::create('arr_integrations', function (Blueprint $table) {
+    $table->id();
+    $table->string('name');                              // "Sonarr - 1080p", "Radarr - 4K"
+    $table->string('type');                              // 'sonarr' | 'radarr'
+    $table->string('url');                               // http://192.168.1.42:8989
+    $table->text('api_key');                             // encrypted at app layer
+    $table->integer('quality_profile_id')->nullable();   // cached from API
+    $table->string('quality_profile_name')->nullable();  // display convenience
+    $table->string('root_folder_path')->nullable();      // cached from API
+    $table->boolean('enabled')->default(true);
+    $table->boolean('guest_enabled')->default(false);
+    $table->timestamp('last_test_at')->nullable();
+    $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+    $table->foreignId('playlist_id')->constrained()->cascadeOnDelete();  // REQUIRED
+    $table->timestamps();
+});
+```
+
+### Model: `app/Models/ArrIntegration.php`
+
+```php
+class ArrIntegration extends Model
+{
+    use HasFactory;
+
+    protected $casts = [
+        'enabled' => 'boolean',
+        'guest_enabled' => 'boolean',
+        'last_test_at' => 'datetime',
+    ];
+
+    protected $hidden = ['api_key'];
+
+    public function user(): BelongsTo { return $this->belongsTo(User::class); }
+    public function playlist(): BelongsTo { return $this->belongsTo(Playlist::class); }
+
+    public function isSonarr(): bool { return $this->type === 'sonarr'; }
+    public function isRadarr(): bool { return $this->type === 'radarr'; }
+
+    public function getBaseUrlAttribute(): string
+    {
+        return rtrim($this->url, '/');
+    }
+
+    public function scopeEnabled($query) { return $query->where('enabled', true); }
+    public function scopeGuestEnabled($query) { return $query->where('guest_enabled', true); }
+}
+```
+
+---
+
+## Phase 2: Service Layer
+
+### Interface: `app/Interfaces/ArrIntegrationInterface.php`
+
+```php
+interface ArrIntegrationInterface
+{
+    public function testConnection(): array;              // { ok, version }
+    public function fetchQualityProfiles(): array;        // [{ id, name }]
+    public function fetchRootFolders(): array;            // [{ id, path, freeSpace }]
+    public function search(string $term): array;          // lookup results
+    public function add(array $payload): array;           // POST to Sonarr/Radarr
+    public function checkExists(int $externalId): array;  // { exists, id }
+    public function fetchReleases(int $contentId): array; // interactive search
+    public function downloadRelease(array $payload): array;
+    public function fetchQueue(): array;                  // download queue
+}
+```
+
+### Factory: `app/Services/ArrService.php`
+
+```php
+class ArrService
+{
+    public static function make(ArrIntegration $integration): ArrIntegrationInterface
+    {
+        return match ($integration->type) {
+            'sonarr' => new SonarrService($integration),
+            'radarr' => new RadarrService($integration),
+            default => throw new InvalidArgumentException("Unsupported arr type: {$integration->type}"),
+        };
+    }
+}
+```
+
+### `app/Services/Arr/SonarrService.php`
+
+- HTTP client using Laravel `Http` facade
+- Auth: `X-Api-Key` header
+- Base path: `/api/v3`
+
+| Method | Endpoint | Notes |
+|---|---|---|
+| `testConnection()` | `GET /system/status` | Returns `{ ok, version }` |
+| `fetchQualityProfiles()` | `GET /qualityprofile` | |
+| `fetchRootFolders()` | `GET /rootfolder` | |
+| `search($term)` | `GET /series/lookup?term={term}` | Returns array with tvdbId, title, year, overview, poster, seasons |
+| `add($payload)` | `POST /series` | `{ tvdbId, title, titleSlug, qualityProfileId, rootFolderPath, monitored: true, addOptions: { searchForMissingEpisodes: true } }` |
+| `checkExists($tvdbId)` | `GET /series/lookup?term=tvdb:{tvdbId}` | |
+| `fetchReleases($seriesId)` | `GET /release?seriesId={seriesId}` | |
+| `downloadRelease($payload)` | `POST /release` | `{ guid, indexerId, seriesId }` |
+| `fetchQueue()` | `GET /queue?includeSeries=true` | Maps progress from `sizeleft/size` |
+
+### `app/Services/Arr/RadarrService.php`
+
+Same pattern, different endpoints and key names (`tmdbId` instead of `tvdbId`):
+
+| Method | Endpoint | Notes |
+|---|---|---|
+| `testConnection()` | `GET /system/status` | |
+| `fetchQualityProfiles()` | `GET /qualityprofile` | |
+| `fetchRootFolders()` | `GET /rootfolder` | |
+| `search($term)` | `GET /movie/lookup?term={term}` | Returns array with tmdbId, title, year, overview, poster, genres |
+| `add($payload)` | `POST /movie` | `{ tmdbId, qualityProfileId, rootFolderPath, monitored: true, addOptions: { searchForMovie: true } }` |
+| `checkExists($tmdbId)` | `GET /movie?tmdbId={tmdbId}` | |
+| `fetchReleases($movieId)` | `GET /release?movieId={movieId}` | |
+| `downloadRelease($payload)` | `POST /release` | `{ guid, indexerId, movieId }` |
+| `fetchQueue()` | `GET /queue?includeMovie=true` | |
+
+---
+
+## Phase 3: Admin Filament Resource
+
+### `ArrIntegrationResource` — `app/Filament/Resources/ArrIntegrationResource.php`
+
+**Navigation:** Integrations group, after MediaServerIntegration
+**Icon:** `heroicon-o-magnifying-glass-circle`
+**Access:** `auth()->user()->canUseIntegrations()`
+
+#### Form Schema
+
+```
+Section "Connection"
+├── TextInput "name"
+│   └── required, max:255
+├── Select "type"
+│   └── options: ['sonarr' => 'Sonarr', 'radarr' => 'Radarr'], required
+├── Select "playlist_id"
+│   └── relationship('playlist', 'name'), searchable, required
+├── TextInput "url"
+│   └── required, url, placeholder "http://192.168.1.42:8989"
+├── TextInput "api_key"
+│   └── required, password (masked)
+├── Action "Test Connection & Discover"
+│   └── Uses form state to create temp ArrIntegration
+│       Calls ArrService::make($temp)->testConnection()
+│       On success: calls fetchQualityProfiles() + fetchRootFolders()
+│       Populates quality_profile_id and root_folder_path selects
+│       Notifies success/failure
+├── Select "quality_profile_id"
+│   └── nullable, label 'Quality Profile'
+│       Options populated by "Test Connection & Discover"
+│       AfterStateHydrated and hidden until profiles loaded
+├── Select "root_folder_path"
+│   └── nullable, label 'Root Folder'
+│       Options populated by "Test Connection & Discover"
+│       AfterStateHydrated and hidden until folders loaded
+├── Toggle "enabled"
+│   └── default true
+└── Toggle "guest_enabled"
+    └── default false, helperText 'Allow guests on this playlist to request content'
+```
+
+#### Table Columns
+
+| Column | Type | Notes |
+|---|---|---|
+| Name | TextColumn | searchable, sortable |
+| Type | TextColumn | badge: Sonarr (blue) / Radarr (purple) |
+| Playlist | TextColumn | `playlist.name`, sortable |
+| URL | TextColumn | copyable, searchable |
+| Quality Profile | TextColumn | `quality_profile_name` or fallback |
+| Enabled | IconColumn | boolean check/x |
+| Guest | IconColumn | boolean check/x |
+| Last Tested | TextColumn | `last_test_at` datetime |
+
+#### Actions
+
+- **Edit** — standard
+- **Delete** — with confirmation
+- **Test Connection** — table action, tests saved credentials and updates `last_test_at`
+- **Sync Profiles** — table action, re-fetches quality profiles and root folders, updates cache
+
+#### Pages to create:
+
+```
+app/Filament/Resources/ArrIntegrationResource/Pages/
+├── ListArrIntegrations.php
+├── CreateArrIntegration.php
+└── EditArrIntegration.php
+```
+
+---
+
+## Phase 4: Admin Request Content Page
+
+### `app/Filament/Pages/RequestContent.php`
+
+- **Navigation:** Integrations group (discoverable via `getNavigationItems()`)
+- **Icon:** `heroicon-o-film`
+- **Access:** `auth()->user()->canUseIntegrations()`
+
+#### Layout
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Integration: [Sonarr - 1080p ▼]    [Queue: 3 active]  │
+├─────────────────────────────────────────────────────────┤
+│  [Search for content...                         🔍]    │
+├─────────────────────────────────────────────────────────┤
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
+│  │ Poster   │ │ Poster   │ │ Poster   │ │ Poster   │  │
+│  │ Title    │ │ Title    │ │ Title    │ │ Title    │  │
+│  │ Year     │ │ Year     │ │ Year     │ │ Year     │  │
+│  │ Overview │ │ Overview │ │ Overview │ │ Overview │  │
+│  │[Request] │ │[Request] │ │[Request] │ │[Request] │  │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘  │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### Request Modal
+
+When "Request" is clicked:
+
+```
+┌────────────────────────────────────┐
+│  Request: "Breaking Bad"           │
+│                                    │
+│  Quality Profile: [HD - 1080p ▼]  │
+│  Root Folder: [/media/tv ▼]       │
+│  ☑ Search immediately             │
+│  ☐ Monitor only specific seasons  │
+│                                    │
+│  [Cancel]              [Request]  │
+└────────────────────────────────────┘
+```
+
+- Quality profile and root folder pre-selected from integration defaults
+- For Sonarr series: optionally show season picker (monitor specific seasons)
+- On success: notification + optionally switch to queue tab
+
+#### Queue Panel
+
+Sidebar or collapsible section showing:
+- Download progress bars (0-100%)
+- Title, status, time remaining
+- Auto-refreshes every 5 seconds via Livewire polling
+
+---
+
+## Phase 5: Guest Request Content Page
+
+### `app/Filament/GuestPanel/Pages/GuestRequestContent.php`
+
+- **Uses trait:** `HasGuestAuth` (session-based playlist auth)
+- **Discovered via:** Filament auto-discovery in `GuestPanelPanelProvider`
+
+#### canAccess()
+
+```php
+public static function canAccess(): bool
+{
+    // Resolve playlist UUID from route or session
+    $uuid = request()->route('uuid') ?? session()->get('playlist_uuid');
+    if (! $uuid) return false;
+
+    $playlist = \App\Models\Playlist::where('uuid', $uuid)->first();
+    if (! $playlist) return false;
+
+    return \App\Models\ArrIntegration::where('playlist_id', $playlist->id)
+        ->where('enabled', true)
+        ->where('guest_enabled', true)
+        ->exists();
+}
+```
+
+#### UI Differences from Admin
+
+- Integration auto-resolved (no selector dropdown)
+- If multiple integrations exist for the playlist, show tabs or selector filtered to guest-enabled ones
+- Request uses integration defaults (quality profile + root folder) — no overrides
+- No delete/edit capability
+- Queue panel shows only their playlist's integrations
+
+---
+
+## Phase 6: Shared Livewire Component
+
+### `app/Livewire/ArrSearch.php`
+
+```php
+use Livewire\Component;
+use App\Models\ArrIntegration;
+use App\Services\ArrService;
+
+class ArrSearch extends Component
+{
+    public ?int $integrationId = null;
+    public string $searchTerm = '';
+    public array $results = [];
+    public bool $isSearching = false;
+    public bool $guestMode = false;
+
+    // keyed by integration
+    public function getIntegrationProperty(): ?ArrIntegration
+    public function getArrServiceProperty(): ?ArrIntegrationInterface
+
+    // Wire:model.live.debounce.300ms on search input
+    public function updatedSearchTerm(): void
+
+    // Search action
+    public function search(): void { ...ArrService::make($this->integration)->search($this->searchTerm) }
+
+    // Request action (opens modal or confirms)
+    public function request(int $externalId, ?int $qualityProfileId, ?string $rootFolderPath): void
+    {
+        $payload = [
+            // Sonarr: 'tvdbId' => $externalId
+            // Radarr: 'tmdbId' => $externalId
+            'qualityProfileId' => $qualityProfileId ?? $this->integration->quality_profile_id,
+            'rootFolderPath' => $rootFolderPath ?? $this->integration->root_folder_path,
+        ];
+        ArrService::make($this->integration)->add($payload);
+    }
+
+    // Queue management
+    public array $queue = [];
+    public function loadQueue(): void { ... }
+    public function getQueuePollInterval(): int { return 5; } // seconds
+
+    public function render()
+    {
+        return view('livewire.arr-search');
+    }
+}
+```
+
+#### View: `resources/views/livewire/arr-search.blade.php`
+
+- Search input with loading indicator
+- Grid of result cards (Tailwind CSS)
+- Request button per result
+- Queue panel with progress bars
+
+---
+
+## Phase 7: Navigation
+
+### Admin Panel (`AdminPanelProvider`)
+
+Add to `->navigation()` builder:
+
+```php
+NavigationGroup::make(fn () => __('Integrations'))
+    ->icon('heroicon-m-server-stack')
+    ->items([
+        ...MediaServerIntegrationResource::getNavigationItems(),
+        ...ArrIntegrationResource::getNavigationItems(),
+        ...RequestContent::getNavigationItems(),
+        ...NetworkResource::getNavigationItems(),
+    ]),
+```
+
+### Guest Panel
+
+Auto-discovered. `GuestRequestContent::canAccess()` controls visibility in top nav.
+
+---
+
+## File Manifest
+
+| # | File | Action |
+|---|---|---|
+| 1 | `database/migrations/YYYY_MM_DD_HHMMSS_create_arr_integrations_table.php` | Create |
+| 2 | `app/Models/ArrIntegration.php` | Create |
+| 3 | `app/Interfaces/ArrIntegrationInterface.php` | Create |
+| 4 | `app/Services/ArrService.php` | Create |
+| 5 | `app/Services/Arr/SonarrService.php` | Create |
+| 6 | `app/Services/Arr/RadarrService.php` | Create |
+| 7 | `app/Filament/Resources/ArrIntegrationResource.php` | Create |
+| 8 | `app/Filament/Resources/ArrIntegrationResource/Pages/ListArrIntegrations.php` | Create |
+| 9 | `app/Filament/Resources/ArrIntegrationResource/Pages/CreateArrIntegration.php` | Create |
+| 10 | `app/Filament/Resources/ArrIntegrationResource/Pages/EditArrIntegration.php` | Create |
+| 11 | `app/Filament/Pages/RequestContent.php` | Create |
+| 12 | `app/Filament/GuestPanel/Pages/GuestRequestContent.php` | Create |
+| 13 | `app/Livewire/ArrSearch.php` | Create |
+| 14 | `resources/views/livewire/arr-search.blade.php` | Create |
+| 15 | `app/Providers/Filament/AdminPanelProvider.php` | Modify |
+
+---
+
+## Implementation Order
+
+1. Migration + Model
+2. Interface + Services (`SonarrService`, `RadarrService`, `ArrService`)
+3. `ArrIntegrationResource` + CRUD pages
+4. Register in `AdminPanelProvider` navigation
+5. Admin `RequestContent` page + `ArrSearch` Livewire component
+6. Guest `GuestRequestContent` page
+7. `vendor/bin/pint --format agent`
+8. Tests

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -86,6 +86,11 @@
     overflow-y: auto;
 } */
 
+/* Copilot Chat — widen the slide-over drawer from max-w-md to max-w-2xl */
+.copilot-chat-widget {
+    max-width: 42rem !important;
+}
+
 /* DVR Status Animations */
 @keyframes dvr-status-spin {
     0% { transform: rotate(0deg); }

--- a/resources/views/filament/guest-panel/pages/request-content.blade.php
+++ b/resources/views/filament/guest-panel/pages/request-content.blade.php
@@ -1,49 +1,20 @@
 <x-filament-panels::page>
-    @if($this->integration)
+    @if($this->integrations->isNotEmpty())
         <x-filament::section>
             <x-slot name="heading">
                 {{ __('Search & Request') }}
             </x-slot>
             <x-slot name="description">
-                {{ __('Request TV shows or movies to be added to :playlist via :integration.', [
+                {{ __('Request TV shows or movies to be added to :playlist.', [
                     'playlist' => $playlistName ?? 'your playlist',
-                    'integration' => $this->integration->name,
                 ]) }}
             </x-slot>
 
-            {{-- For multiple integrations, render one ArrSearch per integration. --}}
-            @if($this->integrations->count() > 1)
-                <div x-data="{ active: {{ $this->integrations->first()->id }} }">
-                    <div class="mb-4 flex flex-wrap gap-2">
-                        @foreach($this->integrations as $integrationOption)
-                            <button
-                                type="button"
-                                @click="active = {{ $integrationOption->id }}"
-                                :class="active === {{ $integrationOption->id }} ? 'bg-primary-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300'"
-                                class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
-                            >
-                                {{ $integrationOption->name }}
-                            </button>
-                        @endforeach
-                    </div>
-
-                    @foreach($this->integrations as $integrationOption)
-                        <div x-show="active === {{ $integrationOption->id }}" x-cloak>
-                            <livewire:arr-search
-                                :integration-id="$integrationOption->id"
-                                :guest-mode="true"
-                                :wire:key="'arr-search-'.$integrationOption->id"
-                            />
-                        </div>
-                    @endforeach
-                </div>
-            @else
-                <livewire:arr-search
-                    :integration-id="$this->integration->id"
-                    :guest-mode="true"
-                    :wire:key="'arr-search-'.$this->integration->id"
-                />
-            @endif
+            <livewire:arr-search
+                :guest-integration-ids="$this->integrations->pluck('id')->all()"
+                :guest-mode="true"
+                wire:key="arr-search-guest"
+            />
         </x-filament::section>
     @else
         <x-filament::section>

--- a/resources/views/filament/guest-panel/pages/request-content.blade.php
+++ b/resources/views/filament/guest-panel/pages/request-content.blade.php
@@ -1,0 +1,61 @@
+<x-filament-panels::page>
+    @if($this->integration)
+        <x-filament::section>
+            <x-slot name="heading">
+                {{ __('Search & Request') }}
+            </x-slot>
+            <x-slot name="description">
+                {{ __('Request TV shows or movies to be added to :playlist via :integration.', [
+                    'playlist' => $playlistName ?? 'your playlist',
+                    'integration' => $this->integration->name,
+                ]) }}
+            </x-slot>
+
+            {{-- For multiple integrations, render one ArrSearch per integration. --}}
+            @if($this->integrations->count() > 1)
+                <div x-data="{ active: {{ $this->integrations->first()->id }} }">
+                    <div class="mb-4 flex flex-wrap gap-2">
+                        @foreach($this->integrations as $integrationOption)
+                            <button
+                                type="button"
+                                @click="active = {{ $integrationOption->id }}"
+                                :class="active === {{ $integrationOption->id }} ? 'bg-primary-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300'"
+                                class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
+                            >
+                                {{ $integrationOption->name }}
+                            </button>
+                        @endforeach
+                    </div>
+
+                    @foreach($this->integrations as $integrationOption)
+                        <div x-show="active === {{ $integrationOption->id }}" x-cloak>
+                            <livewire:arr-search
+                                :integration-id="$integrationOption->id"
+                                :guest-mode="true"
+                                :wire:key="'arr-search-'.$integrationOption->id"
+                            />
+                        </div>
+                    @endforeach
+                </div>
+            @else
+                <livewire:arr-search
+                    :integration-id="$this->integration->id"
+                    :guest-mode="true"
+                    :wire:key="'arr-search-'.$this->integration->id"
+                />
+            @endif
+        </x-filament::section>
+    @else
+        <x-filament::section>
+            <div class="flex flex-col items-center justify-center py-12 text-center">
+                <x-heroicon-o-magnifying-glass-circle class="w-12 h-12 text-gray-300 dark:text-gray-600" />
+                <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                    {{ __('No content request integration is configured for this playlist') }}
+                </h4>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {{ __('Ask the playlist owner to enable Sonarr or Radarr for guest requests.') }}
+                </p>
+            </div>
+        </x-filament::section>
+    @endif
+</x-filament-panels::page>

--- a/resources/views/filament/pages/download-queue.blade.php
+++ b/resources/views/filament/pages/download-queue.blade.php
@@ -1,0 +1,5 @@
+<x-filament-panels::page>
+    <x-filament::section>
+        <livewire:arr-queue-monitor />
+    </x-filament::section>
+</x-filament-panels::page>

--- a/resources/views/filament/pages/request-content.blade.php
+++ b/resources/views/filament/pages/request-content.blade.php
@@ -1,5 +1,34 @@
 <x-filament-panels::page>
-    <x-filament::section>
-        <livewire:arr-search />
-    </x-filament::section>
+    {{-- Download Queue — collapsed by default, auto-expands when items are present --}}
+    <div
+        x-data="{ open: false, count: 0 }"
+        x-on:queue-status.window="count = $event.detail.count; if (count > 0 && !open) open = true"
+        class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm overflow-hidden"
+    >
+        <button
+            @click="open = !open"
+            type="button"
+            class="w-full flex items-center gap-2.5 px-4 py-3.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+        >
+            <x-heroicon-o-arrow-down-tray class="w-4 h-4 text-primary-500 flex-shrink-0" />
+            <span class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ __('Download Queue') }}</span>
+            <span
+                x-show="count > 0"
+                x-text="count"
+                style="display: none"
+                class="inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-primary-600 text-white text-[10px] font-bold leading-none"
+            ></span>
+            <x-heroicon-o-chevron-down
+                class="w-4 h-4 text-gray-400 transition-transform duration-200"
+                x-bind:class="{ 'rotate-180': open }"
+            />
+        </button>
+        <div x-show="open" x-collapse style="display: none">
+            <div class="border-t border-gray-200 dark:border-gray-700 p-4">
+                <livewire:arr-queue-monitor />
+            </div>
+        </div>
+    </div>
+
+    <livewire:arr-search />
 </x-filament-panels::page>

--- a/resources/views/filament/pages/request-content.blade.php
+++ b/resources/views/filament/pages/request-content.blade.php
@@ -1,33 +1,32 @@
 <x-filament-panels::page>
-    {{-- Download Queue — collapsed by default, auto-expands when items are present --}}
+    {{-- Download Queue — collapsed by default, auto-expands when items arrive --}}
     <div
-        x-data="{ open: false, count: 0 }"
-        x-on:queue-status.window="count = $event.detail.count; if (count > 0 && !open) open = true"
-        class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm overflow-hidden"
+        x-data
+        x-on:queue-status.window="if ($event.detail.count > 0) $dispatch('expand-section', { id: 'download-queue' })"
     >
-        <button
-            @click="open = !open"
-            type="button"
-            class="w-full flex items-center gap-2.5 px-4 py-3.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+        <x-filament::section
+            collapsible
+            :collapsed="true"
+            collapse-id="download-queue"
+            icon="heroicon-o-arrow-down-tray"
+            icon-color="primary"
+            heading="{{ __('Download Queue') }}"
         >
-            <x-heroicon-o-arrow-down-tray class="w-4 h-4 text-primary-500 flex-shrink-0" />
-            <span class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ __('Download Queue') }}</span>
-            <span
-                x-show="count > 0"
-                x-text="count"
-                style="display: none"
-                class="inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full bg-primary-600 text-white text-[10px] font-bold leading-none"
-            ></span>
-            <x-heroicon-o-chevron-down
-                class="w-4 h-4 text-gray-400 transition-transform duration-200"
-                x-bind:class="{ 'rotate-180': open }"
-            />
-        </button>
-        <div x-show="open" x-collapse style="display: none">
-            <div class="border-t border-gray-200 dark:border-gray-700 p-4">
-                <livewire:arr-queue-monitor />
-            </div>
-        </div>
+            <x-slot name="afterHeader">
+                <span
+                    x-data="{ count: 0 }"
+                    x-on:queue-status.window="count = $event.detail.count"
+                    x-show="count > 0"
+                    style="display: none"
+                >
+                    <x-filament::badge color="primary">
+                        <span x-text="count"></span>
+                    </x-filament::badge>
+                </span>
+            </x-slot>
+
+            <livewire:arr-queue-monitor />
+        </x-filament::section>
     </div>
 
     <livewire:arr-search />

--- a/resources/views/filament/pages/request-content.blade.php
+++ b/resources/views/filament/pages/request-content.blade.php
@@ -1,24 +1,12 @@
 <x-filament-panels::page>
     {{-- Download Queue — collapsed by default, auto-expands when items arrive --}}
-    <div
-        x-data
-        x-on:queue-status.window="if ($event.detail.count > 0) $dispatch('expand-section', { id: 'download-queue' })"
-    >
-        <x-filament::section
-            collapsible
-            :collapsed="true"
-            collapse-id="download-queue"
-            icon="heroicon-o-arrow-down-tray"
-            icon-color="primary"
-            heading="{{ __('Download Queue') }}"
-        >
+    <div x-data
+        x-on:queue-status.window="if ($event.detail.count > 0) $dispatch('expand-section', { id: 'download-queue' })">
+        <x-filament::section :collapsible="true" compact :collapsed="true" collapse-id="download-queue"
+            icon="heroicon-o-arrow-down-tray" icon-color="primary" heading="{{ __('Download Queue') }}">
             <x-slot name="afterHeader">
-                <span
-                    x-data="{ count: 0 }"
-                    x-on:queue-status.window="count = $event.detail.count"
-                    x-show="count > 0"
-                    style="display: none"
-                >
+                <span x-data="{ count: 0 }" x-on:queue-status.window="count = $event.detail.count" x-show="count > 0"
+                    style="display: none">
                     <x-filament::badge color="primary">
                         <span x-text="count"></span>
                     </x-filament::badge>

--- a/resources/views/filament/pages/request-content.blade.php
+++ b/resources/views/filament/pages/request-content.blade.php
@@ -1,0 +1,5 @@
+<x-filament-panels::page>
+    <x-filament::section>
+        <livewire:arr-search />
+    </x-filament::section>
+</x-filament-panels::page>

--- a/resources/views/livewire/arr-queue-monitor.blade.php
+++ b/resources/views/livewire/arr-queue-monitor.blade.php
@@ -1,0 +1,49 @@
+<div wire:poll.30s="loadQueues">
+    @php
+        $hasSonarr = ! empty($this->sonarrQueues);
+        $hasRadarr = ! empty($this->radarrQueues);
+        $sideBy   = $hasSonarr && $hasRadarr;
+    @endphp
+
+    @if(! $hasSonarr && ! $hasRadarr)
+        <div class="flex flex-col items-center justify-center py-16 text-center">
+            <x-heroicon-o-arrow-down-tray class="w-12 h-12 text-gray-300 dark:text-gray-600" />
+            <h4 class="mt-3 text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('No integrations configured') }}</h4>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {{ __('Enable a Sonarr or Radarr integration to monitor its download queue here.') }}
+            </p>
+        </div>
+    @else
+        <div @class(['grid gap-6', 'grid-cols-1 lg:grid-cols-2' => $sideBy, 'grid-cols-1' => ! $sideBy])>
+
+            {{-- Sonarr panel --}}
+            @if($hasSonarr)
+                <div class="flex flex-col gap-4">
+                    <div class="flex items-center gap-2">
+                        <x-heroicon-o-tv class="w-5 h-5 text-primary-500" />
+                        <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">{{ __('Sonarr — TV Shows') }}</h2>
+                    </div>
+
+                    @foreach($this->sonarrQueues as $queueGroup)
+                        @include('livewire.partials.arr-queue-group', ['queueGroup' => $queueGroup])
+                    @endforeach
+                </div>
+            @endif
+
+            {{-- Radarr panel --}}
+            @if($hasRadarr)
+                <div class="flex flex-col gap-4">
+                    <div class="flex items-center gap-2">
+                        <x-heroicon-o-film class="w-5 h-5 text-warning-500" />
+                        <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">{{ __('Radarr — Movies') }}</h2>
+                    </div>
+
+                    @foreach($this->radarrQueues as $queueGroup)
+                        @include('livewire.partials.arr-queue-group', ['queueGroup' => $queueGroup])
+                    @endforeach
+                </div>
+            @endif
+
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/arr-queue-monitor.blade.php
+++ b/resources/views/livewire/arr-queue-monitor.blade.php
@@ -1,38 +1,41 @@
 <div wire:poll.10s="loadQueues">
     @php
-        $hasSonarr = ! empty($this->sonarrQueues);
-        $hasRadarr = ! empty($this->radarrQueues);
-        $sideBy   = $hasSonarr && $hasRadarr;
+        $hasSonarr = !empty($this->sonarrQueues);
+        $hasRadarr = !empty($this->radarrQueues);
+        $sideBy = $hasSonarr && $hasRadarr;
     @endphp
 
-    @if(! $hasSonarr && ! $hasRadarr)
-        <x-filament::empty-state
-            icon="heroicon-o-arrow-down-tray"
-            heading="{{ __('No integrations configured') }}"
-            description="{{ __('Enable a Sonarr or Radarr integration to monitor its download queue here.') }}"
-        />
+    @if (!$hasSonarr && !$hasRadarr)
+        <x-filament::empty-state icon="heroicon-o-arrow-down-tray" heading="{{ __('No integrations configured') }}"
+            description="{{ __('Enable a Sonarr or Radarr integration to monitor its download queue here.') }}" />
     @else
-        <div @class(['grid gap-6', 'grid-cols-1 lg:grid-cols-2' => $sideBy, 'grid-cols-1' => ! $sideBy])>
+        <div @class([
+            'grid gap-6',
+            'grid-cols-1 lg:grid-cols-2' => $sideBy,
+            'grid-cols-1' => !$sideBy,
+        ])>
 
-            @if($hasSonarr)
+            @if ($hasSonarr)
                 <div class="flex flex-col gap-4">
                     <div class="flex items-center gap-2">
-                        <x-heroicon-o-tv class="w-5 h-5 text-primary-500" />
-                        <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">{{ __('Sonarr — TV Shows') }}</h2>
+                        <x-heroicon-o-tv class="w-5 h-5" />
+                        <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                            {{ __('Sonarr — TV Shows') }}</h2>
                     </div>
-                    @foreach($this->sonarrQueues as $queueGroup)
+                    @foreach ($this->sonarrQueues as $queueGroup)
                         @include('livewire.partials.arr-queue-group', ['queueGroup' => $queueGroup])
                     @endforeach
                 </div>
             @endif
 
-            @if($hasRadarr)
+            @if ($hasRadarr)
                 <div class="flex flex-col gap-4">
                     <div class="flex items-center gap-2">
-                        <x-heroicon-o-film class="w-5 h-5 text-warning-500" />
-                        <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">{{ __('Radarr — Movies') }}</h2>
+                        <x-heroicon-o-film class="w-5 h-5" />
+                        <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">{{ __('Radarr — Movies') }}
+                        </h2>
                     </div>
-                    @foreach($this->radarrQueues as $queueGroup)
+                    @foreach ($this->radarrQueues as $queueGroup)
                         @include('livewire.partials.arr-queue-group', ['queueGroup' => $queueGroup])
                     @endforeach
                 </div>

--- a/resources/views/livewire/arr-queue-monitor.blade.php
+++ b/resources/views/livewire/arr-queue-monitor.blade.php
@@ -1,4 +1,4 @@
-<div wire:poll.30s="loadQueues">
+<div wire:poll.10s="loadQueues">
     @php
         $hasSonarr = ! empty($this->sonarrQueues);
         $hasRadarr = ! empty($this->radarrQueues);

--- a/resources/views/livewire/arr-queue-monitor.blade.php
+++ b/resources/views/livewire/arr-queue-monitor.blade.php
@@ -6,38 +6,32 @@
     @endphp
 
     @if(! $hasSonarr && ! $hasRadarr)
-        <div class="flex flex-col items-center justify-center py-16 text-center">
-            <x-heroicon-o-arrow-down-tray class="w-12 h-12 text-gray-300 dark:text-gray-600" />
-            <h4 class="mt-3 text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('No integrations configured') }}</h4>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                {{ __('Enable a Sonarr or Radarr integration to monitor its download queue here.') }}
-            </p>
-        </div>
+        <x-filament::empty-state
+            icon="heroicon-o-arrow-down-tray"
+            heading="{{ __('No integrations configured') }}"
+            description="{{ __('Enable a Sonarr or Radarr integration to monitor its download queue here.') }}"
+        />
     @else
         <div @class(['grid gap-6', 'grid-cols-1 lg:grid-cols-2' => $sideBy, 'grid-cols-1' => ! $sideBy])>
 
-            {{-- Sonarr panel --}}
             @if($hasSonarr)
                 <div class="flex flex-col gap-4">
                     <div class="flex items-center gap-2">
                         <x-heroicon-o-tv class="w-5 h-5 text-primary-500" />
                         <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">{{ __('Sonarr — TV Shows') }}</h2>
                     </div>
-
                     @foreach($this->sonarrQueues as $queueGroup)
                         @include('livewire.partials.arr-queue-group', ['queueGroup' => $queueGroup])
                     @endforeach
                 </div>
             @endif
 
-            {{-- Radarr panel --}}
             @if($hasRadarr)
                 <div class="flex flex-col gap-4">
                     <div class="flex items-center gap-2">
                         <x-heroicon-o-film class="w-5 h-5 text-warning-500" />
                         <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100">{{ __('Radarr — Movies') }}</h2>
                     </div>
-
                     @foreach($this->radarrQueues as $queueGroup)
                         @include('livewire.partials.arr-queue-group', ['queueGroup' => $queueGroup])
                     @endforeach

--- a/resources/views/livewire/arr-search.blade.php
+++ b/resources/views/livewire/arr-search.blade.php
@@ -981,27 +981,33 @@
                     @endif
 
                     <div class="px-4 space-y-4 pb-4">
-                        {{-- Interactive Search (admin-only, library items only) --}}
-                        @if(! $guestMode && $detailInLibrary && ($this->detailIntegration?->isSonarr() || $this->detailIntegration?->isRadarr()))
-                            <div x-data="{ open: false }" class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+                        {{-- Interactive Search (admin-only, library items only; or any Sonarr item when doing episode-level search) --}}
+                        @if(! $guestMode && ($detailInLibrary || ! empty($detailReleasesLabel)) && ($this->detailIntegration?->isSonarr() || $this->detailIntegration?->isRadarr()))
+                            <div
+                                x-data="{ open: @js(! empty($detailReleases) || $releasesLoading) }"
+                                x-effect="if ($wire.detailReleasesLabel) { open = true; }"
+                                class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
+                            >
                                 <button
                                     @click="open = !open; if (open && @js(empty($detailReleases)) && !@js($releasesLoading)) $wire.call('loadDetailReleases')"
                                     type="button"
                                     class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
                                 >
                                     <x-heroicon-m-chevron-right class="w-4 h-4 flex-shrink-0 text-gray-400 transition-transform duration-200" x-bind:class="{ 'rotate-90': open }" />
-                                    <span class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ __('Interactive Search') }}</span>
-                                    <span wire:loading wire:target="loadDetailReleases"><x-filament::loading-indicator class="h-3 w-3 text-primary-500" /></span>
+                                    <span class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                        {{ __('Interactive Search') }}{{ $detailReleasesLabel ? ' — '.$detailReleasesLabel : '' }}
+                                    </span>
+                                    <span wire:loading wire:target="loadDetailReleases,loadEpisodeReleases"><x-filament::loading-indicator class="h-3 w-3 text-primary-500" /></span>
                                     @if(! empty($detailReleases))
-                                        <span wire:loading.remove wire:target="loadDetailReleases" class="text-xs text-gray-400 dark:text-gray-500">{{ count($detailReleases) }}</span>
+                                        <span wire:loading.remove wire:target="loadDetailReleases,loadEpisodeReleases" class="text-xs text-gray-400 dark:text-gray-500">{{ count($detailReleases) }}</span>
                                     @endif
                                 </button>
                                 <div x-show="open" x-collapse>
                                     <div class="border-t border-gray-200 dark:border-gray-700">
-                                        <div wire:loading wire:target="loadDetailReleases" class="py-4 flex justify-center">
+                                        <div wire:loading wire:target="loadDetailReleases,loadEpisodeReleases" class="py-4 flex justify-center">
                                             <x-filament::loading-indicator class="h-4 w-4 text-primary-500" />
                                         </div>
-                                        <div wire:loading.remove wire:target="loadDetailReleases">
+                                        <div wire:loading.remove wire:target="loadDetailReleases,loadEpisodeReleases">
                                             @if(! empty($detailReleases))
                                                 <div class="divide-y divide-gray-100 dark:divide-gray-800 max-h-72 overflow-y-auto">
                                                     @foreach($detailReleases as $release)
@@ -1053,7 +1059,7 @@
                                                     @endforeach
                                                 </div>
                                                 <div class="px-3 py-2 border-t border-gray-100 dark:border-gray-800 flex justify-end">
-                                                    <button wire:click="loadDetailReleases" wire:loading.attr="disabled" wire:target="loadDetailReleases" class="text-xs text-primary-600 dark:text-primary-400 hover:underline disabled:opacity-40">{{ __('Refresh') }}</button>
+                                                    <button wire:click="loadDetailReleases" wire:loading.attr="disabled" wire:target="loadDetailReleases,loadEpisodeReleases" class="text-xs text-primary-600 dark:text-primary-400 hover:underline disabled:opacity-40">{{ __('Refresh') }}</button>
                                                 </div>
                                             @elseif(! $releasesLoading)
                                                 <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-3">{{ __('No releases found.') }}</p>
@@ -1163,14 +1169,27 @@
                                                     @if($seasonEpisodes !== null && count($seasonEpisodes) > 0)
                                                         <div class="divide-y divide-gray-100 dark:divide-gray-700/50">
                                                             @foreach($seasonEpisodes as $episode)
-                                                                @php $epHasFile = ! empty($detailSonarrEpisodeStatus[$seasonNum][$episode['episodeNumber']]); @endphp
+                                                                @php
+                                                                    $epHasFile  = ! empty($detailSonarrEpisodeStatus[$seasonNum][$episode['episodeNumber']]);
+                                                                    $epFileInfo = $detailSonarrEpisodeFileInfo[$seasonNum][$episode['episodeNumber']] ?? null;
+                                                                    $epQuality  = $epFileInfo['quality'] ?? null;
+                                                                    $epBytes    = $epFileInfo['size'] ?? null;
+                                                                    $epSize     = $epBytes ? match (true) {
+                                                                        $epBytes >= 1_073_741_824 => number_format($epBytes / 1_073_741_824, 2).' GB',
+                                                                        $epBytes >= 1_048_576     => number_format($epBytes / 1_048_576, 2).' MB',
+                                                                        $epBytes > 0              => number_format($epBytes / 1_024, 2).' KB',
+                                                                        default                   => null,
+                                                                    } : null;
+                                                                @endphp
                                                                 <div class="flex items-center gap-2 px-3 py-1.5">
                                                                     <span class="text-xs font-mono text-gray-400 dark:text-gray-500 w-6 flex-shrink-0 text-right">{{ str_pad($episode['episodeNumber'], 2, '0', STR_PAD_LEFT) }}</span>
                                                                     @if($epHasFile)
                                                                         <x-heroicon-s-check-circle class="w-3.5 h-3.5 flex-shrink-0 text-success-500 dark:text-success-400" />
                                                                     @endif
                                                                     <span class="flex-1 text-xs text-gray-800 dark:text-gray-200 min-w-0 truncate">{{ $episode['title'] }}</span>
-                                                                    @if(! empty($episode['airDate']))
+                                                                    @if($epHasFile && ($epQuality || $epSize))
+                                                                        <span class="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 tabular-nums">{{ implode(' · ', array_filter([$epQuality, $epSize])) }}</span>
+                                                                    @elseif(! empty($episode['airDate']))
                                                                         <span class="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 tabular-nums">{{ \Carbon\Carbon::parse($episode['airDate'])->format('M j, Y') }}</span>
                                                                     @endif
                                                                     @if($epHasFile)
@@ -1194,6 +1213,17 @@
                                                                             <x-heroicon-o-arrow-down-tray class="w-3.5 h-3.5" />
                                                                         </button>
                                                                     @endif
+                                                                    @if(! $guestMode)
+                                                                        <button
+                                                                            wire:click="loadEpisodeReleases({{ $seasonNum }}, {{ $episode['episodeNumber'] }})"
+                                                                            wire:loading.attr="disabled"
+                                                                            wire:target="loadEpisodeReleases,requestEpisode"
+                                                                            title="{{ __('Pick a specific release for this episode') }}"
+                                                                            class="flex-shrink-0 p-1 rounded text-gray-300 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors"
+                                                                        >
+                                                                            <x-heroicon-o-magnifying-glass class="w-3.5 h-3.5" />
+                                                                        </button>
+                                                                    @endif
                                                                 </div>
                                                             @endforeach
                                                         </div>
@@ -1213,15 +1243,29 @@
                 <div class="flex-shrink-0 px-4 py-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50">
                     @if($detailInLibrary && $detailIsSonarr)
                         {{-- Sonarr in-library: show status + always allow re-requesting seasons --}}
-                        @php $monitoredCount = collect($selectedSeasons)->filter()->count(); @endphp
+                        @php
+                            $monitoredCount    = collect($selectedSeasons)->filter()->count();
+                            $sonarrSizeBytes   = $detailResult['sizeOnDisk'] ?? 0;
+                            $sonarrSizeDisplay = $sonarrSizeBytes > 0 ? match (true) {
+                                $sonarrSizeBytes >= 1_073_741_824 => number_format($sonarrSizeBytes / 1_073_741_824, 2).' GB',
+                                $sonarrSizeBytes >= 1_048_576     => number_format($sonarrSizeBytes / 1_048_576, 2).' MB',
+                                $sonarrSizeBytes > 0              => number_format($sonarrSizeBytes / 1_024, 2).' KB',
+                                default                           => null,
+                            } : null;
+                        @endphp
                         <div class="space-y-2">
-                            <div class="flex items-center justify-center gap-2 py-0.5 text-sm">
-                                @if($detailIsDownloaded)
-                                    <x-heroicon-o-check-circle class="w-4 h-4 text-success-600 dark:text-success-400 flex-shrink-0" />
-                                    <span class="text-success-700 dark:text-success-400">{{ __('Available in library') }}</span>
-                                @else
-                                    <x-heroicon-s-bookmark class="w-4 h-4 text-amber-500 flex-shrink-0" />
-                                    <span class="text-amber-600 dark:text-amber-400">{{ __('Monitored — searching for releases') }}</span>
+                            <div class="flex flex-col items-center justify-center gap-1 py-0.5">
+                                <div class="flex items-center gap-2 text-sm">
+                                    @if($detailIsDownloaded)
+                                        <x-heroicon-o-check-circle class="w-4 h-4 text-success-600 dark:text-success-400 flex-shrink-0" />
+                                        <span class="text-success-700 dark:text-success-400">{{ __('Available in library') }}</span>
+                                    @else
+                                        <x-heroicon-s-bookmark class="w-4 h-4 text-amber-500 flex-shrink-0" />
+                                        <span class="text-amber-600 dark:text-amber-400">{{ __('Monitored — searching for releases') }}</span>
+                                    @endif
+                                </div>
+                                @if($sonarrSizeDisplay)
+                                    <div class="text-xs text-gray-400 dark:text-gray-500 tabular-nums">{{ $sonarrSizeDisplay }} {{ __('on disk') }}</div>
                                 @endif
                             </div>
                             @if(! $guestMode)
@@ -1253,10 +1297,27 @@
                         </div>
                     @elseif($detailIsDownloaded)
                         {{-- Radarr downloaded --}}
+                        @php
+                            $radarrFileQuality = $detailResult['fileQuality'] ?? null;
+                            $radarrFileBytes   = $detailResult['fileSize'] ?? null;
+                            $radarrFileSize    = $radarrFileBytes ? match (true) {
+                                $radarrFileBytes >= 1_073_741_824 => number_format($radarrFileBytes / 1_073_741_824, 2).' GB',
+                                $radarrFileBytes >= 1_048_576     => number_format($radarrFileBytes / 1_048_576, 2).' MB',
+                                $radarrFileBytes > 0              => number_format($radarrFileBytes / 1_024, 2).' KB',
+                                default                           => null,
+                            } : null;
+                        @endphp
                         <div class="space-y-2">
-                            <div class="flex items-center justify-center gap-2 py-1 text-sm text-success-700 dark:text-success-400">
-                                <x-heroicon-o-check-circle class="w-5 h-5" />
-                                {{ __('This title is available in your library.') }}
+                            <div class="flex flex-col items-center justify-center gap-1 py-1">
+                                <div class="flex items-center gap-2 text-sm text-success-700 dark:text-success-400">
+                                    <x-heroicon-o-check-circle class="w-5 h-5" />
+                                    {{ __('This title is available in your library.') }}
+                                </div>
+                                @if($radarrFileQuality || $radarrFileSize)
+                                    <div class="text-xs text-gray-400 dark:text-gray-500 tabular-nums">
+                                        {{ implode(' · ', array_filter([$radarrFileQuality, $radarrFileSize])) }}
+                                    </div>
+                                @endif
                             </div>
                             @if(! $guestMode)
                                 <button
@@ -1307,15 +1368,31 @@
                         </button>
                     @else
                         {{-- Radarr not in library --}}
-                        <button
-                            wire:click="request({{ $detailIndex }})"
-                            wire:click.stop
-                            wire:loading.attr="disabled"
-                            class="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-                        >
-                            <x-heroicon-o-plus class="w-4 h-4" />
-                            {{ __('Request Movie') }}
-                        </button>
+                        <div class="flex gap-2">
+                            <button
+                                wire:click="request({{ $detailIndex }})"
+                                wire:click.stop
+                                wire:loading.attr="disabled"
+                                wire:target="request,addForInteractiveSearch"
+                                title="{{ __('Add to Radarr and let it auto-select the best release') }}"
+                                class="flex-1 inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition-colors"
+                            >
+                                <x-heroicon-o-plus class="w-4 h-4" />
+                                {{ __('Request') }}
+                            </button>
+                            @if(! $guestMode)
+                                <button
+                                    wire:click="addForInteractiveSearch"
+                                    wire:loading.attr="disabled"
+                                    wire:target="request,addForInteractiveSearch"
+                                    title="{{ __('Add to Radarr and pick a specific release') }}"
+                                    class="flex-1 inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition-colors"
+                                >
+                                    <x-heroicon-o-list-bullet class="w-4 h-4" />
+                                    {{ __('Pick Release') }}
+                                </button>
+                            @endif
+                        </div>
                     @endif
                 </div>
             @endif

--- a/resources/views/livewire/arr-search.blade.php
+++ b/resources/views/livewire/arr-search.blade.php
@@ -536,27 +536,30 @@
                                         @endforeach
                                     </div>
                                     @if($browseTotalPages > 1)
-                                        <div class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 flex items-center justify-center gap-3">
+                                        <div class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 flex items-center justify-center gap-1 sm:gap-2">
                                             <button
                                                 wire:click="goToBrowsePage({{ $browsePage - 1 }})"
                                                 wire:loading.attr="disabled"
                                                 wire:target="goToBrowsePage"
                                                 @disabled($browsePage <= 1)
-                                                class="p-1 rounded text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                                class="p-1 rounded transition-colors {{ $browsePage <= 1 ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100' }}"
                                             >
-                                                <x-heroicon-o-chevron-left class="w-4 h-4" />
+                                                <x-heroicon-m-chevron-left class="w-4 h-4" />
                                             </button>
-                                            <span class="text-xs text-gray-500 dark:text-gray-400" wire:loading.class="opacity-50" wire:target="goToBrowsePage">
-                                                {{ __('Page :current of :total', ['current' => $browsePage, 'total' => $browseTotalPages]) }}
-                                            </span>
+                                            <div class="flex items-center gap-1" wire:loading.class="opacity-50" wire:target="goToBrowsePage">
+                                                <span class="text-xs text-gray-500 dark:text-gray-400">{{ __('Page') }}</span>
+                                                <span class="text-xs font-medium text-gray-700 dark:text-gray-300">{{ $browsePage }}</span>
+                                                <span class="text-xs text-gray-500 dark:text-gray-400">{{ __('of') }}</span>
+                                                <span class="text-xs font-medium text-gray-700 dark:text-gray-300">{{ $browseTotalPages }}</span>
+                                            </div>
                                             <button
                                                 wire:click="goToBrowsePage({{ $browsePage + 1 }})"
                                                 wire:loading.attr="disabled"
                                                 wire:target="goToBrowsePage"
                                                 @disabled($browsePage >= $browseTotalPages)
-                                                class="p-1 rounded text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                                class="p-1 rounded transition-colors {{ $browsePage >= $browseTotalPages ? 'text-gray-300 dark:text-gray-600 cursor-not-allowed' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100' }}"
                                             >
-                                                <x-heroicon-o-chevron-right class="w-4 h-4" />
+                                                <x-heroicon-m-chevron-right class="w-4 h-4" />
                                             </button>
                                         </div>
                                     @endif

--- a/resources/views/livewire/arr-search.blade.php
+++ b/resources/views/livewire/arr-search.blade.php
@@ -1,0 +1,173 @@
+<div wire:poll.{{ $this->queuePollInterval }}s="loadQueue">
+    @if(! $guestMode)
+        {{-- Admin: integration selector --}}
+        <div class="mb-4 flex flex-col sm:flex-row sm:items-center gap-3">
+            <label for="arr-integration-select" class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
+                {{ __('Integration:') }}
+            </label>
+            <select
+                id="arr-integration-select"
+                wire:model.live="integrationId"
+                class="flex-1 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 focus:border-primary-500 focus:ring-primary-500"
+            >
+                <option value="">{{ __('Select a Sonarr/Radarr integration...') }}</option>
+                @foreach(\App\Models\ArrIntegration::query()->where('user_id', auth()->id())->where('enabled', true)->orderBy('name')->get() as $integrationOption)
+                    <option value="{{ $integrationOption->id }}">
+                        {{ $integrationOption->name }} ({{ ucfirst($integrationOption->type) }})
+                    </option>
+                @endforeach
+            </select>
+            @if($queue)
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-300">
+                    <x-heroicon-o-arrow-down-tray class="w-3 h-3 mr-1" />
+                    {{ __('Queue: :count active', ['count' => count($queue)]) }}
+                </span>
+            @endif
+        </div>
+    @endif
+
+    @if($this->integration)
+        {{-- Search input --}}
+        <div class="mb-6">
+            <form wire:submit.prevent="search" class="relative">
+                <input
+                    type="text"
+                    wire:model.live.debounce.300ms="searchTerm"
+                    placeholder="{{ $this->integration->isSonarr() ? __('Search TV series...') : __('Search movies...') }}"
+                    class="w-full pl-10 pr-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 focus:border-primary-500 focus:ring-primary-500"
+                >
+                <x-heroicon-o-magnifying-glass class="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+                <div wire:loading wire:target="search" class="absolute right-3 top-1/2 -translate-y-1/2">
+                    <x-filament::loading-indicator class="h-5 w-5 text-primary-500" />
+                </div>
+            </form>
+        </div>
+
+        {{-- Results grid --}}
+        @if($isSearching)
+            <div class="flex items-center justify-center py-12">
+                <x-filament::loading-indicator class="h-8 w-8 text-primary-500" />
+                <span class="ml-3 text-gray-600 dark:text-gray-400">{{ __('Searching...') }}</span>
+            </div>
+        @elseif(count($results) > 0)
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                @foreach($results as $index => $result)
+                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden flex flex-col">
+                        @if(! empty($result['poster']))
+                            <img
+                                src="{{ $result['poster'] }}"
+                                alt="{{ $result['title'] ?? '' }}"
+                                class="w-full aspect-[2/3] object-cover"
+                                loading="lazy"
+                            >
+                        @else
+                            <div class="w-full aspect-[2/3] bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                                @if($this->integration->isSonarr())
+                                    <x-heroicon-o-tv class="w-12 h-12 text-gray-400 dark:text-gray-500" />
+                                @else
+                                    <x-heroicon-o-film class="w-12 h-12 text-gray-400 dark:text-gray-500" />
+                                @endif
+                            </div>
+                        @endif
+
+                        <div class="p-3 flex-1 flex flex-col">
+                            <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 line-clamp-2">
+                                {{ $result['title'] ?? __('Unknown') }}
+                                @if(! empty($result['year']))
+                                    <span class="text-gray-500 dark:text-gray-400 font-normal">({{ $result['year'] }})</span>
+                                @endif
+                            </h3>
+
+                            @if(! empty($result['overview']))
+                                <p class="mt-1 text-xs text-gray-600 dark:text-gray-400 line-clamp-3 flex-1">
+                                    {{ $result['overview'] }}
+                                </p>
+                            @endif
+
+                            <button
+                                wire:click="request({{ $index }})"
+                                wire:loading.attr="disabled"
+                                class="mt-3 w-full inline-flex items-center justify-center px-3 py-2 text-xs font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
+                            >
+                                <x-heroicon-o-plus class="w-3 h-3 mr-1" />
+                                {{ __('Request') }}
+                            </button>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @elseif(strlen(trim($searchTerm)) >= 2)
+            <div class="flex flex-col items-center justify-center py-12 text-center">
+                <x-heroicon-o-magnifying-glass class="w-12 h-12 text-gray-300 dark:text-gray-600" />
+                <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('No results found') }}</h4>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {{ __('Try a different search term.') }}
+                </p>
+            </div>
+        @else
+            <div class="flex flex-col items-center justify-center py-12 text-center">
+                @if($this->integration->isSonarr())
+                    <x-heroicon-o-tv class="w-12 h-12 text-gray-300 dark:text-gray-600" />
+                @else
+                    <x-heroicon-o-film class="w-12 h-12 text-gray-300 dark:text-gray-600" />
+                @endif
+                <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                    {{ $this->integration->isSonarr() ? __('Search TV series') : __('Search movies') }}
+                </h4>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {{ __('Enter a title to search :server.', ['server' => $this->integration->name]) }}
+                </p>
+            </div>
+        @endif
+
+        {{-- Queue panel --}}
+        @if($queue)
+            <div class="mt-8">
+                <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
+                    <x-heroicon-o-arrow-down-tray class="w-4 h-4 mr-2" />
+                    {{ __('Download Queue') }}
+                </h3>
+                <div class="space-y-2">
+                    @foreach($queue as $item)
+                        <div class="bg-white dark:bg-gray-800 rounded-md border border-gray-200 dark:border-gray-700 p-3">
+                            <div class="flex items-center justify-between">
+                                <div class="flex-1 min-w-0">
+                                    <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                                        {{ $item['title'] ?? __('Unknown') }}
+                                    </p>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                                        {{ $item['status'] ?? '' }}
+                                        @if($item['timeLeft'] ?? null)
+                                            · {{ __(':time left', ['time' => $item['timeLeft']]) }}
+                                        @endif
+                                    </p>
+                                </div>
+                                <span class="text-xs font-medium text-primary-600 dark:text-primary-400 ml-3">
+                                    {{ $item['progress'] ?? 0 }}%
+                                </span>
+                            </div>
+                            <div class="mt-2 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5 overflow-hidden">
+                                <div
+                                    class="bg-primary-600 h-1.5 rounded-full transition-all duration-300"
+                                    style="width: {{ $item['progress'] ?? 0 }}%"
+                                ></div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endif
+    @else
+        <div class="flex flex-col items-center justify-center py-12 text-center">
+            <x-heroicon-o-magnifying-glass-circle class="w-12 h-12 text-gray-300 dark:text-gray-600" />
+            <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                {{ $guestMode ? __('No integrations available') : __('Select an integration to begin') }}
+            </h4>
+            @unless($guestMode)
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {{ __('Choose a Sonarr or Radarr server from the dropdown above.') }}
+                </p>
+            @endunless
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/arr-search.blade.php
+++ b/resources/views/livewire/arr-search.blade.php
@@ -1,130 +1,776 @@
-<div wire:poll.{{ $this->queuePollInterval }}s="loadQueue">
-    @if(! $guestMode)
-        {{-- Admin: integration selector --}}
-        <div class="mb-4 flex flex-col sm:flex-row sm:items-center gap-3">
-            <label for="arr-integration-select" class="text-sm font-medium text-gray-700 dark:text-gray-300 whitespace-nowrap">
-                {{ __('Integration:') }}
-            </label>
-            <select
-                id="arr-integration-select"
-                wire:model.live="integrationId"
-                class="flex-1 rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 focus:border-primary-500 focus:ring-primary-500"
-            >
-                <option value="">{{ __('Select a Sonarr/Radarr integration...') }}</option>
-                @foreach(\App\Models\ArrIntegration::query()->where('user_id', auth()->id())->where('enabled', true)->orderBy('name')->get() as $integrationOption)
-                    <option value="{{ $integrationOption->id }}">
-                        {{ $integrationOption->name }} ({{ ucfirst($integrationOption->type) }})
-                    </option>
-                @endforeach
-            </select>
-            @if($queue)
-                <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-primary-100 text-primary-800 dark:bg-primary-900/30 dark:text-primary-300">
-                    <x-heroicon-o-arrow-down-tray class="w-3 h-3 mr-1" />
-                    {{ __('Queue: :count active', ['count' => count($queue)]) }}
-                </span>
-            @endif
-        </div>
-    @endif
+<div
+    wire:init="loadDiscover"
+    @if($guestMode && $queuePolling) wire:poll.{{ $this->queuePollInterval }}s="loadQueue" @endif
+>
 
-    @if($this->integration)
-        {{-- Search input --}}
-        <div class="mb-6">
+    @if($this->integrationsForSearch->isNotEmpty())
+
+        <div class="space-y-6">
+
+            {{-- ── Search Bar ─────────────────────────────────────────────── --}}
             <form wire:submit.prevent="search" class="relative">
                 <input
                     type="text"
                     wire:model.live.debounce.300ms="searchTerm"
-                    placeholder="{{ $this->integration->isSonarr() ? __('Search TV series...') : __('Search movies...') }}"
-                    class="w-full pl-10 pr-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 focus:border-primary-500 focus:ring-primary-500"
+                    placeholder="{{ __('Search movies & TV series...') }}"
+                    class="w-full pl-10 pr-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 focus:border-primary-500 focus:ring-primary-500 text-sm"
                 >
                 <x-heroicon-o-magnifying-glass class="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                 <div wire:loading wire:target="search" class="absolute right-3 top-1/2 -translate-y-1/2">
                     <x-filament::loading-indicator class="h-5 w-5 text-primary-500" />
                 </div>
             </form>
-        </div>
 
-        {{-- Results grid --}}
-        @if($isSearching)
-            <div class="flex items-center justify-center py-12">
-                <x-filament::loading-indicator class="h-8 w-8 text-primary-500" />
-                <span class="ml-3 text-gray-600 dark:text-gray-400">{{ __('Searching...') }}</span>
-            </div>
-        @elseif(count($results) > 0)
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                @foreach($results as $index => $result)
-                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden flex flex-col">
-                        @if(! empty($result['poster']))
-                            <img
-                                src="{{ $result['poster'] }}"
-                                alt="{{ $result['title'] ?? '' }}"
-                                class="w-full aspect-[2/3] object-cover"
-                                loading="lazy"
-                            >
+            {{-- ── Search Results ──────────────────────────────────────────── --}}
+            @if(strlen(trim($searchTerm)) >= 2 || $isSearching)
+
+                <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm overflow-hidden">
+                    <div class="flex items-center gap-2.5 px-4 py-3.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-white/5">
+                        <x-heroicon-o-magnifying-glass class="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                        <h3 class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ __('Search Results') }}</h3>
+                        @if(count($results) > 0)
+                            <span class="text-xs font-medium text-gray-400 dark:text-gray-500">{{ count($results) }}</span>
+                        @endif
+                    </div>
+
+                    <div class="p-4">
+                        @if($isSearching)
+                            <div class="flex items-center justify-center py-10">
+                                <x-filament::loading-indicator class="h-7 w-7 text-primary-500" />
+                                <span class="ml-3 text-sm text-gray-500 dark:text-gray-400">{{ __('Searching...') }}</span>
+                            </div>
+                        @elseif(count($results) > 0)
+                            <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                                @foreach($results as $index => $result)
+                                    @php
+                                        $isSonarr = ($result['integrationType'] ?? '') === 'sonarr';
+                                        $inLibrary = ! empty($result['existsInLibrary']);
+                                        $isDownloaded = $inLibrary && (
+                                            $isSonarr
+                                                ? ($result['episodeFileCount'] ?? 0) > 0
+                                                : ($result['hasFile'] ?? false)
+                                        );
+                                    @endphp
+                                    <div
+                                        wire:click="openDetail({{ $index }})"
+                                        class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800"
+                                    >
+                                        <div class="relative aspect-[2/3]">
+                                            @if(! empty($result['poster']))
+                                                <img src="{{ $result['poster'] }}" alt="{{ $result['title'] ?? '' }}" class="w-full h-full object-cover" loading="lazy">
+                                            @else
+                                                <div class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                                                    @if($isSonarr)
+                                                        <x-heroicon-o-tv class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                    @else
+                                                        <x-heroicon-o-film class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                    @endif
+                                                </div>
+                                            @endif
+                                            <span class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
+                                                {{ $isSonarr ? __('TV') : __('Movie') }}
+                                            </span>
+                                            @if($isDownloaded)
+                                                <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
+                                                    <x-heroicon-s-check class="w-3.5 h-3.5 text-white" />
+                                                </span>
+                                            @elseif($inLibrary)
+                                                <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
+                                                    <x-heroicon-s-bookmark class="w-3.5 h-3.5 text-white" />
+                                                </span>
+                                            @endif
+                                            @if(! empty($result['rating']['value']))
+                                                <span class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
+                                                    <x-heroicon-s-star class="w-3 h-3" />
+                                                    {{ $result['rating']['value'] }}
+                                                </span>
+                                            @endif
+                                            @if(! empty($result['integrationName']))
+                                                <span
+                                                    class="absolute bottom-2 left-2 px-1.5 py-0.5 text-xs font-medium rounded text-white shadow-sm"
+                                                    style="background:{{ $isSonarr ? 'oklch(0.588 0.158 241.966)' : 'oklch(0.558 0.288 302.321)' }}"
+                                                >{{ $result['integrationName'] }}</span>
+                                            @endif
+                                            <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
+                                                <h3 class="text-white font-semibold text-sm leading-tight line-clamp-2">
+                                                    {{ $result['title'] ?? '' }}
+                                                    @if(! empty($result['year']))
+                                                        <span class="text-white/60 font-normal">({{ $result['year'] }})</span>
+                                                    @endif
+                                                </h3>
+                                                @if(! empty($result['overview']))
+                                                    <p class="text-white/55 text-xs line-clamp-2">{{ $result['overview'] }}</p>
+                                                @endif
+                                                <div class="mt-1.5">
+                                                    @if($isDownloaded)
+                                                        <span class="flex items-center gap-1 text-green-400 text-xs font-medium">
+                                                            <x-heroicon-s-check class="w-3.5 h-3.5" />
+                                                            @if($isSonarr && ($result['totalEpisodeCount'] ?? 0) > 0)
+                                                                {{ $result['episodeFileCount'] }}/{{ $result['totalEpisodeCount'] }} {{ __('eps') }}
+                                                            @else
+                                                                {{ __('Downloaded') }}
+                                                            @endif
+                                                        </span>
+                                                    @elseif($inLibrary)
+                                                        <span class="flex items-center gap-1 text-amber-400 text-xs font-medium">
+                                                            <x-heroicon-s-bookmark class="w-3.5 h-3.5" />
+                                                            {{ __('Monitored') }}
+                                                        </span>
+                                                    @elseif($isSonarr)
+                                                        <span class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
+                                                            {{ __('Select Seasons') }}
+                                                        </span>
+                                                    @else
+                                                        <button
+                                                            wire:click.stop="request({{ $index }})"
+                                                            wire:loading.attr="disabled"
+                                                            wire:target="request"
+                                                            class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 hover:bg-primary-700 disabled:opacity-60 text-white text-xs font-medium transition-colors"
+                                                        >
+                                                            {{ __('Request Movie') }}
+                                                        </button>
+                                                    @endif
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
                         @else
-                            <div class="w-full aspect-[2/3] bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-                                @if($this->integration->isSonarr())
-                                    <x-heroicon-o-tv class="w-12 h-12 text-gray-400 dark:text-gray-500" />
-                                @else
-                                    <x-heroicon-o-film class="w-12 h-12 text-gray-400 dark:text-gray-500" />
-                                @endif
+                            <div class="flex flex-col items-center justify-center py-10 text-center">
+                                <x-heroicon-o-magnifying-glass class="w-10 h-10 text-gray-300 dark:text-gray-600" />
+                                <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('No results found') }}</h4>
+                                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ __('Try a different search term.') }}</p>
                             </div>
                         @endif
-
-                        <div class="p-3 flex-1 flex flex-col">
-                            <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 line-clamp-2">
-                                {{ $result['title'] ?? __('Unknown') }}
-                                @if(! empty($result['year']))
-                                    <span class="text-gray-500 dark:text-gray-400 font-normal">({{ $result['year'] }})</span>
-                                @endif
-                            </h3>
-
-                            @if(! empty($result['overview']))
-                                <p class="mt-1 text-xs text-gray-600 dark:text-gray-400 line-clamp-3 flex-1">
-                                    {{ $result['overview'] }}
-                                </p>
-                            @endif
-
-                            <button
-                                wire:click="request({{ $index }})"
-                                wire:loading.attr="disabled"
-                                class="mt-3 w-full inline-flex items-center justify-center px-3 py-2 text-xs font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500"
-                            >
-                                <x-heroicon-o-plus class="w-3 h-3 mr-1" />
-                                {{ __('Request') }}
-                            </button>
-                        </div>
                     </div>
-                @endforeach
-            </div>
-        @elseif(strlen(trim($searchTerm)) >= 2)
-            <div class="flex flex-col items-center justify-center py-12 text-center">
-                <x-heroicon-o-magnifying-glass class="w-12 h-12 text-gray-300 dark:text-gray-600" />
-                <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('No results found') }}</h4>
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    {{ __('Try a different search term.') }}
-                </p>
-            </div>
-        @else
-            <div class="flex flex-col items-center justify-center py-12 text-center">
-                @if($this->integration->isSonarr())
-                    <x-heroicon-o-tv class="w-12 h-12 text-gray-300 dark:text-gray-600" />
-                @else
-                    <x-heroicon-o-film class="w-12 h-12 text-gray-300 dark:text-gray-600" />
-                @endif
-                <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
-                    {{ $this->integration->isSonarr() ? __('Search TV series') : __('Search movies') }}
-                </h4>
-                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    {{ __('Enter a title to search :server.', ['server' => $this->integration->name]) }}
-                </p>
-            </div>
-        @endif
+                </div>
 
-        {{-- Queue panel --}}
-        @if($queue)
-            <div class="mt-8">
-                <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                    <x-heroicon-o-arrow-down-tray class="w-4 h-4 mr-2" />
+            @endif
+
+            {{-- ── Discover Sections ────────────────────────────────────────── --}}
+            @if($tmdbConfigured && strlen(trim($searchTerm)) < 2)
+
+                @if(! $discoverLoaded)
+                    <div class="flex items-center justify-center py-16">
+                        <x-filament::loading-indicator class="h-8 w-8 text-primary-500" />
+                        <span class="ml-3 text-sm text-gray-500 dark:text-gray-400">{{ __('Loading discover...') }}</span>
+                    </div>
+
+                @else
+
+                    {{-- ── Genre Sections (always under search bar) ──────── --}}
+
+                    @if(count($movieGenres) > 0 || count($tvGenres) > 0)
+                        <x-filament::section collapsible :id="'genres'">
+                            <x-slot name="heading">
+                                <span class="flex items-center gap-2">
+                                    <x-heroicon-o-tag class="w-4 h-4 text-primary-500" />
+                                    {{ __('Browse by Genre') }}
+                                </span>
+                            </x-slot>
+
+                            <div
+                                x-data="{ tab: '{{ $browseGenreType ?? 'movie' }}' }"
+                                x-init="$watch(() => $wire.browseGenreType, v => { if (v) tab = v })"
+                            >
+                                @if(count($movieGenres) > 0 && count($tvGenres) > 0)
+                                    <div class="flex gap-1 mb-4 bg-gray-100 dark:bg-gray-800 rounded-lg p-1 w-fit">
+                                        <button
+                                            @click="tab = 'movie'"
+                                            :class="tab === 'movie' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
+                                            class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all"
+                                        >
+                                            <x-heroicon-o-film class="w-3.5 h-3.5" />
+                                            {{ __('Movies') }}
+                                        </button>
+                                        <button
+                                            @click="tab = 'tv'"
+                                            :class="tab === 'tv' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
+                                            class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all"
+                                        >
+                                            <x-heroicon-o-tv class="w-3.5 h-3.5" />
+                                            {{ __('TV') }}
+                                        </button>
+                                    </div>
+                                @endif
+
+                                @if(count($movieGenres) > 0)
+                                    <div x-show="tab === 'movie'" x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100">
+                                        <div class="flex flex-wrap gap-1.5">
+                                            @foreach($movieGenres as $genre)
+                                                @php $isActive = $browseGenreId === $genre['id'] && $browseGenreType === 'movie'; @endphp
+                                                <button
+                                                    wire:click="{{ $isActive ? 'clearBrowse' : 'browseGenre(' . $genre['id'] . ", 'movie')" }}"
+                                                    @class([
+                                                        'inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors border',
+                                                        'bg-primary-600 text-white border-primary-600' => $isActive,
+                                                        'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-transparent hover:bg-primary-50 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-300 hover:border-primary-200 dark:hover:border-primary-800' => ! $isActive,
+                                                    ])
+                                                >
+                                                    {{ $genre['name'] }}
+                                                    @if($isActive)
+                                                        <x-heroicon-o-x-mark class="w-3 h-3 opacity-80" />
+                                                    @endif
+                                                </button>
+                                            @endforeach
+                                        </div>
+                                    </div>
+                                @endif
+
+                                @if(count($tvGenres) > 0)
+                                    <div x-show="tab === 'tv'" x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100">
+                                        <div class="flex flex-wrap gap-1.5">
+                                            @foreach($tvGenres as $genre)
+                                                @php $isActive = $browseGenreId === $genre['id'] && $browseGenreType === 'tv'; @endphp
+                                                <button
+                                                    wire:click="{{ $isActive ? 'clearBrowse' : 'browseGenre(' . $genre['id'] . ", 'tv')" }}"
+                                                    @class([
+                                                        'inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors border',
+                                                        'bg-primary-600 text-white border-primary-600' => $isActive,
+                                                        'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-transparent hover:bg-primary-50 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-300 hover:border-primary-200 dark:hover:border-primary-800' => ! $isActive,
+                                                    ])
+                                                >
+                                                    {{ $genre['name'] }}
+                                                    @if($isActive)
+                                                        <x-heroicon-o-x-mark class="w-3 h-3 opacity-80" />
+                                                    @endif
+                                                </button>
+                                            @endforeach
+                                        </div>
+                                    </div>
+                                @endif
+                            </div>
+                        </x-filament::section>
+                    @endif
+
+                    {{-- ── Browse Results (genre selected) ──────────────── --}}
+                    @if($browseGenreId !== null)
+
+                        @php
+                            $browseName = collect($browseGenreType === 'tv' ? $tvGenres : $movieGenres)
+                                ->firstWhere('id', $browseGenreId)['name'] ?? '';
+                        @endphp
+
+                        @php
+                            $activeFilterCount =
+                                (int) ($sortBy !== 'popularity') +
+                                (int) ($yearFrom !== null || $yearTo !== null) +
+                                (int) ($minRating > 0) +
+                                (int) ($minVoteCount > 0) +
+                                (int) ($minRuntime !== null || $maxRuntime !== null) +
+                                (int) ($originalLanguage !== '') +
+                                (int) (! empty($selectedProviders)) +
+                                (int) (! empty($tvStatuses));
+                        @endphp
+
+                        <div
+                            x-data="{ filtersOpen: @js($activeFilterCount > 0) }"
+                            class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm overflow-hidden"
+                        >
+                            {{-- Header --}}
+                            <div class="flex items-center gap-2.5 px-4 py-3.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-white/5">
+                                <button
+                                    wire:click="clearBrowse"
+                                    class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700 transition-colors"
+                                >
+                                    <x-heroicon-o-arrow-left class="w-3.5 h-3.5" />
+                                    {{ __('All Genres') }}
+                                </button>
+                                <span class="w-px h-4 bg-gray-200 dark:bg-gray-700"></span>
+                                <h3 class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                    {{ $browseName }}
+                                    <span class="font-normal text-gray-400 dark:text-gray-500 ml-1">
+                                        — {{ $browseGenreType === 'tv' ? __('TV Series') : __('Movies') }}
+                                    </span>
+                                </h3>
+                                @if(count($browseResults) > 0)
+                                    <span class="text-xs font-medium text-gray-400 dark:text-gray-500 mr-1">{{ count($browseResults) }}</span>
+                                @endif
+                                <button
+                                    @click="filtersOpen = !filtersOpen"
+                                    :class="filtersOpen ? 'bg-primary-50 dark:bg-primary-900/30 border-primary-200 dark:border-primary-800 text-primary-700 dark:text-primary-300' : 'bg-gray-100 dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'"
+                                    class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium border transition-colors"
+                                >
+                                    <x-heroicon-o-adjustments-horizontal class="w-3.5 h-3.5" />
+                                    {{ __('Filters') }}
+                                    @if($activeFilterCount > 0)
+                                        <span class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary-600 text-white text-[10px] font-bold leading-none">{{ $activeFilterCount }}</span>
+                                    @endif
+                                </button>
+                            </div>
+
+                            {{-- Filter panel --}}
+                            <div x-show="filtersOpen" x-collapse class="border-b border-gray-200 dark:border-gray-700">
+                                <div class="p-4 space-y-4 bg-gray-50/60 dark:bg-white/[0.02]">
+
+                                    {{-- Row 1: Sort + Language --}}
+                                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                        <div>
+                                            <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">{{ __('Sort By') }}</label>
+                                            <select wire:model.live="sortBy" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                                <option value="popularity">{{ __('Most Popular') }}</option>
+                                                <option value="rating">{{ __('Highest Rated') }}</option>
+                                                <option value="votes">{{ __('Most Voted') }}</option>
+                                                <option value="newest">{{ $browseGenreType === 'tv' ? __('Latest Air Date') : __('Newest Release') }}</option>
+                                                <option value="oldest">{{ $browseGenreType === 'tv' ? __('Earliest Air Date') : __('Oldest Release') }}</option>
+                                                @if($browseGenreType !== 'tv')
+                                                    <option value="revenue">{{ __('Box Office') }}</option>
+                                                @endif
+                                            </select>
+                                        </div>
+                                        <div>
+                                            <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">{{ __('Original Language') }}</label>
+                                            <select wire:model.live="originalLanguage" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                                <option value="">{{ __('Any Language') }}</option>
+                                                <option value="en">{{ __('English') }}</option>
+                                                <option value="fr">{{ __('French') }}</option>
+                                                <option value="de">{{ __('German') }}</option>
+                                                <option value="es">{{ __('Spanish') }}</option>
+                                                <option value="pt">{{ __('Portuguese') }}</option>
+                                                <option value="it">{{ __('Italian') }}</option>
+                                                <option value="ja">{{ __('Japanese') }}</option>
+                                                <option value="ko">{{ __('Korean') }}</option>
+                                                <option value="zh">{{ __('Chinese') }}</option>
+                                                <option value="ru">{{ __('Russian') }}</option>
+                                                <option value="ar">{{ __('Arabic') }}</option>
+                                                <option value="hi">{{ __('Hindi') }}</option>
+                                                <option value="nl">{{ __('Dutch') }}</option>
+                                                <option value="sv">{{ __('Swedish') }}</option>
+                                                <option value="pl">{{ __('Polish') }}</option>
+                                                <option value="tr">{{ __('Turkish') }}</option>
+                                                <option value="th">{{ __('Thai') }}</option>
+                                            </select>
+                                        </div>
+                                    </div>
+
+                                    {{-- Row 2: Year + Rating --}}
+                                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                        <div>
+                                            <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">
+                                                {{ $browseGenreType === 'tv' ? __('First Air Year') : __('Release Year') }}
+                                            </label>
+                                            <div class="flex items-center gap-2">
+                                                <input type="number" wire:model="yearFrom" min="1900" max="{{ date('Y') + 1 }}" placeholder="{{ __('From') }}" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                                <span class="text-gray-400 text-xs flex-shrink-0">—</span>
+                                                <input type="number" wire:model="yearTo" min="1900" max="{{ date('Y') + 1 }}" placeholder="{{ __('To') }}" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                            </div>
+                                        </div>
+                                        <div x-data="{ r: @js($minRating) }" x-init="$watch(() => $wire.minRating, v => r = v ?? 0)">
+                                            <div class="flex items-center justify-between mb-1.5">
+                                                <label class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ __('Min Rating') }}</label>
+                                                <span x-text="r > 0 ? '★ ' + parseFloat(r).toFixed(1) + '+' : '{{ __('Any') }}'" :class="r > 0 ? 'text-yellow-500 dark:text-yellow-400 font-semibold' : 'text-gray-400'" class="text-xs"></span>
+                                            </div>
+                                            <input type="range" x-model="r" @change="$wire.minRating = parseFloat(r)" min="0" max="10" step="0.5" class="w-full h-1.5 rounded-lg appearance-none cursor-pointer accent-primary-600 bg-gray-200 dark:bg-gray-700">
+                                            <div class="flex justify-between text-[10px] text-gray-400 mt-0.5"><span>0</span><span>5</span><span>10</span></div>
+                                        </div>
+                                    </div>
+
+                                    {{-- Row 3: Runtime + Vote Count --}}
+                                    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                        <div>
+                                            <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">{{ __('Runtime (minutes)') }}</label>
+                                            <div class="flex items-center gap-2">
+                                                <input type="number" wire:model="minRuntime" min="0" max="400" placeholder="{{ __('Min') }}" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                                <span class="text-gray-400 text-xs flex-shrink-0">—</span>
+                                                <input type="number" wire:model="maxRuntime" min="0" max="400" placeholder="{{ __('Max') }}" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-center justify-between mb-1.5">
+                                                <label class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ __('Min Vote Count') }}</label>
+                                                @if($minVoteCount > 0)
+                                                    <span class="text-xs font-semibold text-primary-600 dark:text-primary-400">{{ number_format($minVoteCount) }}+</span>
+                                                @else
+                                                    <span class="text-xs text-gray-400">{{ __('Any') }}</span>
+                                                @endif
+                                            </div>
+                                            <input type="range" wire:model="minVoteCount" min="0" max="5000" step="50" class="w-full h-1.5 rounded-lg appearance-none cursor-pointer accent-primary-600 bg-gray-200 dark:bg-gray-700">
+                                            <div class="flex justify-between text-[10px] text-gray-400 mt-0.5"><span>0</span><span>2,500</span><span>5,000</span></div>
+                                        </div>
+                                    </div>
+
+                                    {{-- Row 4 (TV only): Show Status --}}
+                                    @if($browseGenreType === 'tv')
+                                        <div>
+                                            <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">{{ __('Show Status') }}</label>
+                                            <div class="flex flex-wrap gap-1.5">
+                                                @foreach([0 => __('Returning'), 2 => __('In Production'), 3 => __('Ended'), 4 => __('Canceled'), 1 => __('Planned'), 5 => __('Pilot')] as $value => $label)
+                                                    <button
+                                                        wire:click="toggleTvStatus({{ $value }})"
+                                                        @class([
+                                                            'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium transition-colors border',
+                                                            'bg-primary-600 text-white border-primary-600' => in_array($value, $tvStatuses),
+                                                            'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-400 dark:hover:border-primary-600 hover:text-primary-600 dark:hover:text-primary-400' => ! in_array($value, $tvStatuses),
+                                                        ])
+                                                    >{{ $label }}</button>
+                                                @endforeach
+                                            </div>
+                                        </div>
+                                    @endif
+
+                                    {{-- Row 5: Watch Providers --}}
+                                    @if(count($availableProviders) > 0)
+                                        <div>
+                                            <div class="flex items-center justify-between mb-2">
+                                                <label class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ __('Streaming On') }}</label>
+                                                <select wire:model.live="watchRegion" class="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1 px-2 focus:border-primary-500 focus:ring-primary-500">
+                                                    <option value="US">{{ __('US') }}</option>
+                                                    <option value="GB">{{ __('UK') }}</option>
+                                                    <option value="CA">{{ __('Canada') }}</option>
+                                                    <option value="AU">{{ __('Australia') }}</option>
+                                                    <option value="DE">{{ __('Germany') }}</option>
+                                                    <option value="FR">{{ __('France') }}</option>
+                                                    <option value="ES">{{ __('Spain') }}</option>
+                                                    <option value="IT">{{ __('Italy') }}</option>
+                                                    <option value="JP">{{ __('Japan') }}</option>
+                                                    <option value="KR">{{ __('South Korea') }}</option>
+                                                    <option value="BR">{{ __('Brazil') }}</option>
+                                                    <option value="MX">{{ __('Mexico') }}</option>
+                                                    <option value="NL">{{ __('Netherlands') }}</option>
+                                                    <option value="SE">{{ __('Sweden') }}</option>
+                                                    <option value="NO">{{ __('Norway') }}</option>
+                                                    <option value="IN">{{ __('India') }}</option>
+                                                </select>
+                                            </div>
+                                            <div class="flex flex-wrap gap-2">
+                                                @foreach(array_slice($availableProviders, 0, 24) as $provider)
+                                                    @php $isSelected = in_array($provider['id'], $selectedProviders); @endphp
+                                                    <button
+                                                        wire:click="toggleProvider({{ $provider['id'] }})"
+                                                        title="{{ $provider['name'] }}"
+                                                        @class([
+                                                            'relative w-10 h-10 rounded-lg overflow-hidden transition-all border-2 flex-shrink-0',
+                                                            'border-primary-500 ring-2 ring-primary-500/30 shadow-md' => $isSelected,
+                                                            'border-transparent hover:border-gray-300 dark:hover:border-gray-500 opacity-70 hover:opacity-100' => ! $isSelected,
+                                                        ])
+                                                    >
+                                                        @if($provider['logo'])
+                                                            <img src="{{ $provider['logo'] }}" alt="{{ $provider['name'] }}" class="w-full h-full object-cover" loading="lazy">
+                                                        @else
+                                                            <div class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-[9px] font-bold text-gray-500 dark:text-gray-400 text-center leading-tight px-0.5">
+                                                                {{ Str::limit($provider['name'], 8) }}
+                                                            </div>
+                                                        @endif
+                                                        @if($isSelected)
+                                                            <div class="absolute inset-0 bg-primary-600/20 flex items-center justify-center">
+                                                                <x-heroicon-s-check class="w-4 h-4 text-white drop-shadow" />
+                                                            </div>
+                                                        @endif
+                                                    </button>
+                                                @endforeach
+                                            </div>
+                                        </div>
+                                    @endif
+
+                                </div>
+
+                                {{-- Apply / Reset row --}}
+                                <div class="flex items-center justify-end gap-2 px-4 pb-4 bg-gray-50/60 dark:bg-white/[0.02]">
+                                    @if($activeFilterCount > 0)
+                                        <button wire:click="resetFilters" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+                                            <x-heroicon-o-x-mark class="w-3.5 h-3.5" />
+                                            {{ __('Reset All') }}
+                                        </button>
+                                    @endif
+                                    <button wire:click="reloadBrowse" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-primary-600 hover:bg-primary-700 text-white transition-colors">
+                                        <x-heroicon-o-magnifying-glass class="w-3.5 h-3.5" />
+                                        {{ __('Apply') }}
+                                    </button>
+                                </div>
+                            </div>
+
+                            <div class="p-4">
+                                @if($browseLoading)
+                                    <div class="flex items-center justify-center py-10">
+                                        <x-filament::loading-indicator class="h-6 w-6 text-primary-500" />
+                                    </div>
+                                @elseif(count($browseResults) > 0)
+                                    @php
+                                        $browseInitial   = array_slice($browseResults, 0, 10);
+                                        $browseRemaining = array_slice($browseResults, 10);
+                                    @endphp
+                                    <div x-data="{ expanded: false }">
+                                        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                                            @foreach($browseInitial as $item)
+                                                @include('livewire.partials.discover-card', ['item' => $item])
+                                            @endforeach
+                                        </div>
+                                        @if(count($browseRemaining) > 0)
+                                            <div x-show="expanded" x-collapse>
+                                                <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 mt-3">
+                                                    @foreach($browseRemaining as $item)
+                                                        @include('livewire.partials.discover-card', ['item' => $item])
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                            <div class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 text-center">
+                                                <button
+                                                    @click="expanded = !expanded"
+                                                    class="inline-flex items-center gap-1.5 text-xs font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors"
+                                                >
+                                                    <span x-show="!expanded">{{ __('Show :n more', ['n' => count($browseRemaining)]) }}</span>
+                                                    <span x-show="expanded" style="display:none">{{ __('Show less') }}</span>
+                                                    <x-heroicon-o-chevron-down class="w-3.5 h-3.5 transition-transform duration-200" x-bind:class="{ 'rotate-180': expanded }" />
+                                                </button>
+                                            </div>
+                                        @endif
+                                    </div>
+                                @else
+                                    <div class="flex flex-col items-center justify-center py-10 text-center">
+                                        <x-heroicon-o-film class="w-10 h-10 text-gray-300 dark:text-gray-600" />
+                                        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ __('No results found for this genre.') }}</p>
+                                    </div>
+                                @endif
+                            </div>
+                        </div>
+
+                    @else
+
+                        {{-- ── Discovery Content Sections ───────────────── --}}
+                        @php
+                            $discoverSections = [
+                                [
+                                    'id'        => 'trending',
+                                    'label'     => __('Trending This Week'),
+                                    'icon'      => 'heroicon-o-fire',
+                                    'iconClass' => 'text-orange-500',
+                                    'items'     => $trendingItems,
+                                ],
+                                [
+                                    'id'        => 'popular-movies',
+                                    'label'     => __('Popular Movies'),
+                                    'icon'      => 'heroicon-o-film',
+                                    'iconClass' => 'text-blue-500',
+                                    'items'     => $popularMovies,
+                                ],
+                                [
+                                    'id'        => 'popular-tv',
+                                    'label'     => __('Popular TV'),
+                                    'icon'      => 'heroicon-o-tv',
+                                    'iconClass' => 'text-purple-500',
+                                    'items'     => $popularTv,
+                                ],
+                                [
+                                    'id'        => 'upcoming-movies',
+                                    'label'     => __('Upcoming Movies'),
+                                    'icon'      => 'heroicon-o-calendar-days',
+                                    'iconClass' => 'text-green-500',
+                                    'items'     => $upcomingMovies,
+                                ],
+                            ];
+                        @endphp
+
+                        @foreach($discoverSections as $section)
+                            @if(count($section['items']) > 0)
+                                @php
+                                    $initialItems   = array_slice($section['items'], 0, 10);
+                                    $remainingItems = array_slice($section['items'], 10);
+                                @endphp
+
+                                <div
+                                    x-data="{ expanded: false }"
+                                    class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm overflow-hidden"
+                                >
+                                    {{-- Section header --}}
+                                    <div class="flex items-center gap-2.5 px-4 py-3.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-white/5">
+                                        <x-dynamic-component :component="$section['icon']" class="w-4 h-4 flex-shrink-0 {{ $section['iconClass'] }}" />
+                                        <h3 class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $section['label'] }}</h3>
+                                        <span class="text-xs font-medium text-gray-400 dark:text-gray-500">{{ count($section['items']) }}</span>
+                                    </div>
+
+                                    {{-- Grid content --}}
+                                    <div class="p-4">
+                                        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                                            @foreach($initialItems as $item)
+                                                <div
+                                                    wire:click="requestFromDiscover({{ $item['tmdb_id'] }}, '{{ $item['media_type'] }}')"
+                                                    wire:loading.class="opacity-50 pointer-events-none"
+                                                    wire:target="requestFromDiscover"
+                                                    class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800"
+                                                >
+                                                    <div class="relative aspect-[2/3]">
+                                                        @if(! empty($item['poster_url']))
+                                                            <img src="{{ $item['poster_url'] }}" alt="{{ $item['title'] }}" class="w-full h-full object-cover" loading="lazy">
+                                                        @else
+                                                            <div class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                                                                @if($item['media_type'] === 'tv')
+                                                                    <x-heroicon-o-tv class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                                @else
+                                                                    <x-heroicon-o-film class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                                @endif
+                                                            </div>
+                                                        @endif
+                                                        <span class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
+                                                            {{ $item['media_type'] === 'tv' ? __('TV') : __('Movie') }}
+                                                        </span>
+                                                        @if(! empty($item['isDownloaded']))
+                                                            <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
+                                                                <x-heroicon-s-check class="w-3.5 h-3.5 text-white" />
+                                                            </span>
+                                                        @elseif(! empty($item['existsInLibrary']))
+                                                            <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
+                                                                <x-heroicon-s-bookmark class="w-3.5 h-3.5 text-white" />
+                                                            </span>
+                                                        @endif
+                                                        @if(! empty($item['vote_average']))
+                                                            <span class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
+                                                                <x-heroicon-s-star class="w-3 h-3" />
+                                                                {{ $item['vote_average'] }}
+                                                            </span>
+                                                        @endif
+                                                        <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
+                                                            <h3 class="text-white font-semibold text-sm leading-tight line-clamp-2">
+                                                                {{ $item['title'] }}
+                                                                @if(! empty($item['year']))
+                                                                    <span class="text-white/60 font-normal">({{ $item['year'] }})</span>
+                                                                @endif
+                                                            </h3>
+                                                            @if(! empty($item['overview']))
+                                                                <p class="text-white/55 text-xs line-clamp-2">{{ $item['overview'] }}</p>
+                                                            @endif
+                                                            <div class="mt-1.5">
+                                                                @if(! empty($item['isDownloaded']))
+                                                                    <span class="flex items-center gap-1 text-green-400 text-xs font-medium">
+                                                                        <x-heroicon-s-check class="w-3.5 h-3.5" />
+                                                                        {{ __('Downloaded') }}
+                                                                    </span>
+                                                                @elseif(! empty($item['existsInLibrary']))
+                                                                    <span class="flex items-center gap-1 text-amber-400 text-xs font-medium">
+                                                                        <x-heroicon-s-bookmark class="w-3.5 h-3.5" />
+                                                                        {{ __('Monitored') }}
+                                                                    </span>
+                                                                @else
+                                                                    <span class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
+                                                                        {{ $item['media_type'] === 'tv' ? __('Select Seasons') : __('Request Movie') }}
+                                                                    </span>
+                                                                @endif
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            @endforeach
+                                        </div>
+
+                                        {{-- Expandable remaining items --}}
+                                        @if(count($remainingItems) > 0)
+                                            <div x-show="expanded" x-collapse>
+                                                <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 mt-3">
+                                                    @foreach($remainingItems as $item)
+                                                        <div
+                                                            wire:click="requestFromDiscover({{ $item['tmdb_id'] }}, '{{ $item['media_type'] }}')"
+                                                            wire:loading.class="opacity-50 pointer-events-none"
+                                                            wire:target="requestFromDiscover"
+                                                            class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800"
+                                                        >
+                                                            <div class="relative aspect-[2/3]">
+                                                                @if(! empty($item['poster_url']))
+                                                                    <img src="{{ $item['poster_url'] }}" alt="{{ $item['title'] }}" class="w-full h-full object-cover" loading="lazy">
+                                                                @else
+                                                                    <div class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                                                                        @if($item['media_type'] === 'tv')
+                                                                            <x-heroicon-o-tv class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                                        @else
+                                                                            <x-heroicon-o-film class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                                        @endif
+                                                                    </div>
+                                                                @endif
+                                                                <span class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
+                                                                    {{ $item['media_type'] === 'tv' ? __('TV') : __('Movie') }}
+                                                                </span>
+                                                                @if(! empty($item['isDownloaded']))
+                                                                    <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
+                                                                        <x-heroicon-s-check class="w-3.5 h-3.5 text-white" />
+                                                                    </span>
+                                                                @elseif(! empty($item['existsInLibrary']))
+                                                                    <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
+                                                                        <x-heroicon-s-bookmark class="w-3.5 h-3.5 text-white" />
+                                                                    </span>
+                                                                @endif
+                                                                @if(! empty($item['vote_average']))
+                                                                    <span class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
+                                                                        <x-heroicon-s-star class="w-3 h-3" />
+                                                                        {{ $item['vote_average'] }}
+                                                                    </span>
+                                                                @endif
+                                                                <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
+                                                                    <h3 class="text-white font-semibold text-sm leading-tight line-clamp-2">
+                                                                        {{ $item['title'] }}
+                                                                        @if(! empty($item['year']))
+                                                                            <span class="text-white/60 font-normal">({{ $item['year'] }})</span>
+                                                                        @endif
+                                                                    </h3>
+                                                                    @if(! empty($item['overview']))
+                                                                        <p class="text-white/55 text-xs line-clamp-2">{{ $item['overview'] }}</p>
+                                                                    @endif
+                                                                    <div class="mt-1.5">
+                                                                        @if(! empty($item['isDownloaded']))
+                                                                            <span class="flex items-center gap-1 text-green-400 text-xs font-medium">
+                                                                                <x-heroicon-s-check class="w-3.5 h-3.5" />
+                                                                                {{ __('Downloaded') }}
+                                                                            </span>
+                                                                        @elseif(! empty($item['existsInLibrary']))
+                                                                            <span class="flex items-center gap-1 text-amber-400 text-xs font-medium">
+                                                                                <x-heroicon-s-bookmark class="w-3.5 h-3.5" />
+                                                                                {{ __('Monitored') }}
+                                                                            </span>
+                                                                        @else
+                                                                            <span class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
+                                                                                {{ $item['media_type'] === 'tv' ? __('Select Seasons') : __('Request Movie') }}
+                                                                            </span>
+                                                                        @endif
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    @endforeach
+                                                </div>
+                                            </div>
+
+                                            {{-- Show more / Show less footer --}}
+                                            <div class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 text-center">
+                                                <button
+                                                    @click="expanded = !expanded"
+                                                    class="inline-flex items-center gap-1.5 text-xs font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors"
+                                                >
+                                                    <span x-show="!expanded">{{ __('Show :n more', ['n' => count($remainingItems)]) }}</span>
+                                                    <span x-show="expanded" style="display:none">{{ __('Show less') }}</span>
+                                                    <x-heroicon-o-chevron-down class="w-3.5 h-3.5 transition-transform duration-200" x-bind:class="{ 'rotate-180': expanded }" />
+                                                </button>
+                                            </div>
+                                        @endif
+                                    </div>
+                                </div>
+                            @endif
+                        @endforeach
+
+                    @endif
+
+                @endif
+
+            @elseif(! $tmdbConfigured && strlen(trim($searchTerm)) < 2)
+
+                {{-- No TMDB: search prompt --}}
+                <div class="flex flex-col items-center justify-center py-12 text-center">
+                    <div class="flex gap-3 text-gray-300 dark:text-gray-600">
+                        <x-heroicon-o-tv class="w-10 h-10" />
+                        <x-heroicon-o-film class="w-10 h-10" />
+                    </div>
+                    <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('Search movies & TV series') }}</h4>
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        {{ __('Enter a title to search across your Sonarr and Radarr servers.') }}
+                    </p>
+                </div>
+
+            @endif
+
+        </div>
+
+        {{-- ── Guest Download Queue ─────────────────────────────────────── --}}
+        @if($queue && $guestMode)
+            <div class="mt-6">
+                <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2">
+                    <x-heroicon-o-arrow-down-tray class="w-4 h-4" />
                     {{ __('Download Queue') }}
                 </h3>
                 <div class="space-y-2">
@@ -139,6 +785,9 @@
                                         {{ $item['status'] ?? '' }}
                                         @if($item['timeLeft'] ?? null)
                                             · {{ __(':time left', ['time' => $item['timeLeft']]) }}
+                                        @endif
+                                        @if(! empty($item['server']))
+                                            · {{ $item['server'] }}
                                         @endif
                                     </p>
                                 </div>
@@ -157,17 +806,520 @@
                 </div>
             </div>
         @endif
+
     @else
+
         <div class="flex flex-col items-center justify-center py-12 text-center">
             <x-heroicon-o-magnifying-glass-circle class="w-12 h-12 text-gray-300 dark:text-gray-600" />
             <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
-                {{ $guestMode ? __('No integrations available') : __('Select an integration to begin') }}
+                {{ $guestMode ? __('No integrations available') : __('No Sonarr or Radarr integrations configured') }}
             </h4>
             @unless($guestMode)
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    {{ __('Choose a Sonarr or Radarr server from the dropdown above.') }}
+                    {{ __('Add a Sonarr or Radarr integration in Settings to start requesting content.') }}
                 </p>
             @endunless
         </div>
+
     @endif
+
+    {{-- ── Series / Movie Detail Slide-over ──────────────────────────────── --}}
+    <div
+        x-data="{ open: @js($showDetail) }"
+        x-init="$watch('$wire.showDetail', v => { open = v; if (v) $wire.call('loadDetailEpisodes') })"
+        @keydown.escape.window="if (open) $wire.call('closeDetail')"
+        class="fixed inset-0 z-50 pointer-events-none"
+        x-cloak
+    >
+        <div
+            x-show="open"
+            x-transition:enter="transition ease-out duration-200"
+            x-transition:enter-start="opacity-0"
+            x-transition:enter-end="opacity-100"
+            x-transition:leave="transition ease-in duration-150"
+            x-transition:leave-start="opacity-100"
+            x-transition:leave-end="opacity-0"
+            @click="$wire.call('closeDetail')"
+            class="absolute inset-0 bg-black/50 pointer-events-auto"
+            style="display: none;"
+        ></div>
+
+        <div
+            x-show="open"
+            x-transition:enter="transition ease-out duration-300 transform"
+            x-transition:enter-start="translate-x-full"
+            x-transition:enter-end="translate-x-0"
+            x-transition:leave="transition ease-in duration-200 transform"
+            x-transition:leave-start="translate-x-0"
+            x-transition:leave-end="translate-x-full"
+            class="absolute right-0 inset-y-0 w-full sm:max-w-lg bg-white dark:bg-gray-900 shadow-2xl flex flex-col pointer-events-auto"
+            style="display: none;"
+        >
+            @if($detailResult)
+                @php
+                    $detailIsSonarr = ($detailResult['integrationType'] ?? '') === 'sonarr';
+                    $detailInLibrary = ! empty($detailResult['existsInLibrary']);
+
+                    // Use per-episode status from Sonarr /episode API when available —
+                    // this is authoritative; the lookup's statistics may be stale or absent.
+                    if ($detailIsSonarr && ! empty($detailSonarrEpisodeStatus)) {
+                        $sonarrFileCount = collect($detailSonarrEpisodeStatus)
+                            ->flatMap(fn ($eps) => $eps)
+                            ->filter()
+                            ->count();
+                        $detailIsDownloaded = $detailInLibrary && $sonarrFileCount > 0;
+                    } else {
+                        $detailIsDownloaded = $detailInLibrary && (
+                            $detailIsSonarr
+                                ? ($detailResult['episodeFileCount'] ?? 0) > 0
+                                : ($detailResult['hasFile'] ?? false)
+                        );
+                    }
+                @endphp
+                <div class="relative flex-shrink-0">
+                    @if(! empty($detailResult['fanart']))
+                        <div class="relative h-44 overflow-hidden">
+                            <img src="{{ $detailResult['fanart'] }}" alt="" class="w-full h-full object-cover">
+                            <div class="absolute inset-0 bg-gradient-to-t from-gray-900 via-gray-900/60 to-gray-900/10"></div>
+                            <div class="absolute bottom-0 left-0 right-0 px-4 pb-3 pr-12">
+                                <h2 class="text-white font-bold text-base leading-snug line-clamp-2">{{ $detailResult['title'] ?? '' }}</h2>
+                                <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1">
+                                    @if(! empty($detailResult['year'])) <span class="text-white/60 text-xs">{{ $detailResult['year'] }}</span> @endif
+                                    @if(! empty($detailResult['certification'])) <span class="px-1.5 text-xs border border-white/30 text-white/70 rounded leading-5">{{ $detailResult['certification'] }}</span> @endif
+                                    @if(! empty($detailResult['status'])) <span class="text-white/60 text-xs">{{ ucfirst($detailResult['status']) }}</span> @endif
+                                </div>
+                            </div>
+                        </div>
+                    @else
+                        <div class="flex items-center px-4 py-3 border-b border-gray-200 dark:border-gray-700 pr-12">
+                            <div class="min-w-0 flex-1">
+                                <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">{{ $detailResult['title'] ?? '' }}</h2>
+                                <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5">
+                                    @if(! empty($detailResult['year'])) <span class="text-xs text-gray-500 dark:text-gray-400">{{ $detailResult['year'] }}</span> @endif
+                                    @if(! empty($detailResult['certification'])) <span class="px-1.5 text-xs border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 rounded leading-5">{{ $detailResult['certification'] }}</span> @endif
+                                    @if(! empty($detailResult['status'])) <span class="text-xs text-gray-500 dark:text-gray-400">{{ ucfirst($detailResult['status']) }}</span> @endif
+                                </div>
+                            </div>
+                        </div>
+                    @endif
+                    <button
+                        wire:click="closeDetail"
+                        class="absolute top-2.5 right-3 z-10 p-1.5 rounded-full bg-black/40 hover:bg-black/60 text-white focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors"
+                        aria-label="{{ __('Close') }}"
+                    >
+                        <x-heroicon-o-x-mark class="w-4 h-4" />
+                    </button>
+                </div>
+
+                <div class="flex-1 overflow-y-auto">
+                    <div class="flex gap-3 px-4 py-4">
+                        @if(! empty($detailResult['poster']))
+                            <img src="{{ $detailResult['poster'] }}" alt="{{ $detailResult['title'] ?? '' }}" class="w-24 flex-shrink-0 rounded-md object-cover shadow-lg self-start">
+                        @else
+                            <div class="w-24 aspect-[2/3] flex-shrink-0 rounded-md bg-gray-200 dark:bg-gray-700 flex items-center justify-center self-start">
+                                @if($this->detailIntegration?->isSonarr())
+                                    <x-heroicon-o-tv class="w-8 h-8 text-gray-400 dark:text-gray-500" />
+                                @else
+                                    <x-heroicon-o-film class="w-8 h-8 text-gray-400 dark:text-gray-500" />
+                                @endif
+                            </div>
+                        @endif
+                        <div class="flex-1 min-w-0 space-y-1.5 pt-0.5">
+                            @if(! empty($detailResult['rating']))
+                                <div class="flex items-center gap-1.5">
+                                    <x-heroicon-s-star class="w-4 h-4 text-yellow-400 flex-shrink-0" />
+                                    <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ $detailResult['rating']['value'] }}</span>
+                                    <span class="text-xs font-semibold text-gray-400 uppercase tracking-wide">{{ strtoupper($detailResult['rating']['source']) }}</span>
+                                    @if(! empty($detailResult['rating']['votes'])) <span class="text-xs text-gray-400">({{ number_format($detailResult['rating']['votes']) }})</span> @endif
+                                </div>
+                            @endif
+                            @if(! empty($detailResult['network']))
+                                <p class="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
+                                    <x-heroicon-o-building-office-2 class="w-3.5 h-3.5 flex-shrink-0" />
+                                    {{ $detailResult['network'] }}
+                                </p>
+                            @endif
+                            @if(! empty($detailResult['genres'])) <p class="text-xs text-gray-500 dark:text-gray-400">{{ implode(' · ', array_slice($detailResult['genres'], 0, 4)) }}</p> @endif
+                            @if(! empty($detailResult['runtime']))
+                                <p class="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
+                                    <x-heroicon-o-clock class="w-3.5 h-3.5 flex-shrink-0" />
+                                    {{ $detailResult['runtime'] }}m
+                                </p>
+                            @endif
+                            @if($detailIsDownloaded)
+                                @php
+                                    if ($detailIsSonarr && ! empty($detailSonarrEpisodeStatus)) {
+                                        $epFileCount  = collect($detailSonarrEpisodeStatus)->flatMap(fn ($e) => $e)->filter()->count();
+                                        $epTotalCount = collect($detailSonarrEpisodeStatus)->flatMap(fn ($e) => $e)->count();
+                                    } else {
+                                        $epFileCount  = (int) ($detailResult['episodeFileCount'] ?? 0);
+                                        $epTotalCount = (int) ($detailResult['totalEpisodeCount'] ?? 0);
+                                    }
+                                @endphp
+                                <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded bg-success-600 text-white">
+                                    <x-heroicon-o-check class="w-3 h-3" />
+                                    @if($detailIsSonarr && $epTotalCount > 0)
+                                        {{ $epFileCount }}/{{ $epTotalCount }} {{ __('eps downloaded') }}
+                                    @else
+                                        {{ __('Downloaded') }}
+                                    @endif
+                                </span>
+                            @endif
+                            @if($detailInLibrary && ($detailIsSonarr || ! $detailIsDownloaded))
+                                <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded bg-amber-500 text-white">
+                                    <x-heroicon-s-bookmark class="w-3 h-3" />
+                                    {{ __('Monitored') }}
+                                </span>
+                            @endif
+                        </div>
+                    </div>
+
+                    @if(! empty($detailResult['overview']))
+                        <div class="px-4 pb-4 -mt-1">
+                            <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{{ $detailResult['overview'] }}</p>
+                        </div>
+                    @endif
+
+                    <div class="px-4 space-y-4 pb-4">
+                        {{-- Interactive Search (admin-only, library items only) --}}
+                        @if(! $guestMode && $detailInLibrary && ($this->detailIntegration?->isSonarr() || $this->detailIntegration?->isRadarr()))
+                            <div x-data="{ open: false }" class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+                                <button
+                                    @click="open = !open; if (open && @js(empty($detailReleases)) && !@js($releasesLoading)) $wire.call('loadDetailReleases')"
+                                    type="button"
+                                    class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
+                                >
+                                    <x-heroicon-m-chevron-right class="w-4 h-4 flex-shrink-0 text-gray-400 transition-transform duration-200" x-bind:class="{ 'rotate-90': open }" />
+                                    <span class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ __('Interactive Search') }}</span>
+                                    <span wire:loading wire:target="loadDetailReleases"><x-filament::loading-indicator class="h-3 w-3 text-primary-500" /></span>
+                                    @if(! empty($detailReleases))
+                                        <span wire:loading.remove wire:target="loadDetailReleases" class="text-xs text-gray-400 dark:text-gray-500">{{ count($detailReleases) }}</span>
+                                    @endif
+                                </button>
+                                <div x-show="open" x-collapse>
+                                    <div class="border-t border-gray-200 dark:border-gray-700">
+                                        <div wire:loading wire:target="loadDetailReleases" class="py-4 flex justify-center">
+                                            <x-filament::loading-indicator class="h-4 w-4 text-primary-500" />
+                                        </div>
+                                        <div wire:loading.remove wire:target="loadDetailReleases">
+                                            @if(! empty($detailReleases))
+                                                <div class="divide-y divide-gray-100 dark:divide-gray-800 max-h-72 overflow-y-auto">
+                                                    @foreach($detailReleases as $release)
+                                                        @php
+                                                            $releaseBytes = (int) ($release['size'] ?? 0);
+                                                            $releaseSize = match(true) {
+                                                                $releaseBytes >= 1_073_741_824 => number_format($releaseBytes / 1_073_741_824, 2).' GB',
+                                                                $releaseBytes >= 1_048_576     => number_format($releaseBytes / 1_048_576, 2).' MB',
+                                                                $releaseBytes > 0              => number_format($releaseBytes / 1_024, 2).' KB',
+                                                                default                        => '–',
+                                                            };
+                                                            $rejectionReasons = implode('; ', $release['rejections'] ?? []);
+                                                        @endphp
+                                                        <div class="flex items-start gap-2 px-3 py-2 {{ $release['approved'] ? '' : 'opacity-60' }}">
+                                                            <div class="flex-1 min-w-0">
+                                                                <p class="text-xs text-gray-800 dark:text-gray-200 leading-snug break-words">{{ $release['title'] }}</p>
+                                                                <div class="flex flex-wrap items-center gap-1.5 mt-1">
+                                                                    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ $release['quality'] }}</span>
+                                                                    <span class="text-xs text-gray-400 dark:text-gray-500">{{ $releaseSize }}</span>
+                                                                    <span class="text-xs text-gray-400 dark:text-gray-500 uppercase">{{ $release['protocol'] }}</span>
+                                                                    @if(! $release['approved'])
+                                                                        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-danger-100 dark:bg-danger-900/40 text-danger-700 dark:text-danger-400" title="{{ $rejectionReasons }}">{{ __('Rejected') }}</span>
+                                                                    @endif
+                                                                </div>
+                                                                @if(! $release['approved'] && $rejectionReasons)
+                                                                    <p class="text-xs text-danger-500 dark:text-danger-400 mt-1 leading-snug">{{ $rejectionReasons }}</p>
+                                                                @endif
+                                                            </div>
+                                                            @if($release['approved'])
+                                                                <button
+                                                                    wire:click="downloadDetailRelease('{{ $release['guid'] }}', {{ (int) ($release['indexerId'] ?? 0) }})"
+                                                                    wire:loading.attr="disabled"
+                                                                    wire:target="downloadDetailRelease"
+                                                                    title="{{ __('Download this release') }}"
+                                                                    class="flex-shrink-0 p-1.5 rounded text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors mt-0.5"
+                                                                >
+                                                                    <x-heroicon-o-arrow-down-tray class="w-4 h-4" />
+                                                                </button>
+                                                            @else
+                                                                <button
+                                                                    x-on:click="if (confirm('{{ __('This release was rejected by your quality profile. Download anyway?') }}')) $wire.call('downloadDetailRelease', '{{ $release['guid'] }}', {{ (int) ($release['indexerId'] ?? 0) }})"
+                                                                    title="{{ __('Force download (rejected release)') }}"
+                                                                    class="flex-shrink-0 p-1.5 rounded text-gray-300 dark:text-gray-600 hover:text-danger-500 dark:hover:text-danger-400 hover:bg-danger-50 dark:hover:bg-danger-900/20 transition-colors mt-0.5"
+                                                                >
+                                                                    <x-heroicon-o-arrow-down-tray class="w-4 h-4" />
+                                                                </button>
+                                                            @endif
+                                                        </div>
+                                                    @endforeach
+                                                </div>
+                                                <div class="px-3 py-2 border-t border-gray-100 dark:border-gray-800 flex justify-end">
+                                                    <button wire:click="loadDetailReleases" wire:loading.attr="disabled" wire:target="loadDetailReleases" class="text-xs text-primary-600 dark:text-primary-400 hover:underline disabled:opacity-40">{{ __('Refresh') }}</button>
+                                                </div>
+                                            @elseif(! $releasesLoading)
+                                                <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-3">{{ __('No releases found.') }}</p>
+                                            @endif
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        @endif
+
+                        @if($this->detailIntegration?->isSonarr() || $this->detailIntegration?->isRadarr())
+                            <div x-data="{ castOpen: false }" class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+                                <button @click="castOpen = !castOpen" type="button" class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors">
+                                    <x-heroicon-m-chevron-right class="w-4 h-4 flex-shrink-0 text-gray-400 transition-transform duration-200" x-bind:class="{ 'rotate-90': castOpen }" />
+                                    <span class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ __('Cast') }}</span>
+                                    <span wire:loading wire:target="loadDetailEpisodes"><x-filament::loading-indicator class="h-3 w-3 text-primary-500" /></span>
+                                    @if($detailCast) <span wire:loading.remove wire:target="loadDetailEpisodes" class="text-xs text-gray-400 dark:text-gray-500">{{ count($detailCast) }}</span> @endif
+                                </button>
+                                <div x-show="castOpen" x-collapse>
+                                    <div class="border-t border-gray-200 dark:border-gray-700">
+                                        <div wire:loading wire:target="loadDetailEpisodes" class="py-4 flex justify-center">
+                                            <x-filament::loading-indicator class="h-4 w-4 text-primary-500" />
+                                        </div>
+                                        <div wire:loading.remove wire:target="loadDetailEpisodes">
+                                            @if($detailCast)
+                                                <div class="divide-y divide-gray-100 dark:divide-gray-800">
+                                                    @foreach($detailCast as $member)
+                                                        <div class="flex items-center gap-3 px-3 py-2.5">
+                                                            <div class="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-gray-200 dark:bg-gray-700">
+                                                                @if(! empty($member['photo']))
+                                                                    <img src="{{ $member['photo'] }}" alt="{{ $member['actor'] }}" class="w-full h-full object-cover" loading="lazy">
+                                                                @else
+                                                                    <div class="w-full h-full flex items-center justify-center"><x-heroicon-o-user class="w-4 h-4 text-gray-400" /></div>
+                                                                @endif
+                                                            </div>
+                                                            <div class="flex-1 min-w-0">
+                                                                <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ $member['actor'] }}</p>
+                                                                @if(! empty($member['character'])) <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ $member['character'] }}</p> @endif
+                                                            </div>
+                                                        </div>
+                                                    @endforeach
+                                                </div>
+                                            @else
+                                                <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-3">{{ __('No cast information available.') }}</p>
+                                            @endif
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        @endif
+
+                        @if($this->detailIntegration?->isSonarr() && ! empty($detailResult['seasons']))
+                            <div>
+                                <div class="flex items-center justify-between mb-2">
+                                    <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ __('Seasons') }}</h3>
+                                    <div class="flex items-center gap-2">
+                                        <button wire:click="toggleAllSeasons(true)" class="text-xs text-primary-600 dark:text-primary-400 hover:underline">{{ __('All') }}</button>
+                                        <span class="text-gray-300 dark:text-gray-600">·</span>
+                                        <button wire:click="toggleAllSeasons(false)" class="text-xs text-gray-500 dark:text-gray-400 hover:underline">{{ __('None') }}</button>
+                                    </div>
+                                </div>
+                                <div class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden divide-y divide-gray-100 dark:divide-gray-800">
+                                    @foreach(collect($detailResult['seasons'])->sortBy('seasonNumber') as $season)
+                                        @php
+                                            $seasonNum      = (int) $season['seasonNumber'];
+                                            $seasonEpisodes = $detailEpisodes[$seasonNum] ?? null;
+                                            $episodeCount   = $seasonEpisodes !== null
+                                                ? count($seasonEpisodes)
+                                                : ($season['statistics']['totalEpisodeCount'] ?? null);
+
+                                            // Per-episode download counts from Sonarr /episode — authoritative
+                                            $seasonEpStatus  = $detailSonarrEpisodeStatus[$seasonNum] ?? null;
+                                            $seasonFileCount = $seasonEpStatus !== null ? count(array_filter($seasonEpStatus)) : null;
+                                            $seasonEpTotal   = $seasonEpStatus !== null ? count($seasonEpStatus) : null;
+                                        @endphp
+                                        <div x-data="{ expanded: false }">
+                                            <div class="flex items-center hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors">
+                                                <div class="pl-3 py-2.5" @click.stop>
+                                                    <input type="checkbox" wire:model.live="selectedSeasons.{{ $seasonNum }}" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500 dark:bg-gray-800">
+                                                </div>
+                                                <button @click="expanded = !expanded" type="button" class="flex-1 flex items-center gap-2 px-2 py-2.5 pr-3 text-left">
+                                                    <x-heroicon-m-chevron-right class="w-3.5 h-3.5 flex-shrink-0 text-gray-400 transition-transform duration-200" x-bind:class="{ 'rotate-90': expanded }" />
+                                                    <span class="flex-1 text-sm text-gray-800 dark:text-gray-200">
+                                                        {{ $seasonNum === 0 ? __('Specials') : __('Season :n', ['n' => $seasonNum]) }}
+                                                    </span>
+                                                    <span wire:loading wire:target="loadDetailEpisodes"><x-filament::loading-indicator class="h-3 w-3 text-gray-400" /></span>
+                                                    @if($episodeCount !== null)
+                                                        <span wire:loading.remove wire:target="loadDetailEpisodes" class="text-xs text-gray-400 dark:text-gray-500">{{ __(':n ep', ['n' => $episodeCount]) }}</span>
+                                                    @endif
+                                                    @if($seasonFileCount !== null && $seasonEpTotal !== null)
+                                                        @php
+                                                            $seasonBadgeClass = $seasonFileCount === $seasonEpTotal && $seasonEpTotal > 0
+                                                                ? 'bg-success-100 dark:bg-success-900/30 text-success-700 dark:text-success-400'
+                                                                : ($seasonFileCount > 0
+                                                                    ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
+                                                                    : 'text-gray-400 dark:text-gray-500');
+                                                        @endphp
+                                                        <span wire:loading.remove wire:target="loadDetailEpisodes" class="text-xs px-1 {{ $seasonBadgeClass }}">{{ $seasonFileCount }}/{{ $seasonEpTotal }}</span>
+                                                    @endif
+                                                </button>
+                                            </div>
+                                            <div x-show="expanded" x-collapse class="border-t border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30">
+                                                <div wire:loading wire:target="loadDetailEpisodes" class="py-4 flex justify-center">
+                                                    <x-filament::loading-indicator class="h-4 w-4 text-primary-500" />
+                                                </div>
+                                                <div wire:loading.remove wire:target="loadDetailEpisodes">
+                                                    @if($seasonEpisodes !== null && count($seasonEpisodes) > 0)
+                                                        <div class="divide-y divide-gray-100 dark:divide-gray-700/50">
+                                                            @foreach($seasonEpisodes as $episode)
+                                                                @php $epHasFile = ! empty($detailSonarrEpisodeStatus[$seasonNum][$episode['episodeNumber']]); @endphp
+                                                                <div class="flex items-center gap-2 px-3 py-1.5">
+                                                                    <span class="text-xs font-mono text-gray-400 dark:text-gray-500 w-6 flex-shrink-0 text-right">{{ str_pad($episode['episodeNumber'], 2, '0', STR_PAD_LEFT) }}</span>
+                                                                    @if($epHasFile)
+                                                                        <x-heroicon-s-check-circle class="w-3.5 h-3.5 flex-shrink-0 text-success-500 dark:text-success-400" />
+                                                                    @endif
+                                                                    <span class="flex-1 text-xs text-gray-800 dark:text-gray-200 min-w-0 truncate">{{ $episode['title'] }}</span>
+                                                                    @if(! empty($episode['airDate']))
+                                                                        <span class="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 tabular-nums">{{ \Carbon\Carbon::parse($episode['airDate'])->format('M j, Y') }}</span>
+                                                                    @endif
+                                                                    @if($epHasFile)
+                                                                        <button
+                                                                            wire:click="requestEpisode({{ $seasonNum }}, {{ $episode['episodeNumber'] }})"
+                                                                            wire:loading.attr="disabled"
+                                                                            wire:target="requestEpisode"
+                                                                            title="{{ __('Re-download this episode') }}"
+                                                                            class="flex-shrink-0 p-1 rounded text-success-500 dark:text-success-400 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors"
+                                                                        >
+                                                                            <x-heroicon-o-arrow-path class="w-3.5 h-3.5" />
+                                                                        </button>
+                                                                    @else
+                                                                        <button
+                                                                            wire:click="requestEpisode({{ $seasonNum }}, {{ $episode['episodeNumber'] }})"
+                                                                            wire:loading.attr="disabled"
+                                                                            wire:target="requestEpisode"
+                                                                            title="{{ __('Request episode') }}"
+                                                                            class="flex-shrink-0 p-1 rounded text-gray-300 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors"
+                                                                        >
+                                                                            <x-heroicon-o-arrow-down-tray class="w-3.5 h-3.5" />
+                                                                        </button>
+                                                                    @endif
+                                                                </div>
+                                                            @endforeach
+                                                        </div>
+                                                    @elseif($seasonEpisodes !== null)
+                                                        <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-3">{{ __('No episode details available.') }}</p>
+                                                    @endif
+                                                </div>
+                                            </div>
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </div>
+                        @endif
+                    </div>
+                </div>
+
+                <div class="flex-shrink-0 px-4 py-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50">
+                    @if($detailInLibrary && $detailIsSonarr)
+                        {{-- Sonarr in-library: show status + always allow re-requesting seasons --}}
+                        @php $monitoredCount = collect($selectedSeasons)->filter()->count(); @endphp
+                        <div class="space-y-2">
+                            <div class="flex items-center justify-center gap-2 py-0.5 text-sm">
+                                @if($detailIsDownloaded)
+                                    <x-heroicon-o-check-circle class="w-4 h-4 text-success-600 dark:text-success-400 flex-shrink-0" />
+                                    <span class="text-success-700 dark:text-success-400">{{ __('Available in library') }}</span>
+                                @else
+                                    <x-heroicon-s-bookmark class="w-4 h-4 text-amber-500 flex-shrink-0" />
+                                    <span class="text-amber-600 dark:text-amber-400">{{ __('Monitored — searching for releases') }}</span>
+                                @endif
+                            </div>
+                            @if(! $guestMode)
+                                <div class="flex gap-2">
+                                    <button
+                                        wire:click="triggerAutomaticSearch"
+                                        wire:loading.attr="disabled"
+                                        wire:target="triggerAutomaticSearch"
+                                        class="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg transition-colors"
+                                    >
+                                        <x-heroicon-o-magnifying-glass class="w-4 h-4" />
+                                        {{ __('Auto Search') }}
+                                    </button>
+                                    <button
+                                        wire:click="requestDetail"
+                                        wire:loading.attr="disabled"
+                                        @disabled($monitoredCount === 0)
+                                        class="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
+                                    >
+                                        <x-heroicon-o-arrow-path class="w-4 h-4" />
+                                        @if($monitoredCount > 0)
+                                            {{ __('Re-request :n Season(s)', ['n' => $monitoredCount]) }}
+                                        @else
+                                            {{ __('Select Seasons') }}
+                                        @endif
+                                    </button>
+                                </div>
+                            @endif
+                        </div>
+                    @elseif($detailIsDownloaded)
+                        {{-- Radarr downloaded --}}
+                        <div class="space-y-2">
+                            <div class="flex items-center justify-center gap-2 py-1 text-sm text-success-700 dark:text-success-400">
+                                <x-heroicon-o-check-circle class="w-5 h-5" />
+                                {{ __('This title is available in your library.') }}
+                            </div>
+                            @if(! $guestMode)
+                                <button
+                                    wire:click="triggerAutomaticSearch"
+                                    wire:loading.attr="disabled"
+                                    wire:target="triggerAutomaticSearch"
+                                    class="w-full inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg transition-colors"
+                                >
+                                    <x-heroicon-o-magnifying-glass class="w-4 h-4" />
+                                    {{ __('Trigger Automatic Search') }}
+                                </button>
+                            @endif
+                        </div>
+                    @elseif($detailInLibrary)
+                        {{-- Radarr monitored (not yet downloaded) --}}
+                        <div class="space-y-2">
+                            <div class="flex items-center justify-center gap-2 py-1 text-sm text-amber-600 dark:text-amber-400">
+                                <x-heroicon-s-bookmark class="w-5 h-5" />
+                                {{ __('This title is monitored and searching for releases.') }}
+                            </div>
+                            @if(! $guestMode)
+                                <button
+                                    wire:click="triggerAutomaticSearch"
+                                    wire:loading.attr="disabled"
+                                    wire:target="triggerAutomaticSearch"
+                                    class="w-full inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg transition-colors"
+                                >
+                                    <x-heroicon-o-magnifying-glass class="w-4 h-4" />
+                                    {{ __('Trigger Automatic Search') }}
+                                </button>
+                            @endif
+                        </div>
+                    @elseif($detailIsSonarr)
+                        {{-- Sonarr not in library — initial request --}}
+                        @php $monitoredCount = collect($selectedSeasons)->filter()->count(); @endphp
+                        <button
+                            wire:click="requestDetail"
+                            wire:loading.attr="disabled"
+                            @disabled($monitoredCount === 0)
+                            class="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+                        >
+                            <x-heroicon-o-plus class="w-4 h-4" />
+                            @if($monitoredCount > 0)
+                                {{ __('Request :count Season(s)', ['count' => $monitoredCount]) }}
+                            @else
+                                {{ __('Select Seasons to Request') }}
+                            @endif
+                        </button>
+                    @else
+                        {{-- Radarr not in library --}}
+                        <button
+                            wire:click="request({{ $detailIndex }})"
+                            wire:click.stop
+                            wire:loading.attr="disabled"
+                            class="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+                        >
+                            <x-heroicon-o-plus class="w-4 h-4" />
+                            {{ __('Request Movie') }}
+                        </button>
+                    @endif
+                </div>
+            @endif
+        </div>
+    </div>
+
 </div>

--- a/resources/views/livewire/arr-search.blade.php
+++ b/resources/views/livewire/arr-search.blade.php
@@ -24,16 +24,20 @@
             {{-- ── Search Results ──────────────────────────────────────────── --}}
             @if(strlen(trim($searchTerm)) >= 2 || $isSearching)
 
-                <div class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm overflow-hidden">
-                    <div class="flex items-center gap-2.5 px-4 py-3.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-white/5">
-                        <x-heroicon-o-magnifying-glass class="w-4 h-4 text-gray-500 dark:text-gray-400" />
-                        <h3 class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ __('Search Results') }}</h3>
-                        @if(count($results) > 0)
-                            <span class="text-xs font-medium text-gray-400 dark:text-gray-500">{{ count($results) }}</span>
-                        @endif
-                    </div>
+                <x-filament::section heading-tag="h3">
+                    <x-slot name="heading">
+                        <span class="flex items-center gap-2">
+                            <x-heroicon-o-magnifying-glass class="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                            {{ __('Search Results') }}
+                        </span>
+                    </x-slot>
+                    @if(count($results) > 0)
+                        <x-slot name="afterHeader">
+                            <x-filament::badge color="gray">{{ count($results) }}</x-filament::badge>
+                        </x-slot>
+                    @endif
 
-                    <div class="p-4">
+                    <div>
                         @if($isSearching)
                             <div class="flex items-center justify-center py-10">
                                 <x-filament::loading-indicator class="h-7 w-7 text-primary-500" />
@@ -144,7 +148,7 @@
                             </div>
                         @endif
                     </div>
-                </div>
+                </x-filament::section>
 
             @endif
 
@@ -568,19 +572,19 @@
                                     $remainingItems = array_slice($section['items'], 10);
                                 @endphp
 
-                                <div
-                                    x-data="{ expanded: false }"
-                                    class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm overflow-hidden"
-                                >
-                                    {{-- Section header --}}
-                                    <div class="flex items-center gap-2.5 px-4 py-3.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-white/5">
-                                        <x-dynamic-component :component="$section['icon']" class="w-4 h-4 flex-shrink-0 {{ $section['iconClass'] }}" />
-                                        <h3 class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $section['label'] }}</h3>
-                                        <span class="text-xs font-medium text-gray-400 dark:text-gray-500">{{ count($section['items']) }}</span>
-                                    </div>
+                                <x-filament::section heading-tag="h3">
+                                    <x-slot name="heading">
+                                        <span class="flex items-center gap-2">
+                                            <x-dynamic-component :component="$section['icon']" class="w-4 h-4 flex-shrink-0 {{ $section['iconClass'] }}" />
+                                            {{ $section['label'] }}
+                                        </span>
+                                    </x-slot>
 
-                                    {{-- Grid content --}}
-                                    <div class="p-4">
+                                    <x-slot name="afterHeader">
+                                        <x-filament::badge color="gray">{{ count($section['items']) }}</x-filament::badge>
+                                    </x-slot>
+
+                                    <div x-data="{ expanded: false }">
                                         <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
                                             @foreach($initialItems as $item)
                                                 <div
@@ -740,7 +744,7 @@
                                             </div>
                                         @endif
                                     </div>
-                                </div>
+                                </x-filament::section>
                             @endif
                         @endforeach
 
@@ -1071,44 +1075,51 @@
                         @endif
 
                         @if($this->detailIntegration?->isSonarr() || $this->detailIntegration?->isRadarr())
-                            <div x-data="{ castOpen: false }" class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-                                <button @click="castOpen = !castOpen" type="button" class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors">
-                                    <x-heroicon-m-chevron-right class="w-4 h-4 flex-shrink-0 text-gray-400 transition-transform duration-200" x-bind:class="{ 'rotate-90': castOpen }" />
-                                    <span class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{{ __('Cast') }}</span>
-                                    <span wire:loading wire:target="loadDetailEpisodes"><x-filament::loading-indicator class="h-3 w-3 text-primary-500" /></span>
-                                    @if($detailCast) <span wire:loading.remove wire:target="loadDetailEpisodes" class="text-xs text-gray-400 dark:text-gray-500">{{ count($detailCast) }}</span> @endif
-                                </button>
-                                <div x-show="castOpen" x-collapse>
-                                    <div class="border-t border-gray-200 dark:border-gray-700">
-                                        <div wire:loading wire:target="loadDetailEpisodes" class="py-4 flex justify-center">
-                                            <x-filament::loading-indicator class="h-4 w-4 text-primary-500" />
-                                        </div>
-                                        <div wire:loading.remove wire:target="loadDetailEpisodes">
-                                            @if($detailCast)
-                                                <div class="divide-y divide-gray-100 dark:divide-gray-800">
-                                                    @foreach($detailCast as $member)
-                                                        <div class="flex items-center gap-3 px-3 py-2.5">
-                                                            <div class="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-gray-200 dark:bg-gray-700">
-                                                                @if(! empty($member['photo']))
-                                                                    <img src="{{ $member['photo'] }}" alt="{{ $member['actor'] }}" class="w-full h-full object-cover" loading="lazy">
-                                                                @else
-                                                                    <div class="w-full h-full flex items-center justify-center"><x-heroicon-o-user class="w-4 h-4 text-gray-400" /></div>
-                                                                @endif
-                                                            </div>
-                                                            <div class="flex-1 min-w-0">
-                                                                <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ $member['actor'] }}</p>
-                                                                @if(! empty($member['character'])) <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ $member['character'] }}</p> @endif
-                                                            </div>
-                                                        </div>
-                                                    @endforeach
-                                                </div>
-                                            @else
-                                                <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-3">{{ __('No cast information available.') }}</p>
-                                            @endif
-                                        </div>
-                                    </div>
+                            <x-filament::section
+                                collapsible
+                                :collapsed="true"
+                                heading="{{ __('Cast') }}"
+                                heading-tag="h3"
+                                compact
+                            >
+                                <x-slot name="afterHeader">
+                                    <span wire:loading wire:target="loadDetailEpisodes">
+                                        <x-filament::loading-indicator class="h-3 w-3 text-primary-500" />
+                                    </span>
+                                    @if($detailCast)
+                                        <x-filament::badge color="gray" wire:loading.remove wire:target="loadDetailEpisodes">
+                                            {{ count($detailCast) }}
+                                        </x-filament::badge>
+                                    @endif
+                                </x-slot>
+
+                                <div wire:loading wire:target="loadDetailEpisodes" class="py-2 flex justify-center">
+                                    <x-filament::loading-indicator class="h-4 w-4 text-primary-500" />
                                 </div>
-                            </div>
+                                <div wire:loading.remove wire:target="loadDetailEpisodes">
+                                    @if($detailCast)
+                                        <div class="divide-y divide-gray-100 dark:divide-gray-800">
+                                            @foreach($detailCast as $member)
+                                                <div class="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0">
+                                                    <div class="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-gray-200 dark:bg-gray-700">
+                                                        @if(! empty($member['photo']))
+                                                            <img src="{{ $member['photo'] }}" alt="{{ $member['actor'] }}" class="w-full h-full object-cover" loading="lazy">
+                                                        @else
+                                                            <div class="w-full h-full flex items-center justify-center"><x-heroicon-o-user class="w-4 h-4 text-gray-400" /></div>
+                                                        @endif
+                                                    </div>
+                                                    <div class="flex-1 min-w-0">
+                                                        <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ $member['actor'] }}</p>
+                                                        @if(! empty($member['character'])) <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ $member['character'] }}</p> @endif
+                                                    </div>
+                                                </div>
+                                            @endforeach
+                                        </div>
+                                    @else
+                                        <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-2">{{ __('No cast information available.') }}</p>
+                                    @endif
+                                </div>
+                            </x-filament::section>
                         @endif
 
                         @if($this->detailIntegration?->isSonarr() && ! empty($detailResult['seasons']))

--- a/resources/views/livewire/arr-search.blade.php
+++ b/resources/views/livewire/arr-search.blade.php
@@ -530,45 +530,36 @@
                                         <x-filament::loading-indicator class="h-6 w-6 text-primary-500" />
                                     </div>
                                 @elseif(count($browseResults) > 0)
-                                    @php
-                                        $browseInitial = array_slice($browseResults, 0, 10);
-                                        $browseRemaining = array_slice($browseResults, 10);
-                                    @endphp
-                                    <div x-data="{ expanded: false }">
-                                        <div
-                                            class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-                                            @foreach ($browseInitial as $item)
-                                                @include('livewire.partials.discover-card', [
-                                                    'item' => $item,
-                                                ])
-                                            @endforeach
-                                        </div>
-                                        @if (count($browseRemaining) > 0)
-                                            <div x-show="expanded" x-collapse>
-                                                <div
-                                                    class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 mt-3">
-                                                    @foreach ($browseRemaining as $item)
-                                                        @include('livewire.partials.discover-card', [
-                                                            'item' => $item,
-                                                        ])
-                                                    @endforeach
-                                                </div>
-                                            </div>
-                                            <div
-                                                class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 text-center">
-                                                <button @click="expanded = !expanded"
-                                                    class="inline-flex items-center gap-1.5 text-xs font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors">
-                                                    <span
-                                                        x-show="!expanded">{{ __('Show :n more', ['n' => count($browseRemaining)]) }}</span>
-                                                    <span x-show="expanded"
-                                                        style="display:none">{{ __('Show less') }}</span>
-                                                    <x-heroicon-o-chevron-down
-                                                        class="w-3.5 h-3.5 transition-transform duration-200"
-                                                        x-bind:class="{ 'rotate-180': expanded }" />
-                                                </button>
-                                            </div>
-                                        @endif
+                                    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                                        @foreach($browseResults as $item)
+                                            @include('livewire.partials.discover-card', ['item' => $item])
+                                        @endforeach
                                     </div>
+                                    @if($browseTotalPages > 1)
+                                        <div class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 flex items-center justify-center gap-3">
+                                            <button
+                                                wire:click="goToBrowsePage({{ $browsePage - 1 }})"
+                                                wire:loading.attr="disabled"
+                                                wire:target="goToBrowsePage"
+                                                @disabled($browsePage <= 1)
+                                                class="p-1 rounded text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                            >
+                                                <x-heroicon-o-chevron-left class="w-4 h-4" />
+                                            </button>
+                                            <span class="text-xs text-gray-500 dark:text-gray-400" wire:loading.class="opacity-50" wire:target="goToBrowsePage">
+                                                {{ __('Page :current of :total', ['current' => $browsePage, 'total' => $browseTotalPages]) }}
+                                            </span>
+                                            <button
+                                                wire:click="goToBrowsePage({{ $browsePage + 1 }})"
+                                                wire:loading.attr="disabled"
+                                                wire:target="goToBrowsePage"
+                                                @disabled($browsePage >= $browseTotalPages)
+                                                class="p-1 rounded text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                            >
+                                                <x-heroicon-o-chevron-right class="w-4 h-4" />
+                                            </button>
+                                        </div>
+                                    @endif
                                 @else
                                     <div class="flex flex-col items-center justify-center py-10 text-center">
                                         <x-heroicon-o-film class="w-10 h-10 text-gray-300 dark:text-gray-600" />

--- a/resources/views/livewire/arr-search.blade.php
+++ b/resources/views/livewire/arr-search.blade.php
@@ -1,20 +1,15 @@
-<div
-    wire:init="loadDiscover"
-    @if($guestMode && $queuePolling) wire:poll.{{ $this->queuePollInterval }}s="loadQueue" @endif
->
+<div wire:init="loadDiscover"
+    @if ($guestMode && $queuePolling) wire:poll.{{ $this->queuePollInterval }}s="loadQueue" @endif>
 
-    @if($this->integrationsForSearch->isNotEmpty())
+    @if ($this->integrationsForSearch->isNotEmpty())
 
         <div class="space-y-6">
 
             {{-- ── Search Bar ─────────────────────────────────────────────── --}}
             <form wire:submit.prevent="search" class="relative">
-                <input
-                    type="text"
-                    wire:model.live.debounce.300ms="searchTerm"
+                <input type="text" wire:model.live.debounce.300ms="searchTerm"
                     placeholder="{{ __('Search movies & TV series...') }}"
-                    class="w-full pl-10 pr-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 focus:border-primary-500 focus:ring-primary-500 text-sm"
-                >
+                    class="w-full pl-10 pr-4 py-3 rounded-lg border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 focus:border-primary-500 focus:ring-primary-500 text-sm">
                 <x-heroicon-o-magnifying-glass class="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                 <div wire:loading wire:target="search" class="absolute right-3 top-1/2 -translate-y-1/2">
                     <x-filament::loading-indicator class="h-5 w-5 text-primary-500" />
@@ -22,115 +17,120 @@
             </form>
 
             {{-- ── Search Results ──────────────────────────────────────────── --}}
-            @if(strlen(trim($searchTerm)) >= 2 || $isSearching)
+            @if (strlen(trim($searchTerm)) >= 2 || $isSearching)
 
-                <x-filament::section heading-tag="h3">
-                    <x-slot name="heading">
-                        <span class="flex items-center gap-2">
-                            <x-heroicon-o-magnifying-glass class="w-4 h-4 text-gray-500 dark:text-gray-400" />
-                            {{ __('Search Results') }}
-                        </span>
-                    </x-slot>
-                    @if(count($results) > 0)
+                <x-filament::section :collapsible="true" compact heading="{{ __('Search Results') }}"
+                    icon="heroicon-o-magnifying-glass" icon-color="gray">
+                    @if (count($results) > 0)
                         <x-slot name="afterHeader">
                             <x-filament::badge color="gray">{{ count($results) }}</x-filament::badge>
                         </x-slot>
                     @endif
 
                     <div>
-                        @if($isSearching)
+                        @if ($isSearching)
                             <div class="flex items-center justify-center py-10">
                                 <x-filament::loading-indicator class="h-7 w-7 text-primary-500" />
-                                <span class="ml-3 text-sm text-gray-500 dark:text-gray-400">{{ __('Searching...') }}</span>
+                                <span
+                                    class="ml-3 text-sm text-gray-500 dark:text-gray-400">{{ __('Searching...') }}</span>
                             </div>
                         @elseif(count($results) > 0)
                             <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-                                @foreach($results as $index => $result)
+                                @foreach ($results as $index => $result)
                                     @php
                                         $isSonarr = ($result['integrationType'] ?? '') === 'sonarr';
-                                        $inLibrary = ! empty($result['existsInLibrary']);
-                                        $isDownloaded = $inLibrary && (
-                                            $isSonarr
+                                        $inLibrary = !empty($result['existsInLibrary']);
+                                        $isDownloaded =
+                                            $inLibrary &&
+                                            ($isSonarr
                                                 ? ($result['episodeFileCount'] ?? 0) > 0
-                                                : ($result['hasFile'] ?? false)
-                                        );
+                                                : $result['hasFile'] ?? false);
                                     @endphp
-                                    <div
-                                        wire:click="openDetail({{ $index }})"
-                                        class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800"
-                                    >
+                                    <div wire:click="openDetail({{ $index }})"
+                                        class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800">
                                         <div class="relative aspect-[2/3]">
-                                            @if(! empty($result['poster']))
-                                                <img src="{{ $result['poster'] }}" alt="{{ $result['title'] ?? '' }}" class="w-full h-full object-cover" loading="lazy">
+                                            @if (!empty($result['poster']))
+                                                <img src="{{ $result['poster'] }}" alt="{{ $result['title'] ?? '' }}"
+                                                    class="w-full h-full object-cover" loading="lazy">
                                             @else
-                                                <div class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-                                                    @if($isSonarr)
-                                                        <x-heroicon-o-tv class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                <div
+                                                    class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                                                    @if ($isSonarr)
+                                                        <x-heroicon-o-tv
+                                                            class="w-10 h-10 text-gray-400 dark:text-gray-500" />
                                                     @else
-                                                        <x-heroicon-o-film class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                        <x-heroicon-o-film
+                                                            class="w-10 h-10 text-gray-400 dark:text-gray-500" />
                                                     @endif
                                                 </div>
                                             @endif
-                                            <span class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
+                                            <span
+                                                class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
                                                 {{ $isSonarr ? __('TV') : __('Movie') }}
                                             </span>
-                                            @if($isDownloaded)
-                                                <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
+                                            @if ($isDownloaded)
+                                                <span
+                                                    class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
                                                     <x-heroicon-s-check class="w-3.5 h-3.5 text-white" />
                                                 </span>
                                             @elseif($inLibrary)
-                                                <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
+                                                <span
+                                                    class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
                                                     <x-heroicon-s-bookmark class="w-3.5 h-3.5 text-white" />
                                                 </span>
                                             @endif
-                                            @if(! empty($result['rating']['value']))
-                                                <span class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
+                                            @if (!empty($result['rating']['value']))
+                                                <span
+                                                    class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
                                                     <x-heroicon-s-star class="w-3 h-3" />
                                                     {{ $result['rating']['value'] }}
                                                 </span>
                                             @endif
-                                            @if(! empty($result['integrationName']))
+                                            @if (!empty($result['integrationName']))
                                                 <span
                                                     class="absolute bottom-2 left-2 px-1.5 py-0.5 text-xs font-medium rounded text-white shadow-sm"
-                                                    style="background:{{ $isSonarr ? 'oklch(0.588 0.158 241.966)' : 'oklch(0.558 0.288 302.321)' }}"
-                                                >{{ $result['integrationName'] }}</span>
+                                                    style="background:{{ $isSonarr ? 'oklch(0.588 0.158 241.966)' : 'oklch(0.558 0.288 302.321)' }}">{{ $result['integrationName'] }}</span>
                                             @endif
-                                            <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
+                                            <div
+                                                class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
                                                 <h3 class="text-white font-semibold text-sm leading-tight line-clamp-2">
                                                     {{ $result['title'] ?? '' }}
-                                                    @if(! empty($result['year']))
-                                                        <span class="text-white/60 font-normal">({{ $result['year'] }})</span>
+                                                    @if (!empty($result['year']))
+                                                        <span
+                                                            class="text-white/60 font-normal">({{ $result['year'] }})</span>
                                                     @endif
                                                 </h3>
-                                                @if(! empty($result['overview']))
-                                                    <p class="text-white/55 text-xs line-clamp-2">{{ $result['overview'] }}</p>
+                                                @if (!empty($result['overview']))
+                                                    <p class="text-white/55 text-xs line-clamp-2">
+                                                        {{ $result['overview'] }}</p>
                                                 @endif
                                                 <div class="mt-1.5">
-                                                    @if($isDownloaded)
-                                                        <span class="flex items-center gap-1 text-green-400 text-xs font-medium">
+                                                    @if ($isDownloaded)
+                                                        <span
+                                                            class="flex items-center gap-1 text-green-400 text-xs font-medium">
                                                             <x-heroicon-s-check class="w-3.5 h-3.5" />
-                                                            @if($isSonarr && ($result['totalEpisodeCount'] ?? 0) > 0)
-                                                                {{ $result['episodeFileCount'] }}/{{ $result['totalEpisodeCount'] }} {{ __('eps') }}
+                                                            @if ($isSonarr && ($result['totalEpisodeCount'] ?? 0) > 0)
+                                                                {{ $result['episodeFileCount'] }}/{{ $result['totalEpisodeCount'] }}
+                                                                {{ __('eps') }}
                                                             @else
                                                                 {{ __('Downloaded') }}
                                                             @endif
                                                         </span>
                                                     @elseif($inLibrary)
-                                                        <span class="flex items-center gap-1 text-amber-400 text-xs font-medium">
+                                                        <span
+                                                            class="flex items-center gap-1 text-amber-400 text-xs font-medium">
                                                             <x-heroicon-s-bookmark class="w-3.5 h-3.5" />
                                                             {{ __('Monitored') }}
                                                         </span>
                                                     @elseif($isSonarr)
-                                                        <span class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
+                                                        <span
+                                                            class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
                                                             {{ __('Select Seasons') }}
                                                         </span>
                                                     @else
-                                                        <button
-                                                            wire:click.stop="request({{ $index }})"
-                                                            wire:loading.attr="disabled"
-                                                            wire:target="request"
-                                                            class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 hover:bg-primary-700 disabled:opacity-60 text-white text-xs font-medium transition-colors"
-                                                        >
+                                                        <button wire:click.stop="request({{ $index }})"
+                                                            wire:loading.attr="disabled" wire:target="request"
+                                                            class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 hover:bg-primary-700 disabled:opacity-60 text-white text-xs font-medium transition-colors">
                                                             {{ __('Request Movie') }}
                                                         </button>
                                                     @endif
@@ -143,8 +143,10 @@
                         @else
                             <div class="flex flex-col items-center justify-center py-10 text-center">
                                 <x-heroicon-o-magnifying-glass class="w-10 h-10 text-gray-300 dark:text-gray-600" />
-                                <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('No results found') }}</h4>
-                                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ __('Try a different search term.') }}</p>
+                                <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                                    {{ __('No results found') }}</h4>
+                                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                    {{ __('Try a different search term.') }}</p>
                             </div>
                         @endif
                     </div>
@@ -153,67 +155,58 @@
             @endif
 
             {{-- ── Discover Sections ────────────────────────────────────────── --}}
-            @if($tmdbConfigured && strlen(trim($searchTerm)) < 2)
+            @if ($tmdbConfigured && strlen(trim($searchTerm)) < 2)
 
-                @if(! $discoverLoaded)
+                @if (!$discoverLoaded)
                     <div class="flex items-center justify-center py-16">
                         <x-filament::loading-indicator class="h-8 w-8 text-primary-500" />
-                        <span class="ml-3 text-sm text-gray-500 dark:text-gray-400">{{ __('Loading discover...') }}</span>
+                        <span
+                            class="ml-3 text-sm text-gray-500 dark:text-gray-400">{{ __('Loading discover...') }}</span>
                     </div>
-
                 @else
-
                     {{-- ── Genre Sections (always under search bar) ──────── --}}
 
-                    @if(count($movieGenres) > 0 || count($tvGenres) > 0)
-                        <x-filament::section collapsible :id="'genres'">
-                            <x-slot name="heading">
-                                <span class="flex items-center gap-2">
-                                    <x-heroicon-o-tag class="w-4 h-4 text-primary-500" />
-                                    {{ __('Browse by Genre') }}
-                                </span>
-                            </x-slot>
+                    @if (count($movieGenres) > 0 || count($tvGenres) > 0)
+                        <x-filament::section :collapsible="true" compact :id="'genres'"
+                            heading="{{ __('Browse by Genre') }}" icon="heroicon-o-tag" icon-color="primary">
 
-                            <div
-                                x-data="{ tab: '{{ $browseGenreType ?? 'movie' }}' }"
-                                x-init="$watch(() => $wire.browseGenreType, v => { if (v) tab = v })"
-                            >
-                                @if(count($movieGenres) > 0 && count($tvGenres) > 0)
+                            <div x-data="{ tab: '{{ $browseGenreType ?? 'movie' }}' }" x-init="$watch(() => $wire.browseGenreType, v => { if (v) tab = v })">
+                                @if (count($movieGenres) > 0 && count($tvGenres) > 0)
                                     <div class="flex gap-1 mb-4 bg-gray-100 dark:bg-gray-800 rounded-lg p-1 w-fit">
-                                        <button
-                                            @click="tab = 'movie'"
-                                            :class="tab === 'movie' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
-                                            class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all"
-                                        >
+                                        <button @click="tab = 'movie'"
+                                            :class="tab === 'movie' ?
+                                                'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' :
+                                                'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
+                                            class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all">
                                             <x-heroicon-o-film class="w-3.5 h-3.5" />
                                             {{ __('Movies') }}
                                         </button>
-                                        <button
-                                            @click="tab = 'tv'"
-                                            :class="tab === 'tv' ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
-                                            class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all"
-                                        >
+                                        <button @click="tab = 'tv'"
+                                            :class="tab === 'tv' ?
+                                                'bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm' :
+                                                'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200'"
+                                            class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all">
                                             <x-heroicon-o-tv class="w-3.5 h-3.5" />
                                             {{ __('TV') }}
                                         </button>
                                     </div>
                                 @endif
 
-                                @if(count($movieGenres) > 0)
-                                    <div x-show="tab === 'movie'" x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100">
+                                @if (count($movieGenres) > 0)
+                                    <div x-show="tab === 'movie'" x-transition:enter="transition ease-out duration-150"
+                                        x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100">
                                         <div class="flex flex-wrap gap-1.5">
-                                            @foreach($movieGenres as $genre)
+                                            @foreach ($movieGenres as $genre)
                                                 @php $isActive = $browseGenreId === $genre['id'] && $browseGenreType === 'movie'; @endphp
                                                 <button
                                                     wire:click="{{ $isActive ? 'clearBrowse' : 'browseGenre(' . $genre['id'] . ", 'movie')" }}"
                                                     @class([
                                                         'inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors border',
                                                         'bg-primary-600 text-white border-primary-600' => $isActive,
-                                                        'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-transparent hover:bg-primary-50 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-300 hover:border-primary-200 dark:hover:border-primary-800' => ! $isActive,
-                                                    ])
-                                                >
+                                                        'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-transparent hover:bg-primary-50 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-300 hover:border-primary-200 dark:hover:border-primary-800' => !$isActive,
+                                                    ])>
                                                     {{ $genre['name'] }}
-                                                    @if($isActive)
+                                                    @if ($isActive)
                                                         <x-heroicon-o-x-mark class="w-3 h-3 opacity-80" />
                                                     @endif
                                                 </button>
@@ -222,21 +215,21 @@
                                     </div>
                                 @endif
 
-                                @if(count($tvGenres) > 0)
-                                    <div x-show="tab === 'tv'" x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100">
+                                @if (count($tvGenres) > 0)
+                                    <div x-show="tab === 'tv'" x-transition:enter="transition ease-out duration-150"
+                                        x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100">
                                         <div class="flex flex-wrap gap-1.5">
-                                            @foreach($tvGenres as $genre)
+                                            @foreach ($tvGenres as $genre)
                                                 @php $isActive = $browseGenreId === $genre['id'] && $browseGenreType === 'tv'; @endphp
                                                 <button
                                                     wire:click="{{ $isActive ? 'clearBrowse' : 'browseGenre(' . $genre['id'] . ", 'tv')" }}"
                                                     @class([
                                                         'inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors border',
                                                         'bg-primary-600 text-white border-primary-600' => $isActive,
-                                                        'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-transparent hover:bg-primary-50 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-300 hover:border-primary-200 dark:hover:border-primary-800' => ! $isActive,
-                                                    ])
-                                                >
+                                                        'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-transparent hover:bg-primary-50 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-300 hover:border-primary-200 dark:hover:border-primary-800' => !$isActive,
+                                                    ])>
                                                     {{ $genre['name'] }}
-                                                    @if($isActive)
+                                                    @if ($isActive)
                                                         <x-heroicon-o-x-mark class="w-3 h-3 opacity-80" />
                                                     @endif
                                                 </button>
@@ -249,11 +242,14 @@
                     @endif
 
                     {{-- ── Browse Results (genre selected) ──────────────── --}}
-                    @if($browseGenreId !== null)
+                    @if ($browseGenreId !== null)
 
                         @php
-                            $browseName = collect($browseGenreType === 'tv' ? $tvGenres : $movieGenres)
-                                ->firstWhere('id', $browseGenreId)['name'] ?? '';
+                            $browseName =
+                                collect($browseGenreType === 'tv' ? $tvGenres : $movieGenres)->firstWhere(
+                                    'id',
+                                    $browseGenreId,
+                                )['name'] ?? '';
                         @endphp
 
                         @php
@@ -264,20 +260,17 @@
                                 (int) ($minVoteCount > 0) +
                                 (int) ($minRuntime !== null || $maxRuntime !== null) +
                                 (int) ($originalLanguage !== '') +
-                                (int) (! empty($selectedProviders)) +
-                                (int) (! empty($tvStatuses));
+                                (int) !empty($selectedProviders) +
+                                (int) !empty($tvStatuses);
                         @endphp
 
-                        <div
-                            x-data="{ filtersOpen: @js($activeFilterCount > 0) }"
-                            class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm overflow-hidden"
-                        >
+                        <div x-data="{ filtersOpen: @js($activeFilterCount > 0) }"
+                            class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-sm overflow-hidden">
                             {{-- Header --}}
-                            <div class="flex items-center gap-2.5 px-4 py-3.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-white/5">
-                                <button
-                                    wire:click="clearBrowse"
-                                    class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700 transition-colors"
-                                >
+                            <div
+                                class="flex items-center gap-2.5 px-4 py-3.5 border-b border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-white/5">
+                                <button wire:click="clearBrowse"
+                                    class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 border border-gray-200 dark:border-gray-700 transition-colors">
                                     <x-heroicon-o-arrow-left class="w-3.5 h-3.5" />
                                     {{ __('All Genres') }}
                                 </button>
@@ -288,44 +281,55 @@
                                         — {{ $browseGenreType === 'tv' ? __('TV Series') : __('Movies') }}
                                     </span>
                                 </h3>
-                                @if(count($browseResults) > 0)
-                                    <span class="text-xs font-medium text-gray-400 dark:text-gray-500 mr-1">{{ count($browseResults) }}</span>
+                                @if (count($browseResults) > 0)
+                                    <span
+                                        class="text-xs font-medium text-gray-400 dark:text-gray-500 mr-1">{{ count($browseResults) }}</span>
                                 @endif
-                                <button
-                                    @click="filtersOpen = !filtersOpen"
-                                    :class="filtersOpen ? 'bg-primary-50 dark:bg-primary-900/30 border-primary-200 dark:border-primary-800 text-primary-700 dark:text-primary-300' : 'bg-gray-100 dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'"
-                                    class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium border transition-colors"
-                                >
+                                <button @click="filtersOpen = !filtersOpen"
+                                    :class="filtersOpen ?
+                                        'bg-primary-50 dark:bg-primary-900/30 border-primary-200 dark:border-primary-800 text-primary-700 dark:text-primary-300' :
+                                        'bg-gray-100 dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'"
+                                    class="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium border transition-colors">
                                     <x-heroicon-o-adjustments-horizontal class="w-3.5 h-3.5" />
                                     {{ __('Filters') }}
-                                    @if($activeFilterCount > 0)
-                                        <span class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary-600 text-white text-[10px] font-bold leading-none">{{ $activeFilterCount }}</span>
+                                    @if ($activeFilterCount > 0)
+                                        <span
+                                            class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary-600 text-white text-[10px] font-bold leading-none">{{ $activeFilterCount }}</span>
                                     @endif
                                 </button>
                             </div>
 
                             {{-- Filter panel --}}
-                            <div x-show="filtersOpen" x-collapse class="border-b border-gray-200 dark:border-gray-700">
+                            <div x-show="filtersOpen" x-collapse
+                                class="border-b border-gray-200 dark:border-gray-700">
                                 <div class="p-4 space-y-4 bg-gray-50/60 dark:bg-white/[0.02]">
 
                                     {{-- Row 1: Sort + Language --}}
                                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                         <div>
-                                            <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">{{ __('Sort By') }}</label>
-                                            <select wire:model.live="sortBy" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                            <label
+                                                class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">{{ __('Sort By') }}</label>
+                                            <select wire:model.live="sortBy"
+                                                class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
                                                 <option value="popularity">{{ __('Most Popular') }}</option>
                                                 <option value="rating">{{ __('Highest Rated') }}</option>
                                                 <option value="votes">{{ __('Most Voted') }}</option>
-                                                <option value="newest">{{ $browseGenreType === 'tv' ? __('Latest Air Date') : __('Newest Release') }}</option>
-                                                <option value="oldest">{{ $browseGenreType === 'tv' ? __('Earliest Air Date') : __('Oldest Release') }}</option>
-                                                @if($browseGenreType !== 'tv')
+                                                <option value="newest">
+                                                    {{ $browseGenreType === 'tv' ? __('Latest Air Date') : __('Newest Release') }}
+                                                </option>
+                                                <option value="oldest">
+                                                    {{ $browseGenreType === 'tv' ? __('Earliest Air Date') : __('Oldest Release') }}
+                                                </option>
+                                                @if ($browseGenreType !== 'tv')
                                                     <option value="revenue">{{ __('Box Office') }}</option>
                                                 @endif
                                             </select>
                                         </div>
                                         <div>
-                                            <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">{{ __('Original Language') }}</label>
-                                            <select wire:model.live="originalLanguage" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                            <label
+                                                class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">{{ __('Original Language') }}</label>
+                                            <select wire:model.live="originalLanguage"
+                                                class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
                                                 <option value="">{{ __('Any Language') }}</option>
                                                 <option value="en">{{ __('English') }}</option>
                                                 <option value="fr">{{ __('French') }}</option>
@@ -351,74 +355,105 @@
                                     {{-- Row 2: Year + Rating --}}
                                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                         <div>
-                                            <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">
+                                            <label
+                                                class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">
                                                 {{ $browseGenreType === 'tv' ? __('First Air Year') : __('Release Year') }}
                                             </label>
                                             <div class="flex items-center gap-2">
-                                                <input type="number" wire:model="yearFrom" min="1900" max="{{ date('Y') + 1 }}" placeholder="{{ __('From') }}" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                                <input type="number" wire:model="yearFrom" min="1900"
+                                                    max="{{ date('Y') + 1 }}" placeholder="{{ __('From') }}"
+                                                    class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
                                                 <span class="text-gray-400 text-xs flex-shrink-0">—</span>
-                                                <input type="number" wire:model="yearTo" min="1900" max="{{ date('Y') + 1 }}" placeholder="{{ __('To') }}" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                                <input type="number" wire:model="yearTo" min="1900"
+                                                    max="{{ date('Y') + 1 }}" placeholder="{{ __('To') }}"
+                                                    class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
                                             </div>
                                         </div>
                                         <div x-data="{ r: @js($minRating) }" x-init="$watch(() => $wire.minRating, v => r = v ?? 0)">
                                             <div class="flex items-center justify-between mb-1.5">
-                                                <label class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ __('Min Rating') }}</label>
-                                                <span x-text="r > 0 ? '★ ' + parseFloat(r).toFixed(1) + '+' : '{{ __('Any') }}'" :class="r > 0 ? 'text-yellow-500 dark:text-yellow-400 font-semibold' : 'text-gray-400'" class="text-xs"></span>
+                                                <label
+                                                    class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ __('Min Rating') }}</label>
+                                                <span
+                                                    x-text="r > 0 ? '★ ' + parseFloat(r).toFixed(1) + '+' : '{{ __('Any') }}'"
+                                                    :class="r > 0 ? 'text-yellow-500 dark:text-yellow-400 font-semibold' :
+                                                        'text-gray-400'"
+                                                    class="text-xs"></span>
                                             </div>
-                                            <input type="range" x-model="r" @change="$wire.minRating = parseFloat(r)" min="0" max="10" step="0.5" class="w-full h-1.5 rounded-lg appearance-none cursor-pointer accent-primary-600 bg-gray-200 dark:bg-gray-700">
-                                            <div class="flex justify-between text-[10px] text-gray-400 mt-0.5"><span>0</span><span>5</span><span>10</span></div>
+                                            <input type="range" x-model="r"
+                                                @change="$wire.minRating = parseFloat(r)" min="0"
+                                                max="10" step="0.5"
+                                                class="w-full h-1.5 rounded-lg appearance-none cursor-pointer accent-primary-600 bg-gray-200 dark:bg-gray-700">
+                                            <div class="flex justify-between text-[10px] text-gray-400 mt-0.5">
+                                                <span>0</span><span>5</span><span>10</span>
+                                            </div>
                                         </div>
                                     </div>
 
                                     {{-- Row 3: Runtime + Vote Count --}}
                                     <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                                         <div>
-                                            <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">{{ __('Runtime (minutes)') }}</label>
+                                            <label
+                                                class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1.5">{{ __('Runtime (minutes)') }}</label>
                                             <div class="flex items-center gap-2">
-                                                <input type="number" wire:model="minRuntime" min="0" max="400" placeholder="{{ __('Min') }}" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                                <input type="number" wire:model="minRuntime" min="0"
+                                                    max="400" placeholder="{{ __('Min') }}"
+                                                    class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
                                                 <span class="text-gray-400 text-xs flex-shrink-0">—</span>
-                                                <input type="number" wire:model="maxRuntime" min="0" max="400" placeholder="{{ __('Max') }}" class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
+                                                <input type="number" wire:model="maxRuntime" min="0"
+                                                    max="400" placeholder="{{ __('Max') }}"
+                                                    class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1.5 px-2.5 focus:border-primary-500 focus:ring-primary-500">
                                             </div>
                                         </div>
                                         <div>
                                             <div class="flex items-center justify-between mb-1.5">
-                                                <label class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ __('Min Vote Count') }}</label>
-                                                @if($minVoteCount > 0)
-                                                    <span class="text-xs font-semibold text-primary-600 dark:text-primary-400">{{ number_format($minVoteCount) }}+</span>
+                                                <label
+                                                    class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ __('Min Vote Count') }}</label>
+                                                @if ($minVoteCount > 0)
+                                                    <span
+                                                        class="text-xs font-semibold text-primary-600 dark:text-primary-400">{{ number_format($minVoteCount) }}+</span>
                                                 @else
                                                     <span class="text-xs text-gray-400">{{ __('Any') }}</span>
                                                 @endif
                                             </div>
-                                            <input type="range" wire:model="minVoteCount" min="0" max="5000" step="50" class="w-full h-1.5 rounded-lg appearance-none cursor-pointer accent-primary-600 bg-gray-200 dark:bg-gray-700">
-                                            <div class="flex justify-between text-[10px] text-gray-400 mt-0.5"><span>0</span><span>2,500</span><span>5,000</span></div>
+                                            <input type="range" wire:model="minVoteCount" min="0"
+                                                max="5000" step="50"
+                                                class="w-full h-1.5 rounded-lg appearance-none cursor-pointer accent-primary-600 bg-gray-200 dark:bg-gray-700">
+                                            <div class="flex justify-between text-[10px] text-gray-400 mt-0.5">
+                                                <span>0</span><span>2,500</span><span>5,000</span>
+                                            </div>
                                         </div>
                                     </div>
 
                                     {{-- Row 4 (TV only): Show Status --}}
-                                    @if($browseGenreType === 'tv')
+                                    @if ($browseGenreType === 'tv')
                                         <div>
-                                            <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">{{ __('Show Status') }}</label>
+                                            <label
+                                                class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">{{ __('Show Status') }}</label>
                                             <div class="flex flex-wrap gap-1.5">
-                                                @foreach([0 => __('Returning'), 2 => __('In Production'), 3 => __('Ended'), 4 => __('Canceled'), 1 => __('Planned'), 5 => __('Pilot')] as $value => $label)
-                                                    <button
-                                                        wire:click="toggleTvStatus({{ $value }})"
+                                                @foreach ([0 => __('Returning'), 2 => __('In Production'), 3 => __('Ended'), 4 => __('Canceled'), 1 => __('Planned'), 5 => __('Pilot')] as $value => $label)
+                                                    <button wire:click="toggleTvStatus({{ $value }})"
                                                         @class([
                                                             'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium transition-colors border',
-                                                            'bg-primary-600 text-white border-primary-600' => in_array($value, $tvStatuses),
-                                                            'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-400 dark:hover:border-primary-600 hover:text-primary-600 dark:hover:text-primary-400' => ! in_array($value, $tvStatuses),
-                                                        ])
-                                                    >{{ $label }}</button>
+                                                            'bg-primary-600 text-white border-primary-600' => in_array(
+                                                                $value,
+                                                                $tvStatuses),
+                                                            'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-primary-400 dark:hover:border-primary-600 hover:text-primary-600 dark:hover:text-primary-400' => !in_array(
+                                                                $value,
+                                                                $tvStatuses),
+                                                        ])>{{ $label }}</button>
                                                 @endforeach
                                             </div>
                                         </div>
                                     @endif
 
                                     {{-- Row 5: Watch Providers --}}
-                                    @if(count($availableProviders) > 0)
+                                    @if (count($availableProviders) > 0)
                                         <div>
                                             <div class="flex items-center justify-between mb-2">
-                                                <label class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ __('Streaming On') }}</label>
-                                                <select wire:model.live="watchRegion" class="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1 px-2 focus:border-primary-500 focus:ring-primary-500">
+                                                <label
+                                                    class="text-xs font-medium text-gray-600 dark:text-gray-400">{{ __('Streaming On') }}</label>
+                                                <select wire:model.live="watchRegion"
+                                                    class="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-xs py-1 px-2 focus:border-primary-500 focus:ring-primary-500">
                                                     <option value="US">{{ __('US') }}</option>
                                                     <option value="GB">{{ __('UK') }}</option>
                                                     <option value="CA">{{ __('Canada') }}</option>
@@ -438,27 +473,29 @@
                                                 </select>
                                             </div>
                                             <div class="flex flex-wrap gap-2">
-                                                @foreach(array_slice($availableProviders, 0, 24) as $provider)
+                                                @foreach (array_slice($availableProviders, 0, 24) as $provider)
                                                     @php $isSelected = in_array($provider['id'], $selectedProviders); @endphp
-                                                    <button
-                                                        wire:click="toggleProvider({{ $provider['id'] }})"
-                                                        title="{{ $provider['name'] }}"
-                                                        @class([
+                                                    <button wire:click="toggleProvider({{ $provider['id'] }})"
+                                                        title="{{ $provider['name'] }}" @class([
                                                             'relative w-10 h-10 rounded-lg overflow-hidden transition-all border-2 flex-shrink-0',
                                                             'border-primary-500 ring-2 ring-primary-500/30 shadow-md' => $isSelected,
-                                                            'border-transparent hover:border-gray-300 dark:hover:border-gray-500 opacity-70 hover:opacity-100' => ! $isSelected,
-                                                        ])
-                                                    >
-                                                        @if($provider['logo'])
-                                                            <img src="{{ $provider['logo'] }}" alt="{{ $provider['name'] }}" class="w-full h-full object-cover" loading="lazy">
+                                                            'border-transparent hover:border-gray-300 dark:hover:border-gray-500 opacity-70 hover:opacity-100' => !$isSelected,
+                                                        ])>
+                                                        @if ($provider['logo'])
+                                                            <img src="{{ $provider['logo'] }}"
+                                                                alt="{{ $provider['name'] }}"
+                                                                class="w-full h-full object-cover" loading="lazy">
                                                         @else
-                                                            <div class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-[9px] font-bold text-gray-500 dark:text-gray-400 text-center leading-tight px-0.5">
+                                                            <div
+                                                                class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-[9px] font-bold text-gray-500 dark:text-gray-400 text-center leading-tight px-0.5">
                                                                 {{ Str::limit($provider['name'], 8) }}
                                                             </div>
                                                         @endif
-                                                        @if($isSelected)
-                                                            <div class="absolute inset-0 bg-primary-600/20 flex items-center justify-center">
-                                                                <x-heroicon-s-check class="w-4 h-4 text-white drop-shadow" />
+                                                        @if ($isSelected)
+                                                            <div
+                                                                class="absolute inset-0 bg-primary-600/20 flex items-center justify-center">
+                                                                <x-heroicon-s-check
+                                                                    class="w-4 h-4 text-white drop-shadow" />
                                                             </div>
                                                         @endif
                                                     </button>
@@ -470,14 +507,17 @@
                                 </div>
 
                                 {{-- Apply / Reset row --}}
-                                <div class="flex items-center justify-end gap-2 px-4 pb-4 bg-gray-50/60 dark:bg-white/[0.02]">
-                                    @if($activeFilterCount > 0)
-                                        <button wire:click="resetFilters" class="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
+                                <div
+                                    class="flex items-center justify-end gap-2 px-4 pb-4 bg-gray-50/60 dark:bg-white/[0.02]">
+                                    @if ($activeFilterCount > 0)
+                                        <button wire:click="resetFilters"
+                                            class="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors">
                                             <x-heroicon-o-x-mark class="w-3.5 h-3.5" />
                                             {{ __('Reset All') }}
                                         </button>
                                     @endif
-                                    <button wire:click="reloadBrowse" class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-primary-600 hover:bg-primary-700 text-white transition-colors">
+                                    <button wire:click="reloadBrowse"
+                                        class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium bg-primary-600 hover:bg-primary-700 text-white transition-colors">
                                         <x-heroicon-o-magnifying-glass class="w-3.5 h-3.5" />
                                         {{ __('Apply') }}
                                     </button>
@@ -485,37 +525,46 @@
                             </div>
 
                             <div class="p-4">
-                                @if($browseLoading)
+                                @if ($browseLoading)
                                     <div class="flex items-center justify-center py-10">
                                         <x-filament::loading-indicator class="h-6 w-6 text-primary-500" />
                                     </div>
                                 @elseif(count($browseResults) > 0)
                                     @php
-                                        $browseInitial   = array_slice($browseResults, 0, 10);
+                                        $browseInitial = array_slice($browseResults, 0, 10);
                                         $browseRemaining = array_slice($browseResults, 10);
                                     @endphp
                                     <div x-data="{ expanded: false }">
-                                        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-                                            @foreach($browseInitial as $item)
-                                                @include('livewire.partials.discover-card', ['item' => $item])
+                                        <div
+                                            class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                                            @foreach ($browseInitial as $item)
+                                                @include('livewire.partials.discover-card', [
+                                                    'item' => $item,
+                                                ])
                                             @endforeach
                                         </div>
-                                        @if(count($browseRemaining) > 0)
+                                        @if (count($browseRemaining) > 0)
                                             <div x-show="expanded" x-collapse>
-                                                <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 mt-3">
-                                                    @foreach($browseRemaining as $item)
-                                                        @include('livewire.partials.discover-card', ['item' => $item])
+                                                <div
+                                                    class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 mt-3">
+                                                    @foreach ($browseRemaining as $item)
+                                                        @include('livewire.partials.discover-card', [
+                                                            'item' => $item,
+                                                        ])
                                                     @endforeach
                                                 </div>
                                             </div>
-                                            <div class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 text-center">
-                                                <button
-                                                    @click="expanded = !expanded"
-                                                    class="inline-flex items-center gap-1.5 text-xs font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors"
-                                                >
-                                                    <span x-show="!expanded">{{ __('Show :n more', ['n' => count($browseRemaining)]) }}</span>
-                                                    <span x-show="expanded" style="display:none">{{ __('Show less') }}</span>
-                                                    <x-heroicon-o-chevron-down class="w-3.5 h-3.5 transition-transform duration-200" x-bind:class="{ 'rotate-180': expanded }" />
+                                            <div
+                                                class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 text-center">
+                                                <button @click="expanded = !expanded"
+                                                    class="inline-flex items-center gap-1.5 text-xs font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors">
+                                                    <span
+                                                        x-show="!expanded">{{ __('Show :n more', ['n' => count($browseRemaining)]) }}</span>
+                                                    <span x-show="expanded"
+                                                        style="display:none">{{ __('Show less') }}</span>
+                                                    <x-heroicon-o-chevron-down
+                                                        class="w-3.5 h-3.5 transition-transform duration-200"
+                                                        x-bind:class="{ 'rotate-180': expanded }" />
                                                 </button>
                                             </div>
                                         @endif
@@ -523,129 +572,139 @@
                                 @else
                                     <div class="flex flex-col items-center justify-center py-10 text-center">
                                         <x-heroicon-o-film class="w-10 h-10 text-gray-300 dark:text-gray-600" />
-                                        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ __('No results found for this genre.') }}</p>
+                                        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                                            {{ __('No results found for this genre.') }}</p>
                                     </div>
                                 @endif
                             </div>
                         </div>
-
                     @else
-
                         {{-- ── Discovery Content Sections ───────────────── --}}
                         @php
                             $discoverSections = [
                                 [
-                                    'id'        => 'trending',
-                                    'label'     => __('Trending This Week'),
-                                    'icon'      => 'heroicon-o-fire',
-                                    'iconClass' => 'text-orange-500',
-                                    'items'     => $trendingItems,
+                                    'id' => 'trending',
+                                    'label' => __('Trending This Week'),
+                                    'icon' => 'heroicon-o-fire',
+                                    'iconColor' => 'warning',
+                                    'items' => $trendingItems,
                                 ],
                                 [
-                                    'id'        => 'popular-movies',
-                                    'label'     => __('Popular Movies'),
-                                    'icon'      => 'heroicon-o-film',
-                                    'iconClass' => 'text-blue-500',
-                                    'items'     => $popularMovies,
+                                    'id' => 'popular-movies',
+                                    'label' => __('Popular Movies'),
+                                    'icon' => 'heroicon-o-film',
+                                    'iconColor' => 'info',
+                                    'items' => $popularMovies,
                                 ],
                                 [
-                                    'id'        => 'popular-tv',
-                                    'label'     => __('Popular TV'),
-                                    'icon'      => 'heroicon-o-tv',
-                                    'iconClass' => 'text-purple-500',
-                                    'items'     => $popularTv,
+                                    'id' => 'popular-tv',
+                                    'label' => __('Popular TV'),
+                                    'icon' => 'heroicon-o-tv',
+                                    'iconColor' => 'primary',
+                                    'items' => $popularTv,
                                 ],
                                 [
-                                    'id'        => 'upcoming-movies',
-                                    'label'     => __('Upcoming Movies'),
-                                    'icon'      => 'heroicon-o-calendar-days',
-                                    'iconClass' => 'text-green-500',
-                                    'items'     => $upcomingMovies,
+                                    'id' => 'upcoming-movies',
+                                    'label' => __('Upcoming Movies'),
+                                    'icon' => 'heroicon-o-calendar-days',
+                                    'iconColor' => 'success',
+                                    'items' => $upcomingMovies,
                                 ],
                             ];
                         @endphp
 
-                        @foreach($discoverSections as $section)
-                            @if(count($section['items']) > 0)
+                        @foreach ($discoverSections as $section)
+                            @if (count($section['items']) > 0)
                                 @php
-                                    $initialItems   = array_slice($section['items'], 0, 10);
+                                    $initialItems = array_slice($section['items'], 0, 10);
                                     $remainingItems = array_slice($section['items'], 10);
                                 @endphp
 
-                                <x-filament::section heading-tag="h3">
-                                    <x-slot name="heading">
-                                        <span class="flex items-center gap-2">
-                                            <x-dynamic-component :component="$section['icon']" class="w-4 h-4 flex-shrink-0 {{ $section['iconClass'] }}" />
-                                            {{ $section['label'] }}
-                                        </span>
-                                    </x-slot>
-
+                                <x-filament::section :collapsible="true" compact heading="{{ $section['label'] }}"
+                                    icon="{{ $section['icon'] }}" icon-color="{{ $section['iconColor'] }}">
                                     <x-slot name="afterHeader">
-                                        <x-filament::badge color="gray">{{ count($section['items']) }}</x-filament::badge>
+                                        <x-filament::badge
+                                            color="gray">{{ count($section['items']) }}</x-filament::badge>
                                     </x-slot>
 
                                     <div x-data="{ expanded: false }">
-                                        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
-                                            @foreach($initialItems as $item)
-                                                <div
-                                                    wire:click="requestFromDiscover({{ $item['tmdb_id'] }}, '{{ $item['media_type'] }}')"
+                                        <div
+                                            class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">
+                                            @foreach ($initialItems as $item)
+                                                <div wire:click="requestFromDiscover({{ $item['tmdb_id'] }}, '{{ $item['media_type'] }}')"
                                                     wire:loading.class="opacity-50 pointer-events-none"
                                                     wire:target="requestFromDiscover"
-                                                    class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800"
-                                                >
+                                                    class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800">
                                                     <div class="relative aspect-[2/3]">
-                                                        @if(! empty($item['poster_url']))
-                                                            <img src="{{ $item['poster_url'] }}" alt="{{ $item['title'] }}" class="w-full h-full object-cover" loading="lazy">
+                                                        @if (!empty($item['poster_url']))
+                                                            <img src="{{ $item['poster_url'] }}"
+                                                                alt="{{ $item['title'] }}"
+                                                                class="w-full h-full object-cover" loading="lazy">
                                                         @else
-                                                            <div class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-                                                                @if($item['media_type'] === 'tv')
-                                                                    <x-heroicon-o-tv class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                            <div
+                                                                class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                                                                @if ($item['media_type'] === 'tv')
+                                                                    <x-heroicon-o-tv
+                                                                        class="w-10 h-10 text-gray-400 dark:text-gray-500" />
                                                                 @else
-                                                                    <x-heroicon-o-film class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                                    <x-heroicon-o-film
+                                                                        class="w-10 h-10 text-gray-400 dark:text-gray-500" />
                                                                 @endif
                                                             </div>
                                                         @endif
-                                                        <span class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
+                                                        <span
+                                                            class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
                                                             {{ $item['media_type'] === 'tv' ? __('TV') : __('Movie') }}
                                                         </span>
-                                                        @if(! empty($item['isDownloaded']))
-                                                            <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
+                                                        @if (!empty($item['isDownloaded']))
+                                                            <span
+                                                                class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
                                                                 <x-heroicon-s-check class="w-3.5 h-3.5 text-white" />
                                                             </span>
-                                                        @elseif(! empty($item['existsInLibrary']))
-                                                            <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
-                                                                <x-heroicon-s-bookmark class="w-3.5 h-3.5 text-white" />
+                                                        @elseif(!empty($item['existsInLibrary']))
+                                                            <span
+                                                                class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
+                                                                <x-heroicon-s-bookmark
+                                                                    class="w-3.5 h-3.5 text-white" />
                                                             </span>
                                                         @endif
-                                                        @if(! empty($item['vote_average']))
-                                                            <span class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
+                                                        @if (!empty($item['vote_average']))
+                                                            <span
+                                                                class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
                                                                 <x-heroicon-s-star class="w-3 h-3" />
                                                                 {{ $item['vote_average'] }}
                                                             </span>
                                                         @endif
-                                                        <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
-                                                            <h3 class="text-white font-semibold text-sm leading-tight line-clamp-2">
+                                                        <div
+                                                            class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
+                                                            <h3
+                                                                class="text-white font-semibold text-sm leading-tight line-clamp-2">
                                                                 {{ $item['title'] }}
-                                                                @if(! empty($item['year']))
-                                                                    <span class="text-white/60 font-normal">({{ $item['year'] }})</span>
+                                                                @if (!empty($item['year']))
+                                                                    <span
+                                                                        class="text-white/60 font-normal">({{ $item['year'] }})</span>
                                                                 @endif
                                                             </h3>
-                                                            @if(! empty($item['overview']))
-                                                                <p class="text-white/55 text-xs line-clamp-2">{{ $item['overview'] }}</p>
+                                                            @if (!empty($item['overview']))
+                                                                <p class="text-white/55 text-xs line-clamp-2">
+                                                                    {{ $item['overview'] }}</p>
                                                             @endif
                                                             <div class="mt-1.5">
-                                                                @if(! empty($item['isDownloaded']))
-                                                                    <span class="flex items-center gap-1 text-green-400 text-xs font-medium">
+                                                                @if (!empty($item['isDownloaded']))
+                                                                    <span
+                                                                        class="flex items-center gap-1 text-green-400 text-xs font-medium">
                                                                         <x-heroicon-s-check class="w-3.5 h-3.5" />
                                                                         {{ __('Downloaded') }}
                                                                     </span>
-                                                                @elseif(! empty($item['existsInLibrary']))
-                                                                    <span class="flex items-center gap-1 text-amber-400 text-xs font-medium">
+                                                                @elseif(!empty($item['existsInLibrary']))
+                                                                    <span
+                                                                        class="flex items-center gap-1 text-amber-400 text-xs font-medium">
                                                                         <x-heroicon-s-bookmark class="w-3.5 h-3.5" />
                                                                         {{ __('Monitored') }}
                                                                     </span>
                                                                 @else
-                                                                    <span class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
+                                                                    <span
+                                                                        class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
                                                                         {{ $item['media_type'] === 'tv' ? __('Select Seasons') : __('Request Movie') }}
                                                                     </span>
                                                                 @endif
@@ -657,69 +716,89 @@
                                         </div>
 
                                         {{-- Expandable remaining items --}}
-                                        @if(count($remainingItems) > 0)
+                                        @if (count($remainingItems) > 0)
                                             <div x-show="expanded" x-collapse>
-                                                <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 mt-3">
-                                                    @foreach($remainingItems as $item)
-                                                        <div
-                                                            wire:click="requestFromDiscover({{ $item['tmdb_id'] }}, '{{ $item['media_type'] }}')"
+                                                <div
+                                                    class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 mt-3">
+                                                    @foreach ($remainingItems as $item)
+                                                        <div wire:click="requestFromDiscover({{ $item['tmdb_id'] }}, '{{ $item['media_type'] }}')"
                                                             wire:loading.class="opacity-50 pointer-events-none"
                                                             wire:target="requestFromDiscover"
-                                                            class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800"
-                                                        >
+                                                            class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800">
                                                             <div class="relative aspect-[2/3]">
-                                                                @if(! empty($item['poster_url']))
-                                                                    <img src="{{ $item['poster_url'] }}" alt="{{ $item['title'] }}" class="w-full h-full object-cover" loading="lazy">
+                                                                @if (!empty($item['poster_url']))
+                                                                    <img src="{{ $item['poster_url'] }}"
+                                                                        alt="{{ $item['title'] }}"
+                                                                        class="w-full h-full object-cover"
+                                                                        loading="lazy">
                                                                 @else
-                                                                    <div class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-                                                                        @if($item['media_type'] === 'tv')
-                                                                            <x-heroicon-o-tv class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                                    <div
+                                                                        class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                                                                        @if ($item['media_type'] === 'tv')
+                                                                            <x-heroicon-o-tv
+                                                                                class="w-10 h-10 text-gray-400 dark:text-gray-500" />
                                                                         @else
-                                                                            <x-heroicon-o-film class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                                                                            <x-heroicon-o-film
+                                                                                class="w-10 h-10 text-gray-400 dark:text-gray-500" />
                                                                         @endif
                                                                     </div>
                                                                 @endif
-                                                                <span class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
+                                                                <span
+                                                                    class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
                                                                     {{ $item['media_type'] === 'tv' ? __('TV') : __('Movie') }}
                                                                 </span>
-                                                                @if(! empty($item['isDownloaded']))
-                                                                    <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
-                                                                        <x-heroicon-s-check class="w-3.5 h-3.5 text-white" />
+                                                                @if (!empty($item['isDownloaded']))
+                                                                    <span
+                                                                        class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
+                                                                        <x-heroicon-s-check
+                                                                            class="w-3.5 h-3.5 text-white" />
                                                                     </span>
-                                                                @elseif(! empty($item['existsInLibrary']))
-                                                                    <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
-                                                                        <x-heroicon-s-bookmark class="w-3.5 h-3.5 text-white" />
+                                                                @elseif(!empty($item['existsInLibrary']))
+                                                                    <span
+                                                                        class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
+                                                                        <x-heroicon-s-bookmark
+                                                                            class="w-3.5 h-3.5 text-white" />
                                                                     </span>
                                                                 @endif
-                                                                @if(! empty($item['vote_average']))
-                                                                    <span class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
+                                                                @if (!empty($item['vote_average']))
+                                                                    <span
+                                                                        class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
                                                                         <x-heroicon-s-star class="w-3 h-3" />
                                                                         {{ $item['vote_average'] }}
                                                                     </span>
                                                                 @endif
-                                                                <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
-                                                                    <h3 class="text-white font-semibold text-sm leading-tight line-clamp-2">
+                                                                <div
+                                                                    class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
+                                                                    <h3
+                                                                        class="text-white font-semibold text-sm leading-tight line-clamp-2">
                                                                         {{ $item['title'] }}
-                                                                        @if(! empty($item['year']))
-                                                                            <span class="text-white/60 font-normal">({{ $item['year'] }})</span>
+                                                                        @if (!empty($item['year']))
+                                                                            <span
+                                                                                class="text-white/60 font-normal">({{ $item['year'] }})</span>
                                                                         @endif
                                                                     </h3>
-                                                                    @if(! empty($item['overview']))
-                                                                        <p class="text-white/55 text-xs line-clamp-2">{{ $item['overview'] }}</p>
+                                                                    @if (!empty($item['overview']))
+                                                                        <p class="text-white/55 text-xs line-clamp-2">
+                                                                            {{ $item['overview'] }}</p>
                                                                     @endif
                                                                     <div class="mt-1.5">
-                                                                        @if(! empty($item['isDownloaded']))
-                                                                            <span class="flex items-center gap-1 text-green-400 text-xs font-medium">
-                                                                                <x-heroicon-s-check class="w-3.5 h-3.5" />
+                                                                        @if (!empty($item['isDownloaded']))
+                                                                            <span
+                                                                                class="flex items-center gap-1 text-green-400 text-xs font-medium">
+                                                                                <x-heroicon-s-check
+                                                                                    class="w-3.5 h-3.5" />
                                                                                 {{ __('Downloaded') }}
                                                                             </span>
-                                                                        @elseif(! empty($item['existsInLibrary']))
-                                                                            <span class="flex items-center gap-1 text-amber-400 text-xs font-medium">
-                                                                                <x-heroicon-s-bookmark class="w-3.5 h-3.5" />
+                                                                        @elseif(!empty($item['existsInLibrary']))
+                                                                            <span
+                                                                                class="flex items-center gap-1 text-amber-400 text-xs font-medium">
+                                                                                <x-heroicon-s-bookmark
+                                                                                    class="w-3.5 h-3.5" />
                                                                                 {{ __('Monitored') }}
                                                                             </span>
                                                                         @else
-                                                                            <span class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
+                                                                            <span
+                                                                                class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
                                                                                 {{ $item['media_type'] === 'tv' ? __('Select Seasons') : __('Request Movie') }}
                                                                             </span>
                                                                         @endif
@@ -732,14 +811,17 @@
                                             </div>
 
                                             {{-- Show more / Show less footer --}}
-                                            <div class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 text-center">
-                                                <button
-                                                    @click="expanded = !expanded"
-                                                    class="inline-flex items-center gap-1.5 text-xs font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors"
-                                                >
-                                                    <span x-show="!expanded">{{ __('Show :n more', ['n' => count($remainingItems)]) }}</span>
-                                                    <span x-show="expanded" style="display:none">{{ __('Show less') }}</span>
-                                                    <x-heroicon-o-chevron-down class="w-3.5 h-3.5 transition-transform duration-200" x-bind:class="{ 'rotate-180': expanded }" />
+                                            <div
+                                                class="mt-4 pt-3 border-t border-gray-100 dark:border-gray-800 text-center">
+                                                <button @click="expanded = !expanded"
+                                                    class="inline-flex items-center gap-1.5 text-xs font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors">
+                                                    <span
+                                                        x-show="!expanded">{{ __('Show :n more', ['n' => count($remainingItems)]) }}</span>
+                                                    <span x-show="expanded"
+                                                        style="display:none">{{ __('Show less') }}</span>
+                                                    <x-heroicon-o-chevron-down
+                                                        class="w-3.5 h-3.5 transition-transform duration-200"
+                                                        x-bind:class="{ 'rotate-180': expanded }" />
                                                 </button>
                                             </div>
                                         @endif
@@ -751,16 +833,15 @@
                     @endif
 
                 @endif
-
-            @elseif(! $tmdbConfigured && strlen(trim($searchTerm)) < 2)
-
+            @elseif(!$tmdbConfigured && strlen(trim($searchTerm)) < 2)
                 {{-- No TMDB: search prompt --}}
                 <div class="flex flex-col items-center justify-center py-12 text-center">
                     <div class="flex gap-3 text-gray-300 dark:text-gray-600">
                         <x-heroicon-o-tv class="w-10 h-10" />
                         <x-heroicon-o-film class="w-10 h-10" />
                     </div>
-                    <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">{{ __('Search movies & TV series') }}</h4>
+                    <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {{ __('Search movies & TV series') }}</h4>
                     <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
                         {{ __('Enter a title to search across your Sonarr and Radarr servers.') }}
                     </p>
@@ -771,15 +852,16 @@
         </div>
 
         {{-- ── Guest Download Queue ─────────────────────────────────────── --}}
-        @if($queue && $guestMode)
+        @if ($queue && $guestMode)
             <div class="mt-6">
                 <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center gap-2">
                     <x-heroicon-o-arrow-down-tray class="w-4 h-4" />
                     {{ __('Download Queue') }}
                 </h3>
                 <div class="space-y-2">
-                    @foreach($queue as $item)
-                        <div class="bg-white dark:bg-gray-800 rounded-md border border-gray-200 dark:border-gray-700 p-3">
+                    @foreach ($queue as $item)
+                        <div
+                            class="bg-white dark:bg-gray-800 rounded-md border border-gray-200 dark:border-gray-700 p-3">
                             <div class="flex items-center justify-between">
                                 <div class="flex-1 min-w-0">
                                     <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
@@ -787,10 +869,10 @@
                                     </p>
                                     <p class="text-xs text-gray-500 dark:text-gray-400">
                                         {{ $item['status'] ?? '' }}
-                                        @if($item['timeLeft'] ?? null)
+                                        @if ($item['timeLeft'] ?? null)
                                             · {{ __(':time left', ['time' => $item['timeLeft']]) }}
                                         @endif
-                                        @if(! empty($item['server']))
+                                        @if (!empty($item['server']))
                                             · {{ $item['server'] }}
                                         @endif
                                     </p>
@@ -800,25 +882,21 @@
                                 </span>
                             </div>
                             <div class="mt-2 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5 overflow-hidden">
-                                <div
-                                    class="bg-primary-600 h-1.5 rounded-full transition-all duration-300"
-                                    style="width: {{ $item['progress'] ?? 0 }}%"
-                                ></div>
+                                <div class="bg-primary-600 h-1.5 rounded-full transition-all duration-300"
+                                    style="width: {{ $item['progress'] ?? 0 }}%"></div>
                             </div>
                         </div>
                     @endforeach
                 </div>
             </div>
         @endif
-
     @else
-
         <div class="flex flex-col items-center justify-center py-12 text-center">
             <x-heroicon-o-magnifying-glass-circle class="w-12 h-12 text-gray-300 dark:text-gray-600" />
             <h4 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">
                 {{ $guestMode ? __('No integrations available') : __('No Sonarr or Radarr integrations configured') }}
             </h4>
-            @unless($guestMode)
+            @unless ($guestMode)
                 <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
                     {{ __('Add a Sonarr or Radarr integration in Settings to start requesting content.') }}
                 </p>
@@ -828,100 +906,105 @@
     @endif
 
     {{-- ── Series / Movie Detail Slide-over ──────────────────────────────── --}}
-    <div
-        x-data="{ open: @js($showDetail) }"
-        x-init="$watch('$wire.showDetail', v => { open = v; if (v) $wire.call('loadDetailEpisodes') })"
-        @keydown.escape.window="if (open) $wire.call('closeDetail')"
-        class="fixed inset-0 z-50 pointer-events-none"
-        x-cloak
-    >
-        <div
-            x-show="open"
-            x-transition:enter="transition ease-out duration-200"
-            x-transition:enter-start="opacity-0"
-            x-transition:enter-end="opacity-100"
-            x-transition:leave="transition ease-in duration-150"
-            x-transition:leave-start="opacity-100"
-            x-transition:leave-end="opacity-0"
-            @click="$wire.call('closeDetail')"
-            class="absolute inset-0 bg-black/50 pointer-events-auto"
-            style="display: none;"
-        ></div>
+    <div x-data="{ open: @js($showDetail) }" x-init="$watch('$wire.showDetail', v => { open = v; if (v) $wire.call('loadDetailEpisodes') })" @keydown.escape.window="if (open) $wire.call('closeDetail')"
+        class="fixed inset-0 z-50 pointer-events-none" x-cloak>
+        <div x-show="open" x-transition:enter="transition ease-out duration-200"
+            x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
+            x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100"
+            x-transition:leave-end="opacity-0" @click="$wire.call('closeDetail')"
+            class="absolute inset-0 bg-black/50 pointer-events-auto" style="display: none;"></div>
 
-        <div
-            x-show="open"
-            x-transition:enter="transition ease-out duration-300 transform"
-            x-transition:enter-start="translate-x-full"
-            x-transition:enter-end="translate-x-0"
-            x-transition:leave="transition ease-in duration-200 transform"
-            x-transition:leave-start="translate-x-0"
+        <div x-show="open" x-transition:enter="transition ease-out duration-300 transform"
+            x-transition:enter-start="translate-x-full" x-transition:enter-end="translate-x-0"
+            x-transition:leave="transition ease-in duration-200 transform" x-transition:leave-start="translate-x-0"
             x-transition:leave-end="translate-x-full"
             class="absolute right-0 inset-y-0 w-full sm:max-w-lg bg-white dark:bg-gray-900 shadow-2xl flex flex-col pointer-events-auto"
-            style="display: none;"
-        >
-            @if($detailResult)
+            style="display: none;">
+            @if ($detailResult)
                 @php
                     $detailIsSonarr = ($detailResult['integrationType'] ?? '') === 'sonarr';
-                    $detailInLibrary = ! empty($detailResult['existsInLibrary']);
+                    $detailInLibrary = !empty($detailResult['existsInLibrary']);
 
                     // Use per-episode status from Sonarr /episode API when available —
                     // this is authoritative; the lookup's statistics may be stale or absent.
-                    if ($detailIsSonarr && ! empty($detailSonarrEpisodeStatus)) {
-                        $sonarrFileCount = collect($detailSonarrEpisodeStatus)
-                            ->flatMap(fn ($eps) => $eps)
-                            ->filter()
-                            ->count();
-                        $detailIsDownloaded = $detailInLibrary && $sonarrFileCount > 0;
-                    } else {
-                        $detailIsDownloaded = $detailInLibrary && (
-                            $detailIsSonarr
-                                ? ($detailResult['episodeFileCount'] ?? 0) > 0
-                                : ($detailResult['hasFile'] ?? false)
-                        );
+if ($detailIsSonarr && !empty($detailSonarrEpisodeStatus)) {
+    $sonarrFileCount = collect($detailSonarrEpisodeStatus)
+        ->flatMap(fn($eps) => $eps)
+        ->filter()
+        ->count();
+    $detailIsDownloaded = $detailInLibrary && $sonarrFileCount > 0;
+} else {
+    $detailIsDownloaded =
+        $detailInLibrary &&
+        ($detailIsSonarr
+            ? ($detailResult['episodeFileCount'] ?? 0) > 0
+            : $detailResult['hasFile'] ?? false);
                     }
                 @endphp
                 <div class="relative flex-shrink-0">
-                    @if(! empty($detailResult['fanart']))
+                    @if (!empty($detailResult['fanart']))
                         <div class="relative h-44 overflow-hidden">
-                            <img src="{{ $detailResult['fanart'] }}" alt="" class="w-full h-full object-cover">
-                            <div class="absolute inset-0 bg-gradient-to-t from-gray-900 via-gray-900/60 to-gray-900/10"></div>
+                            <img src="{{ $detailResult['fanart'] }}" alt=""
+                                class="w-full h-full object-cover">
+                            <div
+                                class="absolute inset-0 bg-gradient-to-t from-gray-900 via-gray-900/60 to-gray-900/10">
+                            </div>
                             <div class="absolute bottom-0 left-0 right-0 px-4 pb-3 pr-12">
-                                <h2 class="text-white font-bold text-base leading-snug line-clamp-2">{{ $detailResult['title'] ?? '' }}</h2>
+                                <h2 class="text-white font-bold text-base leading-snug line-clamp-2">
+                                    {{ $detailResult['title'] ?? '' }}</h2>
                                 <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1">
-                                    @if(! empty($detailResult['year'])) <span class="text-white/60 text-xs">{{ $detailResult['year'] }}</span> @endif
-                                    @if(! empty($detailResult['certification'])) <span class="px-1.5 text-xs border border-white/30 text-white/70 rounded leading-5">{{ $detailResult['certification'] }}</span> @endif
-                                    @if(! empty($detailResult['status'])) <span class="text-white/60 text-xs">{{ ucfirst($detailResult['status']) }}</span> @endif
+                                    @if (!empty($detailResult['year']))
+                                        <span class="text-white/60 text-xs">{{ $detailResult['year'] }}</span>
+                                    @endif
+                                    @if (!empty($detailResult['certification']))
+                                        <span
+                                            class="px-1.5 text-xs border border-white/30 text-white/70 rounded leading-5">{{ $detailResult['certification'] }}</span>
+                                    @endif
+                                    @if (!empty($detailResult['status']))
+                                        <span
+                                            class="text-white/60 text-xs">{{ ucfirst($detailResult['status']) }}</span>
+                                    @endif
                                 </div>
                             </div>
                         </div>
                     @else
                         <div class="flex items-center px-4 py-3 border-b border-gray-200 dark:border-gray-700 pr-12">
                             <div class="min-w-0 flex-1">
-                                <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">{{ $detailResult['title'] ?? '' }}</h2>
+                                <h2 class="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">
+                                    {{ $detailResult['title'] ?? '' }}</h2>
                                 <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-0.5">
-                                    @if(! empty($detailResult['year'])) <span class="text-xs text-gray-500 dark:text-gray-400">{{ $detailResult['year'] }}</span> @endif
-                                    @if(! empty($detailResult['certification'])) <span class="px-1.5 text-xs border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 rounded leading-5">{{ $detailResult['certification'] }}</span> @endif
-                                    @if(! empty($detailResult['status'])) <span class="text-xs text-gray-500 dark:text-gray-400">{{ ucfirst($detailResult['status']) }}</span> @endif
+                                    @if (!empty($detailResult['year']))
+                                        <span
+                                            class="text-xs text-gray-500 dark:text-gray-400">{{ $detailResult['year'] }}</span>
+                                    @endif
+                                    @if (!empty($detailResult['certification']))
+                                        <span
+                                            class="px-1.5 text-xs border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 rounded leading-5">{{ $detailResult['certification'] }}</span>
+                                    @endif
+                                    @if (!empty($detailResult['status']))
+                                        <span
+                                            class="text-xs text-gray-500 dark:text-gray-400">{{ ucfirst($detailResult['status']) }}</span>
+                                    @endif
                                 </div>
                             </div>
                         </div>
                     @endif
-                    <button
-                        wire:click="closeDetail"
+                    <button wire:click="closeDetail"
                         class="absolute top-2.5 right-3 z-10 p-1.5 rounded-full bg-black/40 hover:bg-black/60 text-white focus:outline-none focus:ring-2 focus:ring-primary-500 transition-colors"
-                        aria-label="{{ __('Close') }}"
-                    >
+                        aria-label="{{ __('Close') }}">
                         <x-heroicon-o-x-mark class="w-4 h-4" />
                     </button>
                 </div>
 
                 <div class="flex-1 overflow-y-auto">
                     <div class="flex gap-3 px-4 py-4">
-                        @if(! empty($detailResult['poster']))
-                            <img src="{{ $detailResult['poster'] }}" alt="{{ $detailResult['title'] ?? '' }}" class="w-24 flex-shrink-0 rounded-md object-cover shadow-lg self-start">
+                        @if (!empty($detailResult['poster']))
+                            <img src="{{ $detailResult['poster'] }}" alt="{{ $detailResult['title'] ?? '' }}"
+                                class="w-24 flex-shrink-0 rounded-md object-cover shadow-lg self-start">
                         @else
-                            <div class="w-24 aspect-[2/3] flex-shrink-0 rounded-md bg-gray-200 dark:bg-gray-700 flex items-center justify-center self-start">
-                                @if($this->detailIntegration?->isSonarr())
+                            <div
+                                class="w-24 aspect-[2/3] flex-shrink-0 rounded-md bg-gray-200 dark:bg-gray-700 flex items-center justify-center self-start">
+                                @if ($this->detailIntegration?->isSonarr())
                                     <x-heroicon-o-tv class="w-8 h-8 text-gray-400 dark:text-gray-500" />
                                 @else
                                     <x-heroicon-o-film class="w-8 h-8 text-gray-400 dark:text-gray-500" />
@@ -929,144 +1012,186 @@
                             </div>
                         @endif
                         <div class="flex-1 min-w-0 space-y-1.5 pt-0.5">
-                            @if(! empty($detailResult['rating']))
+                            @if (!empty($detailResult['rating']))
                                 <div class="flex items-center gap-1.5">
                                     <x-heroicon-s-star class="w-4 h-4 text-yellow-400 flex-shrink-0" />
-                                    <span class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ $detailResult['rating']['value'] }}</span>
-                                    <span class="text-xs font-semibold text-gray-400 uppercase tracking-wide">{{ strtoupper($detailResult['rating']['source']) }}</span>
-                                    @if(! empty($detailResult['rating']['votes'])) <span class="text-xs text-gray-400">({{ number_format($detailResult['rating']['votes']) }})</span> @endif
+                                    <span
+                                        class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ $detailResult['rating']['value'] }}</span>
+                                    <span
+                                        class="text-xs font-semibold text-gray-400 uppercase tracking-wide">{{ strtoupper($detailResult['rating']['source']) }}</span>
+                                    @if (!empty($detailResult['rating']['votes']))
+                                        <span
+                                            class="text-xs text-gray-400">({{ number_format($detailResult['rating']['votes']) }})</span>
+                                    @endif
                                 </div>
                             @endif
-                            @if(! empty($detailResult['network']))
+                            @if (!empty($detailResult['network']))
                                 <p class="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
                                     <x-heroicon-o-building-office-2 class="w-3.5 h-3.5 flex-shrink-0" />
                                     {{ $detailResult['network'] }}
                                 </p>
                             @endif
-                            @if(! empty($detailResult['genres'])) <p class="text-xs text-gray-500 dark:text-gray-400">{{ implode(' · ', array_slice($detailResult['genres'], 0, 4)) }}</p> @endif
-                            @if(! empty($detailResult['runtime']))
+                            @if (!empty($detailResult['genres']))
+                                <p class="text-xs text-gray-500 dark:text-gray-400">
+                                    {{ implode(' · ', array_slice($detailResult['genres'], 0, 4)) }}</p>
+                            @endif
+                            @if (!empty($detailResult['runtime']))
                                 <p class="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
                                     <x-heroicon-o-clock class="w-3.5 h-3.5 flex-shrink-0" />
                                     {{ $detailResult['runtime'] }}m
                                 </p>
                             @endif
-                            @if($detailIsDownloaded)
+                            @if ($detailIsDownloaded)
                                 @php
-                                    if ($detailIsSonarr && ! empty($detailSonarrEpisodeStatus)) {
-                                        $epFileCount  = collect($detailSonarrEpisodeStatus)->flatMap(fn ($e) => $e)->filter()->count();
-                                        $epTotalCount = collect($detailSonarrEpisodeStatus)->flatMap(fn ($e) => $e)->count();
+                                    if ($detailIsSonarr && !empty($detailSonarrEpisodeStatus)) {
+                                        $epFileCount = collect($detailSonarrEpisodeStatus)
+                                            ->flatMap(fn($e) => $e)
+                                            ->filter()
+                                            ->count();
+                                        $epTotalCount = collect($detailSonarrEpisodeStatus)
+                                            ->flatMap(fn($e) => $e)
+                                            ->count();
                                     } else {
-                                        $epFileCount  = (int) ($detailResult['episodeFileCount'] ?? 0);
+                                        $epFileCount = (int) ($detailResult['episodeFileCount'] ?? 0);
                                         $epTotalCount = (int) ($detailResult['totalEpisodeCount'] ?? 0);
                                     }
                                 @endphp
-                                <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded bg-success-600 text-white">
-                                    <x-heroicon-o-check class="w-3 h-3" />
-                                    @if($detailIsSonarr && $epTotalCount > 0)
+                                <x-filament::badge color="success" icon="heroicon-o-check">
+                                    @if ($detailIsSonarr && $epTotalCount > 0)
                                         {{ $epFileCount }}/{{ $epTotalCount }} {{ __('eps downloaded') }}
                                     @else
                                         {{ __('Downloaded') }}
                                     @endif
-                                </span>
+                                </x-filament::badge>
                             @endif
-                            @if($detailInLibrary && ($detailIsSonarr || ! $detailIsDownloaded))
-                                <span class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold rounded bg-amber-500 text-white">
-                                    <x-heroicon-s-bookmark class="w-3 h-3" />
+                            @if ($detailInLibrary && ($detailIsSonarr || !$detailIsDownloaded))
+                                <x-filament::badge color="warning" icon="heroicon-s-bookmark">
                                     {{ __('Monitored') }}
-                                </span>
+                                </x-filament::badge>
                             @endif
                         </div>
                     </div>
 
-                    @if(! empty($detailResult['overview']))
+                    @if (!empty($detailResult['overview']))
                         <div class="px-4 pb-4 -mt-1">
-                            <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{{ $detailResult['overview'] }}</p>
+                            <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                                {{ $detailResult['overview'] }}</p>
                         </div>
                     @endif
 
                     <div class="px-4 space-y-4 pb-4">
                         {{-- Interactive Search (admin-only, library items only; or any Sonarr item when doing episode-level search) --}}
-                        @if(! $guestMode && ($detailInLibrary || ! empty($detailReleasesLabel)) && ($this->detailIntegration?->isSonarr() || $this->detailIntegration?->isRadarr()))
-                            <div
-                                x-data="{ open: @js(! empty($detailReleases) || $releasesLoading) }"
-                                x-effect="if ($wire.detailReleasesLabel) { open = true; }"
-                                class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
-                            >
+                        @if (
+                            !$guestMode &&
+                                ($detailInLibrary || !empty($detailReleasesLabel)) &&
+                                ($this->detailIntegration?->isSonarr() || $this->detailIntegration?->isRadarr()))
+                            <div x-data="{ open: @js(!empty($detailReleases) || $releasesLoading) }" x-effect="if ($wire.detailReleasesLabel) { open = true; }"
+                                class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
                                 <button
                                     @click="open = !open; if (open && @js(empty($detailReleases)) && !@js($releasesLoading)) $wire.call('loadDetailReleases')"
                                     type="button"
-                                    class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
-                                >
-                                    <x-heroicon-m-chevron-right class="w-4 h-4 flex-shrink-0 text-gray-400 transition-transform duration-200" x-bind:class="{ 'rotate-90': open }" />
+                                    class="w-full flex items-center gap-2 px-3 py-2.5 text-left hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors">
+                                    <x-heroicon-m-chevron-right
+                                        class="w-4 h-4 flex-shrink-0 text-gray-400 transition-transform duration-200"
+                                        x-bind:class="{ 'rotate-90': open }" />
                                     <span class="flex-1 text-sm font-semibold text-gray-900 dark:text-gray-100">
-                                        {{ __('Interactive Search') }}{{ $detailReleasesLabel ? ' — '.$detailReleasesLabel : '' }}
+                                        {{ __('Interactive Search') }}{{ $detailReleasesLabel ? ' — ' . $detailReleasesLabel : '' }}
                                     </span>
-                                    <span wire:loading wire:target="loadDetailReleases,loadEpisodeReleases"><x-filament::loading-indicator class="h-3 w-3 text-primary-500" /></span>
-                                    @if(! empty($detailReleases))
-                                        <span wire:loading.remove wire:target="loadDetailReleases,loadEpisodeReleases" class="text-xs text-gray-400 dark:text-gray-500">{{ count($detailReleases) }}</span>
+                                    <span wire:loading
+                                        wire:target="loadDetailReleases,loadEpisodeReleases"><x-filament::loading-indicator
+                                            class="h-3 w-3 text-primary-500" /></span>
+                                    @if (!empty($detailReleases))
+                                        <span wire:loading.remove wire:target="loadDetailReleases,loadEpisodeReleases"
+                                            class="text-xs text-gray-400 dark:text-gray-500">{{ count($detailReleases) }}</span>
                                     @endif
                                 </button>
                                 <div x-show="open" x-collapse>
                                     <div class="border-t border-gray-200 dark:border-gray-700">
-                                        <div wire:loading wire:target="loadDetailReleases,loadEpisodeReleases" class="py-4 flex justify-center">
+                                        <div wire:loading wire:target="loadDetailReleases,loadEpisodeReleases"
+                                            class="py-4 ml-2 flex justify-center">
                                             <x-filament::loading-indicator class="h-4 w-4 text-primary-500" />
                                         </div>
                                         <div wire:loading.remove wire:target="loadDetailReleases,loadEpisodeReleases">
-                                            @if(! empty($detailReleases))
-                                                <div class="divide-y divide-gray-100 dark:divide-gray-800 max-h-72 overflow-y-auto">
-                                                    @foreach($detailReleases as $release)
+                                            @if (!empty($detailReleases))
+                                                <div
+                                                    class="divide-y divide-gray-100 dark:divide-gray-800 max-h-72 overflow-y-auto">
+                                                    @foreach ($detailReleases as $release)
                                                         @php
                                                             $releaseBytes = (int) ($release['size'] ?? 0);
-                                                            $releaseSize = match(true) {
-                                                                $releaseBytes >= 1_073_741_824 => number_format($releaseBytes / 1_073_741_824, 2).' GB',
-                                                                $releaseBytes >= 1_048_576     => number_format($releaseBytes / 1_048_576, 2).' MB',
-                                                                $releaseBytes > 0              => number_format($releaseBytes / 1_024, 2).' KB',
-                                                                default                        => '–',
+                                                            $releaseSize = match (true) {
+                                                                $releaseBytes >= 1_073_741_824 => number_format(
+                                                                    $releaseBytes / 1_073_741_824,
+                                                                    2,
+                                                                ) . ' GB',
+                                                                $releaseBytes >= 1_048_576 => number_format(
+                                                                    $releaseBytes / 1_048_576,
+                                                                    2,
+                                                                ) . ' MB',
+                                                                $releaseBytes > 0 => number_format(
+                                                                    $releaseBytes / 1_024,
+                                                                    2,
+                                                                ) . ' KB',
+                                                                default => '–',
                                                             };
-                                                            $rejectionReasons = implode('; ', $release['rejections'] ?? []);
+                                                            $rejectionReasons = implode(
+                                                                '; ',
+                                                                $release['rejections'] ?? [],
+                                                            );
                                                         @endphp
-                                                        <div class="flex items-start gap-2 px-3 py-2 {{ $release['approved'] ? '' : 'opacity-60' }}">
+                                                        <div
+                                                            class="flex items-start gap-2 px-3 py-2 {{ $release['approved'] ? '' : 'opacity-60' }}">
                                                             <div class="flex-1 min-w-0">
-                                                                <p class="text-xs text-gray-800 dark:text-gray-200 leading-snug break-words">{{ $release['title'] }}</p>
+                                                                <p
+                                                                    class="text-xs text-gray-800 dark:text-gray-200 leading-snug break-words">
+                                                                    {{ $release['title'] }}</p>
                                                                 <div class="flex flex-wrap items-center gap-1.5 mt-1">
-                                                                    <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400">{{ $release['quality'] }}</span>
-                                                                    <span class="text-xs text-gray-400 dark:text-gray-500">{{ $releaseSize }}</span>
-                                                                    <span class="text-xs text-gray-400 dark:text-gray-500 uppercase">{{ $release['protocol'] }}</span>
-                                                                    @if(! $release['approved'])
-                                                                        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-danger-100 dark:bg-danger-900/40 text-danger-700 dark:text-danger-400" title="{{ $rejectionReasons }}">{{ __('Rejected') }}</span>
+                                                                    <x-filament::badge
+                                                                        color="gray">{{ $release['quality'] }}</x-filament::badge>
+                                                                    <span
+                                                                        class="text-xs text-gray-400 dark:text-gray-500">{{ $releaseSize }}</span>
+                                                                    <span
+                                                                        class="text-xs text-gray-400 dark:text-gray-500 uppercase">{{ $release['protocol'] }}</span>
+                                                                    @if (!$release['approved'])
+                                                                        <x-filament::badge
+                                                                            color="danger">{{ __('Rejected') }}</x-filament::badge>
                                                                     @endif
                                                                 </div>
-                                                                @if(! $release['approved'] && $rejectionReasons)
-                                                                    <p class="text-xs text-danger-500 dark:text-danger-400 mt-1 leading-snug">{{ $rejectionReasons }}</p>
+                                                                @if (!$release['approved'] && $rejectionReasons)
+                                                                    <p
+                                                                        class="text-xs text-danger-500 dark:text-danger-400 mt-1 leading-snug">
+                                                                        {{ $rejectionReasons }}</p>
                                                                 @endif
                                                             </div>
-                                                            @if($release['approved'])
+                                                            @if ($release['approved'])
                                                                 <button
                                                                     wire:click="downloadDetailRelease('{{ $release['guid'] }}', {{ (int) ($release['indexerId'] ?? 0) }})"
                                                                     wire:loading.attr="disabled"
                                                                     wire:target="downloadDetailRelease"
                                                                     title="{{ __('Download this release') }}"
-                                                                    class="flex-shrink-0 p-1.5 rounded text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors mt-0.5"
-                                                                >
+                                                                    class="flex-shrink-0 p-1.5 rounded text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors mt-0.5">
                                                                     <x-heroicon-o-arrow-down-tray class="w-4 h-4" />
                                                                 </button>
                                                             @else
                                                                 <button
                                                                     x-on:click="if (confirm('{{ __('This release was rejected by your quality profile. Download anyway?') }}')) $wire.call('downloadDetailRelease', '{{ $release['guid'] }}', {{ (int) ($release['indexerId'] ?? 0) }})"
                                                                     title="{{ __('Force download (rejected release)') }}"
-                                                                    class="flex-shrink-0 p-1.5 rounded text-gray-300 dark:text-gray-600 hover:text-danger-500 dark:hover:text-danger-400 hover:bg-danger-50 dark:hover:bg-danger-900/20 transition-colors mt-0.5"
-                                                                >
+                                                                    class="flex-shrink-0 p-1.5 rounded text-gray-300 dark:text-gray-600 hover:text-danger-500 dark:hover:text-danger-400 hover:bg-danger-50 dark:hover:bg-danger-900/20 transition-colors mt-0.5">
                                                                     <x-heroicon-o-arrow-down-tray class="w-4 h-4" />
                                                                 </button>
                                                             @endif
                                                         </div>
                                                     @endforeach
                                                 </div>
-                                                <div class="px-3 py-2 border-t border-gray-100 dark:border-gray-800 flex justify-end">
-                                                    <button wire:click="loadDetailReleases" wire:loading.attr="disabled" wire:target="loadDetailReleases,loadEpisodeReleases" class="text-xs text-primary-600 dark:text-primary-400 hover:underline disabled:opacity-40">{{ __('Refresh') }}</button>
+                                                <div
+                                                    class="px-3 py-2 border-t border-gray-100 dark:border-gray-800 flex justify-end">
+                                                    <button wire:click="loadDetailReleases"
+                                                        wire:loading.attr="disabled"
+                                                        wire:target="loadDetailReleases,loadEpisodeReleases"
+                                                        class="text-xs text-primary-600 dark:text-primary-400 hover:underline disabled:opacity-40">{{ __('Refresh') }}</button>
                                                 </div>
-                                            @elseif(! $releasesLoading)
-                                                <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-3">{{ __('No releases found.') }}</p>
+                                            @elseif(!$releasesLoading)
+                                                <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-3">
+                                                    {{ __('No releases found.') }}</p>
                                             @endif
                                         </div>
                                     </div>
@@ -1074,20 +1199,16 @@
                             </div>
                         @endif
 
-                        @if($this->detailIntegration?->isSonarr() || $this->detailIntegration?->isRadarr())
-                            <x-filament::section
-                                collapsible
-                                :collapsed="true"
-                                heading="{{ __('Cast') }}"
-                                heading-tag="h3"
-                                compact
-                            >
+                        @if ($this->detailIntegration?->isSonarr() || $this->detailIntegration?->isRadarr())
+                            <x-filament::section :collapsible="true" compact :collapsed="true"
+                                heading="{{ __('Cast') }}" compact>
                                 <x-slot name="afterHeader">
                                     <span wire:loading wire:target="loadDetailEpisodes">
                                         <x-filament::loading-indicator class="h-3 w-3 text-primary-500" />
                                     </span>
-                                    @if($detailCast)
-                                        <x-filament::badge color="gray" wire:loading.remove wire:target="loadDetailEpisodes">
+                                    @if ($detailCast)
+                                        <x-filament::badge color="gray" wire:loading.remove
+                                            wire:target="loadDetailEpisodes">
                                             {{ count($detailCast) }}
                                         </x-filament::badge>
                                     @endif
@@ -1097,121 +1218,178 @@
                                     <x-filament::loading-indicator class="h-4 w-4 text-primary-500" />
                                 </div>
                                 <div wire:loading.remove wire:target="loadDetailEpisodes">
-                                    @if($detailCast)
+                                    @if ($detailCast)
                                         <div class="divide-y divide-gray-100 dark:divide-gray-800">
-                                            @foreach($detailCast as $member)
+                                            @foreach ($detailCast as $member)
                                                 <div class="flex items-center gap-3 py-2.5 first:pt-0 last:pb-0">
-                                                    <div class="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-gray-200 dark:bg-gray-700">
-                                                        @if(! empty($member['photo']))
-                                                            <img src="{{ $member['photo'] }}" alt="{{ $member['actor'] }}" class="w-full h-full object-cover" loading="lazy">
+                                                    <div
+                                                        class="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-gray-200 dark:bg-gray-700">
+                                                        @if (!empty($member['photo']))
+                                                            <img src="{{ $member['photo'] }}"
+                                                                alt="{{ $member['actor'] }}"
+                                                                class="w-full h-full object-cover" loading="lazy">
                                                         @else
-                                                            <div class="w-full h-full flex items-center justify-center"><x-heroicon-o-user class="w-4 h-4 text-gray-400" /></div>
+                                                            <div
+                                                                class="w-full h-full flex items-center justify-center">
+                                                                <x-heroicon-o-user class="w-4 h-4 text-gray-400" />
+                                                            </div>
                                                         @endif
                                                     </div>
                                                     <div class="flex-1 min-w-0">
-                                                        <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{{ $member['actor'] }}</p>
-                                                        @if(! empty($member['character'])) <p class="text-xs text-gray-500 dark:text-gray-400 truncate">{{ $member['character'] }}</p> @endif
+                                                        <p
+                                                            class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                                                            {{ $member['actor'] }}</p>
+                                                        @if (!empty($member['character']))
+                                                            <p
+                                                                class="text-xs text-gray-500 dark:text-gray-400 truncate">
+                                                                {{ $member['character'] }}</p>
+                                                        @endif
                                                     </div>
                                                 </div>
                                             @endforeach
                                         </div>
                                     @else
-                                        <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-2">{{ __('No cast information available.') }}</p>
+                                        <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-2">
+                                            {{ __('No cast information available.') }}</p>
                                     @endif
                                 </div>
                             </x-filament::section>
                         @endif
 
-                        @if($this->detailIntegration?->isSonarr() && ! empty($detailResult['seasons']))
+                        @if ($this->detailIntegration?->isSonarr() && !empty($detailResult['seasons']))
                             <div>
                                 <div class="flex items-center justify-between mb-2">
-                                    <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ __('Seasons') }}</h3>
+                                    <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                        {{ __('Seasons') }}</h3>
                                     <div class="flex items-center gap-2">
-                                        <button wire:click="toggleAllSeasons(true)" class="text-xs text-primary-600 dark:text-primary-400 hover:underline">{{ __('All') }}</button>
+                                        <button wire:click="toggleAllSeasons(true)"
+                                            class="text-xs text-primary-600 dark:text-primary-400 hover:underline">{{ __('All') }}</button>
                                         <span class="text-gray-300 dark:text-gray-600">·</span>
-                                        <button wire:click="toggleAllSeasons(false)" class="text-xs text-gray-500 dark:text-gray-400 hover:underline">{{ __('None') }}</button>
+                                        <button wire:click="toggleAllSeasons(false)"
+                                            class="text-xs text-gray-500 dark:text-gray-400 hover:underline">{{ __('None') }}</button>
                                     </div>
                                 </div>
-                                <div class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden divide-y divide-gray-100 dark:divide-gray-800">
-                                    @foreach(collect($detailResult['seasons'])->sortBy('seasonNumber') as $season)
+                                <div
+                                    class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden divide-y divide-gray-100 dark:divide-gray-800">
+                                    @foreach (collect($detailResult['seasons'])->sortBy('seasonNumber') as $season)
                                         @php
-                                            $seasonNum      = (int) $season['seasonNumber'];
+                                            $seasonNum = (int) $season['seasonNumber'];
                                             $seasonEpisodes = $detailEpisodes[$seasonNum] ?? null;
-                                            $episodeCount   = $seasonEpisodes !== null
-                                                ? count($seasonEpisodes)
-                                                : ($season['statistics']['totalEpisodeCount'] ?? null);
+                                            $episodeCount =
+                                                $seasonEpisodes !== null
+                                                    ? count($seasonEpisodes)
+                                                    : $season['statistics']['totalEpisodeCount'] ?? null;
 
                                             // Per-episode download counts from Sonarr /episode — authoritative
-                                            $seasonEpStatus  = $detailSonarrEpisodeStatus[$seasonNum] ?? null;
-                                            $seasonFileCount = $seasonEpStatus !== null ? count(array_filter($seasonEpStatus)) : null;
-                                            $seasonEpTotal   = $seasonEpStatus !== null ? count($seasonEpStatus) : null;
+                                            $seasonEpStatus = $detailSonarrEpisodeStatus[$seasonNum] ?? null;
+                                            $seasonFileCount =
+                                                $seasonEpStatus !== null ? count(array_filter($seasonEpStatus)) : null;
+                                            $seasonEpTotal = $seasonEpStatus !== null ? count($seasonEpStatus) : null;
                                         @endphp
                                         <div x-data="{ expanded: false }">
-                                            <div class="flex items-center hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors">
+                                            <div
+                                                class="flex items-center hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors">
                                                 <div class="pl-3 py-2.5" @click.stop>
-                                                    <input type="checkbox" wire:model.live="selectedSeasons.{{ $seasonNum }}" class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500 dark:bg-gray-800">
+                                                    <input type="checkbox"
+                                                        wire:model.live="selectedSeasons.{{ $seasonNum }}"
+                                                        class="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500 dark:bg-gray-800">
                                                 </div>
-                                                <button @click="expanded = !expanded" type="button" class="flex-1 flex items-center gap-2 px-2 py-2.5 pr-3 text-left">
-                                                    <x-heroicon-m-chevron-right class="w-3.5 h-3.5 flex-shrink-0 text-gray-400 transition-transform duration-200" x-bind:class="{ 'rotate-90': expanded }" />
+                                                <button @click="expanded = !expanded" type="button"
+                                                    class="flex-1 flex items-center gap-2 px-2 py-2.5 pr-3 text-left">
+                                                    <x-heroicon-m-chevron-right
+                                                        class="w-3.5 h-3.5 flex-shrink-0 text-gray-400 transition-transform duration-200"
+                                                        x-bind:class="{ 'rotate-90': expanded }" />
                                                     <span class="flex-1 text-sm text-gray-800 dark:text-gray-200">
                                                         {{ $seasonNum === 0 ? __('Specials') : __('Season :n', ['n' => $seasonNum]) }}
                                                     </span>
-                                                    <span wire:loading wire:target="loadDetailEpisodes"><x-filament::loading-indicator class="h-3 w-3 text-gray-400" /></span>
-                                                    @if($episodeCount !== null)
-                                                        <span wire:loading.remove wire:target="loadDetailEpisodes" class="text-xs text-gray-400 dark:text-gray-500">{{ __(':n ep', ['n' => $episodeCount]) }}</span>
+                                                    <span wire:loading
+                                                        wire:target="loadDetailEpisodes"><x-filament::loading-indicator
+                                                            class="h-3 w-3 text-gray-400" /></span>
+                                                    @if ($episodeCount !== null)
+                                                        <span wire:loading.remove wire:target="loadDetailEpisodes"
+                                                            class="text-xs text-gray-400 dark:text-gray-500">{{ __(':n ep', ['n' => $episodeCount]) }}</span>
                                                     @endif
-                                                    @if($seasonFileCount !== null && $seasonEpTotal !== null)
+                                                    @if ($seasonFileCount !== null && $seasonEpTotal !== null)
                                                         @php
-                                                            $seasonBadgeClass = $seasonFileCount === $seasonEpTotal && $seasonEpTotal > 0
-                                                                ? 'bg-success-100 dark:bg-success-900/30 text-success-700 dark:text-success-400'
-                                                                : ($seasonFileCount > 0
-                                                                    ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
-                                                                    : 'text-gray-400 dark:text-gray-500');
+                                                            $seasonBadgeColor =
+                                                                $seasonFileCount === $seasonEpTotal &&
+                                                                $seasonEpTotal > 0
+                                                                    ? 'success'
+                                                                    : ($seasonFileCount > 0
+                                                                        ? 'warning'
+                                                                        : 'gray');
                                                         @endphp
-                                                        <span wire:loading.remove wire:target="loadDetailEpisodes" class="text-xs px-1 {{ $seasonBadgeClass }}">{{ $seasonFileCount }}/{{ $seasonEpTotal }}</span>
+                                                        <x-filament::badge wire:loading.remove
+                                                            wire:target="loadDetailEpisodes"
+                                                            :color="$seasonBadgeColor">{{ $seasonFileCount }}/{{ $seasonEpTotal }}</x-filament::badge>
                                                     @endif
                                                 </button>
                                             </div>
-                                            <div x-show="expanded" x-collapse class="border-t border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30">
-                                                <div wire:loading wire:target="loadDetailEpisodes" class="py-4 flex justify-center">
+                                            <div x-show="expanded" x-collapse
+                                                class="border-t border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-gray-800/30">
+                                                <div wire:loading wire:target="loadDetailEpisodes"
+                                                    class="py-4 flex justify-center">
                                                     <x-filament::loading-indicator class="h-4 w-4 text-primary-500" />
                                                 </div>
                                                 <div wire:loading.remove wire:target="loadDetailEpisodes">
-                                                    @if($seasonEpisodes !== null && count($seasonEpisodes) > 0)
+                                                    @if ($seasonEpisodes !== null && count($seasonEpisodes) > 0)
                                                         <div class="divide-y divide-gray-100 dark:divide-gray-700/50">
-                                                            @foreach($seasonEpisodes as $episode)
+                                                            @foreach ($seasonEpisodes as $episode)
                                                                 @php
-                                                                    $epHasFile  = ! empty($detailSonarrEpisodeStatus[$seasonNum][$episode['episodeNumber']]);
-                                                                    $epFileInfo = $detailSonarrEpisodeFileInfo[$seasonNum][$episode['episodeNumber']] ?? null;
-                                                                    $epQuality  = $epFileInfo['quality'] ?? null;
-                                                                    $epBytes    = $epFileInfo['size'] ?? null;
-                                                                    $epSize     = $epBytes ? match (true) {
-                                                                        $epBytes >= 1_073_741_824 => number_format($epBytes / 1_073_741_824, 2).' GB',
-                                                                        $epBytes >= 1_048_576     => number_format($epBytes / 1_048_576, 2).' MB',
-                                                                        $epBytes > 0              => number_format($epBytes / 1_024, 2).' KB',
-                                                                        default                   => null,
-                                                                    } : null;
+                                                                    $epHasFile = !empty(
+                                                                        $detailSonarrEpisodeStatus[$seasonNum][
+                                                                            $episode['episodeNumber']
+                                                                        ]
+                                                                    );
+                                                                    $epFileInfo =
+                                                                        $detailSonarrEpisodeFileInfo[$seasonNum][
+                                                                            $episode['episodeNumber']
+                                                                        ] ?? null;
+                                                                    $epQuality = $epFileInfo['quality'] ?? null;
+                                                                    $epBytes = $epFileInfo['size'] ?? null;
+                                                                    $epSize = $epBytes
+                                                                        ? match (true) {
+                                                                            $epBytes >= 1_073_741_824 => number_format(
+                                                                                $epBytes / 1_073_741_824,
+                                                                                2,
+                                                                            ) . ' GB',
+                                                                            $epBytes >= 1_048_576 => number_format(
+                                                                                $epBytes / 1_048_576,
+                                                                                2,
+                                                                            ) . ' MB',
+                                                                            $epBytes > 0 => number_format(
+                                                                                $epBytes / 1_024,
+                                                                                2,
+                                                                            ) . ' KB',
+                                                                            default => null,
+                                                                        }
+                                                                        : null;
                                                                 @endphp
                                                                 <div class="flex items-center gap-2 px-3 py-1.5">
-                                                                    <span class="text-xs font-mono text-gray-400 dark:text-gray-500 w-6 flex-shrink-0 text-right">{{ str_pad($episode['episodeNumber'], 2, '0', STR_PAD_LEFT) }}</span>
-                                                                    @if($epHasFile)
-                                                                        <x-heroicon-s-check-circle class="w-3.5 h-3.5 flex-shrink-0 text-success-500 dark:text-success-400" />
+                                                                    <span
+                                                                        class="text-xs font-mono text-gray-400 dark:text-gray-500 w-6 flex-shrink-0 text-right">{{ str_pad($episode['episodeNumber'], 2, '0', STR_PAD_LEFT) }}</span>
+                                                                    @if ($epHasFile)
+                                                                        <x-heroicon-s-check-circle
+                                                                            class="w-3.5 h-3.5 flex-shrink-0 text-success-500 dark:text-success-400" />
                                                                     @endif
-                                                                    <span class="flex-1 text-xs text-gray-800 dark:text-gray-200 min-w-0 truncate">{{ $episode['title'] }}</span>
-                                                                    @if($epHasFile && ($epQuality || $epSize))
-                                                                        <span class="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 tabular-nums">{{ implode(' · ', array_filter([$epQuality, $epSize])) }}</span>
-                                                                    @elseif(! empty($episode['airDate']))
-                                                                        <span class="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 tabular-nums">{{ \Carbon\Carbon::parse($episode['airDate'])->format('M j, Y') }}</span>
+                                                                    <span
+                                                                        class="flex-1 text-xs text-gray-800 dark:text-gray-200 min-w-0 truncate">{{ $episode['title'] }}</span>
+                                                                    @if ($epHasFile && ($epQuality || $epSize))
+                                                                        <span
+                                                                            class="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 tabular-nums">{{ implode(' · ', array_filter([$epQuality, $epSize])) }}</span>
+                                                                    @elseif(!empty($episode['airDate']))
+                                                                        <span
+                                                                            class="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0 tabular-nums">{{ \Carbon\Carbon::parse($episode['airDate'])->format('M j, Y') }}</span>
                                                                     @endif
-                                                                    @if($epHasFile)
+                                                                    @if ($epHasFile)
                                                                         <button
                                                                             wire:click="requestEpisode({{ $seasonNum }}, {{ $episode['episodeNumber'] }})"
                                                                             wire:loading.attr="disabled"
                                                                             wire:target="requestEpisode"
                                                                             title="{{ __('Re-download this episode') }}"
-                                                                            class="flex-shrink-0 p-1 rounded text-success-500 dark:text-success-400 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors"
-                                                                        >
-                                                                            <x-heroicon-o-arrow-path class="w-3.5 h-3.5" />
+                                                                            class="flex-shrink-0 p-1 rounded text-success-500 dark:text-success-400 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors">
+                                                                            <x-heroicon-o-arrow-path
+                                                                                class="w-3.5 h-3.5" />
                                                                         </button>
                                                                     @else
                                                                         <button
@@ -1219,27 +1397,29 @@
                                                                             wire:loading.attr="disabled"
                                                                             wire:target="requestEpisode"
                                                                             title="{{ __('Request episode') }}"
-                                                                            class="flex-shrink-0 p-1 rounded text-gray-300 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors"
-                                                                        >
-                                                                            <x-heroicon-o-arrow-down-tray class="w-3.5 h-3.5" />
+                                                                            class="flex-shrink-0 p-1 rounded text-gray-300 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors">
+                                                                            <x-heroicon-o-arrow-down-tray
+                                                                                class="w-3.5 h-3.5" />
                                                                         </button>
                                                                     @endif
-                                                                    @if(! $guestMode)
+                                                                    @if (!$guestMode)
                                                                         <button
                                                                             wire:click="loadEpisodeReleases({{ $seasonNum }}, {{ $episode['episodeNumber'] }})"
                                                                             wire:loading.attr="disabled"
                                                                             wire:target="loadEpisodeReleases,requestEpisode"
                                                                             title="{{ __('Pick a specific release for this episode') }}"
-                                                                            class="flex-shrink-0 p-1 rounded text-gray-300 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors"
-                                                                        >
-                                                                            <x-heroicon-o-magnifying-glass class="w-3.5 h-3.5" />
+                                                                            class="flex-shrink-0 p-1 rounded text-gray-300 dark:text-gray-600 hover:text-primary-600 dark:hover:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40 transition-colors">
+                                                                            <x-heroicon-o-magnifying-glass
+                                                                                class="w-3.5 h-3.5" />
                                                                         </button>
                                                                     @endif
                                                                 </div>
                                                             @endforeach
                                                         </div>
                                                     @elseif($seasonEpisodes !== null)
-                                                        <p class="text-xs text-gray-400 dark:text-gray-500 text-center py-3">{{ __('No episode details available.') }}</p>
+                                                        <p
+                                                            class="text-xs text-gray-400 dark:text-gray-500 text-center py-3">
+                                                            {{ __('No episode details available.') }}</p>
                                                     @endif
                                                 </div>
                                             </div>
@@ -1251,53 +1431,61 @@
                     </div>
                 </div>
 
-                <div class="flex-shrink-0 px-4 py-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50">
-                    @if($detailInLibrary && $detailIsSonarr)
+                <div
+                    class="flex-shrink-0 px-4 py-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50">
+                    @if ($detailInLibrary && $detailIsSonarr)
                         {{-- Sonarr in-library: show status + always allow re-requesting seasons --}}
                         @php
-                            $monitoredCount    = collect($selectedSeasons)->filter()->count();
-                            $sonarrSizeBytes   = $detailResult['sizeOnDisk'] ?? 0;
-                            $sonarrSizeDisplay = $sonarrSizeBytes > 0 ? match (true) {
-                                $sonarrSizeBytes >= 1_073_741_824 => number_format($sonarrSizeBytes / 1_073_741_824, 2).' GB',
-                                $sonarrSizeBytes >= 1_048_576     => number_format($sonarrSizeBytes / 1_048_576, 2).' MB',
-                                $sonarrSizeBytes > 0              => number_format($sonarrSizeBytes / 1_024, 2).' KB',
-                                default                           => null,
-                            } : null;
+                            $monitoredCount = collect($selectedSeasons)->filter()->count();
+                            $sonarrSizeBytes = $detailResult['sizeOnDisk'] ?? 0;
+                            $sonarrSizeDisplay =
+                                $sonarrSizeBytes > 0
+                                    ? match (true) {
+                                        $sonarrSizeBytes >= 1_073_741_824 => number_format(
+                                            $sonarrSizeBytes / 1_073_741_824,
+                                            2,
+                                        ) . ' GB',
+                                        $sonarrSizeBytes >= 1_048_576 => number_format(
+                                            $sonarrSizeBytes / 1_048_576,
+                                            2,
+                                        ) . ' MB',
+                                        $sonarrSizeBytes > 0 => number_format($sonarrSizeBytes / 1_024, 2) . ' KB',
+                                        default => null,
+                                    }
+                                    : null;
                         @endphp
                         <div class="space-y-2">
                             <div class="flex flex-col items-center justify-center gap-1 py-0.5">
                                 <div class="flex items-center gap-2 text-sm">
-                                    @if($detailIsDownloaded)
-                                        <x-heroicon-o-check-circle class="w-4 h-4 text-success-600 dark:text-success-400 flex-shrink-0" />
-                                        <span class="text-success-700 dark:text-success-400">{{ __('Available in library') }}</span>
+                                    @if ($detailIsDownloaded)
+                                        <x-heroicon-o-check-circle
+                                            class="w-4 h-4 text-success-600 dark:text-success-400 flex-shrink-0" />
+                                        <span
+                                            class="text-success-700 dark:text-success-400">{{ __('Available in library') }}</span>
                                     @else
                                         <x-heroicon-s-bookmark class="w-4 h-4 text-amber-500 flex-shrink-0" />
-                                        <span class="text-amber-600 dark:text-amber-400">{{ __('Monitored — searching for releases') }}</span>
+                                        <span
+                                            class="text-amber-600 dark:text-amber-400">{{ __('Monitored — searching for releases') }}</span>
                                     @endif
                                 </div>
-                                @if($sonarrSizeDisplay)
-                                    <div class="text-xs text-gray-400 dark:text-gray-500 tabular-nums">{{ $sonarrSizeDisplay }} {{ __('on disk') }}</div>
+                                @if ($sonarrSizeDisplay)
+                                    <div class="text-xs text-gray-400 dark:text-gray-500 tabular-nums">
+                                        {{ $sonarrSizeDisplay }} {{ __('on disk') }}</div>
                                 @endif
                             </div>
-                            @if(! $guestMode)
+                            @if (!$guestMode)
                                 <div class="flex gap-2">
-                                    <button
-                                        wire:click="triggerAutomaticSearch"
-                                        wire:loading.attr="disabled"
+                                    <button wire:click="triggerAutomaticSearch" wire:loading.attr="disabled"
                                         wire:target="triggerAutomaticSearch"
-                                        class="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg transition-colors"
-                                    >
+                                        class="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg transition-colors">
                                         <x-heroicon-o-magnifying-glass class="w-4 h-4" />
                                         {{ __('Auto Search') }}
                                     </button>
-                                    <button
-                                        wire:click="requestDetail"
-                                        wire:loading.attr="disabled"
+                                    <button wire:click="requestDetail" wire:loading.attr="disabled"
                                         @disabled($monitoredCount === 0)
-                                        class="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
-                                    >
+                                        class="flex-1 inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors">
                                         <x-heroicon-o-arrow-path class="w-4 h-4" />
-                                        @if($monitoredCount > 0)
+                                        @if ($monitoredCount > 0)
                                             {{ __('Re-request :n Season(s)', ['n' => $monitoredCount]) }}
                                         @else
                                             {{ __('Select Seasons') }}
@@ -1310,13 +1498,19 @@
                         {{-- Radarr downloaded --}}
                         @php
                             $radarrFileQuality = $detailResult['fileQuality'] ?? null;
-                            $radarrFileBytes   = $detailResult['fileSize'] ?? null;
-                            $radarrFileSize    = $radarrFileBytes ? match (true) {
-                                $radarrFileBytes >= 1_073_741_824 => number_format($radarrFileBytes / 1_073_741_824, 2).' GB',
-                                $radarrFileBytes >= 1_048_576     => number_format($radarrFileBytes / 1_048_576, 2).' MB',
-                                $radarrFileBytes > 0              => number_format($radarrFileBytes / 1_024, 2).' KB',
-                                default                           => null,
-                            } : null;
+                            $radarrFileBytes = $detailResult['fileSize'] ?? null;
+                            $radarrFileSize = $radarrFileBytes
+                                ? match (true) {
+                                    $radarrFileBytes >= 1_073_741_824 => number_format(
+                                        $radarrFileBytes / 1_073_741_824,
+                                        2,
+                                    ) . ' GB',
+                                    $radarrFileBytes >= 1_048_576 => number_format($radarrFileBytes / 1_048_576, 2) .
+                                        ' MB',
+                                    $radarrFileBytes > 0 => number_format($radarrFileBytes / 1_024, 2) . ' KB',
+                                    default => null,
+                                }
+                                : null;
                         @endphp
                         <div class="space-y-2">
                             <div class="flex flex-col items-center justify-center gap-1 py-1">
@@ -1324,19 +1518,16 @@
                                     <x-heroicon-o-check-circle class="w-5 h-5" />
                                     {{ __('This title is available in your library.') }}
                                 </div>
-                                @if($radarrFileQuality || $radarrFileSize)
+                                @if ($radarrFileQuality || $radarrFileSize)
                                     <div class="text-xs text-gray-400 dark:text-gray-500 tabular-nums">
                                         {{ implode(' · ', array_filter([$radarrFileQuality, $radarrFileSize])) }}
                                     </div>
                                 @endif
                             </div>
-                            @if(! $guestMode)
-                                <button
-                                    wire:click="triggerAutomaticSearch"
-                                    wire:loading.attr="disabled"
+                            @if (!$guestMode)
+                                <button wire:click="triggerAutomaticSearch" wire:loading.attr="disabled"
                                     wire:target="triggerAutomaticSearch"
-                                    class="w-full inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg transition-colors"
-                                >
+                                    class="w-full inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg transition-colors">
                                     <x-heroicon-o-magnifying-glass class="w-4 h-4" />
                                     {{ __('Trigger Automatic Search') }}
                                 </button>
@@ -1345,17 +1536,15 @@
                     @elseif($detailInLibrary)
                         {{-- Radarr monitored (not yet downloaded) --}}
                         <div class="space-y-2">
-                            <div class="flex items-center justify-center gap-2 py-1 text-sm text-amber-600 dark:text-amber-400">
+                            <div
+                                class="flex items-center justify-center gap-2 py-1 text-sm text-amber-600 dark:text-amber-400">
                                 <x-heroicon-s-bookmark class="w-5 h-5" />
                                 {{ __('This title is monitored and searching for releases.') }}
                             </div>
-                            @if(! $guestMode)
-                                <button
-                                    wire:click="triggerAutomaticSearch"
-                                    wire:loading.attr="disabled"
+                            @if (!$guestMode)
+                                <button wire:click="triggerAutomaticSearch" wire:loading.attr="disabled"
                                     wire:target="triggerAutomaticSearch"
-                                    class="w-full inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg transition-colors"
-                                >
+                                    class="w-full inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg transition-colors">
                                     <x-heroicon-o-magnifying-glass class="w-4 h-4" />
                                     {{ __('Trigger Automatic Search') }}
                                 </button>
@@ -1364,14 +1553,10 @@
                     @elseif($detailIsSonarr)
                         {{-- Sonarr not in library — initial request --}}
                         @php $monitoredCount = collect($selectedSeasons)->filter()->count(); @endphp
-                        <button
-                            wire:click="requestDetail"
-                            wire:loading.attr="disabled"
-                            @disabled($monitoredCount === 0)
-                            class="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-                        >
+                        <button wire:click="requestDetail" wire:loading.attr="disabled" @disabled($monitoredCount === 0)
+                            class="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2">
                             <x-heroicon-o-plus class="w-4 h-4" />
-                            @if($monitoredCount > 0)
+                            @if ($monitoredCount > 0)
                                 {{ __('Request :count Season(s)', ['count' => $monitoredCount]) }}
                             @else
                                 {{ __('Select Seasons to Request') }}
@@ -1380,25 +1565,18 @@
                     @else
                         {{-- Radarr not in library --}}
                         <div class="flex gap-2">
-                            <button
-                                wire:click="request({{ $detailIndex }})"
-                                wire:click.stop
-                                wire:loading.attr="disabled"
-                                wire:target="request,addForInteractiveSearch"
+                            <button wire:click="request({{ $detailIndex }})" wire:click.stop
+                                wire:loading.attr="disabled" wire:target="request,addForInteractiveSearch"
                                 title="{{ __('Add to Radarr and let it auto-select the best release') }}"
-                                class="flex-1 inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition-colors"
-                            >
+                                class="flex-1 inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:opacity-50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition-colors">
                                 <x-heroicon-o-plus class="w-4 h-4" />
                                 {{ __('Request') }}
                             </button>
-                            @if(! $guestMode)
-                                <button
-                                    wire:click="addForInteractiveSearch"
-                                    wire:loading.attr="disabled"
+                            @if (!$guestMode)
+                                <button wire:click="addForInteractiveSearch" wire:loading.attr="disabled"
                                     wire:target="request,addForInteractiveSearch"
                                     title="{{ __('Add to Radarr and pick a specific release') }}"
-                                    class="flex-1 inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition-colors"
-                                >
+                                    class="flex-1 inline-flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 transition-colors">
                                     <x-heroicon-o-list-bullet class="w-4 h-4" />
                                     {{ __('Pick Release') }}
                                 </button>

--- a/resources/views/livewire/partials/arr-queue-group.blade.php
+++ b/resources/views/livewire/partials/arr-queue-group.blade.php
@@ -1,0 +1,86 @@
+<div class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+    {{-- Integration header --}}
+    <div class="flex items-center justify-between px-4 py-2.5 bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
+        <span class="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wide">
+            {{ $queueGroup['integration']['name'] }}
+        </span>
+        @if($queueGroup['error'])
+            <span class="inline-flex items-center gap-1 text-xs text-danger-600 dark:text-danger-400">
+                <x-heroicon-o-exclamation-circle class="w-3.5 h-3.5" />
+                {{ __('Unreachable') }}
+            </span>
+        @else
+            <span class="text-xs text-gray-500 dark:text-gray-500">
+                {{ trans_choice(':count item|:count items', count($queueGroup['items'])) }}
+            </span>
+        @endif
+    </div>
+
+    @if(! $queueGroup['error'] && count($queueGroup['items']) > 0)
+        <div class="divide-y divide-gray-100 dark:divide-gray-700/50">
+            @foreach($queueGroup['items'] as $item)
+                @php
+                    $badge = \App\Livewire\ArrQueueMonitor::statusBadge($item['status'] ?? 'unknown');
+                    $showProgress = in_array($item['status'] ?? '', ['downloading', 'queued', 'paused']);
+                @endphp
+                <div class="px-4 py-3 bg-white dark:bg-gray-900/30">
+                    <div class="flex items-start justify-between gap-3">
+                        <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate flex-1 min-w-0">
+                            {{ $item['title'] ?? __('Unknown') }}
+                        </p>
+                        <span @class([
+                            'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap flex-shrink-0',
+                            'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400' => $badge['color'] === 'primary',
+                            'bg-warning-100 text-warning-700 dark:bg-warning-900/30 dark:text-warning-400' => $badge['color'] === 'warning',
+                            'bg-success-100 text-success-700 dark:bg-success-900/30 dark:text-success-400' => $badge['color'] === 'success',
+                            'bg-danger-100 text-danger-700 dark:bg-danger-900/30 dark:text-danger-400' => $badge['color'] === 'danger',
+                            'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400' => $badge['color'] === 'gray',
+                        ])>
+                            {{ $badge['label'] }}
+                        </span>
+                    </div>
+
+                    <div class="mt-1 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-500">
+                        @if($item['quality'] ?? null)
+                            <span class="font-medium text-gray-600 dark:text-gray-400">{{ $item['quality'] }}</span>
+                        @endif
+                        @if($showProgress && ($item['size'] ?? 0) > 0)
+                            <span>{{ $item['formattedSize'] }}</span>
+                        @endif
+                        @if($showProgress && ($item['timeLeft'] ?? null))
+                            <span>·</span>
+                            <span>{{ $item['timeLeft'] }} {{ __('left') }}</span>
+                        @endif
+                        @if($showProgress)
+                            <span class="ml-auto font-medium text-gray-700 dark:text-gray-300">{{ $item['progress'] }}%</span>
+                        @elseif($item['last_event_at'] ?? null)
+                            <span class="ml-auto text-gray-400 dark:text-gray-600 text-xs">
+                                {{ \Carbon\Carbon::parse($item['last_event_at'])->diffForHumans() }}
+                            </span>
+                        @endif
+                    </div>
+
+                    @if($showProgress)
+                        <div class="mt-1.5 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5 overflow-hidden">
+                            <div
+                                @class([
+                                    'h-1.5 rounded-full transition-all duration-500',
+                                    'bg-primary-500' => $badge['color'] === 'primary',
+                                    'bg-warning-500' => $badge['color'] === 'warning',
+                                    'bg-success-500' => $badge['color'] === 'success',
+                                    'bg-danger-500' => $badge['color'] === 'danger',
+                                    'bg-gray-400' => $badge['color'] === 'gray',
+                                ])
+                                style="width: {{ $item['progress'] }}%"
+                            ></div>
+                        </div>
+                    @endif
+                </div>
+            @endforeach
+        </div>
+    @elseif(! $queueGroup['error'])
+        <div class="px-4 py-6 text-center bg-white dark:bg-gray-900/30">
+            <p class="text-xs text-gray-400 dark:text-gray-600">{{ __('Queue is empty') }}</p>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/partials/arr-queue-group.blade.php
+++ b/resources/views/livewire/partials/arr-queue-group.blade.php
@@ -1,12 +1,6 @@
-<x-filament::section
-    :heading="$queueGroup['integration']['name']"
-    heading-tag="h3"
-    collapsible
-    :collapse-id="'queue-group-' . $queueGroup['integration']['id']"
-    persist-collapsed
->
+<x-filament::section :heading="$queueGroup['integration']['name']" collapsible="true" compact :collapse-id="'queue-group-' . $queueGroup['integration']['id']" persist-collapsed>
     <x-slot name="afterHeader">
-        @if($queueGroup['error'])
+        @if ($queueGroup['error'])
             <x-filament::badge color="danger" icon="heroicon-o-exclamation-circle">
                 {{ __('Unreachable') }}
             </x-filament::badge>
@@ -17,9 +11,9 @@
         @endif
     </x-slot>
 
-    @if(! $queueGroup['error'] && count($queueGroup['items']) > 0)
+    @if (!$queueGroup['error'] && count($queueGroup['items']) > 0)
         <div class="divide-y divide-gray-100 dark:divide-gray-700/50">
-            @foreach($queueGroup['items'] as $item)
+            @foreach ($queueGroup['items'] as $item)
                 @php
                     $badge = \App\Livewire\ArrQueueMonitor::statusBadge($item['status'] ?? 'unknown');
                     $showProgress = in_array($item['status'] ?? '', ['downloading', 'queued', 'paused', 'importing']);
@@ -33,38 +27,36 @@
                             <x-filament::badge :color="$badge['color']">
                                 {{ $badge['label'] }}
                             </x-filament::badge>
-                            @if($item['can_dismiss'] ?? false)
-                                <x-filament::icon-button
-                                    color="gray"
-                                    icon="heroicon-o-x-mark"
-                                    size="sm"
+                            @if ($item['can_dismiss'] ?? false)
+                                <x-filament::icon-button color="gray" icon="heroicon-o-x-mark" size="sm"
                                     :tooltip="__('Dismiss')"
-                                    wire:click="dismissItem('{{ $item['dismiss_source'] }}', '{{ $item['dismiss_key'] }}')"
-                                />
+                                    wire:click="dismissItem('{{ $item['dismiss_source'] }}', '{{ $item['dismiss_key'] }}')" />
                             @endif
                         </div>
                     </div>
 
-                    @if($item['episode'] ?? null)
+                    @if ($item['episode'] ?? null)
                         <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400 truncate">{{ $item['episode'] }}</p>
                     @endif
 
                     <div class="mt-1 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-500">
-                        @if($item['quality'] ?? null)
+                        @if ($item['quality'] ?? null)
                             <span class="font-medium text-gray-600 dark:text-gray-400">{{ $item['quality'] }}</span>
                         @endif
-                        @if($item['protocol'] ?? null)
-                            <span class="uppercase tracking-wide text-gray-400 dark:text-gray-600">{{ $item['protocol'] === 'usenet' ? 'NZB' : ucfirst($item['protocol']) }}</span>
+                        @if ($item['protocol'] ?? null)
+                            <span
+                                class="uppercase tracking-wide text-gray-400 dark:text-gray-600">{{ $item['protocol'] === 'usenet' ? 'NZB' : ucfirst($item['protocol']) }}</span>
                         @endif
-                        @if($showProgress && ($item['size'] ?? 0) > 0)
+                        @if ($showProgress && ($item['size'] ?? 0) > 0)
                             <span>{{ $item['formattedSize'] }}</span>
                         @endif
-                        @if($showProgress && ($item['timeLeft'] ?? null))
+                        @if ($showProgress && ($item['timeLeft'] ?? null))
                             <span>·</span>
                             <span>{{ $item['timeLeft'] }} {{ __('left') }}</span>
                         @endif
-                        @if($showProgress)
-                            <span class="ml-auto font-medium text-gray-700 dark:text-gray-300">{{ $item['progress'] }}%</span>
+                        @if ($showProgress)
+                            <span
+                                class="ml-auto font-medium text-gray-700 dark:text-gray-300">{{ $item['progress'] }}%</span>
                         @elseif($item['last_event_at'] ?? null)
                             <span class="ml-auto text-xs text-gray-400 dark:text-gray-600">
                                 {{ \Carbon\Carbon::parse($item['last_event_at'])->diffForHumans() }}
@@ -72,29 +64,26 @@
                         @endif
                     </div>
 
-                    @if($item['indexer'] ?? null)
+                    @if ($item['indexer'] ?? null)
                         <p class="mt-0.5 text-xs text-gray-400 dark:text-gray-600 truncate">{{ $item['indexer'] }}</p>
                     @endif
 
-                    @if($showProgress)
+                    @if ($showProgress)
                         <div class="mt-1.5 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5 overflow-hidden">
-                            <div
-                                @class([
-                                    'h-1.5 rounded-full transition-all duration-500',
-                                    'bg-primary-500' => $badge['color'] === 'primary',
-                                    'bg-warning-500' => $badge['color'] === 'warning',
-                                    'bg-success-500' => $badge['color'] === 'success',
-                                    'bg-danger-500' => $badge['color'] === 'danger',
-                                    'bg-gray-400'    => $badge['color'] === 'gray',
-                                ])
-                                style="width: {{ $item['progress'] }}%"
-                            ></div>
+                            <div @class([
+                                'h-1.5 rounded-full transition-all duration-500',
+                                'bg-primary-500' => $badge['color'] === 'primary',
+                                'bg-warning-500' => $badge['color'] === 'warning',
+                                'bg-success-500' => $badge['color'] === 'success',
+                                'bg-danger-500' => $badge['color'] === 'danger',
+                                'bg-gray-400' => $badge['color'] === 'gray',
+                            ]) style="width: {{ $item['progress'] }}%"></div>
                         </div>
                     @endif
                 </div>
             @endforeach
         </div>
-    @elseif(! $queueGroup['error'])
+    @elseif(!$queueGroup['error'])
         <p class="text-xs text-center text-gray-400 dark:text-gray-600">{{ __('Queue is empty') }}</p>
     @endif
 </x-filament::section>

--- a/resources/views/livewire/partials/arr-queue-group.blade.php
+++ b/resources/views/livewire/partials/arr-queue-group.blade.php
@@ -1,20 +1,21 @@
-<div class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-    {{-- Integration header --}}
-    <div class="flex items-center justify-between px-4 py-2.5 bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-        <span class="text-xs font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wide">
-            {{ $queueGroup['integration']['name'] }}
-        </span>
+<x-filament::section
+    :heading="$queueGroup['integration']['name']"
+    heading-tag="h3"
+    collapsible
+    :collapse-id="'queue-group-' . $queueGroup['integration']['id']"
+    persist-collapsed
+>
+    <x-slot name="afterHeader">
         @if($queueGroup['error'])
-            <span class="inline-flex items-center gap-1 text-xs text-danger-600 dark:text-danger-400">
-                <x-heroicon-o-exclamation-circle class="w-3.5 h-3.5" />
+            <x-filament::badge color="danger" icon="heroicon-o-exclamation-circle">
                 {{ __('Unreachable') }}
-            </span>
+            </x-filament::badge>
         @else
-            <span class="text-xs text-gray-500 dark:text-gray-500">
+            <x-filament::badge color="gray">
                 {{ trans_choice(':count item|:count items', count($queueGroup['items'])) }}
-            </span>
+            </x-filament::badge>
         @endif
-    </div>
+    </x-slot>
 
     @if(! $queueGroup['error'] && count($queueGroup['items']) > 0)
         <div class="divide-y divide-gray-100 dark:divide-gray-700/50">
@@ -23,32 +24,24 @@
                     $badge = \App\Livewire\ArrQueueMonitor::statusBadge($item['status'] ?? 'unknown');
                     $showProgress = in_array($item['status'] ?? '', ['downloading', 'queued', 'paused', 'importing']);
                 @endphp
-                <div class="px-4 py-3 bg-white dark:bg-gray-900/30">
+                <div class="py-3 first:pt-0 last:pb-0">
                     <div class="flex items-start justify-between gap-3">
                         <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate flex-1 min-w-0">
                             {{ $item['title'] ?? __('Unknown') }}
                         </p>
-                        <div class="flex items-center gap-1.5 flex-shrink-0">
-                        <span @class([
-                            'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap flex-shrink-0',
-                            'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400' => $badge['color'] === 'primary',
-                            'bg-warning-100 text-warning-700 dark:bg-warning-900/30 dark:text-warning-400' => $badge['color'] === 'warning',
-                            'bg-success-100 text-success-700 dark:bg-success-900/30 dark:text-success-400' => $badge['color'] === 'success',
-                            'bg-danger-100 text-danger-700 dark:bg-danger-900/30 dark:text-danger-400' => $badge['color'] === 'danger',
-                            'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400' => $badge['color'] === 'gray',
-                        ])>
-                            {{ $badge['label'] }}
-                        </span>
-                        @if($item['can_dismiss'] ?? false)
-                            <button
-                                wire:click="dismissItem('{{ $item['dismiss_source'] }}', '{{ $item['dismiss_key'] }}')"
-                                wire:loading.attr="disabled"
-                                title="{{ __('Dismiss') }}"
-                                class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
-                            >
-                                <x-heroicon-o-x-mark class="w-3.5 h-3.5" />
-                            </button>
-                        @endif
+                        <div class="flex items-center gap-1 shrink-0">
+                            <x-filament::badge :color="$badge['color']">
+                                {{ $badge['label'] }}
+                            </x-filament::badge>
+                            @if($item['can_dismiss'] ?? false)
+                                <x-filament::icon-button
+                                    color="gray"
+                                    icon="heroicon-o-x-mark"
+                                    size="sm"
+                                    :tooltip="__('Dismiss')"
+                                    wire:click="dismissItem('{{ $item['dismiss_source'] }}', '{{ $item['dismiss_key'] }}')"
+                                />
+                            @endif
                         </div>
                     </div>
 
@@ -73,7 +66,7 @@
                         @if($showProgress)
                             <span class="ml-auto font-medium text-gray-700 dark:text-gray-300">{{ $item['progress'] }}%</span>
                         @elseif($item['last_event_at'] ?? null)
-                            <span class="ml-auto text-gray-400 dark:text-gray-600 text-xs">
+                            <span class="ml-auto text-xs text-gray-400 dark:text-gray-600">
                                 {{ \Carbon\Carbon::parse($item['last_event_at'])->diffForHumans() }}
                             </span>
                         @endif
@@ -92,7 +85,7 @@
                                     'bg-warning-500' => $badge['color'] === 'warning',
                                     'bg-success-500' => $badge['color'] === 'success',
                                     'bg-danger-500' => $badge['color'] === 'danger',
-                                    'bg-gray-400' => $badge['color'] === 'gray',
+                                    'bg-gray-400'    => $badge['color'] === 'gray',
                                 ])
                                 style="width: {{ $item['progress'] }}%"
                             ></div>
@@ -102,8 +95,6 @@
             @endforeach
         </div>
     @elseif(! $queueGroup['error'])
-        <div class="px-4 py-6 text-center bg-white dark:bg-gray-900/30">
-            <p class="text-xs text-gray-400 dark:text-gray-600">{{ __('Queue is empty') }}</p>
-        </div>
+        <p class="text-xs text-center text-gray-400 dark:text-gray-600">{{ __('Queue is empty') }}</p>
     @endif
-</div>
+</x-filament::section>

--- a/resources/views/livewire/partials/arr-queue-group.blade.php
+++ b/resources/views/livewire/partials/arr-queue-group.blade.php
@@ -21,13 +21,14 @@
             @foreach($queueGroup['items'] as $item)
                 @php
                     $badge = \App\Livewire\ArrQueueMonitor::statusBadge($item['status'] ?? 'unknown');
-                    $showProgress = in_array($item['status'] ?? '', ['downloading', 'queued', 'paused']);
+                    $showProgress = in_array($item['status'] ?? '', ['downloading', 'queued', 'paused', 'importing']);
                 @endphp
                 <div class="px-4 py-3 bg-white dark:bg-gray-900/30">
                     <div class="flex items-start justify-between gap-3">
                         <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate flex-1 min-w-0">
                             {{ $item['title'] ?? __('Unknown') }}
                         </p>
+                        <div class="flex items-center gap-1.5 flex-shrink-0">
                         <span @class([
                             'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium whitespace-nowrap flex-shrink-0',
                             'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400' => $badge['color'] === 'primary',
@@ -38,11 +39,29 @@
                         ])>
                             {{ $badge['label'] }}
                         </span>
+                        @if($item['can_dismiss'] ?? false)
+                            <button
+                                wire:click="dismissItem('{{ $item['dismiss_source'] }}', '{{ $item['dismiss_key'] }}')"
+                                wire:loading.attr="disabled"
+                                title="{{ __('Dismiss') }}"
+                                class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                            >
+                                <x-heroicon-o-x-mark class="w-3.5 h-3.5" />
+                            </button>
+                        @endif
+                        </div>
                     </div>
+
+                    @if($item['episode'] ?? null)
+                        <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400 truncate">{{ $item['episode'] }}</p>
+                    @endif
 
                     <div class="mt-1 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-500">
                         @if($item['quality'] ?? null)
                             <span class="font-medium text-gray-600 dark:text-gray-400">{{ $item['quality'] }}</span>
+                        @endif
+                        @if($item['protocol'] ?? null)
+                            <span class="uppercase tracking-wide text-gray-400 dark:text-gray-600">{{ $item['protocol'] === 'usenet' ? 'NZB' : ucfirst($item['protocol']) }}</span>
                         @endif
                         @if($showProgress && ($item['size'] ?? 0) > 0)
                             <span>{{ $item['formattedSize'] }}</span>
@@ -59,6 +78,10 @@
                             </span>
                         @endif
                     </div>
+
+                    @if($item['indexer'] ?? null)
+                        <p class="mt-0.5 text-xs text-gray-400 dark:text-gray-600 truncate">{{ $item['indexer'] }}</p>
+                    @endif
 
                     @if($showProgress)
                         <div class="mt-1.5 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5 overflow-hidden">

--- a/resources/views/livewire/partials/discover-card.blade.php
+++ b/resources/views/livewire/partials/discover-card.blade.php
@@ -1,15 +1,13 @@
-<div
-    wire:click="requestFromDiscover({{ $item['tmdb_id'] }}, '{{ $item['media_type'] }}')"
-    wire:loading.class="opacity-50 pointer-events-none"
-    wire:target="requestFromDiscover"
-    class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800"
->
+<div wire:click="requestFromDiscover({{ $item['tmdb_id'] }}, '{{ $item['media_type'] }}')"
+    wire:loading.class="opacity-50 pointer-events-none" wire:target="requestFromDiscover"
+    class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800">
     <div class="relative aspect-[2/3]">
-        @if(! empty($item['poster_url']))
-            <img src="{{ $item['poster_url'] }}" alt="{{ $item['title'] }}" class="w-full h-full object-cover" loading="lazy">
+        @if (!empty($item['poster_url']))
+            <img src="{{ $item['poster_url'] }}" alt="{{ $item['title'] }}" class="w-full h-full object-cover"
+                loading="lazy">
         @else
             <div class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-                @if($item['media_type'] === 'tv')
+                @if ($item['media_type'] === 'tv')
                     <x-heroicon-o-tv class="w-10 h-10 text-gray-400 dark:text-gray-500" />
                 @else
                     <x-heroicon-o-film class="w-10 h-10 text-gray-400 dark:text-gray-500" />
@@ -19,44 +17,49 @@
         <span class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
             {{ $item['media_type'] === 'tv' ? __('TV') : __('Movie') }}
         </span>
-        @if(! empty($item['isDownloaded']))
-            <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
+        @if (!empty($item['isDownloaded']))
+            <span
+                class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
                 <x-heroicon-s-check class="w-3.5 h-3.5 text-white" />
             </span>
-        @elseif(! empty($item['existsInLibrary']))
-            <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
+        @elseif(!empty($item['existsInLibrary']))
+            <span
+                class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
                 <x-heroicon-s-bookmark class="w-3.5 h-3.5 text-white" />
             </span>
         @endif
-        @if(! empty($item['vote_average']))
-            <span class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
+        @if (!empty($item['vote_average']))
+            <span
+                class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
                 <x-heroicon-s-star class="w-3 h-3" />
                 {{ $item['vote_average'] }}
             </span>
         @endif
-        <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
+        <div
+            class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
             <h3 class="text-white font-semibold text-sm leading-tight line-clamp-2">
                 {{ $item['title'] }}
-                @if(! empty($item['year']))
+                @if (!empty($item['year']))
                     <span class="text-white/60 font-normal">({{ $item['year'] }})</span>
                 @endif
             </h3>
-            @if(! empty($item['overview']))
+            @if (!empty($item['overview']))
                 <p class="text-white/55 text-xs line-clamp-2">{{ $item['overview'] }}</p>
             @endif
             <div class="mt-1.5">
-                @if(! empty($item['isDownloaded']))
+                @if (!empty($item['isDownloaded']))
                     <span class="flex items-center gap-1 text-green-400 text-xs font-medium">
                         <x-heroicon-s-check class="w-3.5 h-3.5" />
                         {{ __('Downloaded') }}
                     </span>
-                @elseif(! empty($item['existsInLibrary']))
+                @elseif(!empty($item['existsInLibrary']))
                     <span class="flex items-center gap-1 text-amber-400 text-xs font-medium">
                         <x-heroicon-s-bookmark class="w-3.5 h-3.5" />
                         {{ __('Monitored') }}
                     </span>
                 @else
-                    <span class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
+                    <span
+                        class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
                         {{ $item['media_type'] === 'tv' ? __('Select Seasons') : __('Request Movie') }}
                     </span>
                 @endif

--- a/resources/views/livewire/partials/discover-card.blade.php
+++ b/resources/views/livewire/partials/discover-card.blade.php
@@ -1,0 +1,66 @@
+<div
+    wire:click="requestFromDiscover({{ $item['tmdb_id'] }}, '{{ $item['media_type'] }}')"
+    wire:loading.class="opacity-50 pointer-events-none"
+    wire:target="requestFromDiscover"
+    class="group relative cursor-pointer rounded-lg overflow-hidden shadow-sm hover:shadow-xl transition-shadow duration-200 bg-gray-200 dark:bg-gray-800"
+>
+    <div class="relative aspect-[2/3]">
+        @if(! empty($item['poster_url']))
+            <img src="{{ $item['poster_url'] }}" alt="{{ $item['title'] }}" class="w-full h-full object-cover" loading="lazy">
+        @else
+            <div class="w-full h-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+                @if($item['media_type'] === 'tv')
+                    <x-heroicon-o-tv class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                @else
+                    <x-heroicon-o-film class="w-10 h-10 text-gray-400 dark:text-gray-500" />
+                @endif
+            </div>
+        @endif
+        <span class="absolute top-2 left-2 px-1.5 py-0.5 text-xs font-semibold rounded bg-black/60 text-white">
+            {{ $item['media_type'] === 'tv' ? __('TV') : __('Movie') }}
+        </span>
+        @if(! empty($item['isDownloaded']))
+            <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-green-500 flex items-center justify-center shadow-sm">
+                <x-heroicon-s-check class="w-3.5 h-3.5 text-white" />
+            </span>
+        @elseif(! empty($item['existsInLibrary']))
+            <span class="absolute top-2 right-2 w-6 h-6 rounded-full bg-amber-500 flex items-center justify-center shadow-sm">
+                <x-heroicon-s-bookmark class="w-3.5 h-3.5 text-white" />
+            </span>
+        @endif
+        @if(! empty($item['vote_average']))
+            <span class="absolute bottom-2 right-2 flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-black/70 text-yellow-400 text-xs font-semibold">
+                <x-heroicon-s-star class="w-3 h-3" />
+                {{ $item['vote_average'] }}
+            </span>
+        @endif
+        <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-gradient-to-t from-black/95 via-black/65 to-black/20 flex flex-col justify-end p-3 gap-1">
+            <h3 class="text-white font-semibold text-sm leading-tight line-clamp-2">
+                {{ $item['title'] }}
+                @if(! empty($item['year']))
+                    <span class="text-white/60 font-normal">({{ $item['year'] }})</span>
+                @endif
+            </h3>
+            @if(! empty($item['overview']))
+                <p class="text-white/55 text-xs line-clamp-2">{{ $item['overview'] }}</p>
+            @endif
+            <div class="mt-1.5">
+                @if(! empty($item['isDownloaded']))
+                    <span class="flex items-center gap-1 text-green-400 text-xs font-medium">
+                        <x-heroicon-s-check class="w-3.5 h-3.5" />
+                        {{ __('Downloaded') }}
+                    </span>
+                @elseif(! empty($item['existsInLibrary']))
+                    <span class="flex items-center gap-1 text-amber-400 text-xs font-medium">
+                        <x-heroicon-s-bookmark class="w-3.5 h-3.5" />
+                        {{ __('Monitored') }}
+                    </span>
+                @else
+                    <span class="block w-full text-center px-2 py-1.5 rounded-md bg-primary-600 text-white text-xs font-medium">
+                        {{ $item['media_type'] === 'tv' ? __('Select Seasons') : __('Request Movie') }}
+                    </span>
+                @endif
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,8 +3,16 @@
 use App\Http\Controllers\Api\DispatcharrController;
 use App\Http\Controllers\Api\EpgApiController;
 use App\Http\Controllers\Api\M3uProxyApiController;
+use App\Http\Controllers\ArrWebhookController;
 use App\Http\Controllers\DvrCallbackController;
 use Illuminate\Support\Facades\Route;
+
+/*
+ * Arr (Sonarr/Radarr) webhook receiver.
+ * Routed by the integration's unique webhook_secret so no additional auth header is needed.
+ */
+Route::post('webhooks/arr/{integration:webhook_secret}', [ArrWebhookController::class, 'receive'])
+    ->name('webhooks.arr');
 
 /*
  * EPG API routes

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Route;
  * Routed by the integration's unique webhook_secret so no additional auth header is needed.
  */
 Route::post('webhooks/arr/{integration:webhook_secret}', [ArrWebhookController::class, 'receive'])
+    ->middleware('throttle:120,1')
     ->name('webhooks.arr');
 
 /*

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -5,3 +5,7 @@ use Illuminate\Support\Facades\Broadcast;
 Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
 });
+
+Broadcast::channel('arr-queue.{userId}', function ($user, $userId) {
+    return (int) $user->id === (int) $userId;
+});

--- a/tests/Feature/ArrIntegrationResourceTest.php
+++ b/tests/Feature/ArrIntegrationResourceTest.php
@@ -5,7 +5,6 @@ use App\Filament\Resources\ArrIntegrations\Pages\CreateArrIntegration;
 use App\Filament\Resources\ArrIntegrations\Pages\EditArrIntegration;
 use App\Filament\Resources\ArrIntegrations\Pages\ListArrIntegrations;
 use App\Models\ArrIntegration;
-use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
@@ -17,7 +16,6 @@ beforeEach(function () {
     Bus::fake();
     $this->user = User::factory()->create(['permissions' => ['use_integrations']]);
     $this->actingAs($this->user);
-    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
 });
 
 it('hides navigation when user cannot use integrations', function () {
@@ -36,18 +34,9 @@ it('shows navigation when user has permission', function () {
 
 it('scopes table query to current user', function () {
     $other = User::factory()->create();
-    $otherPlaylist = Playlist::factory()->create(['user_id' => $other->id]);
 
-    ArrIntegration::factory()->create([
-        'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
-        'name' => 'Mine',
-    ]);
-    ArrIntegration::factory()->create([
-        'user_id' => $other->id,
-        'playlist_id' => $otherPlaylist->id,
-        'name' => 'Theirs',
-    ]);
+    ArrIntegration::factory()->create(['user_id' => $this->user->id, 'name' => 'Mine']);
+    ArrIntegration::factory()->create(['user_id' => $other->id, 'name' => 'Theirs']);
 
     $query = ArrIntegrationResource::getEloquentQuery();
     $names = $query->pluck('name')->all();
@@ -61,7 +50,6 @@ it('can create an integration', function () {
         ->fillForm([
             'name' => 'Sonarr 1080p',
             'type' => 'sonarr',
-            'playlist_id' => $this->playlist->id,
             'url' => 'http://192.168.1.42:8989',
             'api_key' => 'secret-key-123',
             'enabled' => true,
@@ -78,23 +66,10 @@ it('can create an integration', function () {
     expect($integration->api_key)->toBe('secret-key-123');
 });
 
-it('requires playlist_id on create', function () {
-    Livewire::test(CreateArrIntegration::class)
-        ->fillForm([
-            'name' => 'No Playlist',
-            'type' => 'sonarr',
-            'url' => 'http://192.168.1.42:8989',
-            'api_key' => 'secret',
-        ])
-        ->call('create')
-        ->assertHasFormErrors(['playlist_id' => 'required']);
-});
-
 it('requires type on create', function () {
     Livewire::test(CreateArrIntegration::class)
         ->fillForm([
             'name' => 'No Type',
-            'playlist_id' => $this->playlist->id,
             'url' => 'http://192.168.1.42:8989',
             'api_key' => 'secret',
         ])
@@ -105,7 +80,6 @@ it('requires type on create', function () {
 it('can edit an existing integration', function () {
     $integration = ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'name' => 'Old Name',
     ]);
 
@@ -125,7 +99,6 @@ it('can edit an existing integration', function () {
 it('preserves api_key on edit when left blank', function () {
     $integration = ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'api_key' => 'original-key',
     ]);
 
@@ -141,10 +114,7 @@ it('preserves api_key on edit when left blank', function () {
 });
 
 it('can delete an integration', function () {
-    $integration = ArrIntegration::factory()->create([
-        'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
-    ]);
+    $integration = ArrIntegration::factory()->create(['user_id' => $this->user->id]);
 
     $this->assertDatabaseHas('arr_integrations', ['id' => $integration->id]);
 
@@ -155,11 +125,7 @@ it('can delete an integration', function () {
 });
 
 it('lists the page without error', function () {
-    ArrIntegration::factory()->create([
-        'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
-        'name' => 'My Sonarr',
-    ]);
+    ArrIntegration::factory()->create(['user_id' => $this->user->id, 'name' => 'My Sonarr']);
 
     Livewire::test(ListArrIntegrations::class)
         ->assertOk();

--- a/tests/Feature/ArrIntegrationResourceTest.php
+++ b/tests/Feature/ArrIntegrationResourceTest.php
@@ -1,0 +1,166 @@
+<?php
+
+use App\Filament\Resources\ArrIntegrations\ArrIntegrationResource;
+use App\Filament\Resources\ArrIntegrations\Pages\CreateArrIntegration;
+use App\Filament\Resources\ArrIntegrations\Pages\EditArrIntegration;
+use App\Filament\Resources\ArrIntegrations\Pages\ListArrIntegrations;
+use App\Models\ArrIntegration;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Bus::fake();
+    $this->user = User::factory()->create(['permissions' => ['use_integrations']]);
+    $this->actingAs($this->user);
+    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+});
+
+it('hides navigation when user cannot use integrations', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    expect(ArrIntegrationResource::canAccess())->toBeFalse();
+});
+
+it('shows navigation when user has permission', function () {
+    $user = User::factory()->create(['permissions' => ['use_integrations']]);
+    $this->actingAs($user);
+
+    expect(ArrIntegrationResource::canAccess())->toBeTrue();
+});
+
+it('scopes table query to current user', function () {
+    $other = User::factory()->create();
+    $otherPlaylist = Playlist::factory()->create(['user_id' => $other->id]);
+
+    ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Mine',
+    ]);
+    ArrIntegration::factory()->create([
+        'user_id' => $other->id,
+        'playlist_id' => $otherPlaylist->id,
+        'name' => 'Theirs',
+    ]);
+
+    $query = ArrIntegrationResource::getEloquentQuery();
+    $names = $query->pluck('name')->all();
+
+    expect($names)->toContain('Mine');
+    expect($names)->not->toContain('Theirs');
+});
+
+it('can create an integration', function () {
+    Livewire::test(CreateArrIntegration::class)
+        ->fillForm([
+            'name' => 'Sonarr 1080p',
+            'type' => 'sonarr',
+            'playlist_id' => $this->playlist->id,
+            'url' => 'http://192.168.1.42:8989',
+            'api_key' => 'secret-key-123',
+            'enabled' => true,
+            'guest_enabled' => false,
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors()
+        ->assertNotified();
+
+    $integration = ArrIntegration::where('name', 'Sonarr 1080p')->first();
+    expect($integration)->not->toBeNull();
+    expect($integration->user_id)->toBe($this->user->id);
+    expect($integration->isSonarr())->toBeTrue();
+    expect($integration->api_key)->toBe('secret-key-123');
+});
+
+it('requires playlist_id on create', function () {
+    Livewire::test(CreateArrIntegration::class)
+        ->fillForm([
+            'name' => 'No Playlist',
+            'type' => 'sonarr',
+            'url' => 'http://192.168.1.42:8989',
+            'api_key' => 'secret',
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['playlist_id' => 'required']);
+});
+
+it('requires type on create', function () {
+    Livewire::test(CreateArrIntegration::class)
+        ->fillForm([
+            'name' => 'No Type',
+            'playlist_id' => $this->playlist->id,
+            'url' => 'http://192.168.1.42:8989',
+            'api_key' => 'secret',
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['type' => 'required']);
+});
+
+it('can edit an existing integration', function () {
+    $integration = ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Old Name',
+    ]);
+
+    Livewire::test(EditArrIntegration::class, [
+        'record' => $integration->id,
+    ])
+        ->fillForm(['name' => 'New Name', 'guest_enabled' => true])
+        ->call('save')
+        ->assertHasNoFormErrors()
+        ->assertNotified();
+
+    $integration->refresh();
+    expect($integration->name)->toBe('New Name');
+    expect($integration->guest_enabled)->toBeTrue();
+});
+
+it('preserves api_key on edit when left blank', function () {
+    $integration = ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'api_key' => 'original-key',
+    ]);
+
+    Livewire::test(EditArrIntegration::class, [
+        'record' => $integration->id,
+    ])
+        ->fillForm(['name' => 'New Name'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $integration->refresh();
+    expect($integration->api_key)->toBe('original-key');
+});
+
+it('can delete an integration', function () {
+    $integration = ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $this->assertDatabaseHas('arr_integrations', ['id' => $integration->id]);
+
+    $integration->delete();
+
+    expect(ArrIntegration::find($integration->id))->toBeNull();
+    $this->assertDatabaseMissing('arr_integrations', ['id' => $integration->id]);
+});
+
+it('lists the page without error', function () {
+    ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'My Sonarr',
+    ]);
+
+    Livewire::test(ListArrIntegrations::class)
+        ->assertOk();
+});

--- a/tests/Feature/ArrIntegrationTest.php
+++ b/tests/Feature/ArrIntegrationTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Models\ArrIntegration;
-use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
@@ -11,18 +10,15 @@ uses(RefreshDatabase::class);
 beforeEach(function () {
     Bus::fake();
     $this->user = User::factory()->create();
-    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
 });
 
 it('can be created via factory', function () {
     $integration = ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     expect($integration)->toBeInstanceOf(ArrIntegration::class);
     expect($integration->user_id)->toBe($this->user->id);
-    expect($integration->playlist_id)->toBe($this->playlist->id);
     expect($integration->enabled)->toBeTrue();
     expect($integration->guest_enabled)->toBeFalse();
 });
@@ -30,7 +26,6 @@ it('can be created via factory', function () {
 it('casts api_key to encrypted', function () {
     $integration = ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'api_key' => 'plain-secret-key',
     ]);
 
@@ -46,34 +41,24 @@ it('casts api_key to encrypted', function () {
 it('hides api_key from array/serialization', function () {
     $integration = ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $array = $integration->toArray();
     expect($array)->not->toHaveKey('api_key');
 });
 
-it('has user and playlist relationships', function () {
+it('has a user relationship', function () {
     $integration = ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     expect($integration->user)->toBeInstanceOf(User::class);
     expect($integration->user->id)->toBe($this->user->id);
-    expect($integration->playlist)->toBeInstanceOf(Playlist::class);
-    expect($integration->playlist->id)->toBe($this->playlist->id);
 });
 
 it('has isSonarr and isRadarr helpers', function () {
-    $sonarr = ArrIntegration::factory()->sonarr()->create([
-        'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
-    ]);
-    $radarr = ArrIntegration::factory()->radarr()->create([
-        'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
-    ]);
+    $sonarr = ArrIntegration::factory()->sonarr()->create(['user_id' => $this->user->id]);
+    $radarr = ArrIntegration::factory()->radarr()->create(['user_id' => $this->user->id]);
 
     expect($sonarr->isSonarr())->toBeTrue();
     expect($sonarr->isRadarr())->toBeFalse();
@@ -84,7 +69,6 @@ it('has isSonarr and isRadarr helpers', function () {
 it('strips trailing slash from base_url', function () {
     $integration = ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'url' => 'http://192.168.1.42:8989/',
     ]);
 
@@ -94,19 +78,16 @@ it('strips trailing slash from base_url', function () {
 it('scopeEnabled and scopeGuestEnabled filter correctly', function () {
     ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'enabled' => true,
         'guest_enabled' => true,
     ]);
     ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'enabled' => false,
         'guest_enabled' => true,
     ]);
     ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'enabled' => true,
         'guest_enabled' => false,
     ]);

--- a/tests/Feature/ArrIntegrationTest.php
+++ b/tests/Feature/ArrIntegrationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Models\ArrIntegration;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Bus::fake();
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+});
+
+it('can be created via factory', function () {
+    $integration = ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    expect($integration)->toBeInstanceOf(ArrIntegration::class);
+    expect($integration->user_id)->toBe($this->user->id);
+    expect($integration->playlist_id)->toBe($this->playlist->id);
+    expect($integration->enabled)->toBeTrue();
+    expect($integration->guest_enabled)->toBeFalse();
+});
+
+it('casts api_key to encrypted', function () {
+    $integration = ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'api_key' => 'plain-secret-key',
+    ]);
+
+    // Decrypt attribute returns the original
+    expect($integration->api_key)->toBe('plain-secret-key');
+
+    // Underlying DB column is encrypted (not the plaintext)
+    $raw = DB::table('arr_integrations')->where('id', $integration->id)->value('api_key');
+    expect($raw)->not->toBe('plain-secret-key');
+    expect(strlen($raw))->toBeGreaterThan(20);
+});
+
+it('hides api_key from array/serialization', function () {
+    $integration = ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $array = $integration->toArray();
+    expect($array)->not->toHaveKey('api_key');
+});
+
+it('has user and playlist relationships', function () {
+    $integration = ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    expect($integration->user)->toBeInstanceOf(User::class);
+    expect($integration->user->id)->toBe($this->user->id);
+    expect($integration->playlist)->toBeInstanceOf(Playlist::class);
+    expect($integration->playlist->id)->toBe($this->playlist->id);
+});
+
+it('has isSonarr and isRadarr helpers', function () {
+    $sonarr = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    expect($sonarr->isSonarr())->toBeTrue();
+    expect($sonarr->isRadarr())->toBeFalse();
+    expect($radarr->isRadarr())->toBeTrue();
+    expect($radarr->isSonarr())->toBeFalse();
+});
+
+it('strips trailing slash from base_url', function () {
+    $integration = ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'url' => 'http://192.168.1.42:8989/',
+    ]);
+
+    expect($integration->base_url)->toBe('http://192.168.1.42:8989');
+});
+
+it('scopeEnabled and scopeGuestEnabled filter correctly', function () {
+    ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'enabled' => true,
+        'guest_enabled' => true,
+    ]);
+    ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'enabled' => false,
+        'guest_enabled' => true,
+    ]);
+    ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'enabled' => true,
+        'guest_enabled' => false,
+    ]);
+
+    expect(ArrIntegration::enabled()->count())->toBe(2);
+    expect(ArrIntegration::guestEnabled()->count())->toBe(2);
+    expect(ArrIntegration::enabled()->guestEnabled()->count())->toBe(1);
+});

--- a/tests/Feature/ArrQueueMonitorTest.php
+++ b/tests/Feature/ArrQueueMonitorTest.php
@@ -161,6 +161,83 @@ it('returns correct status badge color for known statuses', function () {
     expect(ArrQueueMonitor::statusBadge('paused')['color'])->toBe('gray');
 });
 
+it('snapshots a live item that vanishes between polls and marks it completed', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    // First poll returns an active item; second poll returns empty (item completed and left the queue).
+    Http::fake([
+        '*/api/v3/queue*' => Http::sequence()
+            ->push([
+                'records' => [[
+                    'id' => 1,
+                    'downloadId' => 'ghost-dl-abc',
+                    'status' => 'downloading',
+                    'size' => 1_073_741_824,
+                    'sizeleft' => 536_870_912,
+                    'timeleft' => '00:05:00',
+                    'series' => ['title' => 'Severance'],
+                ]],
+            ], 200)
+            ->push(['records' => []], 200),
+    ]);
+
+    $component = Livewire::test(ArrQueueMonitor::class);
+
+    expect($component->get("queues.{$integration->id}.items.0.title"))->toBe('Severance');
+    expect($component->get("queues.{$integration->id}.items.0.source"))->toBe('live');
+
+    $component->call('loadQueues');
+
+    $items = $component->get("queues.{$integration->id}.items");
+    $snapshot = collect($items)->firstWhere('source', 'snapshot');
+
+    expect($snapshot)->not->toBeNull()
+        ->and($snapshot['title'])->toBe('Severance')
+        ->and($snapshot['status'])->toBe('completed')
+        ->and($snapshot['progress'])->toBe(100)
+        ->and($snapshot['can_dismiss'])->toBeTrue();
+
+    expect($component->get('completedSnapshots'))->toHaveCount(1);
+});
+
+it('caps completed snapshots at MAX_SNAPSHOTS_PER_INTEGRATION per integration', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    // Seed the component with 26 orphan live items across two polls, one per cycle.
+    $component = null;
+    for ($i = 1; $i <= 26; $i++) {
+        // Each iteration: previous item gone, new item present.
+        Http::fake([
+            '*/api/v3/queue*' => Http::response([
+                'records' => [[
+                    'id' => $i,
+                    'downloadId' => "dl-{$i}",
+                    'status' => 'downloading',
+                    'size' => 0,
+                    'sizeleft' => 0,
+                    'series' => ['title' => "Show {$i}"],
+                ]],
+            ], 200),
+        ]);
+
+        if ($component === null) {
+            $component = Livewire::test(ArrQueueMonitor::class);
+        } else {
+            $component->call('loadQueues');
+        }
+
+        // Now clear the queue so the item becomes an orphan on next poll.
+        Http::fake(['*/api/v3/queue*' => Http::response(['records' => []], 200)]);
+        $component->call('loadQueues');
+    }
+
+    expect(count($component->get('completedSnapshots')))->toBeLessThanOrEqual(25);
+});
+
 it('counts total items across all queues', function () {
     ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,

--- a/tests/Feature/ArrQueueMonitorTest.php
+++ b/tests/Feature/ArrQueueMonitorTest.php
@@ -1,0 +1,184 @@
+<?php
+
+use App\Livewire\ArrQueueMonitor;
+use App\Models\ArrIntegration;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+    $this->user = User::factory()->create(['permissions' => ['use_integrations']]);
+    $this->actingAs($this->user);
+    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+});
+
+it('renders with no integrations', function () {
+    Livewire::test(ArrQueueMonitor::class)
+        ->assertOk()
+        ->assertSet('queues', []);
+});
+
+it('loads the sonarr queue on mount', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/queue*' => Http::response([
+            'records' => [
+                [
+                    'id' => 1,
+                    'status' => 'downloading',
+                    'size' => 1_073_741_824,
+                    'sizeleft' => 268_435_456,
+                    'timeleft' => '00:10:00',
+                    'series' => ['title' => 'Breaking Bad'],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrQueueMonitor::class);
+
+    expect($component->get("queues.{$integration->id}.items.0.title"))->toBe('Breaking Bad');
+    expect($component->get("queues.{$integration->id}.items.0.progress"))->toBe(75);
+    expect($component->get("queues.{$integration->id}.items.0.formattedSize"))->toBe('1.00 GB');
+    expect($component->get("queues.{$integration->id}.integration.type"))->toBe('sonarr');
+});
+
+it('loads the radarr queue on mount', function () {
+    $integration = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/queue*' => Http::response([
+            'records' => [
+                [
+                    'id' => 10,
+                    'status' => 'queued',
+                    'size' => 2_147_483_648,
+                    'sizeleft' => 2_147_483_648,
+                    'timeleft' => null,
+                    'movie' => ['title' => 'Inception'],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrQueueMonitor::class);
+
+    expect($component->get("queues.{$integration->id}.items.0.title"))->toBe('Inception');
+    expect($component->get("queues.{$integration->id}.items.0.progress"))->toBe(0);
+    expect($component->get("queues.{$integration->id}.integration.type"))->toBe('radarr');
+});
+
+it('groups queues by type via computed properties', function () {
+    $sonarr = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/queue*' => Http::response(['records' => []], 200),
+    ]);
+
+    $component = Livewire::test(ArrQueueMonitor::class);
+
+    expect($component->get('sonarrQueues'))->toHaveCount(1);
+    expect($component->get('radarrQueues'))->toHaveCount(1);
+    expect($component->get('sonarrQueues.0.integration.id'))->toBe($sonarr->id);
+    expect($component->get('radarrQueues.0.integration.id'))->toBe($radarr->id);
+});
+
+it('continues loading other integrations when one is unreachable', function () {
+    $sonarr = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'url' => 'http://sonarr.local',
+    ]);
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'url' => 'http://radarr.local',
+    ]);
+
+    Http::fake([
+        'sonarr.local/*' => function () {
+            throw new ConnectionException('connection refused');
+        },
+        'radarr.local/*' => Http::response([
+            'records' => [
+                [
+                    'id' => 5,
+                    'status' => 'downloading',
+                    'size' => 1_048_576,
+                    'sizeleft' => 0,
+                    'timeleft' => null,
+                    'movie' => ['title' => 'Dune'],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrQueueMonitor::class);
+
+    expect($component->get("queues.{$sonarr->id}.error"))->toBeTrue();
+    expect($component->get("queues.{$sonarr->id}.items"))->toBeEmpty();
+    expect($component->get("queues.{$radarr->id}.error"))->toBeFalse();
+    expect($component->get("queues.{$radarr->id}.items.0.title"))->toBe('Dune');
+});
+
+it('only shows integrations belonging to the authenticated user', function () {
+    $otherUser = User::factory()->create(['permissions' => ['use_integrations']]);
+    ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $otherUser->id,
+    ]);
+
+    // No fake needed — no HTTP calls should be made for another user's integrations
+    Livewire::test(ArrQueueMonitor::class)
+        ->assertSet('queues', []);
+});
+
+it('formats bytes correctly', function () {
+    expect(ArrQueueMonitor::formatBytes(0))->toBe('–');
+    expect(ArrQueueMonitor::formatBytes(1_024))->toBe('1.00 KB');
+    expect(ArrQueueMonitor::formatBytes(1_048_576))->toBe('1.00 MB');
+    expect(ArrQueueMonitor::formatBytes(1_073_741_824))->toBe('1.00 GB');
+});
+
+it('returns correct status badge color for known statuses', function () {
+    expect(ArrQueueMonitor::statusBadge('downloading')['color'])->toBe('primary');
+    expect(ArrQueueMonitor::statusBadge('queued')['color'])->toBe('warning');
+    expect(ArrQueueMonitor::statusBadge('completed')['color'])->toBe('success');
+    expect(ArrQueueMonitor::statusBadge('failed')['color'])->toBe('danger');
+    expect(ArrQueueMonitor::statusBadge('paused')['color'])->toBe('gray');
+});
+
+it('counts total items across all queues', function () {
+    ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+    ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/queue*' => Http::response([
+            'records' => [
+                ['id' => 1, 'status' => 'downloading', 'size' => 0, 'sizeleft' => 0, 'series' => ['title' => 'A']],
+                ['id' => 2, 'status' => 'queued', 'size' => 0, 'sizeleft' => 0, 'movie' => ['title' => 'B']],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrQueueMonitor::class);
+
+    expect($component->get('totalCount'))->toBe(4);
+});

--- a/tests/Feature/ArrSearchTest.php
+++ b/tests/Feature/ArrSearchTest.php
@@ -1199,7 +1199,10 @@ it('browseGenre loads discover results filtered by genre', function () {
     app()->bind(TmdbService::class, function () use ($genreResults) {
         $mock = Mockery::mock(TmdbService::class)->makePartial();
         $mock->shouldReceive('isConfigured')->andReturn(true);
-        $mock->shouldReceive('discoverMovies')->with(['with_genres' => 28])->andReturn($genreResults);
+        $mock->shouldReceive('getWatchProviders')->andReturn([]);
+        $mock->shouldReceive('discoverMovies')
+            ->with(Mockery::on(fn ($p) => ($p['with_genres'] ?? null) === 28))
+            ->andReturn($genreResults);
 
         return $mock;
     });

--- a/tests/Feature/ArrSearchTest.php
+++ b/tests/Feature/ArrSearchTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Jobs\MonitorArrSearch;
+use App\Jobs\RequestArrEpisode;
 use App\Livewire\ArrSearch;
 use App\Models\ArrIntegration;
 use App\Models\Playlist;
@@ -1188,21 +1190,17 @@ it('loadDiscover is a no-op when TMDB is not configured', function () {
 });
 
 it('browseGenre loads discover results filtered by genre', function () {
-    $radarr = ArrIntegration::factory()->radarr()->create([
-        'user_id' => $this->user->id,
-    ]);
+    ArrIntegration::factory()->radarr()->create(['user_id' => $this->user->id]);
 
-    $genreResults = [
-        ['tmdb_id' => 101, 'title' => 'Action Movie', 'media_type' => 'movie', 'year' => '2024', 'overview' => null, 'poster_url' => null, 'backdrop_url' => null, 'vote_average' => 7.5, 'genre_ids' => [28]],
-    ];
+    $genreItem = ['tmdb_id' => 101, 'title' => 'Action Movie', 'media_type' => 'movie', 'year' => '2024', 'overview' => null, 'poster_url' => null, 'backdrop_url' => null, 'vote_average' => 7.5, 'genre_ids' => [28]];
 
-    app()->bind(TmdbService::class, function () use ($genreResults) {
+    app()->bind(TmdbService::class, function () use ($genreItem) {
         $mock = Mockery::mock(TmdbService::class)->makePartial();
         $mock->shouldReceive('isConfigured')->andReturn(true);
         $mock->shouldReceive('getWatchProviders')->andReturn([]);
         $mock->shouldReceive('discoverMovies')
-            ->with(Mockery::on(fn ($p) => ($p['with_genres'] ?? null) === 28))
-            ->andReturn($genreResults);
+            ->with(Mockery::on(fn ($p) => ($p['with_genres'] ?? null) === 28 && ($p['page'] ?? null) === 1))
+            ->andReturn(['results' => [$genreItem], 'total_pages' => 3]);
 
         return $mock;
     });
@@ -1221,6 +1219,46 @@ it('browseGenre loads discover results filtered by genre', function () {
     expect($component->get('browseResults'))->toHaveCount(1);
     expect($component->get('browseResults.0.title'))->toBe('Action Movie');
     expect($component->get('browseLoading'))->toBeFalse();
+    expect($component->get('browseTotalPages'))->toBe(3);
+    expect($component->get('browsePage'))->toBe(1);
+});
+
+it('goToBrowsePage replaces results with the requested page', function () {
+    ArrIntegration::factory()->radarr()->create(['user_id' => $this->user->id]);
+
+    $page2Item = ['tmdb_id' => 202, 'title' => 'Action Sequel', 'media_type' => 'movie', 'year' => '2025', 'overview' => null, 'poster_url' => null, 'backdrop_url' => null, 'vote_average' => 6.8, 'genre_ids' => [28]];
+
+    app()->bind(TmdbService::class, function () use ($page2Item) {
+        $mock = Mockery::mock(TmdbService::class)->makePartial();
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('getWatchProviders')->andReturn([]);
+        $mock->shouldReceive('discoverMovies')
+            ->with(Mockery::on(fn ($p) => ($p['page'] ?? null) === 2))
+            ->andReturn(['results' => [$page2Item], 'total_pages' => 3]);
+
+        return $mock;
+    });
+
+    Http::fake([
+        '*/api/v3/series*' => Http::response([], 200),
+        '*/api/v3/movie*' => Http::response([], 200),
+    ]);
+
+    $existing = ['tmdb_id' => 101, 'title' => 'Action Movie', 'media_type' => 'movie', 'year' => '2024', 'overview' => null, 'poster_url' => null, 'backdrop_url' => null, 'vote_average' => 7.5, 'genre_ids' => [28], 'existsInLibrary' => false, 'isDownloaded' => false];
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('tmdbConfigured', true)
+        ->set('browseGenreId', 28)
+        ->set('browseGenreType', 'movie')
+        ->set('browsePage', 1)
+        ->set('browseTotalPages', 3)
+        ->set('browseResults', [$existing])
+        ->call('goToBrowsePage', 2);
+
+    expect($component->get('browseResults'))->toHaveCount(1);
+    expect($component->get('browseResults.0.title'))->toBe('Action Sequel');
+    expect($component->get('browsePage'))->toBe(2);
+    expect($component->get('browseTotalPages'))->toBe(3);
 });
 
 it('clearBrowse resets genre browse state', function () {
@@ -1230,10 +1268,14 @@ it('clearBrowse resets genre browse state', function () {
         ->set('browseGenreId', 28)
         ->set('browseGenreType', 'movie')
         ->set('browseResults', [['tmdb_id' => 1, 'title' => 'Test']])
+        ->set('browsePage', 3)
+        ->set('browseTotalPages', 5)
         ->call('clearBrowse')
         ->assertSet('browseGenreId', null)
         ->assertSet('browseGenreType', null)
-        ->assertSet('browseResults', []);
+        ->assertSet('browseResults', [])
+        ->assertSet('browsePage', 1)
+        ->assertSet('browseTotalPages', 0);
 });
 
 it('requestFromDiscover resolves a Radarr movie and opens detail panel', function () {
@@ -1392,34 +1434,38 @@ it('radarr search includes libraryId when item exists in library', function () {
 
 // ── triggerAutomaticSearch ────────────────────────────────────────────────────
 
-it('sonarr triggerAutomaticSearch posts SeriesSearch command', function () {
+it('sonarr triggerAutomaticSearch posts SeriesSearch command and returns command id', function () {
     Http::fake([
-        '*/api/v3/command*' => Http::response([], 201),
+        '*/api/v3/command*' => Http::response(['id' => 77], 201),
     ]);
 
     $service = new SonarrService($this->sonarr);
     $result = $service->triggerAutomaticSearch(42);
 
-    expect($result['ok'])->toBeTrue();
+    expect($result['ok'])->toBeTrue()
+        ->and($result['data'])->toBe(77);
+
     Http::assertSent(fn ($req) => str_contains($req->url(), '/command')
         && $req->data()['name'] === 'SeriesSearch'
         && $req->data()['seriesId'] === 42
     );
 });
 
-it('radarr triggerAutomaticSearch posts MoviesSearch command', function () {
+it('radarr triggerAutomaticSearch posts MoviesSearch command and returns command id', function () {
     $radarr = ArrIntegration::factory()->radarr()->create([
         'user_id' => $this->user->id,
     ]);
 
     Http::fake([
-        '*/api/v3/command*' => Http::response([], 201),
+        '*/api/v3/command*' => Http::response(['id' => 88], 201),
     ]);
 
     $service = new RadarrService($radarr);
     $result = $service->triggerAutomaticSearch(99);
 
-    expect($result['ok'])->toBeTrue();
+    expect($result['ok'])->toBeTrue()
+        ->and($result['data'])->toBe(88);
+
     Http::assertSent(fn ($req) => str_contains($req->url(), '/command')
         && $req->data()['name'] === 'MoviesSearch'
         && $req->data()['movieIds'] === [99]
@@ -1440,12 +1486,12 @@ it('triggerAutomaticSearch returns error when command fails', function () {
 
 // ── Livewire: triggerAutomaticSearch action ───────────────────────────────────
 
-it('livewire triggerAutomaticSearch triggers search for library item', function () {
+it('livewire triggerAutomaticSearch triggers search and dispatches MonitorArrSearch job', function () {
     Http::fake([
         '*/api/v3/series/lookup*' => Http::response([
             ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008, 'seasons' => []],
         ], 200),
-        '*/api/v3/command*' => Http::response([], 201),
+        '*/api/v3/command*' => Http::response(['id' => 55], 201),
     ]);
 
     Livewire::test(ArrSearch::class)
@@ -1456,6 +1502,11 @@ it('livewire triggerAutomaticSearch triggers search for library item', function 
 
     Http::assertSent(fn ($req) => str_contains($req->url(), '/command')
         && $req->data()['name'] === 'SeriesSearch'
+    );
+
+    Bus::assertDispatched(MonitorArrSearch::class, fn ($job) => $job->contentId === 42
+        && $job->contentTitle === 'Breaking Bad'
+        && $job->userId === $this->user->id
     );
 });
 
@@ -1588,31 +1639,12 @@ it('loadQueue does not dispatch refreshArrQueue in guest mode', function () {
 
 // ── requestEpisode retry ─────────────────────────────────────────────────────
 
-it('requestEpisode retries episode fetch when series was just added and episodes not yet indexed', function () {
-    SonarrService::$episodeRetryDelayUs = 0;
-
-    // NOTE: Http::fake map-invokes ALL stubs for every request, so a Http::sequence() on *episode*
-    // would be consumed by monitor requests too. Use a closure that returns null for monitor URLs.
-    $episodeFetchCalls = 0;
-
+it('requestEpisode dispatches a background job when the series was just added to Sonarr', function () {
     Http::fake([
         '*/api/v3/series/lookup*' => Http::response([
             ['tvdbId' => 12345, 'title' => 'Dark', 'titleSlug' => 'dark', 'seasons' => [['seasonNumber' => 1]]],
         ], 200),
         '*/api/v3/series' => Http::response(['id' => 77, 'title' => 'Dark'], 201),
-        '*/api/v3/episode/monitor' => Http::response(null, 200),
-        '*/api/v3/command' => Http::response(['id' => 1], 201),
-        // Return null for monitor URLs so the specific stub above wins; simulate empty then populated.
-        '*/api/v3/episode*' => function ($request) use (&$episodeFetchCalls) {
-            if (str_contains($request->url(), '/monitor')) {
-                return null;
-            }
-            $episodeFetchCalls++;
-
-            return $episodeFetchCalls === 1
-                ? Http::response([], 200)
-                : Http::response([['id' => 301, 'episodeNumber' => 1, 'seasonNumber' => 1, 'title' => 'Secrets']], 200);
-        },
         'api.tvmaze.com/*' => Http::response(['id' => 1], 200),
     ]);
 
@@ -1621,35 +1653,47 @@ it('requestEpisode retries episode fetch when series was just added and episodes
         ->call('openDetail', 0)
         ->call('requestEpisode', 1, 1)
         ->assertNotified();
+
+    Bus::assertDispatched(RequestArrEpisode::class, fn ($job) => $job->integrationId === $this->sonarr->id
+        && $job->sonarrSeriesId === 77
+        && $job->seasonNumber === 1
+        && $job->episodeNumber === 1
+        && $job->showTitle === 'Dark'
+    );
+
+    // monitor and command must NOT be called from the web worker — they happen inside the job
+    Http::assertNotSent(fn ($r) => str_ends_with($r->url(), '/api/v3/episode/monitor'));
+    Http::assertNotSent(fn ($r) => str_ends_with($r->url(), '/api/v3/command'));
+});
+
+it('requestEpisode monitors and searches synchronously when series already exists in Sonarr', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            // id present → series already in library, no POST /series
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Dark', 'titleSlug' => 'dark', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        '*/api/v3/episode/monitor' => Http::response(null, 200),
+        '*/api/v3/command' => Http::response(['id' => 1], 201),
+        '*/api/v3/episode*' => Http::response([
+            ['id' => 301, 'episodeNumber' => 1, 'seasonNumber' => 1, 'title' => 'Secrets'],
+        ], 200),
+        'api.tvmaze.com/*' => Http::response(['id' => 1], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'dark')
+        ->call('openDetail', 0)
+        ->call('requestEpisode', 1, 1)
+        ->assertNotified();
+
+    // No job dispatched — handled synchronously
+    Bus::assertNotDispatched(RequestArrEpisode::class);
 
     Http::assertSent(fn ($r) => $r->method() === 'PUT' && str_ends_with($r->url(), '/api/v3/episode/monitor')
         && in_array(301, $r->data()['episodeIds'] ?? []));
-
     Http::assertSent(fn ($r) => $r->method() === 'POST' && str_ends_with($r->url(), '/api/v3/command')
         && ($r->data()['name'] ?? '') === 'EpisodeSearch');
-})->after(fn () => SonarrService::$episodeRetryDelayUs = 500_000);
-
-it('requestEpisode shows error when episode still not found after all retries', function () {
-    SonarrService::$episodeRetryDelayUs = 0;
-
-    Http::fake([
-        '*/api/v3/series/lookup*' => Http::response([
-            ['tvdbId' => 12345, 'title' => 'Dark', 'titleSlug' => 'dark', 'seasons' => [['seasonNumber' => 1]]],
-        ], 200),
-        '*/api/v3/series' => Http::response(['id' => 77, 'title' => 'Dark'], 201),
-        // All attempts return empty — episode never indexes in time
-        '*/api/v3/episode*' => Http::response([], 200),
-        'api.tvmaze.com/*' => Http::response(['id' => 1], 200),
-    ]);
-
-    Livewire::test(ArrSearch::class)
-        ->set('searchTerm', 'dark')
-        ->call('openDetail', 0)
-        ->call('requestEpisode', 1, 1)
-        ->assertNotified();
-
-    Http::assertNotSent(fn ($r) => str_ends_with($r->url(), '/api/v3/command'));
-})->after(fn () => SonarrService::$episodeRetryDelayUs = 500_000);
+});
 
 // ── Livewire: loadEpisodeReleases action ─────────────────────────────────────
 

--- a/tests/Feature/ArrSearchTest.php
+++ b/tests/Feature/ArrSearchTest.php
@@ -4,6 +4,9 @@ use App\Livewire\ArrSearch;
 use App\Models\ArrIntegration;
 use App\Models\Playlist;
 use App\Models\User;
+use App\Services\Arr\RadarrService;
+use App\Services\Arr\SonarrService;
+use App\Services\TmdbService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Bus;
@@ -20,27 +23,53 @@ beforeEach(function () {
     $this->user = User::factory()->create(['permissions' => ['use_integrations']]);
     $this->actingAs($this->user);
     $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
-    $this->integration = ArrIntegration::factory()->sonarr()->create([
+    $this->sonarr = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'quality_profile_id' => 1,
         'root_folder_path' => '/media/tv',
     ]);
 });
 
-it('renders without an integration selected', function () {
+it('renders without any integrations configured', function () {
+    $this->sonarr->delete();
+
     Livewire::test(ArrSearch::class)
         ->assertOk();
 });
 
-it('returns the active integration', function () {
-    $component = Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id]);
+it('renders with integrations available', function () {
+    Http::fake(); // no requests expected on mount
 
-    expect($component->get('integration'))->toBeInstanceOf(ArrIntegration::class);
-    expect($component->get('integration')->id)->toBe($this->integration->id);
+    Livewire::test(ArrSearch::class)
+        ->assertOk()
+        ->assertSet('results', []);
 });
 
-it('searches the Sonarr API', function () {
+it('searches all enabled integrations simultaneously', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008],
+        ], 200),
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['tmdbId' => 27205, 'title' => 'Breaking Dawn', 'year' => 2011],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking');
+
+    // Both integrations contribute results
+    expect($component->get('results'))->toHaveCount(2);
+
+    $types = collect($component->get('results'))->pluck('integrationType')->sort()->values()->all();
+    expect($types)->toBe(['radarr', 'sonarr']);
+});
+
+it('searches the Sonarr API for TV series', function () {
     Http::fake([
         '*/api/v3/series/lookup*' => Http::response([
             [
@@ -53,56 +82,164 @@ it('searches the Sonarr API', function () {
         ], 200),
     ]);
 
-    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
-        ->set('searchTerm', 'breaking')
-        ->assertSet('results.0.title', 'Breaking Bad')
-        ->assertSet('results.0.tvdbId', 12345);
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking');
+
+    expect($component->get('results.0.title'))->toBe('Breaking Bad');
+    expect($component->get('results.0.tvdbId'))->toBe(12345);
+    expect($component->get('results.0.existsInLibrary'))->toBeFalse();
+    expect($component->get('results.0.integrationType'))->toBe('sonarr');
+    expect($component->get('results.0.integrationId'))->toBe($this->sonarr->id);
 });
 
-it('searches the Radarr API when integration is radarr', function () {
+it('marks sonarr results as existsInLibrary when the API returns an id', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->assertSet('results.0.existsInLibrary', true);
+});
+
+it('surfaces sonarr episode statistics when series is in library', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'id' => 42,
+                'tvdbId' => 12345,
+                'title' => 'Breaking Bad',
+                'year' => 2008,
+                'statistics' => [
+                    'episodeFileCount' => 5,
+                    'totalEpisodeCount' => 62,
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking');
+
+    expect($component->get('results.0.episodeFileCount'))->toBe(5);
+    expect($component->get('results.0.totalEpisodeCount'))->toBe(62);
+});
+
+it('returns zero episode counts for sonarr results not in library', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking');
+
+    expect($component->get('results.0.episodeFileCount'))->toBe(0);
+    expect($component->get('results.0.totalEpisodeCount'))->toBe(0);
+});
+
+it('searches the Radarr API for movies', function () {
     $radarr = ArrIntegration::factory()->radarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([], 200),
         '*/api/v3/movie/lookup*' => Http::response([
             ['tmdbId' => 27205, 'title' => 'Inception', 'year' => 2010],
         ], 200),
     ]);
 
-    Livewire::test(ArrSearch::class, ['integrationId' => $radarr->id])
-        ->set('searchTerm', 'inception')
-        ->assertSet('results.0.title', 'Inception')
-        ->assertSet('results.0.tmdbId', 27205);
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'inception');
+
+    expect($component->get('results.0.title'))->toBe('Inception');
+    expect($component->get('results.0.tmdbId'))->toBe(27205);
+    expect($component->get('results.0.existsInLibrary'))->toBeFalse();
+    expect($component->get('results.0.integrationType'))->toBe('radarr');
+    expect($component->get('results.0.integrationId'))->toBe($radarr->id);
+});
+
+it('marks radarr results as existsInLibrary when the API returns an id', function () {
+    ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([], 200),
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['id' => 7, 'tmdbId' => 27205, 'title' => 'Inception', 'year' => 2010],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'inception');
+
+    // Find the Radarr result
+    $radarrResult = collect($component->get('results'))->firstWhere('integrationType', 'radarr');
+    expect($radarrResult['existsInLibrary'])->toBeTrue();
+});
+
+it('surfaces radarr hasFile when the movie file exists on disk', function () {
+    ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([], 200),
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['id' => 7, 'tmdbId' => 27205, 'title' => 'Inception', 'year' => 2010, 'hasFile' => true],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'inception');
+
+    $radarrResult = collect($component->get('results'))->firstWhere('integrationType', 'radarr');
+    expect($radarrResult['hasFile'])->toBeTrue();
+});
+
+it('returns hasFile false for radarr movies not yet downloaded', function () {
+    ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([], 200),
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['id' => 7, 'tmdbId' => 27205, 'title' => 'Inception', 'year' => 2010, 'hasFile' => false],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'inception');
+
+    $radarrResult = collect($component->get('results'))->firstWhere('integrationType', 'radarr');
+    expect($radarrResult['hasFile'])->toBeFalse();
 });
 
 it('does not search when term is too short', function () {
-    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
+    Livewire::test(ArrSearch::class)
         ->set('searchTerm', 'a')
         ->assertSet('results', []);
 });
 
-it('clears results when integration changes', function () {
-    $other = ArrIntegration::factory()->radarr()->create([
-        'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
-    ]);
-
+it('skips failed integrations without throwing', function () {
     Http::fake([
-        '*/api/v3/series/lookup*' => Http::response([['tvdbId' => 1, 'title' => 'Foo']], 200),
+        '*/api/v3/series/lookup*' => function () {
+            throw new ConnectionException('connection refused');
+        },
     ]);
 
-    $component = Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
-        ->set('searchTerm', 'foo')
-        ->assertSet('results.0.title', 'Foo');
-
-    $component->set('integrationId', $other->id)
-        ->assertSet('results', [])
-        ->assertSet('searchTerm', '');
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->assertSet('results', []);
 });
 
-it('submits a request to Sonarr when request action fires', function () {
+it('submits a request to Sonarr using the result integration', function () {
     Http::fake([
         '*/api/v3/series/lookup*' => Http::response([
             ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad'],
@@ -110,7 +247,7 @@ it('submits a request to Sonarr when request action fires', function () {
         '*/api/v3/series' => Http::response(['id' => 99, 'title' => 'Breaking Bad'], 201),
     ]);
 
-    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
+    Livewire::test(ArrSearch::class)
         ->set('searchTerm', 'breaking')
         ->call('request', 0);
 
@@ -129,22 +266,22 @@ it('submits a request to Sonarr when request action fires', function () {
     });
 });
 
-it('submits a request to Radarr with tmdbId', function () {
+it('submits a request to Radarr using the result integration', function () {
     $radarr = ArrIntegration::factory()->radarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'quality_profile_id' => 2,
         'root_folder_path' => '/media/movies',
     ]);
 
     Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([], 200),
         '*/api/v3/movie/lookup*' => Http::response([
             ['tmdbId' => 27205, 'title' => 'Inception'],
         ], 200),
         '*/api/v3/movie' => Http::response(['id' => 99, 'title' => 'Inception'], 201),
     ]);
 
-    Livewire::test(ArrSearch::class, ['integrationId' => $radarr->id])
+    Livewire::test(ArrSearch::class)
         ->set('searchTerm', 'inception')
         ->call('request', 0);
 
@@ -161,7 +298,12 @@ it('submits a request to Radarr with tmdbId', function () {
     });
 });
 
-it('loads the queue on mount', function () {
+it('admin mode returns empty queue on mount', function () {
+    Livewire::test(ArrSearch::class)
+        ->assertSet('queue', []);
+});
+
+it('guest mode loads queue on mount', function () {
     Http::fake([
         '*/api/v3/queue*' => Http::response([
             'records' => [
@@ -178,35 +320,1115 @@ it('loads the queue on mount', function () {
         ], 200),
     ]);
 
-    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
+    Livewire::test(ArrSearch::class, [
+        'guestMode' => true,
+        'guestIntegrationIds' => [$this->sonarr->id],
+    ])
         ->assertSet('queue.0.title', 'Breaking Bad')
         ->assertSet('queue.0.progress', 75);
 });
 
-it('returns empty queue when no integration selected', function () {
-    Livewire::test(ArrSearch::class)
-        ->assertSet('queue', []);
+it('guest mode restricts search to provided integration IDs', function () {
+    $otherUser = User::factory()->create();
+    $otherSonarr = ArrIntegration::factory()->sonarr()->create(['user_id' => $otherUser->id]);
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 1, 'title' => 'Guest Show'],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class, [
+        'guestMode' => true,
+        'guestIntegrationIds' => [$this->sonarr->id],
+    ])->set('searchTerm', 'guest');
+
+    // Only results from the guest integration, not from $otherSonarr
+    expect($component->get('results'))->toHaveCount(1);
+    expect($component->get('results.0.integrationId'))->toBe($this->sonarr->id);
 });
 
-it('returns poll interval of 5 seconds when polling enabled', function () {
-    $component = Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id]);
+it('returns poll interval of 5 seconds in guest mode', function () {
+    $component = Livewire::test(ArrSearch::class, [
+        'guestMode' => true,
+        'guestIntegrationIds' => [$this->sonarr->id],
+    ]);
 
     expect($component->get('queuePollInterval'))->toBe(5);
 });
 
-it('passes guestMode through to the component', function () {
-    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id, 'guestMode' => true])
-        ->assertSet('guestMode', true);
+it('returns poll interval of 0 in admin mode', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    expect($component->get('queuePollInterval'))->toBe(0);
 });
 
-it('handles search errors gracefully', function () {
+it('passes guestMode through to the component', function () {
+    Livewire::test(ArrSearch::class, [
+        'guestMode' => true,
+        'guestIntegrationIds' => [$this->sonarr->id],
+    ])->assertSet('guestMode', true);
+});
+
+// --- Series detail slide-over ---
+
+it('openDetail sets showDetail, detailResult, and detailIntegrationId', function () {
     Http::fake([
-        '*/api/v3/series/lookup*' => function () {
-            throw new ConnectionException('connection refused');
-        },
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'tvdbId' => 12345,
+                'title' => 'Breaking Bad',
+                'year' => 2008,
+                'seasons' => [
+                    ['seasonNumber' => 0, 'monitored' => false],
+                    ['seasonNumber' => 1, 'monitored' => true],
+                    ['seasonNumber' => 2, 'monitored' => true],
+                ],
+            ],
+        ], 200),
     ]);
 
-    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
+    $component = Livewire::test(ArrSearch::class)
         ->set('searchTerm', 'breaking')
-        ->assertSet('results', []);
+        ->call('openDetail', 0);
+
+    $component->assertSet('showDetail', true)
+        ->assertSet('detailResult.title', 'Breaking Bad')
+        ->assertSet('detailIndex', 0);
+
+    expect($component->get('detailIntegrationId'))->toBe($this->sonarr->id);
+});
+
+it('openDetail pre-checks all seasons except specials', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'tvdbId' => 12345,
+                'title' => 'Breaking Bad',
+                'seasons' => [
+                    ['seasonNumber' => 0],
+                    ['seasonNumber' => 1],
+                    ['seasonNumber' => 2],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0);
+
+    expect($component->get('selectedSeasons.0'))->toBeFalse(); // specials off
+    expect($component->get('selectedSeasons.1'))->toBeTrue();
+    expect($component->get('selectedSeasons.2'))->toBeTrue();
+});
+
+it('closeDetail resets all detail state', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 1, 'title' => 'Show', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'show')
+        ->call('openDetail', 0)
+        ->call('closeDetail')
+        ->assertSet('showDetail', false)
+        ->assertSet('detailResult', null)
+        ->assertSet('detailIndex', null)
+        ->assertSet('detailIntegrationId', null)
+        ->assertSet('selectedSeasons', []);
+});
+
+it('toggleAllSeasons checks all seasons', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'tvdbId' => 1,
+                'title' => 'Show',
+                'seasons' => [
+                    ['seasonNumber' => 0],
+                    ['seasonNumber' => 1],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'show')
+        ->call('openDetail', 0)
+        ->call('toggleAllSeasons', true);
+
+    expect($component->get('selectedSeasons.0'))->toBeTrue();
+    expect($component->get('selectedSeasons.1'))->toBeTrue();
+});
+
+it('toggleAllSeasons unchecks all seasons', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'tvdbId' => 1,
+                'title' => 'Show',
+                'seasons' => [
+                    ['seasonNumber' => 1],
+                    ['seasonNumber' => 2],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'show')
+        ->call('openDetail', 0)
+        ->call('toggleAllSeasons', false);
+
+    expect($component->get('selectedSeasons.1'))->toBeFalse();
+    expect($component->get('selectedSeasons.2'))->toBeFalse();
+});
+
+it('requestDetail sends full seasons payload with monitored flags', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'tvdbId' => 12345,
+                'title' => 'Breaking Bad',
+                'titleSlug' => 'breaking-bad',
+                'seasons' => [
+                    ['seasonNumber' => 0],
+                    ['seasonNumber' => 1],
+                    ['seasonNumber' => 2],
+                ],
+            ],
+        ], 200),
+        '*/api/v3/series' => Http::response(['id' => 99, 'title' => 'Breaking Bad'], 201),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('toggleAllSeasons', false)  // deselect all
+        ->set('selectedSeasons.1', true)   // select only season 1
+        ->call('requestDetail');
+
+    Http::assertSent(function ($request) {
+        if (! str_ends_with($request->url(), '/api/v3/series')) {
+            return false;
+        }
+
+        $body = $request->data();
+        $seasons = collect($body['seasons']);
+
+        // All seasons sent, only season 1 is monitored
+        return count($body['seasons']) === 3
+            && $seasons->firstWhere('seasonNumber', 0)['monitored'] === false
+            && $seasons->firstWhere('seasonNumber', 1)['monitored'] === true
+            && $seasons->firstWhere('seasonNumber', 2)['monitored'] === false;
+    });
+});
+
+it('requestDetail shows warning when no seasons are selected', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'tvdbId' => 1,
+                'title' => 'Show',
+                'seasons' => [['seasonNumber' => 1]],
+            ],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'show')
+        ->call('openDetail', 0)
+        ->call('toggleAllSeasons', false)
+        ->call('requestDetail')
+        ->assertNotified();
+
+    Http::assertNotSent(fn ($r) => $r->method() === 'POST' && str_ends_with($r->url(), '/api/v3/series'));
+});
+
+it('requestDetail closes the panel after successful submission', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'tvdbId' => 1,
+                'title' => 'Show',
+                'titleSlug' => 'show',
+                'seasons' => [['seasonNumber' => 1]],
+            ],
+        ], 200),
+        '*/api/v3/series' => Http::response(['id' => 1], 201),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'show')
+        ->call('openDetail', 0)
+        ->call('requestDetail')
+        ->assertSet('showDetail', false)
+        ->assertSet('detailResult', null);
+});
+
+function tvMazeFake(int $tvMazeId = 169, array $episodes = [], array $cast = []): void
+{
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => $tvMazeId], 200),
+        "api.tvmaze.com/shows/{$tvMazeId}/episodes*" => Http::response($episodes, 200),
+        "api.tvmaze.com/shows/{$tvMazeId}/cast*" => Http::response($cast, 200),
+    ]);
+}
+
+it('loadDetailEpisodes fetches episodes from TV Maze by tvdbId', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'seasons' => [['seasonNumber' => 1], ['seasonNumber' => 2]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => 169], 200),
+        'api.tvmaze.com/shows/169/episodes*' => Http::response([
+            ['season' => 1, 'number' => 1, 'name' => 'Pilot', 'airdate' => '2008-01-20', 'summary' => null],
+            ['season' => 1, 'number' => 2, 'name' => "Cat's in the Bag", 'airdate' => '2008-01-27', 'summary' => null],
+            ['season' => 2, 'number' => 1, 'name' => 'Seven Thirty-Seven', 'airdate' => '2009-03-08', 'summary' => null],
+        ], 200),
+        'api.tvmaze.com/shows/169/cast*' => Http::response([], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes');
+
+    expect($component->get('detailEpisodes.1.0.title'))->toBe('Pilot');
+    expect($component->get('detailEpisodes.1.0.airDate'))->toBe('2008-01-20');
+    expect($component->get('detailEpisodes.1.1.title'))->toBe("Cat's in the Bag");
+    expect($component->get('detailEpisodes.2.0.title'))->toBe('Seven Thirty-Seven');
+});
+
+it('loadDetailEpisodes strips HTML from episode overviews', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 99, 'title' => 'Show', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => 1], 200),
+        'api.tvmaze.com/shows/1/episodes*' => Http::response([
+            ['season' => 1, 'number' => 1, 'name' => 'Pilot', 'airdate' => null, 'summary' => '<p>A <b>great</b> episode.</p>'],
+        ], 200),
+        'api.tvmaze.com/shows/1/cast*' => Http::response([], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'show')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes');
+
+    expect($component->get('detailEpisodes.1.0.overview'))->toBe('A great episode.');
+});
+
+it('loadDetailEpisodes fetches cast alongside episodes', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => 169], 200),
+        'api.tvmaze.com/shows/169/episodes*' => Http::response([], 200),
+        'api.tvmaze.com/shows/169/cast*' => Http::response([
+            [
+                'person' => ['name' => 'Bryan Cranston', 'image' => ['medium' => 'https://example.com/bc.jpg']],
+                'character' => ['name' => 'Walter White'],
+                'self' => false,
+                'voice' => false,
+            ],
+            [
+                'person' => ['name' => 'Aaron Paul', 'image' => null],
+                'character' => ['name' => 'Jesse Pinkman'],
+                'self' => false,
+                'voice' => false,
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes');
+
+    expect($component->get('detailCast.0.actor'))->toBe('Bryan Cranston');
+    expect($component->get('detailCast.0.character'))->toBe('Walter White');
+    expect($component->get('detailCast.0.photo'))->toBe('https://example.com/bc.jpg');
+    expect($component->get('detailCast.1.actor'))->toBe('Aaron Paul');
+    expect($component->get('detailCast.1.photo'))->toBeNull();
+});
+
+it('loadDetailEpisodes excludes voice actors and self appearances from cast', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 1, 'title' => 'Show', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => 1], 200),
+        'api.tvmaze.com/shows/1/episodes*' => Http::response([], 200),
+        'api.tvmaze.com/shows/1/cast*' => Http::response([
+            ['person' => ['name' => 'Real Actor', 'image' => null], 'character' => ['name' => 'Hero'], 'self' => false, 'voice' => false],
+            ['person' => ['name' => 'Voice Guy', 'image' => null], 'character' => ['name' => 'Narrator'], 'self' => false, 'voice' => true],
+            ['person' => ['name' => 'Himself', 'image' => null], 'character' => ['name' => 'Himself'], 'self' => true, 'voice' => false],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'show')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes');
+
+    expect($component->get('detailCast'))->toHaveCount(1);
+    expect($component->get('detailCast.0.actor'))->toBe('Real Actor');
+});
+
+it('loadDetailEpisodes returns empty arrays when TV Maze lookup fails', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        'api.tvmaze.com/*' => Http::response(null, 404),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes');
+
+    expect($component->get('detailEpisodes'))->toBe([]);
+    expect($component->get('detailCast'))->toBe([]);
+});
+
+it('loadDetailEpisodes is a no-op for Radarr results', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([], 200),
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['tmdbId' => 27205, 'title' => 'Inception'],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'inception')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes');
+
+    expect($component->get('detailEpisodes'))->toBe([]);
+    expect($component->get('detailCast'))->toBe([]);
+
+    Http::assertNotSent(fn ($r) => str_contains($r->url(), 'tvmaze'));
+});
+
+it('closeDetail resets detailEpisodes and detailCast', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 1, 'title' => 'Show', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => 1], 200),
+        'api.tvmaze.com/shows/1/episodes*' => Http::response([
+            ['season' => 1, 'number' => 1, 'name' => 'Pilot', 'airdate' => null, 'summary' => null],
+        ], 200),
+        'api.tvmaze.com/shows/1/cast*' => Http::response([
+            ['person' => ['name' => 'Actor', 'image' => null], 'character' => ['name' => 'Hero'], 'self' => false, 'voice' => false],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'show')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes')
+        ->call('closeDetail')
+        ->assertSet('detailEpisodes', [])
+        ->assertSet('detailCast', []);
+});
+
+it('loadDetailEpisodes fetches Sonarr episode status for in-library series', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'seasons' => [['seasonNumber' => 1], ['seasonNumber' => 2]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => 169], 200),
+        'api.tvmaze.com/shows/169/episodes*' => Http::response([], 200),
+        'api.tvmaze.com/shows/169/cast*' => Http::response([], 200),
+        '*/api/v3/episode*' => Http::response([
+            ['seasonNumber' => 1, 'episodeNumber' => 1, 'hasFile' => true],
+            ['seasonNumber' => 1, 'episodeNumber' => 2, 'hasFile' => false],
+            ['seasonNumber' => 2, 'episodeNumber' => 1, 'hasFile' => true],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes');
+
+    expect($component->get('detailSonarrEpisodeStatus.1.1'))->toBeTrue();
+    expect($component->get('detailSonarrEpisodeStatus.1.2'))->toBeFalse();
+    expect($component->get('detailSonarrEpisodeStatus.2.1'))->toBeTrue();
+});
+
+it('loadDetailEpisodes does not fetch Sonarr episode status when series is not in library', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            // No 'id' key — not in library
+            ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => 169], 200),
+        'api.tvmaze.com/shows/169/episodes*' => Http::response([], 200),
+        'api.tvmaze.com/shows/169/cast*' => Http::response([], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes');
+
+    expect($component->get('detailSonarrEpisodeStatus'))->toBe([]);
+    Http::assertNotSent(fn ($r) => str_contains($r->url(), '/api/v3/episode'));
+});
+
+it('closeDetail resets detailSonarrEpisodeStatus', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 1, 'title' => 'Show', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => 1], 200),
+        'api.tvmaze.com/shows/1/episodes*' => Http::response([], 200),
+        'api.tvmaze.com/shows/1/cast*' => Http::response([], 200),
+        '*/api/v3/episode*' => Http::response([
+            ['seasonNumber' => 1, 'episodeNumber' => 1, 'hasFile' => true],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'show')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes')
+        ->call('closeDetail')
+        ->assertSet('detailSonarrEpisodeStatus', []);
+});
+
+// --- Individual episode requests ---
+
+it('requestEpisode triggers EpisodeSearch for a series already in library', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::sequence()
+            ->push([['tvdbId' => 12345, 'id' => 42, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad', 'seasons' => [['seasonNumber' => 1]]]], 200)
+            // requestEpisode internal lookup
+            ->push([['tvdbId' => 12345, 'id' => 42, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad', 'seasons' => [['seasonNumber' => 1]]]], 200),
+        '*/api/v3/episode*' => Http::response([
+            ['id' => 101, 'episodeNumber' => 1, 'seasonNumber' => 1, 'title' => 'Pilot'],
+            ['id' => 102, 'episodeNumber' => 2, 'seasonNumber' => 1, 'title' => "Cat's in the Bag"],
+        ], 200),
+        '*/api/v3/episode/monitor' => Http::response(null, 200),
+        '*/api/v3/command' => Http::response(['id' => 1], 201),
+        'api.tvmaze.com/*' => Http::response(['id' => 1], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('requestEpisode', 1, 2)
+        ->assertNotified();
+
+    Http::assertSent(fn ($r) => $r->method() === 'PUT' && str_ends_with($r->url(), '/api/v3/episode/monitor')
+        && in_array(102, $r->data()['episodeIds'] ?? []));
+
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_ends_with($r->url(), '/api/v3/command')
+        && ($r->data()['name'] ?? '') === 'EpisodeSearch'
+        && in_array(102, $r->data()['episodeIds'] ?? []));
+});
+
+it('requestEpisode adds the series first when not in library', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::sequence()
+            // initial search
+            ->push([['tvdbId' => 12345, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad', 'seasons' => [['seasonNumber' => 1]]]], 200)
+            // internal lookup in requestEpisode — no 'id', not in library
+            ->push([['tvdbId' => 12345, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad', 'seasons' => [['seasonNumber' => 1]]]], 200),
+        '*/api/v3/series' => Http::response(['id' => 99, 'title' => 'Breaking Bad'], 201),
+        '*/api/v3/episode*' => Http::response([
+            ['id' => 201, 'episodeNumber' => 1, 'seasonNumber' => 1, 'title' => 'Pilot'],
+        ], 200),
+        '*/api/v3/episode/monitor' => Http::response(null, 200),
+        '*/api/v3/command' => Http::response(['id' => 1], 201),
+        'api.tvmaze.com/*' => Http::response(['id' => 1], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('requestEpisode', 1, 1)
+        ->assertNotified();
+
+    // Series should be added with seasons unmonitored
+    Http::assertSent(function ($r) {
+        if ($r->method() !== 'POST' || ! str_ends_with($r->url(), '/api/v3/series')) {
+            return false;
+        }
+        $seasons = $r->data()['seasons'] ?? [];
+
+        return collect($seasons)->every(fn ($s) => $s['monitored'] === false)
+            && ($r->data()['addOptions']['searchForMissingEpisodes'] ?? true) === false;
+    });
+});
+
+it('requestEpisode is a no-op when no detail is open', function () {
+    Livewire::test(ArrSearch::class)
+        ->call('requestEpisode', 1, 1);
+
+    Http::assertNothingSent();
+});
+
+it('requestDetail is a no-op for Radarr results', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([], 200),
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['tmdbId' => 100, 'title' => 'Inception'],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'inception')
+        ->call('openDetail', 0)
+        ->call('requestDetail')
+        ->assertSet('showDetail', true); // panel stays open, nothing submitted
+
+    Http::assertNotSent(fn ($r) => $r->method() === 'POST' && str_ends_with($r->url(), '/api/v3/movie'));
+});
+
+// ── Discover ──────────────────────────────────────────────────────────────────
+
+it('sets tmdbConfigured to true when TMDB is configured', function () {
+    config(['services.tmdb.api_key' => null]);
+
+    app()->bind(TmdbService::class, function () {
+        $mock = Mockery::mock(TmdbService::class)->makePartial();
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+
+        return $mock;
+    });
+
+    Http::fake();
+
+    $component = Livewire::test(ArrSearch::class);
+
+    expect($component->get('tmdbConfigured'))->toBeTrue();
+});
+
+it('sets tmdbConfigured to false when TMDB is not configured', function () {
+    app()->bind(TmdbService::class, function () {
+        $mock = Mockery::mock(TmdbService::class)->makePartial();
+        $mock->shouldReceive('isConfigured')->andReturn(false);
+
+        return $mock;
+    });
+
+    Http::fake();
+
+    $component = Livewire::test(ArrSearch::class);
+
+    expect($component->get('tmdbConfigured'))->toBeFalse();
+});
+
+it('loadDiscover populates trending and popular sections', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $trendingItems = [
+        ['id' => 10, 'title' => 'Trending Movie', 'media_type' => 'movie', 'poster_path' => '/poster.jpg', 'overview' => 'Great movie', 'release_date' => '2024-01-01', 'vote_average' => 8.5],
+    ];
+    $popularMovies = [
+        ['id' => 20, 'title' => 'Popular Movie', 'poster_path' => null, 'overview' => null, 'release_date' => '2024-03-01', 'vote_average' => 7.2],
+    ];
+
+    app()->bind(TmdbService::class, function () use ($trendingItems, $popularMovies) {
+        $mock = Mockery::mock(TmdbService::class)->makePartial();
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('getTrending')->andReturn(array_map(fn ($i) => [
+            'tmdb_id' => $i['id'],
+            'title' => $i['title'],
+            'media_type' => $i['media_type'],
+            'year' => '2024',
+            'overview' => $i['overview'],
+            'poster_url' => $i['poster_path'] ? 'https://image.tmdb.org/t/p/w500'.$i['poster_path'] : null,
+            'backdrop_url' => null,
+            'vote_average' => $i['vote_average'],
+            'genre_ids' => [],
+        ], $trendingItems));
+        $mock->shouldReceive('getPopularMovies')->andReturn(array_map(fn ($i) => [
+            'tmdb_id' => $i['id'],
+            'title' => $i['title'],
+            'media_type' => 'movie',
+            'year' => '2024',
+            'overview' => null,
+            'poster_url' => null,
+            'backdrop_url' => null,
+            'vote_average' => $i['vote_average'],
+            'genre_ids' => [],
+        ], $popularMovies));
+        $mock->shouldReceive('getPopularTv')->andReturn([]);
+        $mock->shouldReceive('getUpcomingMovies')->andReturn([]);
+        $mock->shouldReceive('getMovieGenres')->andReturn([]);
+        $mock->shouldReceive('getTvGenres')->andReturn([]);
+
+        return $mock;
+    });
+
+    Http::fake([
+        '*/api/v3/series*' => Http::response([], 200),
+        '*/api/v3/movie*' => Http::response([], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->call('loadDiscover');
+
+    expect($component->get('discoverLoaded'))->toBeTrue();
+    expect($component->get('trendingItems'))->toHaveCount(1);
+    expect($component->get('trendingItems.0.tmdb_id'))->toBe(10);
+    expect($component->get('popularMovies'))->toHaveCount(1);
+    expect($component->get('popularMovies.0.tmdb_id'))->toBe(20);
+});
+
+it('loadDiscover marks items already in library', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    app()->bind(TmdbService::class, function () {
+        $mock = Mockery::mock(TmdbService::class)->makePartial();
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('getTrending')->andReturn([
+            ['tmdb_id' => 999, 'title' => 'In Library Movie', 'media_type' => 'movie', 'year' => '2023', 'overview' => null, 'poster_url' => null, 'backdrop_url' => null, 'vote_average' => null, 'genre_ids' => []],
+            ['tmdb_id' => 888, 'title' => 'Not In Library', 'media_type' => 'movie', 'year' => '2023', 'overview' => null, 'poster_url' => null, 'backdrop_url' => null, 'vote_average' => null, 'genre_ids' => []],
+        ]);
+        $mock->shouldReceive('getPopularMovies')->andReturn([]);
+        $mock->shouldReceive('getPopularTv')->andReturn([]);
+        $mock->shouldReceive('getUpcomingMovies')->andReturn([]);
+        $mock->shouldReceive('getMovieGenres')->andReturn([]);
+        $mock->shouldReceive('getTvGenres')->andReturn([]);
+
+        return $mock;
+    });
+
+    // Radarr library contains tmdbId 999 (downloaded), not 888
+    Http::fake([
+        '*/api/v3/series*' => Http::response([], 200),
+        '*/api/v3/movie*' => Http::response([
+            ['id' => 1, 'tmdbId' => 999, 'title' => 'In Library Movie', 'hasFile' => true],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->call('loadDiscover');
+
+    expect($component->get('trendingItems.0.existsInLibrary'))->toBeTrue();
+    expect($component->get('trendingItems.0.isDownloaded'))->toBeTrue();
+    expect($component->get('trendingItems.1.existsInLibrary'))->toBeFalse();
+    expect($component->get('trendingItems.1.isDownloaded'))->toBeFalse();
+});
+
+it('loadDiscover is a no-op when TMDB is not configured', function () {
+    app()->bind(TmdbService::class, function () {
+        $mock = Mockery::mock(TmdbService::class)->makePartial();
+        $mock->shouldReceive('isConfigured')->andReturn(false);
+        $mock->shouldNotReceive('getTrending');
+
+        return $mock;
+    });
+
+    Http::fake();
+
+    $component = Livewire::test(ArrSearch::class)
+        ->call('loadDiscover');
+
+    expect($component->get('discoverLoaded'))->toBeTrue();
+    expect($component->get('trendingItems'))->toBeEmpty();
+});
+
+it('browseGenre loads discover results filtered by genre', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $genreResults = [
+        ['tmdb_id' => 101, 'title' => 'Action Movie', 'media_type' => 'movie', 'year' => '2024', 'overview' => null, 'poster_url' => null, 'backdrop_url' => null, 'vote_average' => 7.5, 'genre_ids' => [28]],
+    ];
+
+    app()->bind(TmdbService::class, function () use ($genreResults) {
+        $mock = Mockery::mock(TmdbService::class)->makePartial();
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('discoverMovies')->with(['with_genres' => 28])->andReturn($genreResults);
+
+        return $mock;
+    });
+
+    Http::fake([
+        '*/api/v3/series*' => Http::response([], 200),
+        '*/api/v3/movie*' => Http::response([], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('tmdbConfigured', true)
+        ->call('browseGenre', 28, 'movie');
+
+    expect($component->get('browseGenreId'))->toBe(28);
+    expect($component->get('browseGenreType'))->toBe('movie');
+    expect($component->get('browseResults'))->toHaveCount(1);
+    expect($component->get('browseResults.0.title'))->toBe('Action Movie');
+    expect($component->get('browseLoading'))->toBeFalse();
+});
+
+it('clearBrowse resets genre browse state', function () {
+    Http::fake();
+
+    Livewire::test(ArrSearch::class)
+        ->set('browseGenreId', 28)
+        ->set('browseGenreType', 'movie')
+        ->set('browseResults', [['tmdb_id' => 1, 'title' => 'Test']])
+        ->call('clearBrowse')
+        ->assertSet('browseGenreId', null)
+        ->assertSet('browseGenreType', null)
+        ->assertSet('browseResults', []);
+});
+
+it('requestFromDiscover resolves a Radarr movie and opens detail panel', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'quality_profile_id' => 1,
+        'root_folder_path' => '/media/movies',
+    ]);
+
+    Http::fake([
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['tmdbId' => 27205, 'title' => 'Inception', 'year' => 2010, 'titleSlug' => 'inception'],
+        ], 200),
+        // library fetch (no matches)
+        '*/api/v3/movie*' => Http::response([], 200),
+        '*/api/v3/series*' => Http::response([], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('tmdbConfigured', true)
+        ->call('requestFromDiscover', 27205, 'movie');
+
+    expect($component->get('showDetail'))->toBeTrue();
+    expect($component->get('detailResult.title'))->toBe('Inception');
+    expect($component->get('detailResult.integrationType'))->toBe('radarr');
+});
+
+it('requestFromDiscover resolves a Sonarr TV show via TVDB and opens detail panel', function () {
+    Http::fake([
+        // TMDB external IDs
+        'api.themoviedb.org/3/tv/*/external_ids*' => Http::response(['tvdb_id' => 12345, 'imdb_id' => null], 200),
+        // Sonarr lookup
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        // library fetches
+        '*/api/v3/series*' => Http::response([], 200),
+    ]);
+
+    app()->bind(TmdbService::class, function () {
+        $mock = Mockery::mock(TmdbService::class)->makePartial();
+        $mock->shouldReceive('isConfigured')->andReturn(true);
+        $mock->shouldReceive('getTvExternalIds')->with(1396)->andReturn(['tvdb_id' => 12345]);
+
+        return $mock;
+    });
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('tmdbConfigured', true)
+        ->call('requestFromDiscover', 1396, 'tv');
+
+    expect($component->get('showDetail'))->toBeTrue();
+    expect($component->get('detailResult.title'))->toBe('Breaking Bad');
+    expect($component->get('detailResult.integrationType'))->toBe('sonarr');
+});
+
+it('requestFromDiscover shows warning when title cannot be resolved', function () {
+    Http::fake([
+        '*/api/v3/movie/lookup*' => Http::response([], 200),
+        '*/api/v3/movie*' => Http::response([], 200),
+        '*/api/v3/series*' => Http::response([], 200),
+    ]);
+
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('tmdbConfigured', true)
+        ->call('requestFromDiscover', 99999, 'movie')
+        ->assertSet('showDetail', false)
+        ->assertNotified();
+});
+
+it('fetchLibraryTmdbIds returns radarr movie tmdb ids with download status', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/movie*' => Http::response([
+            ['id' => 1, 'tmdbId' => 500, 'title' => 'Movie A', 'hasFile' => true],
+            ['id' => 2, 'tmdbId' => 501, 'title' => 'Movie B', 'hasFile' => false],
+            ['id' => 3, 'title' => 'Movie No TMDB'],
+        ], 200),
+    ]);
+
+    $service = new RadarrService($radarr);
+    $map = $service->fetchLibraryTmdbIds();
+
+    expect($map)->toBe([500 => true, 501 => false]);
+});
+
+it('fetchLibraryTmdbIds returns sonarr series tmdb ids with download status', function () {
+    Http::fake([
+        '*/api/v3/series*' => Http::response([
+            ['id' => 1, 'tmdbId' => 200, 'title' => 'Show A', 'statistics' => ['episodeFileCount' => 5, 'totalEpisodeCount' => 62]],
+            ['id' => 2, 'tmdbId' => 201, 'title' => 'Show B', 'statistics' => ['episodeFileCount' => 0, 'totalEpisodeCount' => 10]],
+            ['id' => 3, 'title' => 'Show No TMDB'],
+        ], 200),
+    ]);
+
+    $service = new SonarrService($this->sonarr);
+    $map = $service->fetchLibraryTmdbIds();
+
+    expect($map)->toBe([200 => true, 201 => false]);
+});
+
+// ── libraryId in search results ───────────────────────────────────────────────
+
+it('sonarr search includes libraryId when item exists in library', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 77, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008],
+        ], 200),
+    ]);
+
+    $service = new SonarrService($this->sonarr);
+    $results = $service->search('breaking');
+
+    expect($results[0]['existsInLibrary'])->toBeTrue();
+    expect($results[0]['libraryId'])->toBe(77);
+});
+
+it('sonarr search has null libraryId when item is not in library', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008],
+        ], 200),
+    ]);
+
+    $service = new SonarrService($this->sonarr);
+    $results = $service->search('breaking');
+
+    expect($results[0]['existsInLibrary'])->toBeFalse();
+    expect($results[0]['libraryId'])->toBeNull();
+});
+
+it('radarr search includes libraryId when item exists in library', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['id' => 55, 'tmdbId' => 27205, 'title' => 'Inception', 'year' => 2010],
+        ], 200),
+    ]);
+
+    $service = new RadarrService($radarr);
+    $results = $service->search('inception');
+
+    expect($results[0]['existsInLibrary'])->toBeTrue();
+    expect($results[0]['libraryId'])->toBe(55);
+});
+
+// ── triggerAutomaticSearch ────────────────────────────────────────────────────
+
+it('sonarr triggerAutomaticSearch posts SeriesSearch command', function () {
+    Http::fake([
+        '*/api/v3/command*' => Http::response([], 201),
+    ]);
+
+    $service = new SonarrService($this->sonarr);
+    $result = $service->triggerAutomaticSearch(42);
+
+    expect($result['ok'])->toBeTrue();
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/command')
+        && $req->data()['name'] === 'SeriesSearch'
+        && $req->data()['seriesId'] === 42
+    );
+});
+
+it('radarr triggerAutomaticSearch posts MoviesSearch command', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/command*' => Http::response([], 201),
+    ]);
+
+    $service = new RadarrService($radarr);
+    $result = $service->triggerAutomaticSearch(99);
+
+    expect($result['ok'])->toBeTrue();
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/command')
+        && $req->data()['name'] === 'MoviesSearch'
+        && $req->data()['movieIds'] === [99]
+    );
+});
+
+it('triggerAutomaticSearch returns error when command fails', function () {
+    Http::fake([
+        '*/api/v3/command*' => Http::response(['title' => 'Server error'], 500),
+    ]);
+
+    $service = new SonarrService($this->sonarr);
+    $result = $service->triggerAutomaticSearch(42);
+
+    expect($result['ok'])->toBeFalse();
+    expect($result['error'])->not->toBeEmpty();
+});
+
+// ── Livewire: triggerAutomaticSearch action ───────────────────────────────────
+
+it('livewire triggerAutomaticSearch triggers search for library item', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008, 'seasons' => []],
+        ], 200),
+        '*/api/v3/command*' => Http::response([], 201),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('triggerAutomaticSearch')
+        ->assertNotified();
+
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/command')
+        && $req->data()['name'] === 'SeriesSearch'
+    );
+});
+
+it('livewire triggerAutomaticSearch is blocked in guest mode', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008, 'seasons' => []],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class, ['guestMode' => true, 'guestIntegrationIds' => [$this->sonarr->id]])
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('triggerAutomaticSearch');
+
+    Http::assertNotSent(fn ($req) => str_contains($req->url(), '/command'));
+});
+
+// ── Livewire: loadDetailReleases action ──────────────────────────────────────
+
+it('livewire loadDetailReleases fetches releases for library item', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008, 'seasons' => []],
+        ], 200),
+        '*/api/v3/release*' => Http::response([
+            [
+                'guid' => 'abc-123',
+                'title' => 'Breaking.Bad.S01.1080p.BluRay',
+                'indexerId' => 1,
+                'size' => 15_000_000_000,
+                'quality' => ['quality' => ['name' => 'Bluray-1080p']],
+                'protocol' => 'torrent',
+                'rejections' => [],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadDetailReleases');
+
+    expect($component->get('detailReleases'))->toHaveCount(1);
+    expect($component->get('detailReleases.0.title'))->toBe('Breaking.Bad.S01.1080p.BluRay');
+    expect($component->get('detailReleases.0.approved'))->toBeTrue();
+    expect($component->get('detailReleases.0.guid'))->toBe('abc-123');
+});
+
+it('livewire loadDetailReleases is blocked in guest mode', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008, 'seasons' => []],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class, ['guestMode' => true, 'guestIntegrationIds' => [$this->sonarr->id]])
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadDetailReleases');
+
+    expect($component->get('detailReleases'))->toBe([]);
+    Http::assertNotSent(fn ($req) => str_contains($req->url(), '/release'));
+});
+
+// ── Livewire: downloadDetailRelease action ───────────────────────────────────
+
+it('livewire downloadDetailRelease sends release to download client', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008, 'seasons' => []],
+        ], 200),
+        '*/api/v3/release*' => Http::response([], 201),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('downloadDetailRelease', 'abc-guid', 7)
+        ->assertNotified();
+
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/release')
+        && $req->data()['guid'] === 'abc-guid'
+        && $req->data()['indexerId'] === 7
+        && $req->data()['seriesId'] === 42
+    );
+});
+
+it('livewire closeDetail clears detailReleases', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'year' => 2008, 'seasons' => []],
+        ], 200),
+        '*/api/v3/release*' => Http::response([
+            ['guid' => 'abc', 'title' => 'Release A', 'indexerId' => 1, 'size' => 0, 'quality' => ['quality' => ['name' => 'HD']], 'protocol' => 'torrent', 'rejections' => []],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadDetailReleases');
+
+    expect($component->get('detailReleases'))->toHaveCount(1);
+
+    $component->call('closeDetail');
+
+    expect($component->get('detailReleases'))->toBe([]);
+    expect($component->get('showDetail'))->toBeFalse();
 });

--- a/tests/Feature/ArrSearchTest.php
+++ b/tests/Feature/ArrSearchTest.php
@@ -1,0 +1,212 @@
+<?php
+
+use App\Livewire\ArrSearch;
+use App\Models\ArrIntegration;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Bus::fake();
+    // Prevent any test from accidentally hitting the real network.
+    // Specific tests can call Http::fake([...]) to override.
+    Http::preventStrayRequests();
+    $this->user = User::factory()->create(['permissions' => ['use_integrations']]);
+    $this->actingAs($this->user);
+    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+    $this->integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'quality_profile_id' => 1,
+        'root_folder_path' => '/media/tv',
+    ]);
+});
+
+it('renders without an integration selected', function () {
+    Livewire::test(ArrSearch::class)
+        ->assertOk();
+});
+
+it('returns the active integration', function () {
+    $component = Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id]);
+
+    expect($component->get('integration'))->toBeInstanceOf(ArrIntegration::class);
+    expect($component->get('integration')->id)->toBe($this->integration->id);
+});
+
+it('searches the Sonarr API', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'tvdbId' => 12345,
+                'title' => 'Breaking Bad',
+                'year' => 2008,
+                'overview' => 'A chemistry teacher...',
+                'remotePoster' => 'https://example.com/poster.jpg',
+            ],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
+        ->set('searchTerm', 'breaking')
+        ->assertSet('results.0.title', 'Breaking Bad')
+        ->assertSet('results.0.tvdbId', 12345);
+});
+
+it('searches the Radarr API when integration is radarr', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['tmdbId' => 27205, 'title' => 'Inception', 'year' => 2010],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class, ['integrationId' => $radarr->id])
+        ->set('searchTerm', 'inception')
+        ->assertSet('results.0.title', 'Inception')
+        ->assertSet('results.0.tmdbId', 27205);
+});
+
+it('does not search when term is too short', function () {
+    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
+        ->set('searchTerm', 'a')
+        ->assertSet('results', []);
+});
+
+it('clears results when integration changes', function () {
+    $other = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([['tvdbId' => 1, 'title' => 'Foo']], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
+        ->set('searchTerm', 'foo')
+        ->assertSet('results.0.title', 'Foo');
+
+    $component->set('integrationId', $other->id)
+        ->assertSet('results', [])
+        ->assertSet('searchTerm', '');
+});
+
+it('submits a request to Sonarr when request action fires', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad'],
+        ], 200),
+        '*/api/v3/series' => Http::response(['id' => 99, 'title' => 'Breaking Bad'], 201),
+    ]);
+
+    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
+        ->set('searchTerm', 'breaking')
+        ->call('request', 0);
+
+    Http::assertSent(function ($request) {
+        if (! str_ends_with($request->url(), '/api/v3/series')) {
+            return false;
+        }
+
+        $body = $request->data();
+
+        return $request->method() === 'POST'
+            && $body['tvdbId'] === 12345
+            && $body['qualityProfileId'] === 1
+            && $body['rootFolderPath'] === '/media/tv'
+            && $body['addOptions']['searchForMissingEpisodes'] === true;
+    });
+});
+
+it('submits a request to Radarr with tmdbId', function () {
+    $radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'quality_profile_id' => 2,
+        'root_folder_path' => '/media/movies',
+    ]);
+
+    Http::fake([
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['tmdbId' => 27205, 'title' => 'Inception'],
+        ], 200),
+        '*/api/v3/movie' => Http::response(['id' => 99, 'title' => 'Inception'], 201),
+    ]);
+
+    Livewire::test(ArrSearch::class, ['integrationId' => $radarr->id])
+        ->set('searchTerm', 'inception')
+        ->call('request', 0);
+
+    Http::assertSent(function ($request) {
+        if (! str_ends_with($request->url(), '/api/v3/movie')) {
+            return false;
+        }
+
+        $body = $request->data();
+
+        return $body['tmdbId'] === 27205
+            && $body['qualityProfileId'] === 2
+            && $body['rootFolderPath'] === '/media/movies';
+    });
+});
+
+it('loads the queue on mount', function () {
+    Http::fake([
+        '*/api/v3/queue*' => Http::response([
+            'records' => [
+                [
+                    'id' => 1,
+                    'title' => 'Episode 1',
+                    'status' => 'downloading',
+                    'size' => 1000,
+                    'sizeleft' => 250,
+                    'timeleft' => '00:05:00',
+                    'series' => ['title' => 'Breaking Bad'],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
+        ->assertSet('queue.0.title', 'Breaking Bad')
+        ->assertSet('queue.0.progress', 75);
+});
+
+it('returns empty queue when no integration selected', function () {
+    Livewire::test(ArrSearch::class)
+        ->assertSet('queue', []);
+});
+
+it('returns poll interval of 5 seconds when polling enabled', function () {
+    $component = Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id]);
+
+    expect($component->get('queuePollInterval'))->toBe(5);
+});
+
+it('passes guestMode through to the component', function () {
+    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id, 'guestMode' => true])
+        ->assertSet('guestMode', true);
+});
+
+it('handles search errors gracefully', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => function () {
+            throw new ConnectionException('connection refused');
+        },
+    ]);
+
+    Livewire::test(ArrSearch::class, ['integrationId' => $this->integration->id])
+        ->set('searchTerm', 'breaking')
+        ->assertSet('results', []);
+});

--- a/tests/Feature/ArrSearchTest.php
+++ b/tests/Feature/ArrSearchTest.php
@@ -221,6 +221,79 @@ it('returns hasFile false for radarr movies not yet downloaded', function () {
     expect($radarrResult['hasFile'])->toBeFalse();
 });
 
+it('surfaces radarr fileQuality and fileSize when movieFile is present', function () {
+    ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([], 200),
+        '*/api/v3/movie/lookup*' => Http::response([
+            [
+                'id' => 7,
+                'tmdbId' => 27205,
+                'title' => 'Inception',
+                'year' => 2010,
+                'hasFile' => true,
+                'movieFile' => [
+                    'quality' => ['quality' => ['name' => 'Bluray-1080p']],
+                    'size' => 8589934592,
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'inception');
+
+    $radarrResult = collect($component->get('results'))->firstWhere('integrationType', 'radarr');
+    expect($radarrResult['fileQuality'])->toBe('Bluray-1080p');
+    expect($radarrResult['fileSize'])->toBe(8589934592);
+});
+
+it('returns null fileQuality and fileSize for radarr movies without a file', function () {
+    ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([], 200),
+        '*/api/v3/movie/lookup*' => Http::response([
+            ['id' => 7, 'tmdbId' => 27205, 'title' => 'Inception', 'year' => 2010, 'hasFile' => false],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'inception');
+
+    $radarrResult = collect($component->get('results'))->firstWhere('integrationType', 'radarr');
+    expect($radarrResult['fileQuality'])->toBeNull();
+    expect($radarrResult['fileSize'])->toBeNull();
+});
+
+it('surfaces sonarr sizeOnDisk when series is in library', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'id' => 42,
+                'tvdbId' => 12345,
+                'title' => 'Breaking Bad',
+                'year' => 2008,
+                'statistics' => [
+                    'episodeFileCount' => 5,
+                    'totalEpisodeCount' => 62,
+                    'sizeOnDisk' => 42949672960,
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking');
+
+    expect($component->get('results.0.sizeOnDisk'))->toBe(42949672960);
+});
+
 it('does not search when term is too short', function () {
     Livewire::test(ArrSearch::class)
         ->set('searchTerm', 'a')
@@ -811,6 +884,64 @@ it('closeDetail resets detailSonarrEpisodeStatus', function () {
         ->call('loadDetailEpisodes')
         ->call('closeDetail')
         ->assertSet('detailSonarrEpisodeStatus', []);
+});
+
+it('loadDetailEpisodes populates detailSonarrEpisodeFileInfo when episodeFile is embedded', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => 169], 200),
+        'api.tvmaze.com/shows/169/episodes*' => Http::response([], 200),
+        'api.tvmaze.com/shows/169/cast*' => Http::response([], 200),
+        '*/api/v3/episode*' => Http::response([
+            [
+                'seasonNumber' => 1,
+                'episodeNumber' => 1,
+                'hasFile' => true,
+                'episodeFile' => [
+                    'quality' => ['quality' => ['name' => 'WEBDL-1080p']],
+                    'size' => 1073741824,
+                ],
+            ],
+            ['seasonNumber' => 1, 'episodeNumber' => 2, 'hasFile' => false],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes');
+
+    expect($component->get('detailSonarrEpisodeFileInfo.1.1.quality'))->toBe('WEBDL-1080p');
+    expect($component->get('detailSonarrEpisodeFileInfo.1.1.size'))->toBe(1073741824);
+    expect($component->get('detailSonarrEpisodeFileInfo.1'))->not->toHaveKey(2);
+});
+
+it('closeDetail resets detailSonarrEpisodeFileInfo', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 1, 'title' => 'Show', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        'api.tvmaze.com/lookup/shows*' => Http::response(['id' => 1], 200),
+        'api.tvmaze.com/shows/1/episodes*' => Http::response([], 200),
+        'api.tvmaze.com/shows/1/cast*' => Http::response([], 200),
+        '*/api/v3/episode*' => Http::response([
+            [
+                'seasonNumber' => 1,
+                'episodeNumber' => 1,
+                'hasFile' => true,
+                'episodeFile' => ['quality' => ['quality' => ['name' => 'WEBDL-1080p']], 'size' => 1073741824],
+            ],
+        ], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'show')
+        ->call('openDetail', 0)
+        ->call('loadDetailEpisodes')
+        ->call('closeDetail')
+        ->assertSet('detailSonarrEpisodeFileInfo', []);
 });
 
 // --- Individual episode requests ---
@@ -1431,4 +1562,236 @@ it('livewire closeDetail clears detailReleases', function () {
 
     expect($component->get('detailReleases'))->toBe([]);
     expect($component->get('showDetail'))->toBeFalse();
+});
+
+// ── Live queue refresh ───────────────────────────────────────────────────────
+
+it('loadQueue dispatches refreshArrQueue event in admin mode', function () {
+    Livewire::test(ArrSearch::class)
+        ->call('loadQueue')
+        ->assertDispatched('refreshArrQueue');
+});
+
+it('loadQueue does not dispatch refreshArrQueue in guest mode', function () {
+    Http::fake(['*/api/v3/queue*' => Http::response(['records' => []], 200)]);
+
+    Livewire::test(ArrSearch::class, [
+        'guestMode' => true,
+        'guestIntegrationIds' => [$this->sonarr->id],
+    ])
+        ->call('loadQueue')
+        ->assertNotDispatched('refreshArrQueue');
+});
+
+// ── requestEpisode retry ─────────────────────────────────────────────────────
+
+it('requestEpisode retries episode fetch when series was just added and episodes not yet indexed', function () {
+    SonarrService::$episodeRetryDelayUs = 0;
+
+    // NOTE: Http::fake map-invokes ALL stubs for every request, so a Http::sequence() on *episode*
+    // would be consumed by monitor requests too. Use a closure that returns null for monitor URLs.
+    $episodeFetchCalls = 0;
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Dark', 'titleSlug' => 'dark', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        '*/api/v3/series' => Http::response(['id' => 77, 'title' => 'Dark'], 201),
+        '*/api/v3/episode/monitor' => Http::response(null, 200),
+        '*/api/v3/command' => Http::response(['id' => 1], 201),
+        // Return null for monitor URLs so the specific stub above wins; simulate empty then populated.
+        '*/api/v3/episode*' => function ($request) use (&$episodeFetchCalls) {
+            if (str_contains($request->url(), '/monitor')) {
+                return null;
+            }
+            $episodeFetchCalls++;
+
+            return $episodeFetchCalls === 1
+                ? Http::response([], 200)
+                : Http::response([['id' => 301, 'episodeNumber' => 1, 'seasonNumber' => 1, 'title' => 'Secrets']], 200);
+        },
+        'api.tvmaze.com/*' => Http::response(['id' => 1], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'dark')
+        ->call('openDetail', 0)
+        ->call('requestEpisode', 1, 1)
+        ->assertNotified();
+
+    Http::assertSent(fn ($r) => $r->method() === 'PUT' && str_ends_with($r->url(), '/api/v3/episode/monitor')
+        && in_array(301, $r->data()['episodeIds'] ?? []));
+
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_ends_with($r->url(), '/api/v3/command')
+        && ($r->data()['name'] ?? '') === 'EpisodeSearch');
+})->after(fn () => SonarrService::$episodeRetryDelayUs = 500_000);
+
+it('requestEpisode shows error when episode still not found after all retries', function () {
+    SonarrService::$episodeRetryDelayUs = 0;
+
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Dark', 'titleSlug' => 'dark', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        '*/api/v3/series' => Http::response(['id' => 77, 'title' => 'Dark'], 201),
+        // All attempts return empty — episode never indexes in time
+        '*/api/v3/episode*' => Http::response([], 200),
+        'api.tvmaze.com/*' => Http::response(['id' => 1], 200),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'dark')
+        ->call('openDetail', 0)
+        ->call('requestEpisode', 1, 1)
+        ->assertNotified();
+
+    Http::assertNotSent(fn ($r) => str_ends_with($r->url(), '/api/v3/command'));
+})->after(fn () => SonarrService::$episodeRetryDelayUs = 500_000);
+
+// ── Livewire: loadEpisodeReleases action ─────────────────────────────────────
+
+it('loadEpisodeReleases fetches episode releases for an in-library series', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        '*/api/v3/episode*' => Http::response([
+            ['id' => 101, 'episodeNumber' => 1, 'seasonNumber' => 1, 'title' => 'Pilot'],
+        ], 200),
+        '*/api/v3/release*' => Http::response([
+            [
+                'guid' => 'ep-guid-1',
+                'title' => 'Breaking.Bad.S01E01.1080p',
+                'indexerId' => 3,
+                'size' => 2_000_000_000,
+                'quality' => ['quality' => ['name' => 'Bluray-1080p']],
+                'protocol' => 'torrent',
+                'rejections' => [],
+            ],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadEpisodeReleases', 1, 1);
+
+    expect($component->get('detailReleases'))->toHaveCount(1);
+    expect($component->get('detailReleases.0.guid'))->toBe('ep-guid-1');
+    expect($component->get('detailEpisodeId'))->toBe(101);
+    expect($component->get('detailReleasesLabel'))->toBe('S01E01');
+
+    // Should have passed episodeId to /release
+    Http::assertSent(fn ($r) => str_contains($r->url(), '/api/v3/release')
+        && $r->method() === 'GET'
+        && ($r->data()['episodeId'] ?? null) == 101);
+});
+
+it('loadEpisodeReleases adds the series first when not in library', function () {
+    SonarrService::$episodeRetryDelayUs = 0;
+
+    Http::fake([
+        // Initial search — series not in library
+        '*/api/v3/series/lookup*' => Http::response([
+            ['tvdbId' => 12345, 'title' => 'Dark', 'titleSlug' => 'dark', 'seasons' => [['seasonNumber' => 2]]],
+        ], 200),
+        '*/api/v3/series' => Http::response(['id' => 55, 'title' => 'Dark'], 201),
+        '*/api/v3/episode*' => Http::response([
+            ['id' => 201, 'episodeNumber' => 3, 'seasonNumber' => 2, 'title' => 'The Cave'],
+        ], 200),
+        '*/api/v3/release*' => Http::response([
+            [
+                'guid' => 'dark-ep-guid',
+                'title' => 'Dark.S02E03',
+                'indexerId' => 2,
+                'size' => 1_500_000_000,
+                'quality' => ['quality' => ['name' => '1080p']],
+                'protocol' => 'usenet',
+                'rejections' => [],
+            ],
+        ], 200),
+        'api.tvmaze.com/*' => Http::response(['id' => 1], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'dark')
+        ->call('openDetail', 0)
+        ->call('loadEpisodeReleases', 2, 3);
+
+    expect($component->get('detailReleases'))->toHaveCount(1);
+    expect($component->get('detailReleasesLabel'))->toBe('S02E03');
+    expect($component->get('detailResult.existsInLibrary'))->toBeTrue();
+    expect($component->get('detailResult.libraryId'))->toBe(55);
+
+    Http::assertSent(fn ($r) => $r->method() === 'POST' && str_ends_with($r->url(), '/api/v3/series')
+        && ($r->data()['addOptions']['searchForMissingEpisodes'] ?? true) === false);
+})->after(fn () => SonarrService::$episodeRetryDelayUs = 500_000);
+
+it('loadEpisodeReleases is blocked in guest mode', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad', 'seasons' => []],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class, ['guestMode' => true, 'guestIntegrationIds' => [$this->sonarr->id]])
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadEpisodeReleases', 1, 1);
+
+    expect($component->get('detailReleases'))->toBe([]);
+    Http::assertNotSent(fn ($r) => str_contains($r->url(), '/episode'));
+});
+
+it('downloadDetailRelease includes episodeId when in episode search context', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        '*/api/v3/episode*' => Http::response([
+            ['id' => 101, 'episodeNumber' => 1, 'seasonNumber' => 1, 'title' => 'Pilot'],
+        ], 200),
+        '*/api/v3/release*' => Http::response([], 201),
+    ]);
+
+    Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->set('detailEpisodeId', 101)
+        ->call('downloadDetailRelease', 'ep-guid', 5)
+        ->assertNotified();
+
+    Http::assertSent(fn ($r) => $r->method() === 'POST'
+        && str_contains($r->url(), '/release')
+        && $r->data()['guid'] === 'ep-guid'
+        && $r->data()['seriesId'] === 42
+        && ($r->data()['episodeId'] ?? null) === 101);
+});
+
+it('closeDetail clears episode search context', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad', 'titleSlug' => 'breaking-bad', 'seasons' => [['seasonNumber' => 1]]],
+        ], 200),
+        '*/api/v3/episode*' => Http::response([
+            ['id' => 101, 'episodeNumber' => 1, 'seasonNumber' => 1, 'title' => 'Pilot'],
+        ], 200),
+        '*/api/v3/release*' => Http::response([
+            ['guid' => 'ep-g', 'title' => 'S01E01', 'indexerId' => 1, 'size' => 0, 'quality' => ['quality' => ['name' => 'HD']], 'protocol' => 'torrent', 'rejections' => []],
+        ], 200),
+    ]);
+
+    $component = Livewire::test(ArrSearch::class)
+        ->set('searchTerm', 'breaking')
+        ->call('openDetail', 0)
+        ->call('loadEpisodeReleases', 1, 1);
+
+    expect($component->get('detailReleasesLabel'))->toBe('S01E01');
+    expect($component->get('detailEpisodeId'))->toBe(101);
+
+    $component->call('closeDetail');
+
+    expect($component->get('detailReleasesLabel'))->toBeNull();
+    expect($component->get('detailEpisodeId'))->toBeNull();
+    expect($component->get('detailReleases'))->toBe([]);
 });

--- a/tests/Feature/ArrServiceTest.php
+++ b/tests/Feature/ArrServiceTest.php
@@ -1,0 +1,480 @@
+<?php
+
+use App\Models\ArrIntegration;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\Arr\ArrService;
+use App\Services\Arr\Contracts\ArrIntegrationInterface;
+use App\Services\Arr\RadarrService;
+use App\Services\Arr\SonarrService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Bus::fake();
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+});
+
+it('dispatches sonarr integrations to SonarrService', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    expect(ArrService::make($integration))->toBeInstanceOf(SonarrService::class);
+});
+
+it('dispatches radarr integrations to RadarrService', function () {
+    $integration = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    expect(ArrService::make($integration))->toBeInstanceOf(RadarrService::class);
+});
+
+it('returns the integration from getIntegration', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $service = ArrService::make($integration);
+
+    expect($service->getIntegration()->is($integration))->toBeTrue();
+});
+
+it('throws for unknown arr types', function () {
+    $integration = ArrIntegration::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'type' => 'unsupported',
+    ]);
+
+    ArrService::make($integration);
+})->throws(InvalidArgumentException::class);
+
+it('returns the correct interface', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    expect(ArrService::make($integration))->toBeInstanceOf(ArrIntegrationInterface::class);
+});
+
+it('testConnection returns version on success', function () {
+    Http::fake([
+        '*/api/v3/system/status' => Http::response(['version' => '4.7.0'], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $result = ArrService::make($integration)->testConnection();
+
+    expect($result['ok'])->toBeTrue();
+    expect($result['version'])->toBe('4.7.0');
+});
+
+it('testConnection returns error on failure', function () {
+    Http::fake([
+        '*/api/v3/system/status' => Http::response('Unauthorized', 401),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $result = ArrService::make($integration)->testConnection();
+
+    expect($result['ok'])->toBeFalse();
+    expect($result['error'])->toContain('401');
+});
+
+it('testConnection handles network errors', function () {
+    Http::fake([
+        '*/api/v3/system/status' => function () {
+            throw new ConnectionException('timeout');
+        },
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $result = ArrService::make($integration)->testConnection();
+
+    expect($result['ok'])->toBeFalse();
+    expect($result['error'])->toContain('timeout');
+});
+
+it('sends X-Api-Key header on requests', function () {
+    Http::fake([
+        '*/api/v3/system/status' => Http::response(['version' => '4.7.0'], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'api_key' => 'my-secret-token',
+    ]);
+
+    ArrService::make($integration)->testConnection();
+
+    Http::assertSent(function ($request) {
+        return $request->hasHeader('X-Api-Key', 'my-secret-token');
+    });
+});
+
+it('fetchQualityProfiles returns formatted profiles', function () {
+    Http::fake([
+        '*/api/v3/qualityprofile' => Http::response([
+            ['id' => 1, 'name' => 'HD-1080p'],
+            ['id' => 2, 'name' => '4K-UHD'],
+        ], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $profiles = ArrService::make($integration)->fetchQualityProfiles();
+
+    expect($profiles)->toHaveCount(2);
+    expect($profiles[0])->toBe(['id' => 1, 'name' => 'HD-1080p']);
+    expect($profiles[1])->toBe(['id' => 2, 'name' => '4K-UHD']);
+});
+
+it('fetchRootFolders returns formatted folders', function () {
+    Http::fake([
+        '*/api/v3/rootfolder' => Http::response([
+            ['id' => 1, 'path' => '/media/tv', 'freeSpace' => 500000000000],
+        ], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $folders = ArrService::make($integration)->fetchRootFolders();
+
+    expect($folders)->toHaveCount(1);
+    expect($folders[0]['path'])->toBe('/media/tv');
+    expect($folders[0]['freeSpace'])->toBe(500000000000);
+});
+
+it('search returns formatted results', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            [
+                'tvdbId' => 12345,
+                'title' => 'Breaking Bad',
+                'titleSlug' => 'breaking-bad',
+                'year' => 2008,
+                'overview' => 'A chemistry teacher...',
+                'remotePoster' => 'https://example.com/poster.jpg',
+                'seasons' => [['seasonNumber' => 1]],
+            ],
+        ], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $results = ArrService::make($integration)->search('breaking');
+
+    expect($results)->toHaveCount(1);
+    expect($results[0]['title'])->toBe('Breaking Bad');
+    expect($results[0]['tvdbId'])->toBe(12345);
+    expect($results[0]['poster'])->toBe('https://example.com/poster.jpg');
+});
+
+it('RadarrService search uses tmdbId', function () {
+    Http::fake([
+        '*/api/v3/movie/lookup*' => Http::response([
+            [
+                'tmdbId' => 27205,
+                'title' => 'Inception',
+                'year' => 2010,
+                'overview' => 'A thief who steals...',
+                'runtime' => 148,
+                'genres' => ['Action', 'Sci-Fi'],
+            ],
+        ], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $results = ArrService::make($integration)->search('inception');
+
+    expect($results)->toHaveCount(1);
+    expect($results[0]['title'])->toBe('Inception');
+    expect($results[0]['tmdbId'])->toBe(27205);
+    expect($results[0]['runtime'])->toBe(148);
+    expect($results[0]['genres'])->toBe(['Action', 'Sci-Fi']);
+});
+
+it('add posts correct payload for Sonarr', function () {
+    Http::fake([
+        '*/api/v3/series' => Http::response(['id' => 99, 'title' => 'Breaking Bad'], 201),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'quality_profile_id' => 2,
+        'root_folder_path' => '/media/tv',
+    ]);
+
+    $result = ArrService::make($integration)->add([
+        'tvdbId' => 12345,
+        'title' => 'Breaking Bad',
+        'titleSlug' => 'breaking-bad',
+    ]);
+
+    expect($result['ok'])->toBeTrue();
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+
+        return $request->url() === $request->url() // any host
+            && $request->method() === 'POST'
+            && $body['tvdbId'] === 12345
+            && $body['qualityProfileId'] === 2
+            && $body['rootFolderPath'] === '/media/tv'
+            && $body['monitored'] === true
+            && $body['addOptions']['searchForMissingEpisodes'] === true;
+    });
+});
+
+it('add posts correct payload for Radarr', function () {
+    Http::fake([
+        '*/api/v3/movie' => Http::response(['id' => 99, 'title' => 'Inception'], 201),
+    ]);
+
+    $integration = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'quality_profile_id' => 3,
+        'root_folder_path' => '/media/movies',
+    ]);
+
+    $result = ArrService::make($integration)->add([
+        'tmdbId' => 27205,
+        'title' => 'Inception',
+    ]);
+
+    expect($result['ok'])->toBeTrue();
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+
+        return $request->method() === 'POST'
+            && $body['tmdbId'] === 27205
+            && $body['qualityProfileId'] === 3
+            && $body['rootFolderPath'] === '/media/movies'
+            && $body['addOptions']['searchForMovie'] === true;
+    });
+});
+
+it('checkExists returns true when found', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([
+            ['id' => 42, 'tvdbId' => 12345, 'title' => 'Breaking Bad'],
+        ], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $result = ArrService::make($integration)->checkExists(12345);
+
+    expect($result['exists'])->toBeTrue();
+    expect($result['id'])->toBe(42);
+});
+
+it('checkExists returns false when not found', function () {
+    Http::fake([
+        '*/api/v3/series/lookup*' => Http::response([], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $result = ArrService::make($integration)->checkExists(99999);
+
+    expect($result['exists'])->toBeFalse();
+});
+
+it('RadarrService checkExists uses /movie endpoint', function () {
+    Http::fake([
+        '*/api/v3/movie*' => Http::response([
+            ['id' => 77, 'tmdbId' => 27205, 'title' => 'Inception'],
+        ], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $result = ArrService::make($integration)->checkExists(27205);
+
+    expect($result['exists'])->toBeTrue();
+    expect($result['id'])->toBe(77);
+});
+
+it('fetchQueue maps progress from sizeleft/size', function () {
+    Http::fake([
+        '*/api/v3/queue*' => Http::response([
+            'records' => [
+                [
+                    'id' => 1,
+                    'title' => 'Episode 1',
+                    'status' => 'downloading',
+                    'size' => 1000,
+                    'sizeleft' => 250,
+                    'timeleft' => '00:05:00',
+                    'series' => ['title' => 'Breaking Bad'],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $queue = ArrService::make($integration)->fetchQueue();
+
+    expect($queue)->toHaveCount(1);
+    expect($queue[0]['title'])->toBe('Breaking Bad');
+    expect($queue[0]['progress'])->toBe(75);
+    expect($queue[0]['sizeLeft'])->toBe(250);
+});
+
+it('fetchReleases returns formatted releases with approval flag', function () {
+    Http::fake([
+        '*/api/v3/release*' => Http::response([
+            [
+                'guid' => 'abc-123',
+                'title' => 'Breaking.Bad.S01E01.1080p',
+                'indexerId' => 1,
+                'size' => 1500000000,
+                'quality' => ['quality' => ['name' => 'HD-1080p']],
+                'protocol' => 'torrent',
+                'rejections' => [],
+            ],
+            [
+                'guid' => 'def-456',
+                'title' => 'Breaking.Bad.S01E01.720p',
+                'indexerId' => 2,
+                'size' => 800000000,
+                'quality' => ['quality' => ['name' => 'HD-720p']],
+                'protocol' => 'torrent',
+                'rejections' => ['Quality not allowed'],
+            ],
+        ], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $releases = ArrService::make($integration)->fetchReleases(42);
+
+    expect($releases)->toHaveCount(2);
+    expect($releases[0]['approved'])->toBeTrue();
+    expect($releases[0]['quality'])->toBe('HD-1080p');
+    expect($releases[1]['approved'])->toBeFalse();
+});
+
+it('downloadRelease posts to /release endpoint', function () {
+    Http::fake([
+        '*/api/v3/release' => Http::response('', 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $result = ArrService::make($integration)->downloadRelease([
+        'guid' => 'abc-123',
+        'indexerId' => 1,
+        'seriesId' => 42,
+    ]);
+
+    expect($result['ok'])->toBeTrue();
+
+    Http::assertSent(function ($request) {
+        $body = $request->data();
+
+        return $request->method() === 'POST'
+            && $body['guid'] === 'abc-123'
+            && $body['seriesId'] === 42;
+    });
+});
+
+it('downloadRelease returns error on server failure', function () {
+    Http::fake([
+        '*/api/v3/release' => Http::response('Bad Request', 400),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+    ]);
+
+    $result = ArrService::make($integration)->downloadRelease([
+        'guid' => 'abc-123',
+        'indexerId' => 1,
+        'seriesId' => 42,
+    ]);
+
+    expect($result['ok'])->toBeFalse();
+    expect($result['error'])->not->toBeEmpty();
+});
+
+it('base url strips trailing slash for client requests', function () {
+    Http::fake([
+        '*/api/v3/system/status' => Http::response(['version' => '4.0.0'], 200),
+    ]);
+
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'url' => 'http://sonarr.example.com:8989/', // trailing slash
+    ]);
+
+    ArrService::make($integration)->testConnection();
+
+    Http::assertSent(function ($request) {
+        // Should hit /api/v3/system/status on the host (no double slash)
+        return str_contains($request->url(), 'http://sonarr.example.com:8989/api/v3/system/status')
+            && ! str_contains($request->url(), '//api');
+    });
+});

--- a/tests/Feature/ArrServiceTest.php
+++ b/tests/Feature/ArrServiceTest.php
@@ -23,7 +23,6 @@ beforeEach(function () {
 it('dispatches sonarr integrations to SonarrService', function () {
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     expect(ArrService::make($integration))->toBeInstanceOf(SonarrService::class);
@@ -32,7 +31,6 @@ it('dispatches sonarr integrations to SonarrService', function () {
 it('dispatches radarr integrations to RadarrService', function () {
     $integration = ArrIntegration::factory()->radarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     expect(ArrService::make($integration))->toBeInstanceOf(RadarrService::class);
@@ -41,7 +39,6 @@ it('dispatches radarr integrations to RadarrService', function () {
 it('returns the integration from getIntegration', function () {
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $service = ArrService::make($integration);
@@ -52,7 +49,6 @@ it('returns the integration from getIntegration', function () {
 it('throws for unknown arr types', function () {
     $integration = ArrIntegration::factory()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'type' => 'unsupported',
     ]);
 
@@ -62,7 +58,6 @@ it('throws for unknown arr types', function () {
 it('returns the correct interface', function () {
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     expect(ArrService::make($integration))->toBeInstanceOf(ArrIntegrationInterface::class);
@@ -75,7 +70,6 @@ it('testConnection returns version on success', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $result = ArrService::make($integration)->testConnection();
@@ -91,7 +85,6 @@ it('testConnection returns error on failure', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $result = ArrService::make($integration)->testConnection();
@@ -109,7 +102,6 @@ it('testConnection handles network errors', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $result = ArrService::make($integration)->testConnection();
@@ -125,7 +117,6 @@ it('sends X-Api-Key header on requests', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'api_key' => 'my-secret-token',
     ]);
 
@@ -146,7 +137,6 @@ it('fetchQualityProfiles returns formatted profiles', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $profiles = ArrService::make($integration)->fetchQualityProfiles();
@@ -165,7 +155,6 @@ it('fetchRootFolders returns formatted folders', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $folders = ArrService::make($integration)->fetchRootFolders();
@@ -192,7 +181,6 @@ it('search returns formatted results', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $results = ArrService::make($integration)->search('breaking');
@@ -219,7 +207,6 @@ it('RadarrService search uses tmdbId', function () {
 
     $integration = ArrIntegration::factory()->radarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $results = ArrService::make($integration)->search('inception');
@@ -238,7 +225,6 @@ it('add posts correct payload for Sonarr', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'quality_profile_id' => 2,
         'root_folder_path' => '/media/tv',
     ]);
@@ -271,7 +257,6 @@ it('add posts correct payload for Radarr', function () {
 
     $integration = ArrIntegration::factory()->radarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'quality_profile_id' => 3,
         'root_folder_path' => '/media/movies',
     ]);
@@ -303,7 +288,6 @@ it('checkExists returns true when found', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $result = ArrService::make($integration)->checkExists(12345);
@@ -319,7 +303,6 @@ it('checkExists returns false when not found', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $result = ArrService::make($integration)->checkExists(99999);
@@ -336,7 +319,6 @@ it('RadarrService checkExists uses /movie endpoint', function () {
 
     $integration = ArrIntegration::factory()->radarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $result = ArrService::make($integration)->checkExists(27205);
@@ -364,7 +346,6 @@ it('fetchQueue maps progress from sizeleft/size', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $queue = ArrService::make($integration)->fetchQueue();
@@ -401,7 +382,6 @@ it('fetchReleases returns formatted releases with approval flag', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $releases = ArrService::make($integration)->fetchReleases(42);
@@ -419,7 +399,6 @@ it('downloadRelease posts to /release endpoint', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $result = ArrService::make($integration)->downloadRelease([
@@ -446,7 +425,6 @@ it('downloadRelease returns error on server failure', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
     ]);
 
     $result = ArrService::make($integration)->downloadRelease([
@@ -466,7 +444,6 @@ it('base url strips trailing slash for client requests', function () {
 
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->user->id,
-        'playlist_id' => $this->playlist->id,
         'url' => 'http://sonarr.example.com:8989/', // trailing slash
     ]);
 

--- a/tests/Feature/ArrWebhookTest.php
+++ b/tests/Feature/ArrWebhookTest.php
@@ -195,3 +195,36 @@ it('exposes a webhook_url accessor', function () {
         ->toContain('/api/webhooks/arr/')
         ->toContain($this->radarr->webhook_secret);
 });
+
+it('handles duplicate Grab events for the same download_id idempotently', function () {
+    $payload = [
+        'eventType' => 'Grab',
+        'movie' => ['title' => 'Conclave', 'tmdbId' => 974635],
+        'release' => [
+            'releaseTitle' => 'Conclave.2024.1080p.BluRay.x264',
+            'quality' => ['quality' => ['name' => 'Bluray-1080p']],
+            'size' => 14_000_000_000,
+        ],
+        'downloadId' => 'abc123',
+    ];
+
+    $this->postJson('/api/webhooks/arr/'.$this->radarr->webhook_secret, $payload)->assertNoContent();
+    $this->postJson('/api/webhooks/arr/'.$this->radarr->webhook_secret, $payload)->assertNoContent();
+
+    // updateOrCreate on download_id means only one record exists.
+    expect(ArrQueueEvent::where('download_id', 'abc123')->count())->toBe(1);
+    expect(ArrQueueEvent::where('status', 'grabbing')->count())->toBe(1);
+    // Broadcast fires for each webhook call (intentional — UI always refreshes).
+    Event::assertDispatchedTimes(ArrQueueUpdated::class, 2);
+});
+
+it('logs debug for unknown event types and still broadcasts', function () {
+    $response = $this->postJson(
+        '/api/webhooks/arr/'.$this->radarr->webhook_secret,
+        ['eventType' => 'EpisodeFileDelete', 'movie' => ['title' => 'Test', 'tmdbId' => 1]]
+    );
+
+    $response->assertNoContent();
+    expect(ArrQueueEvent::count())->toBe(0);
+    Event::assertDispatched(ArrQueueUpdated::class);
+});

--- a/tests/Feature/ArrWebhookTest.php
+++ b/tests/Feature/ArrWebhookTest.php
@@ -1,0 +1,197 @@
+<?php
+
+use App\Events\ArrQueueUpdated;
+use App\Models\ArrIntegration;
+use App\Models\ArrQueueEvent;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Only fake the specific broadcast event — faking ALL events swallows Eloquent
+    // model lifecycle events (creating/saving), which breaks the webhook_secret observer.
+    Event::fake([ArrQueueUpdated::class]);
+    $this->user = User::factory()->create(['permissions' => ['use_integrations']]);
+    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+    $this->radarr = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+        'quality_profile_id' => 1,
+        'root_folder_path' => '/media/movies',
+    ]);
+    $this->sonarr = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->user->id,
+        'quality_profile_id' => 1,
+        'root_folder_path' => '/media/tv',
+    ]);
+});
+
+it('returns 204 for Radarr Test event without creating a record', function () {
+    $response = $this->postJson(
+        '/api/webhooks/arr/'.$this->radarr->webhook_secret,
+        ['eventType' => 'Test', 'movie' => ['title' => 'Test Movie', 'tmdbId' => 1]]
+    );
+
+    $response->assertNoContent();
+    expect(ArrQueueEvent::count())->toBe(0);
+    Event::assertNotDispatched(ArrQueueUpdated::class);
+});
+
+it('returns 404 for an unknown webhook secret', function () {
+    $response = $this->postJson('/api/webhooks/arr/not-a-real-secret', [
+        'eventType' => 'Grab',
+    ]);
+
+    $response->assertNotFound();
+});
+
+it('creates a monitored event on MovieAdded and broadcasts', function () {
+    $response = $this->postJson(
+        '/api/webhooks/arr/'.$this->radarr->webhook_secret,
+        [
+            'eventType' => 'MovieAdded',
+            'movie' => ['id' => 5, 'title' => 'Conclave', 'tmdbId' => 974635, 'year' => 2024],
+            'addMethod' => ['addedBy' => 'manual'],
+        ]
+    );
+
+    $response->assertNoContent();
+
+    $event = ArrQueueEvent::first();
+    expect($event)->not->toBeNull()
+        ->and($event->title)->toBe('Conclave')
+        ->and($event->status)->toBe('monitored')
+        ->and($event->event_type)->toBe('MovieAdded')
+        ->and($event->external_id)->toBe('974635')
+        ->and($event->download_id)->toBeNull();
+
+    Event::assertDispatched(ArrQueueUpdated::class, fn ($e) => $e->userId === $this->user->id);
+});
+
+it('creates a grabbing event on Grab and promotes monitored to grabbing', function () {
+    // Pre-existing monitored event from MovieAdded
+    ArrQueueEvent::factory()->create([
+        'arr_integration_id' => $this->radarr->id,
+        'user_id' => $this->user->id,
+        'external_id' => '974635',
+        'title' => 'Conclave',
+        'event_type' => 'MovieAdded',
+        'status' => 'monitored',
+        'download_id' => null,
+        'last_event_at' => now()->subMinutes(5),
+    ]);
+
+    $response = $this->postJson(
+        '/api/webhooks/arr/'.$this->radarr->webhook_secret,
+        [
+            'eventType' => 'Grab',
+            'movie' => ['title' => 'Conclave', 'tmdbId' => 974635],
+            'release' => [
+                'releaseTitle' => 'Conclave.2024.1080p.BluRay.x264',
+                'quality' => ['quality' => ['name' => 'Bluray-1080p']],
+                'size' => 14_000_000_000,
+            ],
+            'downloadId' => 'abc123',
+        ]
+    );
+
+    $response->assertNoContent();
+
+    // Monitored row should be deleted; a grabbing row should replace it.
+    expect(ArrQueueEvent::where('status', 'monitored')->count())->toBe(0);
+
+    $grabbing = ArrQueueEvent::where('status', 'grabbing')->first();
+    expect($grabbing)->not->toBeNull()
+        ->and($grabbing->download_id)->toBe('abc123')
+        ->and($grabbing->quality)->toBe('Bluray-1080p')
+        ->and($grabbing->size)->toBe(14_000_000_000);
+
+    Event::assertDispatched(ArrQueueUpdated::class);
+});
+
+it('marks a grab event as imported on Download', function () {
+    ArrQueueEvent::factory()->create([
+        'arr_integration_id' => $this->radarr->id,
+        'user_id' => $this->user->id,
+        'external_id' => '974635',
+        'download_id' => 'abc123',
+        'title' => 'Conclave',
+        'event_type' => 'Grab',
+        'status' => 'grabbing',
+        'quality' => 'Bluray-1080p',
+        'last_event_at' => now()->subMinutes(30),
+    ]);
+
+    $response = $this->postJson(
+        '/api/webhooks/arr/'.$this->radarr->webhook_secret,
+        [
+            'eventType' => 'Download',
+            'movie' => ['title' => 'Conclave', 'tmdbId' => 974635],
+            'downloadId' => 'abc123',
+            'movieFile' => ['quality' => ['quality' => ['name' => 'Bluray-1080p']]],
+        ]
+    );
+
+    $response->assertNoContent();
+
+    $event = ArrQueueEvent::where('download_id', 'abc123')->first();
+    expect($event)->not->toBeNull()
+        ->and($event->status)->toBe('imported')
+        ->and($event->progress)->toBe(100);
+
+    Event::assertDispatched(ArrQueueUpdated::class);
+});
+
+it('marks an event as manual_required on ManualInteractionRequired', function () {
+    $response = $this->postJson(
+        '/api/webhooks/arr/'.$this->radarr->webhook_secret,
+        [
+            'eventType' => 'ManualInteractionRequired',
+            'movie' => ['title' => 'Conclave', 'tmdbId' => 974635],
+            'downloadId' => 'abc123',
+        ]
+    );
+
+    $response->assertNoContent();
+
+    $event = ArrQueueEvent::where('status', 'manual_required')->first();
+    expect($event)->not->toBeNull()
+        ->and($event->title)->toBe('Conclave');
+
+    Event::assertDispatched(ArrQueueUpdated::class);
+});
+
+it('handles Sonarr SeriesAdd event', function () {
+    $response = $this->postJson(
+        '/api/webhooks/arr/'.$this->sonarr->webhook_secret,
+        [
+            'eventType' => 'SeriesAdd',
+            'series' => ['id' => 10, 'title' => 'Severance', 'tvdbId' => 371980],
+        ]
+    );
+
+    $response->assertNoContent();
+
+    $event = ArrQueueEvent::first();
+    expect($event)->not->toBeNull()
+        ->and($event->title)->toBe('Severance')
+        ->and($event->status)->toBe('monitored')
+        ->and($event->external_id)->toBe('371980');
+});
+
+it('auto-generates a webhook_secret on creation', function () {
+    $integration = ArrIntegration::factory()->radarr()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    expect($integration->webhook_secret)->not->toBeNull()
+        ->and(strlen($integration->webhook_secret))->toBeGreaterThan(20);
+});
+
+it('exposes a webhook_url accessor', function () {
+    expect($this->radarr->webhook_url)
+        ->toContain('/api/webhooks/arr/')
+        ->toContain($this->radarr->webhook_secret);
+});

--- a/tests/Feature/GuestRequestContentTest.php
+++ b/tests/Feature/GuestRequestContentTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Filament\GuestPanel\Pages\GuestRequestContent;
+use App\Models\ArrIntegration;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Request;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Bus::fake();
+    $this->owner = User::factory()->create();
+    $this->playlist = Playlist::factory()->create(['user_id' => $this->owner->id]);
+});
+
+function setGuestAuthContext(string $uuid, ?string $username = 'guest', ?string $password = 'secret'): void
+{
+    $request = Request::create('/');
+    $request->attributes->set('playlist_uuid', $uuid);
+    app()->instance('request', $request);
+
+    if ($username) {
+        session([
+            base64_encode($uuid).'_guest_auth_username' => $username,
+            base64_encode($uuid).'_guest_auth_password' => $password,
+        ]);
+    } else {
+        session()->forget([
+            base64_encode($uuid).'_guest_auth_username',
+            base64_encode($uuid).'_guest_auth_password',
+        ]);
+    }
+}
+
+it('hides the page when no session auth', function () {
+    ArrIntegration::factory()->create([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'enabled' => true,
+        'guest_enabled' => true,
+    ]);
+
+    $request = Request::create('/');
+    $request->attributes->set('playlist_uuid', $this->playlist->uuid);
+    app()->instance('request', $request);
+    session()->forget([
+        base64_encode($this->playlist->uuid).'_guest_auth_username',
+        base64_encode($this->playlist->uuid).'_guest_auth_password',
+    ]);
+
+    expect(GuestRequestContent::canAccess())->toBeFalse();
+});
+
+it('hides the page when no integration is guest-enabled', function () {
+    ArrIntegration::factory()->create([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'enabled' => true,
+        'guest_enabled' => false,
+    ]);
+
+    setGuestAuthContext($this->playlist->uuid);
+
+    expect(GuestRequestContent::canAccess())->toBeFalse();
+});
+
+it('hides the page when no integration exists at all', function () {
+    setGuestAuthContext($this->playlist->uuid);
+
+    expect(GuestRequestContent::canAccess())->toBeFalse();
+});
+
+it('shows the page when an integration is guest-enabled', function () {
+    ArrIntegration::factory()->create([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'enabled' => true,
+        'guest_enabled' => true,
+    ]);
+
+    setGuestAuthContext($this->playlist->uuid);
+
+    expect(GuestRequestContent::canAccess())->toBeTrue();
+});
+
+it('hides the page when integration is disabled', function () {
+    ArrIntegration::factory()->create([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'enabled' => false,
+        'guest_enabled' => true,
+    ]);
+
+    setGuestAuthContext($this->playlist->uuid);
+
+    expect(GuestRequestContent::canAccess())->toBeFalse();
+});
+
+it('hides the page for unknown playlist UUID', function () {
+    setGuestAuthContext('unknown-uuid');
+
+    expect(GuestRequestContent::canAccess())->toBeFalse();
+});
+
+it('resolves the integration via the integration property', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create([
+        'user_id' => $this->owner->id,
+        'playlist_id' => $this->playlist->id,
+        'enabled' => true,
+        'guest_enabled' => true,
+        'name' => 'My Sonarr',
+    ]);
+
+    setGuestAuthContext($this->playlist->uuid);
+
+    $page = new GuestRequestContent;
+    $resolved = $page->getIntegrationProperty();
+
+    expect($resolved)->toBeInstanceOf(ArrIntegration::class);
+    expect($resolved->id)->toBe($integration->id);
+});

--- a/tests/Feature/GuestRequestContentTest.php
+++ b/tests/Feature/GuestRequestContentTest.php
@@ -3,6 +3,7 @@
 use App\Filament\GuestPanel\Pages\GuestRequestContent;
 use App\Models\ArrIntegration;
 use App\Models\Playlist;
+use App\Models\PlaylistRequestSetting;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
@@ -36,9 +37,13 @@ function setGuestAuthContext(string $uuid, ?string $username = 'guest', ?string 
 }
 
 it('hides the page when no session auth', function () {
+    PlaylistRequestSetting::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->owner->id,
+        'enabled' => true,
+    ]);
     ArrIntegration::factory()->create([
         'user_id' => $this->owner->id,
-        'playlist_id' => $this->playlist->id,
         'enabled' => true,
         'guest_enabled' => true,
     ]);
@@ -55,9 +60,13 @@ it('hides the page when no session auth', function () {
 });
 
 it('hides the page when no integration is guest-enabled', function () {
+    PlaylistRequestSetting::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->owner->id,
+        'enabled' => true,
+    ]);
     ArrIntegration::factory()->create([
         'user_id' => $this->owner->id,
-        'playlist_id' => $this->playlist->id,
         'enabled' => true,
         'guest_enabled' => false,
     ]);
@@ -68,15 +77,54 @@ it('hides the page when no integration is guest-enabled', function () {
 });
 
 it('hides the page when no integration exists at all', function () {
+    PlaylistRequestSetting::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->owner->id,
+        'enabled' => true,
+    ]);
+
     setGuestAuthContext($this->playlist->uuid);
 
     expect(GuestRequestContent::canAccess())->toBeFalse();
 });
 
-it('shows the page when an integration is guest-enabled', function () {
+it('hides the page when request setting is disabled', function () {
+    PlaylistRequestSetting::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->owner->id,
+        'enabled' => false,
+    ]);
     ArrIntegration::factory()->create([
         'user_id' => $this->owner->id,
+        'enabled' => true,
+        'guest_enabled' => true,
+    ]);
+
+    setGuestAuthContext($this->playlist->uuid);
+
+    expect(GuestRequestContent::canAccess())->toBeFalse();
+});
+
+it('hides the page when no request setting exists', function () {
+    ArrIntegration::factory()->create([
+        'user_id' => $this->owner->id,
+        'enabled' => true,
+        'guest_enabled' => true,
+    ]);
+
+    setGuestAuthContext($this->playlist->uuid);
+
+    expect(GuestRequestContent::canAccess())->toBeFalse();
+});
+
+it('shows the page when request setting is enabled and an integration is guest-enabled', function () {
+    PlaylistRequestSetting::factory()->create([
         'playlist_id' => $this->playlist->id,
+        'user_id' => $this->owner->id,
+        'enabled' => true,
+    ]);
+    ArrIntegration::factory()->create([
+        'user_id' => $this->owner->id,
         'enabled' => true,
         'guest_enabled' => true,
     ]);
@@ -87,9 +135,13 @@ it('shows the page when an integration is guest-enabled', function () {
 });
 
 it('hides the page when integration is disabled', function () {
+    PlaylistRequestSetting::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->owner->id,
+        'enabled' => true,
+    ]);
     ArrIntegration::factory()->create([
         'user_id' => $this->owner->id,
-        'playlist_id' => $this->playlist->id,
         'enabled' => false,
         'guest_enabled' => true,
     ]);
@@ -106,9 +158,13 @@ it('hides the page for unknown playlist UUID', function () {
 });
 
 it('resolves the integration via the integration property', function () {
+    PlaylistRequestSetting::factory()->create([
+        'playlist_id' => $this->playlist->id,
+        'user_id' => $this->owner->id,
+        'enabled' => true,
+    ]);
     $integration = ArrIntegration::factory()->sonarr()->create([
         'user_id' => $this->owner->id,
-        'playlist_id' => $this->playlist->id,
         'enabled' => true,
         'guest_enabled' => true,
         'name' => 'My Sonarr',

--- a/tests/Feature/MonitorArrSearchTest.php
+++ b/tests/Feature/MonitorArrSearchTest.php
@@ -1,0 +1,111 @@
+<?php
+
+use App\Jobs\MonitorArrSearch;
+use App\Models\ArrIntegration;
+use App\Models\User;
+use Filament\Notifications\DatabaseNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+    NotificationFacade::fake();
+});
+
+function makeMonitorJob(ArrIntegration $integration, int $contentId = 42): MonitorArrSearch
+{
+    return new MonitorArrSearch(
+        integrationId: $integration->id,
+        contentId: $contentId,
+        contentTitle: 'Conclave',
+        userId: $integration->user_id,
+    );
+}
+
+it('sends a warning notification when all releases are rejected', function () {
+    $integration = ArrIntegration::factory()->radarr()->create();
+    $user = User::find($integration->user_id);
+
+    Http::fake([
+        '*/api/v3/release*' => Http::response([
+            ['title' => 'Conclave.2024.1080p', 'approved' => false, 'rejections' => ['Quality not wanted']],
+            ['title' => 'Conclave.2024.4K', 'approved' => false, 'rejections' => ['Quality not wanted']],
+        ], 200),
+    ]);
+
+    makeMonitorJob($integration)->handle();
+
+    NotificationFacade::assertSentTo($user, DatabaseNotification::class);
+});
+
+it('sends a warning notification when the release list is empty', function () {
+    $integration = ArrIntegration::factory()->radarr()->create();
+    $user = User::find($integration->user_id);
+
+    Http::fake([
+        '*/api/v3/release*' => Http::response([], 200),
+    ]);
+
+    makeMonitorJob($integration)->handle();
+
+    NotificationFacade::assertSentTo($user, DatabaseNotification::class);
+});
+
+it('does not notify when at least one release is approved', function () {
+    $integration = ArrIntegration::factory()->radarr()->create();
+
+    Http::fake([
+        '*/api/v3/release*' => Http::response([
+            ['title' => 'Conclave.2024.4K', 'approved' => true, 'rejections' => []],
+            ['title' => 'Conclave.2024.1080p', 'approved' => false, 'rejections' => ['Quality not wanted']],
+        ], 200),
+    ]);
+
+    makeMonitorJob($integration)->handle();
+
+    NotificationFacade::assertNothingSent();
+});
+
+it('does nothing for Sonarr integrations', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create();
+
+    Http::fake();
+
+    makeMonitorJob($integration)->handle();
+
+    Http::assertNothingSent();
+    NotificationFacade::assertNothingSent();
+});
+
+it('does nothing when the integration no longer exists', function () {
+    $integration = ArrIntegration::factory()->radarr()->create();
+    $integrationId = $integration->id;
+    $userId = $integration->user_id;
+    $integration->delete();
+
+    Http::fake();
+
+    $job = new MonitorArrSearch(
+        integrationId: $integrationId,
+        contentId: 42,
+        contentTitle: 'Conclave',
+        userId: $userId,
+    );
+
+    $job->handle();
+
+    Http::assertNothingSent();
+    NotificationFacade::assertNothingSent();
+});
+
+it('sends a warning notification when the job exhausts all retries', function () {
+    $integration = ArrIntegration::factory()->radarr()->create();
+    $user = User::find($integration->user_id);
+
+    makeMonitorJob($integration)->failed(new RuntimeException('Connection timed out.'));
+
+    NotificationFacade::assertSentTo($user, DatabaseNotification::class);
+});

--- a/tests/Feature/RequestArrEpisodeTest.php
+++ b/tests/Feature/RequestArrEpisodeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Jobs\RequestArrEpisode;
+use App\Models\ArrIntegration;
+use App\Models\User;
+use Filament\Notifications\DatabaseNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+    NotificationFacade::fake();
+});
+
+function makeEpisodeJob(ArrIntegration $integration, int $sonarrSeriesId = 77, int $season = 1, int $episode = 1): RequestArrEpisode
+{
+    return new RequestArrEpisode(
+        integrationId: $integration->id,
+        sonarrSeriesId: $sonarrSeriesId,
+        seasonNumber: $season,
+        episodeNumber: $episode,
+        userId: $integration->user_id,
+        showTitle: 'Dark',
+    );
+}
+
+it('monitors and searches the episode when Sonarr has finished indexing', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create();
+
+    Http::fake([
+        '*/api/v3/episode*' => Http::response([
+            ['id' => 301, 'episodeNumber' => 1, 'seasonNumber' => 1, 'title' => 'Secrets'],
+        ], 200),
+        '*/api/v3/episode/monitor' => Http::response(null, 200),
+        '*/api/v3/command' => Http::response(['id' => 1], 201),
+    ]);
+
+    makeEpisodeJob($integration)->handle();
+
+    Http::assertSent(fn ($r) => $r->method() === 'PUT'
+        && str_ends_with($r->url(), '/api/v3/episode/monitor')
+        && in_array(301, $r->data()['episodeIds'] ?? []));
+
+    Http::assertSent(fn ($r) => $r->method() === 'POST'
+        && str_ends_with($r->url(), '/api/v3/command')
+        && ($r->data()['name'] ?? '') === 'EpisodeSearch');
+
+    NotificationFacade::assertSentTo(
+        User::find($integration->user_id),
+        DatabaseNotification::class,
+    );
+});
+
+it('throws when episode is not yet indexed so the queue retries', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create();
+
+    Http::fake([
+        '*/api/v3/episode*' => Http::response([], 200),
+    ]);
+
+    expect(fn () => makeEpisodeJob($integration)->handle())
+        ->toThrow(RuntimeException::class, 'not yet indexed');
+});
+
+it('sends a failure notification when the job exhausts all retries', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create();
+    $user = User::find($integration->user_id);
+
+    makeEpisodeJob($integration)->failed(new RuntimeException('Episode S01E01 not yet indexed by Sonarr.'));
+
+    NotificationFacade::assertSentTo($user, DatabaseNotification::class);
+});
+
+it('does nothing when the integration no longer exists', function () {
+    $integration = ArrIntegration::factory()->sonarr()->create();
+    $integrationId = $integration->id;
+    $userId = $integration->user_id;
+    $integration->delete();
+
+    Http::fake();
+
+    $job = new RequestArrEpisode(
+        integrationId: $integrationId,
+        sonarrSeriesId: 77,
+        seasonNumber: 1,
+        episodeNumber: 1,
+        userId: $userId,
+        showTitle: 'Dark',
+    );
+
+    $job->handle();
+
+    Http::assertNothingSent();
+});


### PR DESCRIPTION
## Summary

- **Genre browse pagination**: Replaced expand/collapse with prev/next page controls. TMDB `/discover` endpoint returns 20 results per page; `goToBrowsePage()` replaces (not appends) `browseResults`. `browsePage` and `browseTotalPages` are Livewire state. Pagination styled to match the epg-viewer Livewire pattern (mini chevrons, gray disabled state).
- **Automatic search release check**: When "Automatic Search" is triggered for a movie (Radarr), a `MonitorArrSearch` background job runs `fetchReleases()` and sends a "No Approved Releases" warning notification if all releases are rejected by the quality profile/indexers. TV shows (Sonarr) are skipped.
- **Episode monitoring**: `RequestArrEpisode` job + tests for Sonarr episode-level search polling.

## Changed files

- `TmdbService`: `discoverMovies`/`discoverTv` return `{results, total_pages}`
- `ArrSearch` (Livewire): pagination state + `goToBrowsePage()`; dispatches `MonitorArrSearch` on automatic search
- `arr-search.blade.php`: flat grid + prev/next pagination controls matching epg-viewer style
- `BaseArrService`: `getCommandStatus()` shared implementation
- `SonarrService`/`RadarrService`: `triggerAutomaticSearch` returns `commandId`; `fetchRecentGrabCount` added
- `ArrIntegrationInterface`: extended with `getCommandStatus`, `fetchRecentGrabCount`, `getSearchEndpoint`, `parseSearchResponse`
- New: `MonitorArrSearch` job, `RequestArrEpisode` job, matching test files

## Test plan

- [ ] Browse a movie or TV genre — verify prev/next pagination works, page counter updates
- [ ] Trigger automatic search for a movie with all-rejected releases → confirm "No Approved Releases" DB notification arrives
- [ ] Trigger automatic search for a movie with an approved release → confirm no extra notification
- [ ] Trigger automatic search for a TV show → confirm no release-check notification (Sonarr skipped)
- [ ] `php artisan test --compact tests/Feature/ArrSearchTest.php tests/Feature/MonitorArrSearchTest.php tests/Feature/RequestArrEpisodeTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)