### PR TITLE
fix: make scrubber preserve disabled failover channels

### DIFF
--- a/app/Filament/Resources/ChannelScrubbers/ChannelScrubberResource.php
+++ b/app/Filament/Resources/ChannelScrubbers/ChannelScrubberResource.php
@@ -380,6 +380,15 @@ class ChannelScrubberResource extends Resource implements CopilotResource
                                 ->helperText(__('Re-enable disabled channels that are found to be live. Requires "Scan all channels" to be on.'))
                                 ->default(false)
                                 ->visible(fn (Get $get): bool => (bool) $get('scan_all')),
+                            Toggle::make('protect_failover_channels')
+                                ->label(__('Keep failover channels hidden'))
+                                ->hintIcon(
+                                    'heroicon-s-information-circle',
+                                    tooltip: 'When re-enabling live channels, channels that are disabled because they are configured as failovers will be logged as live but left disabled.',
+                                )
+                                ->helperText(__('Prevents the scrubber from undoing auto-merge failover deactivation while still counting live failover channels as live.'))
+                                ->default(true)
+                                ->visible(fn (Get $get): bool => (bool) $get('scan_all') && (bool) $get('enable_live')),
                         ]),
                 ]),
         ];

--- a/app/Jobs/ProcessChannelScrubber.php
+++ b/app/Jobs/ProcessChannelScrubber.php
@@ -110,6 +110,7 @@ class ProcessChannelScrubber implements ShouldQueue
                     probeTimeout: $scrubber->probe_timeout ?? 10,
                     disableDead: $scrubber->disable_dead ?? true,
                     enableLive: $scrubber->enable_live ?? false,
+                    protectFailoverChannels: $scrubber->protect_failover_channels ?? true,
                 ))
                 ->all();
 

--- a/app/Jobs/ProcessChannelScrubberChunk.php
+++ b/app/Jobs/ProcessChannelScrubberChunk.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Enums\Status;
 use App\Models\Channel;
+use App\Models\ChannelFailover;
 use App\Models\ChannelScrubber;
 use App\Models\ChannelScrubberLog;
 use App\Models\ChannelScrubberLogChannel;
@@ -47,6 +48,7 @@ class ProcessChannelScrubberChunk implements ShouldQueue
         public int $probeTimeout = 10,
         public bool $disableDead = true,
         public bool $enableLive = false,
+        public bool $protectFailoverChannels = true,
     ) {}
 
     /**
@@ -62,6 +64,9 @@ class ProcessChannelScrubberChunk implements ShouldQueue
         }
         if (! isset($this->enableLive)) {
             $this->enableLive = false;
+        }
+        if (! isset($this->protectFailoverChannels)) {
+            $this->protectFailoverChannels = true;
         }
     }
 
@@ -79,6 +84,9 @@ class ProcessChannelScrubberChunk implements ShouldQueue
 
         // Snapshot enabled state before probing so we know which were disabled going in
         $wasEnabled = $channels->pluck('enabled', 'id')->map(fn ($v) => (bool) $v)->all();
+        $protectedFailoverIds = $this->protectFailoverChannels
+            ? $this->protectedFailoverIds($channels->pluck('id')->all())
+            : [];
 
         $deadIds = $this->checkMethod === 'ffprobe'
             ? $this->probeFfprobeBatch($channels)
@@ -123,7 +131,11 @@ class ProcessChannelScrubberChunk implements ShouldQueue
             $liveCount++;
 
             // Re-enable disabled channels that are now live (only when enableLive is set)
-            if ($this->enableLive && ! ($wasEnabled[$channel->id] ?? true)) {
+            if (
+                $this->enableLive
+                && ! ($wasEnabled[$channel->id] ?? true)
+                && ! isset($protectedFailoverIds[$channel->id])
+            ) {
                 try {
                     $channel->update(['enabled' => true]);
                 } catch (Exception $e) {
@@ -150,6 +162,23 @@ class ProcessChannelScrubberChunk implements ShouldQueue
             $newProgress = min(95, $scrubber->progress + $increment);
             $scrubber->update(['progress' => $newProgress]);
         }
+    }
+
+    /**
+     * @param  array<int>  $channelIds
+     * @return array<int, true>
+     */
+    private function protectedFailoverIds(array $channelIds): array
+    {
+        if (empty($channelIds)) {
+            return [];
+        }
+
+        return ChannelFailover::query()
+            ->whereIn('channel_failover_id', $channelIds)
+            ->pluck('channel_failover_id')
+            ->mapWithKeys(fn (mixed $id): array => [(int) $id => true])
+            ->all();
     }
 
     /**

--- a/app/Models/ChannelScrubber.php
+++ b/app/Models/ChannelScrubber.php
@@ -25,6 +25,7 @@ class ChannelScrubber extends Model
             'probe_timeout' => 'integer',
             'disable_dead' => 'boolean',
             'enable_live' => 'boolean',
+            'protect_failover_channels' => 'boolean',
             'channel_count' => 'integer',
             'dead_count' => 'integer',
             'user_id' => 'integer',

--- a/database/migrations/2026_06_20_000001_add_protect_failover_channels_to_channel_scrubbers.php
+++ b/database/migrations/2026_06_20_000001_add_protect_failover_channels_to_channel_scrubbers.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channel_scrubbers', function (Blueprint $table) {
+            $table->boolean('protect_failover_channels')
+                ->default(true)
+                ->after('enable_live');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channel_scrubbers', function (Blueprint $table) {
+            $table->dropColumn('protect_failover_channels');
+        });
+    }
+};

--- a/tests/Feature/ProcessChannelScrubberChunkTest.php
+++ b/tests/Feature/ProcessChannelScrubberChunkTest.php
@@ -3,6 +3,7 @@
 use App\Enums\Status;
 use App\Jobs\ProcessChannelScrubberChunk;
 use App\Models\Channel;
+use App\Models\ChannelFailover;
 use App\Models\ChannelScrubber;
 use App\Models\ChannelScrubberLog;
 use App\Models\Playlist;
@@ -11,16 +12,25 @@ use Illuminate\Support\Facades\Http;
 
 beforeEach(function () {
     $this->user = User::factory()->create();
-    $this->playlist = Playlist::factory()->for($this->user)->createQuietly();
+    $this->playlist = Playlist::withoutEvents(fn () => Playlist::factory()->for($this->user)->create());
 
-    $this->scrubber = ChannelScrubber::create([
+    $this->channel = function (array $attributes = []): Channel {
+        return Channel::withoutEvents(fn () => Channel::factory()->create([
+            'user_id' => $this->user->id,
+            'playlist_id' => $this->playlist->id,
+            'group_id' => null,
+            ...$attributes,
+        ]));
+    };
+
+    $this->scrubber = ChannelScrubber::withoutEvents(fn () => ChannelScrubber::create([
         'name' => 'Test Scrubber',
-        'uuid' => 'test-batch-uuid',
+        'uuid' => '00000000-0000-4000-8000-000000000001',
         'status' => Status::Processing,
         'user_id' => $this->user->id,
         'playlist_id' => $this->playlist->id,
         'progress' => 0,
-    ]);
+    ]));
 
     $this->log = ChannelScrubberLog::create([
         'channel_scrubber_id' => $this->scrubber->id,
@@ -36,8 +46,7 @@ beforeEach(function () {
 
 it('marks a channel dead via ffprobe when ensureStreamStats returns empty', function () {
     // No URL and no stream_stats → ensureStreamStats() returns [] → dead
-    $channel = Channel::factory()->for($this->playlist)->create([
-        'user_id' => $this->user->id,
+    $channel = ($this->channel)([
         'enabled' => true,
         'url' => null,
         'url_custom' => null,
@@ -67,8 +76,7 @@ it('marks a channel dead via ffprobe even when stream_stats are cached', functio
     // producing false negatives for dead streams that had been probed before.
     // The new lightweight ffprobe probe always makes a fresh network call — cached stats
     // are irrelevant. A null URL with cached stats is still dead.
-    $channel = Channel::factory()->for($this->playlist)->create([
-        'user_id' => $this->user->id,
+    $channel = ($this->channel)([
         'enabled' => true,
         'url' => null,
         'url_custom' => null,
@@ -96,14 +104,12 @@ it('marks a channel dead via ffprobe even when stream_stats are cached', functio
 });
 
 it('increments dead_count on the scrubber for each dead channel', function () {
-    $dead1 = Channel::factory()->for($this->playlist)->create([
-        'user_id' => $this->user->id,
+    $dead1 = ($this->channel)([
         'url' => null,
         'url_custom' => null,
         'stream_stats' => null,
     ]);
-    $dead2 = Channel::factory()->for($this->playlist)->create([
-        'user_id' => $this->user->id,
+    $dead2 = ($this->channel)([
         'url' => null,
         'url_custom' => null,
         'stream_stats' => null,
@@ -127,8 +133,7 @@ it('increments dead_count on the scrubber for each dead channel', function () {
 // ──────────────────────────────────────────────────────────────────────────────
 
 it('skips processing when the batch uuid does not match', function () {
-    $channel = Channel::factory()->for($this->playlist)->create([
-        'user_id' => $this->user->id,
+    $channel = ($this->channel)([
         'enabled' => true,
         'url' => null,
         'stream_stats' => null,
@@ -150,8 +155,7 @@ it('skips processing when the batch uuid does not match', function () {
 it('skips processing when the scrubber is cancelled', function () {
     $this->scrubber->update(['status' => Status::Cancelled]);
 
-    $channel = Channel::factory()->for($this->playlist)->create([
-        'user_id' => $this->user->id,
+    $channel = ($this->channel)([
         'enabled' => true,
         'url' => null,
         'stream_stats' => null,
@@ -175,8 +179,7 @@ it('skips processing when the scrubber is cancelled', function () {
 // ──────────────────────────────────────────────────────────────────────────────
 
 it('does not disable dead channels when disableDead is false', function () {
-    $channel = Channel::factory()->for($this->playlist)->create([
-        'user_id' => $this->user->id,
+    $channel = ($this->channel)([
         'enabled' => true,
         'url' => null,
         'url_custom' => null,
@@ -210,8 +213,7 @@ it('does not disable dead channels when disableDead is false', function () {
 // ──────────────────────────────────────────────────────────────────────────────
 
 it('re-enables a previously disabled live channel when enableLive is true', function () {
-    $channel = Channel::factory()->for($this->playlist)->create([
-        'user_id' => $this->user->id,
+    $channel = ($this->channel)([
         'enabled' => false,
         'url' => 'http://example.invalid/stream',
         'url_custom' => null,
@@ -236,5 +238,81 @@ it('re-enables a previously disabled live channel when enableLive is true', func
     $channel->refresh();
     expect($channel->enabled)->toBeTrue();
 
+    expect($this->log->fresh()->live_count)->toBe(1);
+});
+
+it('keeps a disabled live failover channel hidden when failover protection is enabled', function () {
+    $master = ($this->channel)([
+        'enabled' => true,
+    ]);
+
+    $failover = ($this->channel)([
+        'enabled' => false,
+        'url' => 'http://example.invalid/failover',
+        'url_custom' => null,
+        'stream_stats' => null,
+    ]);
+
+    ChannelFailover::create([
+        'user_id' => $this->user->id,
+        'channel_id' => $master->id,
+        'channel_failover_id' => $failover->id,
+    ]);
+
+    Http::fake([
+        'http://example.invalid/failover' => Http::response('', 200),
+    ]);
+
+    (new ProcessChannelScrubberChunk(
+        channelIds: [$failover->id],
+        scrubberId: $this->scrubber->id,
+        logId: $this->log->id,
+        checkMethod: 'http',
+        batchNo: $this->scrubber->uuid,
+        totalChannels: 1,
+        enableLive: true,
+        protectFailoverChannels: true,
+    ))->handle();
+
+    $failover->refresh();
+    expect($failover->enabled)->toBeFalse();
+    expect($this->log->fresh()->live_count)->toBe(1);
+});
+
+it('re-enables a disabled live failover channel when failover protection is disabled', function () {
+    $master = ($this->channel)([
+        'enabled' => true,
+    ]);
+
+    $failover = ($this->channel)([
+        'enabled' => false,
+        'url' => 'http://example.invalid/failover',
+        'url_custom' => null,
+        'stream_stats' => null,
+    ]);
+
+    ChannelFailover::create([
+        'user_id' => $this->user->id,
+        'channel_id' => $master->id,
+        'channel_failover_id' => $failover->id,
+    ]);
+
+    Http::fake([
+        'http://example.invalid/failover' => Http::response('', 200),
+    ]);
+
+    (new ProcessChannelScrubberChunk(
+        channelIds: [$failover->id],
+        scrubberId: $this->scrubber->id,
+        logId: $this->log->id,
+        checkMethod: 'http',
+        batchNo: $this->scrubber->uuid,
+        totalChannels: 1,
+        enableLive: true,
+        protectFailoverChannels: false,
+    ))->handle();
+
+    $failover->refresh();
+    expect($failover->enabled)->toBeTrue();
     expect($this->log->fresh()->live_count)->toBe(1);
 });


### PR DESCRIPTION
Add a protect_failover_channels scrubber setting that defaults on and prevents live checks from re-enabling channels that are registered as failovers.

This lets the scrubber count protected failover channels as live without undoing auto-merge failover deactivation. Add focused coverage for the protected and opt-out behaviours.