### PR TITLE
fix: make auto-merge respect scrubber availability

### DIFF
--- a/app/Filament/Resources/ChannelScrubbers/ChannelScrubberResource.php
+++ b/app/Filament/Resources/ChannelScrubbers/ChannelScrubberResource.php
@@ -291,7 +291,8 @@ class ChannelScrubberResource extends Resource implements CopilotResource
                 ->label(__('Playlist'))
                 ->helperText(__('Select the playlist whose channels you want to scrub.'))
                 ->options(Playlist::where('user_id', Auth::id())->get(['name', 'id'])->pluck('name', 'id'))
-                ->searchable(),
+                ->searchable()
+                ->live(),
             Toggle::make('recurring')
                 ->label(__('Recurring'))
                 ->inline(false)
@@ -391,11 +392,21 @@ class ChannelScrubberResource extends Resource implements CopilotResource
                                 ->visible(fn (Get $get): bool => (bool) $get('scan_all') && (bool) $get('enable_live')),
                             Toggle::make('rebuild_failovers_after_scan')
                                 ->label(__('Rebuild failovers after scan'))
+                                ->columnSpanFull()
                                 ->hintIcon(
                                     'heroicon-s-information-circle',
                                     tooltip: 'After a successful scrubber scan, dispatch the playlist native auto-merge job so failovers can be rebuilt using fresh scan results.',
                                 )
                                 ->helperText(__('Runs native auto-merge after this scrubber completes when playlist auto-merge is enabled.'))
+                                ->hidden(function (Get $get): ?string {
+                                    $playlistId = $get('playlist_id');
+                                    if (! $playlistId) {
+                                        return null;
+                                    }
+                                    $playlist = Playlist::find($playlistId);
+
+                                    return $playlist && ! $playlist->auto_merge_channels_enabled;
+                                })
                                 ->default(false),
                         ]),
                 ]),

--- a/app/Filament/Resources/ChannelScrubbers/ChannelScrubberResource.php
+++ b/app/Filament/Resources/ChannelScrubbers/ChannelScrubberResource.php
@@ -380,6 +380,15 @@ class ChannelScrubberResource extends Resource implements CopilotResource
                                 ->helperText(__('Re-enable disabled channels that are found to be live. Requires "Scan all channels" to be on.'))
                                 ->default(false)
                                 ->visible(fn (Get $get): bool => (bool) $get('scan_all')),
+                            Toggle::make('protect_failover_channels')
+                                ->label(__('Keep failover channels hidden'))
+                                ->hintIcon(
+                                    'heroicon-s-information-circle',
+                                    tooltip: 'When re-enabling live channels, channels that are disabled because they are configured as failovers will be logged as live but left disabled.',
+                                )
+                                ->helperText(__('Prevents the scrubber from undoing auto-merge failover deactivation while still counting live failover channels as live.'))
+                                ->default(true)
+                                ->visible(fn (Get $get): bool => (bool) $get('scan_all') && (bool) $get('enable_live')),
                             Toggle::make('rebuild_failovers_after_scan')
                                 ->label(__('Rebuild failovers after scan'))
                                 ->hintIcon(

--- a/app/Filament/Resources/ChannelScrubbers/ChannelScrubberResource.php
+++ b/app/Filament/Resources/ChannelScrubbers/ChannelScrubberResource.php
@@ -380,6 +380,14 @@ class ChannelScrubberResource extends Resource implements CopilotResource
                                 ->helperText(__('Re-enable disabled channels that are found to be live. Requires "Scan all channels" to be on.'))
                                 ->default(false)
                                 ->visible(fn (Get $get): bool => (bool) $get('scan_all')),
+                            Toggle::make('rebuild_failovers_after_scan')
+                                ->label(__('Rebuild failovers after scan'))
+                                ->hintIcon(
+                                    'heroicon-s-information-circle',
+                                    tooltip: 'After a successful scrubber scan, dispatch the playlist native auto-merge job so failovers can be rebuilt using fresh scan results.',
+                                )
+                                ->helperText(__('Runs native auto-merge after this scrubber completes when playlist auto-merge is enabled.'))
+                                ->default(false),
                         ]),
                 ]),
         ];

--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -228,6 +228,22 @@ class ChannelResource extends Resource implements CopilotResource
                 ->label(__('Merge Enabled'))
                 ->toggleable()
                 ->sortable(),
+            IconColumn::make('last_scrubber_result')
+                ->label(__('Scrubber'))
+                ->getStateUsing(fn ($record): string => self::resolveScrubberStatus($record))
+                ->icon(fn (string $state): string => self::resolveScrubberStatusIcon($state))
+                ->color(fn (string $state): string => self::resolveScrubberStatusColor($state))
+                ->tooltip(fn ($record): string => self::resolveScrubberStatusTooltip($record))
+                ->toggleable()
+                ->sortable(),
+            TextColumn::make('last_scrubbed_at')
+                ->label(__('Last Scrubbed'))
+                ->formatStateUsing(fn ($state) => app(DateFormatService::class)->format($state))
+                ->tooltip(fn ($record): string => $record->last_scrubbed_at
+                    ? __('Scrubbed').' '.$record->last_scrubbed_at->diffForHumans()
+                    : __('Never scrubbed'))
+                ->toggleable()
+                ->sortable(),
             TextColumn::make('failovers_count')
                 ->label(__('Failovers'))
                 ->counts('failovers')
@@ -1320,6 +1336,18 @@ class ChannelResource extends Resource implements CopilotResource
                             ->boolean()
                             ->trueColor('success')
                             ->falseColor('danger'),
+                        IconEntry::make('last_scrubber_result')
+                            ->label(__('Scrubber'))
+                            ->state(fn ($record): string => self::resolveScrubberStatus($record))
+                            ->icon(fn (string $state): string => self::resolveScrubberStatusIcon($state))
+                            ->color(fn (string $state): string => self::resolveScrubberStatusColor($state))
+                            ->tooltip(fn ($record): string => self::resolveScrubberStatusTooltip($record)),
+                        TextEntry::make('last_scrubbed_at')
+                            ->label(__('Last Scrubbed'))
+                            ->state(fn ($record) => app(DateFormatService::class)->format($record?->last_scrubbed_at))
+                            ->tooltip(fn ($record): string => $record?->last_scrubbed_at
+                                ? __('Scrubbed').' '.$record->last_scrubbed_at->diffForHumans()
+                                : __('Never scrubbed')),
                     ]),
                 Section::make(__('Technical Details'))
                     ->collapsible()
@@ -1939,6 +1967,48 @@ class ChannelResource extends Resource implements CopilotResource
                         ->defaultItems(0),
                 ]),
         ];
+    }
+
+    private static function resolveScrubberStatus(?Channel $record): string
+    {
+        return match ($record?->last_scrubber_result) {
+            'live' => 'live',
+            'dead' => 'dead',
+            default => 'unknown',
+        };
+    }
+
+    private static function resolveScrubberStatusIcon(string $state): string
+    {
+        return match ($state) {
+            'live' => 'heroicon-o-check-circle',
+            'dead' => 'heroicon-o-x-circle',
+            default => 'heroicon-o-question-mark-circle',
+        };
+    }
+
+    private static function resolveScrubberStatusColor(string $state): string
+    {
+        return match ($state) {
+            'live' => 'success',
+            'dead' => 'danger',
+            default => 'gray',
+        };
+    }
+
+    private static function resolveScrubberStatusTooltip(?Channel $record): string
+    {
+        $checkedAt = $record?->last_scrubbed_at;
+
+        return match (self::resolveScrubberStatus($record)) {
+            'live' => $checkedAt
+                ? __('Last scrubber result: live').' ('.$checkedAt->diffForHumans().')'
+                : __('Last scrubber result: live'),
+            'dead' => $checkedAt
+                ? __('Last scrubber result: dead').' ('.$checkedAt->diffForHumans().')'
+                : __('Last scrubber result: dead'),
+            default => __('No scrubber result recorded yet'),
+        };
     }
 
     /**

--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -228,7 +228,7 @@ class ChannelResource extends Resource implements CopilotResource
                 ->label(__('Merge Enabled'))
                 ->toggleable()
                 ->sortable(),
-            IconColumn::make('last_scrubber_result')
+            IconColumn::make('last_scrubber_live')
                 ->label(__('Scrubber'))
                 ->getStateUsing(fn ($record): string => self::resolveScrubberStatus($record))
                 ->icon(fn (string $state): string => self::resolveScrubberStatusIcon($state))
@@ -1336,7 +1336,7 @@ class ChannelResource extends Resource implements CopilotResource
                             ->boolean()
                             ->trueColor('success')
                             ->falseColor('danger'),
-                        IconEntry::make('last_scrubber_result')
+                        IconEntry::make('last_scrubber_live')
                             ->label(__('Scrubber'))
                             ->state(fn ($record): string => self::resolveScrubberStatus($record))
                             ->icon(fn (string $state): string => self::resolveScrubberStatusIcon($state))
@@ -1971,9 +1971,9 @@ class ChannelResource extends Resource implements CopilotResource
 
     private static function resolveScrubberStatus(?Channel $record): string
     {
-        return match ($record?->last_scrubber_result) {
-            'live' => 'live',
-            'dead' => 'dead',
+        return match ($record?->last_scrubber_live) {
+            true => 'live',
+            false => 'dead',
             default => 'unknown',
         };
     }

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2218,6 +2218,15 @@ class PlaylistResource extends Resource implements CopilotResource
                                     tooltip: 'Channels from disabled groups will never be selected as master, only as failovers.'
                                 )
                                 ->default(false),
+                            Toggle::make('auto_merge_config.scrubber_aware_master_selection')
+                                ->label(__('Scrubber-aware master selection'))
+                                ->inline(false)
+                                ->hintIcon(
+                                    'heroicon-m-exclamation-triangle',
+                                    tooltip: 'When enabled, channels confirmed dead by the scrubber are excluded from master selection. Leave disabled to allow all channels to be eligible as master (default behavior).'
+                                )
+                                ->helperText(__('When enabled, channels confirmed dead by the scrubber are excluded from master selection.'))
+                                ->default(false),
                         ]),
 
                     Fieldset::make(__('Fallback matching for channels without IDs'))

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -254,6 +254,7 @@ class MergeChannels implements ShouldQueue
                 $this->filterUnavailableMergeCandidates($group->where('id', '!=', $master->id)),
                 $playlistPriority,
             );
+            $this->pruneUnavailableFailovers($master, $group, $failoverChannels);
 
             $sortOrder = 1;
             foreach ($failoverChannels as $failover) {
@@ -322,7 +323,7 @@ class MergeChannels implements ShouldQueue
             ->when($this->newChannelsOnly, fn ($query) => $query->where('new', true))
             ->select(['id', 'user_id', 'playlist_id', 'group_id', 'title', 'title_custom',
                 'name', 'name_custom', 'stream_id', 'stream_id_custom', 'sort',
-                'catchup', 'enabled', 'stream_stats'])
+                'catchup', 'enabled', 'stream_stats', 'last_scrubber_result'])
             ->cursor();
 
         $groupedChannels = $channels
@@ -383,7 +384,7 @@ class MergeChannels implements ShouldQueue
             ->when($this->groupId, fn ($q) => $q->where('group_id', $this->groupId))
             ->select(['id', 'user_id', 'playlist_id', 'group_id', 'title', 'title_custom',
                 'name', 'name_custom', 'stream_id', 'stream_id_custom', 'sort',
-                'catchup', 'enabled'])
+                'catchup', 'enabled', 'last_scrubber_result'])
             ->chunk(500, function ($chunk) use ($validPatterns, &$matchesByPattern) {
                 foreach ($chunk as $channel) {
                     $title = $channel->title_custom ?: $channel->title;
@@ -420,6 +421,7 @@ class MergeChannels implements ShouldQueue
                 $this->filterUnavailableMergeCandidates($matches->where('id', '!=', $master->id)),
                 $playlistPriority,
             );
+            $this->pruneUnavailableFailovers($master, $matches, $sorted);
 
             foreach ($sorted as $failover) {
                 ChannelFailover::updateOrCreate(
@@ -524,6 +526,10 @@ class MergeChannels implements ShouldQueue
     protected function filterUnavailableMergeCandidates(Collection $group): Collection
     {
         return $group->filter(function ($channel) {
+            if ($channel->last_scrubber_result === 'dead') {
+                return false;
+            }
+
             return (bool) $channel->enabled
                 || isset($this->existingFailoverChannelIds[(int) $channel->id])
                 || in_array($channel->group_id, $this->disabledGroupIds, true);
@@ -533,6 +539,10 @@ class MergeChannels implements ShouldQueue
     protected function shouldEnableSelectedMaster(Channel $master): bool
     {
         if ($master->enabled) {
+            return false;
+        }
+
+        if ($master->last_scrubber_result === 'dead') {
             return false;
         }
 
@@ -552,6 +562,36 @@ class MergeChannels implements ShouldQueue
         if ($this->shouldEnableSelectedMaster($master)) {
             $master->update(['enabled' => true]);
         }
+    }
+
+    protected function pruneUnavailableFailovers(Channel $master, Collection $group, Collection $failoverChannels): void
+    {
+        $candidateIds = $group
+            ->where('id', '!=', $master->id)
+            ->pluck('id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->values()
+            ->all();
+
+        if ($candidateIds === []) {
+            return;
+        }
+
+        $activeFailoverIds = $failoverChannels
+            ->pluck('id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->values()
+            ->all();
+
+        $query = ChannelFailover::where('user_id', $this->user->id)
+            ->where('channel_id', $master->id)
+            ->whereIn('channel_failover_id', $candidateIds);
+
+        if ($activeFailoverIds !== []) {
+            $query->whereNotIn('channel_failover_id', $activeFailoverIds);
+        }
+
+        $query->delete();
     }
 
     /**

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -50,16 +50,18 @@ class MergeChannels implements ShouldQueue
     protected ?array $normalizedPriorityOrder = null;
 
     /**
-     * Channel IDs that are already configured as native failovers.
-     *
-     * Disabled channels in this set may be hidden by auto-merge rather than
-     * unavailable, so they remain eligible to become master again during a
-     * re-merge. Other disabled channels are treated as unavailable for master
-     * selection and are not silently re-enabled by this job.
+     * Channel IDs that are already configured as native failover children.
      *
      * @var array<int, true>
      */
     protected array $existingFailoverChannelIds = [];
+
+    /**
+     * Channel IDs that already own native failover children.
+     *
+     * @var array<int, true>
+     */
+    protected array $existingFailoverMasterIds = [];
 
     /**
      * Create a new job instance.
@@ -122,7 +124,16 @@ class MergeChannels implements ShouldQueue
             ->map(fn (mixed $id): int => (int) $id)
             ->toArray();
 
+        $existingFailoverMasterIds = ChannelFailover::where('user_id', $this->user->id)
+            ->whereHas('channel', function ($query) use ($playlistIds) {
+                $query->whereIn('playlist_id', $playlistIds);
+            })
+            ->pluck('channel_id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->toArray();
+
         $this->existingFailoverChannelIds = array_fill_keys($existingFailoverChannelIds, true);
+        $this->existingFailoverMasterIds = array_fill_keys($existingFailoverMasterIds, true);
 
         // Get all channels for the requested content type and merge key.
         // Exclude channels that are already configured as failovers (unless we're re-merging everything).
@@ -250,11 +261,10 @@ class MergeChannels implements ShouldQueue
 
             $this->prepareSelectedMaster($master);
 
-            $failoverChannels = $this->sortChannelsByScore(
-                $this->filterUnavailableMergeCandidates($group->where('id', '!=', $master->id)),
+            $failoverChannels = $this->sortFailoverChannelsByScore(
+                $this->filterFailoverCandidates($group->where('id', '!=', $master->id)),
                 $playlistPriority,
             );
-            $this->pruneUnavailableFailovers($master, $group, $failoverChannels);
 
             $sortOrder = 1;
             foreach ($failoverChannels as $failover) {
@@ -417,11 +427,10 @@ class MergeChannels implements ShouldQueue
 
             $maxSort = ChannelFailover::where('channel_id', $master->id)->max('sort') ?? 0;
             $sortOrder = $maxSort + 1;
-            $sorted = $this->sortChannelsByScore(
-                $this->filterUnavailableMergeCandidates($matches->where('id', '!=', $master->id)),
+            $sorted = $this->sortFailoverChannelsByScore(
+                $this->filterFailoverCandidates($matches->where('id', '!=', $master->id)),
                 $playlistPriority,
             );
-            $this->pruneUnavailableFailovers($master, $matches, $sorted);
 
             foreach ($sorted as $failover) {
                 ChannelFailover::updateOrCreate(
@@ -483,7 +492,7 @@ class MergeChannels implements ShouldQueue
             return null;
         }
 
-        $eligibleGroup = $this->filterUnavailableMergeCandidates($eligibleGroup);
+        $eligibleGroup = $this->filterMasterCandidates($eligibleGroup);
 
         if ($eligibleGroup->isEmpty()) {
             return null;
@@ -513,17 +522,13 @@ class MergeChannels implements ShouldQueue
     }
 
     /**
-     * Keep unavailable disabled channels out of merge selection.
+     * Keep unavailable disabled channels out of master selection.
      *
-     * A disabled channel that is already in channel_failovers may simply be a
-     * hidden failover created by auto-merge. A disabled channel in an excluded
-     * disabled group is also allowed to remain a failover because the native
-     * `exclude_disabled_groups` option means "not master, failover only".
-     * Other disabled channels may have been disabled manually or by the
-     * scrubber and should not be silently promoted, re-enabled, or added as
-     * runtime failovers here.
+     * Scrubber-dead channels should not be selected as the current master.
+     * Disabled channels that are already part of native failover topology can
+     * become master again after the scrubber reports them live.
      */
-    protected function filterUnavailableMergeCandidates(Collection $group): Collection
+    protected function filterMasterCandidates(Collection $group): Collection
     {
         return $group->filter(function ($channel) {
             if ($channel->last_scrubber_live === false) {
@@ -531,7 +536,26 @@ class MergeChannels implements ShouldQueue
             }
 
             return (bool) $channel->enabled
-                || isset($this->existingFailoverChannelIds[(int) $channel->id])
+                || $this->isExistingFailoverTopologyChannel($channel);
+        });
+    }
+
+    /**
+     * Keep existing native failover topology intact while avoiding new dead or
+     * manually disabled failovers.
+     */
+    protected function filterFailoverCandidates(Collection $group): Collection
+    {
+        return $group->filter(function ($channel) {
+            if ($this->isExistingFailoverTopologyChannel($channel)) {
+                return true;
+            }
+
+            if ($channel->last_scrubber_live === false) {
+                return false;
+            }
+
+            return (bool) $channel->enabled
                 || in_array($channel->group_id, $this->disabledGroupIds, true);
         });
     }
@@ -550,7 +574,7 @@ class MergeChannels implements ShouldQueue
             return false;
         }
 
-        return isset($this->existingFailoverChannelIds[(int) $master->id]);
+        return $this->isExistingFailoverTopologyChannel($master);
     }
 
     protected function prepareSelectedMaster(Channel $master): void
@@ -564,34 +588,12 @@ class MergeChannels implements ShouldQueue
         }
     }
 
-    protected function pruneUnavailableFailovers(Channel $master, Collection $group, Collection $failoverChannels): void
+    protected function isExistingFailoverTopologyChannel(Channel $channel): bool
     {
-        $candidateIds = $group
-            ->where('id', '!=', $master->id)
-            ->pluck('id')
-            ->map(fn (mixed $id): int => (int) $id)
-            ->values()
-            ->all();
+        $id = (int) $channel->id;
 
-        if ($candidateIds === []) {
-            return;
-        }
-
-        $activeFailoverIds = $failoverChannels
-            ->pluck('id')
-            ->map(fn (mixed $id): int => (int) $id)
-            ->values()
-            ->all();
-
-        $query = ChannelFailover::where('user_id', $this->user->id)
-            ->where('channel_id', $master->id)
-            ->whereIn('channel_failover_id', $candidateIds);
-
-        if ($activeFailoverIds !== []) {
-            $query->whereNotIn('channel_failover_id', $activeFailoverIds);
-        }
-
-        $query->delete();
+        return isset($this->existingFailoverChannelIds[$id])
+            || isset($this->existingFailoverMasterIds[$id]);
     }
 
     /**
@@ -838,6 +840,34 @@ class MergeChannels implements ShouldQueue
         }
 
         return $channels->sortBy(fn ($channel) => [
+            $this->preferCatchupAsPrimary && empty($channel->catchup) ? 1 : 0,
+            (int) ($playlistPriority[$channel->playlist_id] ?? 999),
+            $channel->sort ?? 999999,
+        ]);
+    }
+
+    protected function sortFailoverChannelsByScore(Collection $channels, array $playlistPriority): Collection
+    {
+        if ($this->weightedConfig !== null) {
+            return $channels->sortBy(fn ($channel) => [
+                $channel->last_scrubber_live === false ? 1 : 0,
+                -$this->calculateChannelScore($channel, $playlistPriority),
+                $channel->sort ?? 999999,
+            ]);
+        }
+
+        if ($this->checkResolution) {
+            return $channels->sortBy(fn ($channel) => [
+                $channel->last_scrubber_live === false ? 1 : 0,
+                $this->preferCatchupAsPrimary && empty($channel->catchup) ? 1 : 0,
+                -(int) $this->getResolution($channel),
+                (int) ($playlistPriority[$channel->playlist_id] ?? 999),
+                $channel->sort ?? 999999,
+            ]);
+        }
+
+        return $channels->sortBy(fn ($channel) => [
+            $channel->last_scrubber_live === false ? 1 : 0,
             $this->preferCatchupAsPrimary && empty($channel->catchup) ? 1 : 0,
             (int) ($playlistPriority[$channel->playlist_id] ?? 999),
             $channel->sort ?? 999999,

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -541,8 +541,8 @@ class MergeChannels implements ShouldQueue
     }
 
     /**
-     * Keep existing native failover topology intact while avoiding new dead or
-     * manually disabled failovers.
+     * Keep existing native failover topology intact and allow matched disabled
+     * channels to be hidden failovers, unless the scrubber already marked them dead.
      */
     protected function filterFailoverCandidates(Collection $group): Collection
     {
@@ -555,8 +555,7 @@ class MergeChannels implements ShouldQueue
                 return false;
             }
 
-            return (bool) $channel->enabled
-                || in_array($channel->group_id, $this->disabledGroupIds, true);
+            return true;
         });
     }
 

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -81,6 +81,7 @@ class MergeChannels implements ShouldQueue
         public ?array $fallbackMergeConfig = null,
         public string $contentType = 'live',
         public string $mergeKey = 'stream_id',
+        public bool $scrubberAwareMasterSelection = false,
     ) {
         $this->contentType = in_array($this->contentType, ['live', 'vod'], true) ? $this->contentType : 'live';
         $this->mergeKey = in_array($this->mergeKey, ['stream_id', 'tmdb_id'], true) ? $this->mergeKey : 'stream_id';
@@ -524,12 +525,15 @@ class MergeChannels implements ShouldQueue
     /**
      * Keep unavailable disabled channels out of master selection.
      *
-     * Scrubber-dead channels should not be selected as the current master.
-     * Disabled channels that are already part of native failover topology can
-     * become master again after the scrubber reports them live.
+     * Only active when scrubberAwareMasterSelection is enabled on the playlist.
+     * When disabled (default), all channels are eligible as master (legacy behavior).
      */
     protected function filterMasterCandidates(Collection $group): Collection
     {
+        if (! $this->scrubberAwareMasterSelection) {
+            return $group;
+        }
+
         return $group->filter(function ($channel) {
             if ($channel->last_scrubber_live === false) {
                 return false;
@@ -555,11 +559,15 @@ class MergeChannels implements ShouldQueue
             return false;
         }
 
-        if ($master->last_scrubber_live === false) {
+        if (in_array($master->group_id, $this->disabledGroupIds, true)) {
             return false;
         }
 
-        if (in_array($master->group_id, $this->disabledGroupIds, true)) {
+        if (! $this->scrubberAwareMasterSelection) {
+            return true;
+        }
+
+        if ($master->last_scrubber_live === false) {
             return false;
         }
 

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -50,6 +50,18 @@ class MergeChannels implements ShouldQueue
     protected ?array $normalizedPriorityOrder = null;
 
     /**
+     * Channel IDs that are already configured as native failovers.
+     *
+     * Disabled channels in this set may be hidden by auto-merge rather than
+     * unavailable, so they remain eligible to become master again during a
+     * re-merge. Other disabled channels are treated as unavailable for master
+     * selection and are not silently re-enabled by this job.
+     *
+     * @var array<int, true>
+     */
+    protected array $existingFailoverChannelIds = [];
+
+    /**
      * Create a new job instance.
      */
     public function __construct(
@@ -107,7 +119,10 @@ class MergeChannels implements ShouldQueue
                 $query->whereIn('playlist_id', $playlistIds);
             })
             ->pluck('channel_failover_id')
+            ->map(fn (mixed $id): int => (int) $id)
             ->toArray();
+
+        $this->existingFailoverChannelIds = array_fill_keys($existingFailoverChannelIds, true);
 
         // Get all channels for the requested content type and merge key.
         // Exclude channels that are already configured as failovers (unless we're re-merging everything).
@@ -233,11 +248,12 @@ class MergeChannels implements ShouldQueue
                 continue;
             }
 
-            if (! $master->enabled && ! in_array($master->group_id, $this->disabledGroupIds, true)) {
-                $master->update(['enabled' => true]);
-            }
+            $this->prepareSelectedMaster($master);
 
-            $failoverChannels = $this->sortChannelsByScore($group->where('id', '!=', $master->id), $playlistPriority);
+            $failoverChannels = $this->sortChannelsByScore(
+                $this->filterUnavailableMergeCandidates($group->where('id', '!=', $master->id)),
+                $playlistPriority,
+            );
 
             $sortOrder = 1;
             foreach ($failoverChannels as $failover) {
@@ -391,12 +407,21 @@ class MergeChannels implements ShouldQueue
                 continue;
             }
 
-            $sorted = $this->sortChannelsByScore($matches, $playlistPriority);
-            $master = $sorted->first();
+            $master = $this->selectMasterChannel($matches, $playlistPriority);
+            if (! $master) {
+                continue;
+            }
+
+            $this->prepareSelectedMaster($master);
+
             $maxSort = ChannelFailover::where('channel_id', $master->id)->max('sort') ?? 0;
             $sortOrder = $maxSort + 1;
+            $sorted = $this->sortChannelsByScore(
+                $this->filterUnavailableMergeCandidates($matches->where('id', '!=', $master->id)),
+                $playlistPriority,
+            );
 
-            foreach ($sorted->skip(1) as $failover) {
+            foreach ($sorted as $failover) {
                 ChannelFailover::updateOrCreate(
                     [
                         'channel_id' => $master->id,
@@ -456,6 +481,12 @@ class MergeChannels implements ShouldQueue
             return null;
         }
 
+        $eligibleGroup = $this->filterUnavailableMergeCandidates($eligibleGroup);
+
+        if ($eligibleGroup->isEmpty()) {
+            return null;
+        }
+
         // Use weighted priority system if config provided
         if ($this->weightedConfig !== null) {
             return $this->selectMasterByWeightedScore($eligibleGroup, $playlistPriority);
@@ -477,6 +508,50 @@ class MergeChannels implements ShouldQueue
         return $group->filter(function ($channel) {
             return ! in_array($channel->group_id, $this->disabledGroupIds);
         });
+    }
+
+    /**
+     * Keep unavailable disabled channels out of merge selection.
+     *
+     * A disabled channel that is already in channel_failovers may simply be a
+     * hidden failover created by auto-merge. A disabled channel in an excluded
+     * disabled group is also allowed to remain a failover because the native
+     * `exclude_disabled_groups` option means "not master, failover only".
+     * Other disabled channels may have been disabled manually or by the
+     * scrubber and should not be silently promoted, re-enabled, or added as
+     * runtime failovers here.
+     */
+    protected function filterUnavailableMergeCandidates(Collection $group): Collection
+    {
+        return $group->filter(function ($channel) {
+            return (bool) $channel->enabled
+                || isset($this->existingFailoverChannelIds[(int) $channel->id])
+                || in_array($channel->group_id, $this->disabledGroupIds, true);
+        });
+    }
+
+    protected function shouldEnableSelectedMaster(Channel $master): bool
+    {
+        if ($master->enabled) {
+            return false;
+        }
+
+        if (in_array($master->group_id, $this->disabledGroupIds, true)) {
+            return false;
+        }
+
+        return isset($this->existingFailoverChannelIds[(int) $master->id]);
+    }
+
+    protected function prepareSelectedMaster(Channel $master): void
+    {
+        ChannelFailover::where('user_id', $this->user->id)
+            ->where('channel_failover_id', $master->id)
+            ->delete();
+
+        if ($this->shouldEnableSelectedMaster($master)) {
+            $master->update(['enabled' => true]);
+        }
     }
 
     /**

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -541,22 +541,12 @@ class MergeChannels implements ShouldQueue
     }
 
     /**
-     * Keep existing native failover topology intact and allow matched disabled
-     * channels to be hidden failovers, unless the scrubber already marked them dead.
+     * Keep matched channels eligible as failovers. Scrubber-dead state affects
+     * ordering, not whether the failover relationship can exist.
      */
     protected function filterFailoverCandidates(Collection $group): Collection
     {
-        return $group->filter(function ($channel) {
-            if ($this->isExistingFailoverTopologyChannel($channel)) {
-                return true;
-            }
-
-            if ($channel->last_scrubber_live === false) {
-                return false;
-            }
-
-            return true;
-        });
+        return $group;
     }
 
     protected function shouldEnableSelectedMaster(Channel $master): bool

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -323,7 +323,7 @@ class MergeChannels implements ShouldQueue
             ->when($this->newChannelsOnly, fn ($query) => $query->where('new', true))
             ->select(['id', 'user_id', 'playlist_id', 'group_id', 'title', 'title_custom',
                 'name', 'name_custom', 'stream_id', 'stream_id_custom', 'sort',
-                'catchup', 'enabled', 'stream_stats', 'last_scrubber_result'])
+                'catchup', 'enabled', 'stream_stats', 'last_scrubber_live'])
             ->cursor();
 
         $groupedChannels = $channels
@@ -384,7 +384,7 @@ class MergeChannels implements ShouldQueue
             ->when($this->groupId, fn ($q) => $q->where('group_id', $this->groupId))
             ->select(['id', 'user_id', 'playlist_id', 'group_id', 'title', 'title_custom',
                 'name', 'name_custom', 'stream_id', 'stream_id_custom', 'sort',
-                'catchup', 'enabled', 'last_scrubber_result'])
+                'catchup', 'enabled', 'last_scrubber_live'])
             ->chunk(500, function ($chunk) use ($validPatterns, &$matchesByPattern) {
                 foreach ($chunk as $channel) {
                     $title = $channel->title_custom ?: $channel->title;
@@ -526,7 +526,7 @@ class MergeChannels implements ShouldQueue
     protected function filterUnavailableMergeCandidates(Collection $group): Collection
     {
         return $group->filter(function ($channel) {
-            if ($channel->last_scrubber_result === 'dead') {
+            if ($channel->last_scrubber_live === false) {
                 return false;
             }
 
@@ -542,7 +542,7 @@ class MergeChannels implements ShouldQueue
             return false;
         }
 
-        if ($master->last_scrubber_result === 'dead') {
+        if ($master->last_scrubber_live === false) {
             return false;
         }
 

--- a/app/Jobs/ProcessChannelScrubber.php
+++ b/app/Jobs/ProcessChannelScrubber.php
@@ -110,6 +110,7 @@ class ProcessChannelScrubber implements ShouldQueue
                     probeTimeout: $scrubber->probe_timeout ?? 10,
                     disableDead: $scrubber->disable_dead ?? true,
                     enableLive: $scrubber->enable_live ?? false,
+                    protectFailoverChannels: $scrubber->protect_failover_channels ?? true,
                 ))
                 ->all();
 

--- a/app/Jobs/ProcessChannelScrubberChunk.php
+++ b/app/Jobs/ProcessChannelScrubberChunk.php
@@ -106,7 +106,7 @@ class ProcessChannelScrubberChunk implements ShouldQueue
 
                 $updates = [
                     'last_scrubbed_at' => $checkedAt,
-                    'last_scrubber_result' => 'dead',
+                    'last_scrubber_live' => false,
                 ];
 
                 if ($this->disableDead && $channel->enabled) {
@@ -132,7 +132,7 @@ class ProcessChannelScrubberChunk implements ShouldQueue
 
             $updates = [
                 'last_scrubbed_at' => $checkedAt,
-                'last_scrubber_result' => 'live',
+                'last_scrubber_live' => true,
             ];
 
             // Re-enable disabled channels that are now live (only when enableLive is set)

--- a/app/Jobs/ProcessChannelScrubberChunk.php
+++ b/app/Jobs/ProcessChannelScrubberChunk.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Enums\Status;
 use App\Models\Channel;
+use App\Models\ChannelFailover;
 use App\Models\ChannelScrubber;
 use App\Models\ChannelScrubberLog;
 use App\Models\ChannelScrubberLogChannel;
@@ -47,6 +48,7 @@ class ProcessChannelScrubberChunk implements ShouldQueue
         public int $probeTimeout = 10,
         public bool $disableDead = true,
         public bool $enableLive = false,
+        public bool $protectFailoverChannels = true,
     ) {}
 
     /**
@@ -62,6 +64,9 @@ class ProcessChannelScrubberChunk implements ShouldQueue
         }
         if (! isset($this->enableLive)) {
             $this->enableLive = false;
+        }
+        if (! isset($this->protectFailoverChannels)) {
+            $this->protectFailoverChannels = true;
         }
     }
 
@@ -79,6 +84,9 @@ class ProcessChannelScrubberChunk implements ShouldQueue
 
         // Snapshot enabled state before probing so we know which were disabled going in
         $wasEnabled = $channels->pluck('enabled', 'id')->map(fn ($v) => (bool) $v)->all();
+        $protectedFailoverIds = $this->protectFailoverChannels
+            ? $this->protectedFailoverIds($channels->pluck('id')->all())
+            : [];
 
         $deadIds = $this->checkMethod === 'ffprobe'
             ? $this->probeFfprobeBatch($channels)
@@ -136,7 +144,11 @@ class ProcessChannelScrubberChunk implements ShouldQueue
             ];
 
             // Re-enable disabled channels that are now live (only when enableLive is set)
-            if ($this->enableLive && ! ($wasEnabled[$channel->id] ?? true)) {
+            if (
+                $this->enableLive
+                && ! ($wasEnabled[$channel->id] ?? true)
+                && ! isset($protectedFailoverIds[$channel->id])
+            ) {
                 $updates['enabled'] = true;
             }
 
@@ -165,6 +177,23 @@ class ProcessChannelScrubberChunk implements ShouldQueue
             $newProgress = min(95, $scrubber->progress + $increment);
             $scrubber->update(['progress' => $newProgress]);
         }
+    }
+
+    /**
+     * @param  array<int>  $channelIds
+     * @return array<int, true>
+     */
+    private function protectedFailoverIds(array $channelIds): array
+    {
+        if (empty($channelIds)) {
+            return [];
+        }
+
+        return ChannelFailover::query()
+            ->whereIn('channel_failover_id', $channelIds)
+            ->pluck('channel_failover_id')
+            ->mapWithKeys(fn (mixed $id): array => [(int) $id => true])
+            ->all();
     }
 
     /**

--- a/app/Jobs/ProcessChannelScrubberChunk.php
+++ b/app/Jobs/ProcessChannelScrubberChunk.php
@@ -87,6 +87,7 @@ class ProcessChannelScrubberChunk implements ShouldQueue
         $deadSet = array_flip($deadIds);
         $deadCount = count($deadIds);
         $disabledCount = 0;
+        $checkedAt = now();
 
         // Process dead channels
         foreach ($deadIds as $channelId) {
@@ -103,10 +104,17 @@ class ProcessChannelScrubberChunk implements ShouldQueue
                     'url' => ($channel->url_custom ?? $channel->url) ?? '',
                 ]);
 
+                $updates = [
+                    'last_scrubbed_at' => $checkedAt,
+                    'last_scrubber_result' => 'dead',
+                ];
+
                 if ($this->disableDead && $channel->enabled) {
-                    $channel->update(['enabled' => false]);
+                    $updates['enabled'] = false;
                     $disabledCount++;
                 }
+
+                $channel->update($updates);
             } catch (Exception $e) {
                 Log::warning("Channel scrubber: error processing dead channel #{$channel->id}: {$e->getMessage()}");
             }
@@ -122,13 +130,20 @@ class ProcessChannelScrubberChunk implements ShouldQueue
 
             $liveCount++;
 
+            $updates = [
+                'last_scrubbed_at' => $checkedAt,
+                'last_scrubber_result' => 'live',
+            ];
+
             // Re-enable disabled channels that are now live (only when enableLive is set)
             if ($this->enableLive && ! ($wasEnabled[$channel->id] ?? true)) {
-                try {
-                    $channel->update(['enabled' => true]);
-                } catch (Exception $e) {
-                    Log::warning("Channel scrubber: error re-enabling channel #{$channel->id}: {$e->getMessage()}");
-                }
+                $updates['enabled'] = true;
+            }
+
+            try {
+                $channel->update($updates);
+            } catch (Exception $e) {
+                Log::warning("Channel scrubber: error updating live channel state #{$channel->id}: {$e->getMessage()}");
             }
         }
 

--- a/app/Jobs/ProcessChannelScrubberComplete.php
+++ b/app/Jobs/ProcessChannelScrubberComplete.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Enums\Status;
+use App\Listeners\SyncListener;
 use App\Models\ChannelScrubber;
 use App\Models\ChannelScrubberLog;
 use Carbon\Carbon;
@@ -79,6 +80,8 @@ class ProcessChannelScrubberComplete implements ShouldQueue
             'errors' => null,
         ]);
 
+        $this->dispatchPostScanMerge($scrubber);
+
         Notification::make()
             ->success()
             ->title("Channel Scrubber \"{$scrubber->name}\" completed")
@@ -93,5 +96,24 @@ class ProcessChannelScrubberComplete implements ShouldQueue
     public function failed(Throwable $exception): void
     {
         Log::error("Channel scrubber complete job failed: {$exception->getMessage()}");
+    }
+
+    private function dispatchPostScanMerge(ChannelScrubber $scrubber): void
+    {
+        if (! $scrubber->rebuild_failovers_after_scan) {
+            return;
+        }
+
+        $playlist = $scrubber->playlist;
+        if (! $playlist || ! $playlist->auto_merge_channels_enabled) {
+            return;
+        }
+
+        $mergeJob = SyncListener::getMergeJob($playlist);
+        if ($mergeJob === null) {
+            return;
+        }
+
+        dispatch($mergeJob);
     }
 }

--- a/app/Jobs/ProcessChannelScrubberComplete.php
+++ b/app/Jobs/ProcessChannelScrubberComplete.php
@@ -114,6 +114,9 @@ class ProcessChannelScrubberComplete implements ShouldQueue
             return;
         }
 
+        $mergeJob->newChannelsOnly = false;
+        $mergeJob->forceCompleteRemerge = true;
+
         dispatch($mergeJob);
     }
 }

--- a/app/Listeners/SyncListener.php
+++ b/app/Listeners/SyncListener.php
@@ -213,6 +213,7 @@ class SyncListener
         $preferredPlaylistId = $config['preferred_playlist_id'] ?? null;
         $failoverPlaylists = $config['failover_playlists'] ?? [];
         $deactivateFailover = (bool) ($playlist->auto_merge_deactivate_failover ?? false);
+        $scrubberAwareMasterSelection = (bool) ($config['scrubber_aware_master_selection'] ?? false);
 
         $playlists = collect([['playlist_failover_id' => $playlist->id]]);
 
@@ -239,6 +240,7 @@ class SyncListener
             fallbackMergeConfig: PlaylistService::buildMergeFallbackConfig($config),
             contentType: ($config['merge_key'] ?? 'stream_id') === 'tmdb_id' ? 'vod' : 'live',
             mergeKey: $config['merge_key'] ?? 'stream_id',
+            scrubberAwareMasterSelection: $scrubberAwareMasterSelection,
         );
     }
 

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -65,6 +65,8 @@ class Channel extends Model
         'stream_stats' => 'array',
         'stream_stats_probed_at' => 'datetime',
         'probe_enabled' => 'boolean',
+        'last_scrubbed_at' => 'datetime',
+        'last_scrubber_result' => 'string',
         'year' => 'integer',
         'edition' => 'string',
     ];

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -66,7 +66,7 @@ class Channel extends Model
         'stream_stats_probed_at' => 'datetime',
         'probe_enabled' => 'boolean',
         'last_scrubbed_at' => 'datetime',
-        'last_scrubber_result' => 'string',
+        'last_scrubber_live' => 'boolean',
         'year' => 'integer',
         'edition' => 'string',
     ];

--- a/app/Models/ChannelScrubber.php
+++ b/app/Models/ChannelScrubber.php
@@ -25,6 +25,7 @@ class ChannelScrubber extends Model
             'probe_timeout' => 'integer',
             'disable_dead' => 'boolean',
             'enable_live' => 'boolean',
+            'rebuild_failovers_after_scan' => 'boolean',
             'channel_count' => 'integer',
             'dead_count' => 'integer',
             'user_id' => 'integer',

--- a/app/Models/ChannelScrubber.php
+++ b/app/Models/ChannelScrubber.php
@@ -25,6 +25,7 @@ class ChannelScrubber extends Model
             'probe_timeout' => 'integer',
             'disable_dead' => 'boolean',
             'enable_live' => 'boolean',
+            'protect_failover_channels' => 'boolean',
             'rebuild_failovers_after_scan' => 'boolean',
             'channel_count' => 'integer',
             'dead_count' => 'integer',

--- a/database/migrations/2026_06_20_000001_add_protect_failover_channels_to_channel_scrubbers.php
+++ b/database/migrations/2026_06_20_000001_add_protect_failover_channels_to_channel_scrubbers.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channel_scrubbers', function (Blueprint $table) {
+            $table->boolean('protect_failover_channels')
+                ->default(true)
+                ->after('enable_live');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channel_scrubbers', function (Blueprint $table) {
+            $table->dropColumn('protect_failover_channels');
+        });
+    }
+};

--- a/database/migrations/2026_06_20_000002_add_last_scrubber_state_to_channels_table.php
+++ b/database/migrations/2026_06_20_000002_add_last_scrubber_state_to_channels_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::table('channels', function (Blueprint $table) {
             $table->timestamp('last_scrubbed_at')->nullable()->after('probe_enabled');
-            $table->string('last_scrubber_result')->nullable()->after('last_scrubbed_at');
+            $table->boolean('last_scrubber_live')->nullable()->after('last_scrubbed_at');
         });
     }
 
@@ -23,7 +23,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('channels', function (Blueprint $table) {
-            $table->dropColumn(['last_scrubbed_at', 'last_scrubber_result']);
+            $table->dropColumn(['last_scrubbed_at', 'last_scrubber_live']);
         });
     }
 };

--- a/database/migrations/2026_06_20_000002_add_last_scrubber_state_to_channels_table.php
+++ b/database/migrations/2026_06_20_000002_add_last_scrubber_state_to_channels_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->timestamp('last_scrubbed_at')->nullable()->after('probe_enabled');
+            $table->string('last_scrubber_result')->nullable()->after('last_scrubbed_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropColumn(['last_scrubbed_at', 'last_scrubber_result']);
+        });
+    }
+};

--- a/database/migrations/2026_06_20_000003_add_rebuild_failovers_after_scan_to_channel_scrubbers.php
+++ b/database/migrations/2026_06_20_000003_add_rebuild_failovers_after_scan_to_channel_scrubbers.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channel_scrubbers', function (Blueprint $table) {
+            $table->boolean('rebuild_failovers_after_scan')
+                ->default(false)
+                ->after('enable_live');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channel_scrubbers', function (Blueprint $table) {
+            $table->dropColumn('rebuild_failovers_after_scan');
+        });
+    }
+};

--- a/tests/Feature/ChannelInfoTechnicalDetailsTest.php
+++ b/tests/Feature/ChannelInfoTechnicalDetailsTest.php
@@ -1,14 +1,20 @@
 <?php
 
+use App\Events\PlaylistCreated;
+use App\Events\PlaylistUpdated;
+use App\Filament\Resources\Channels\ChannelResource;
 use App\Filament\Resources\Channels\Pages\ViewChannel;
 use App\Jobs\ProbeChannelStreams;
 use App\Models\Channel;
 use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
 use Livewire\Livewire;
 
 beforeEach(function () {
+    Event::fake([PlaylistCreated::class, PlaylistUpdated::class]);
+
     $this->user = User::factory()->create();
     $this->actingAs($this->user);
     $this->playlist = Playlist::factory()->for($this->user)->createQuietly();
@@ -51,6 +57,29 @@ it('renders the Technical Details section on the view page', function () {
 
     Livewire::test(ViewChannel::class, ['record' => $channel->getRouteKey()])
         ->assertSee('Technical Details');
+});
+
+it('registers scrubber status columns on the channel table', function () {
+    $columnNames = collect(ChannelResource::getTableColumns())
+        ->map(fn ($column) => $column->getName())
+        ->all();
+
+    expect($columnNames)->toContain('last_scrubber_result')
+        ->and($columnNames)->toContain('last_scrubbed_at');
+});
+
+it('loads the view page when scrubber state is present', function () {
+    $checkedAt = now()->subMinutes(10);
+    $channel = Channel::factory()->for($this->playlist)->create([
+        'user_id' => $this->playlist->user_id,
+        'is_vod' => false,
+        'last_scrubber_result' => 'dead',
+        'last_scrubbed_at' => $checkedAt,
+    ]);
+
+    Livewire::test(ViewChannel::class, ['record' => $channel->getRouteKey()])
+        ->assertOk()
+        ->assertSee('Channel Details');
 });
 
 it('renders compact stream details for a probed channel', function () {

--- a/tests/Feature/ChannelInfoTechnicalDetailsTest.php
+++ b/tests/Feature/ChannelInfoTechnicalDetailsTest.php
@@ -64,7 +64,7 @@ it('registers scrubber status columns on the channel table', function () {
         ->map(fn ($column) => $column->getName())
         ->all();
 
-    expect($columnNames)->toContain('last_scrubber_result')
+    expect($columnNames)->toContain('last_scrubber_live')
         ->and($columnNames)->toContain('last_scrubbed_at');
 });
 
@@ -73,7 +73,7 @@ it('loads the view page when scrubber state is present', function () {
     $channel = Channel::factory()->for($this->playlist)->create([
         'user_id' => $this->playlist->user_id,
         'is_vod' => false,
-        'last_scrubber_result' => 'dead',
+        'last_scrubber_live' => false,
         'last_scrubbed_at' => $checkedAt,
     ]);
 

--- a/tests/Feature/ProcessChannelScrubberChunkTest.php
+++ b/tests/Feature/ProcessChannelScrubberChunkTest.php
@@ -71,7 +71,7 @@ it('marks a channel dead via ffprobe when ensureStreamStats returns empty', func
 
     $channel->refresh();
     expect($channel->enabled)->toBeFalse();
-    expect($channel->last_scrubber_result)->toBe('dead');
+    expect($channel->last_scrubber_live)->toBeFalse();
     expect($channel->last_scrubbed_at)->not->toBeNull();
 
     $this->assertDatabaseHas('channel_scrubber_log_channels', [
@@ -106,7 +106,7 @@ it('marks a channel dead via ffprobe even when stream_stats are cached', functio
 
     $channel->refresh();
     expect($channel->enabled)->toBeFalse();
-    expect($channel->last_scrubber_result)->toBe('dead');
+    expect($channel->last_scrubber_live)->toBeFalse();
     expect($channel->last_scrubbed_at)->not->toBeNull();
 
     $this->assertDatabaseHas('channel_scrubber_log_channels', [
@@ -215,7 +215,7 @@ it('does not disable dead channels when disableDead is false', function () {
 
     $channel->refresh();
     expect($channel->enabled)->toBeTrue();
-    expect($channel->last_scrubber_result)->toBe('dead');
+    expect($channel->last_scrubber_live)->toBeFalse();
     expect($channel->last_scrubbed_at)->not->toBeNull();
 
     $this->assertDatabaseHas('channel_scrubber_log_channels', [
@@ -257,7 +257,7 @@ it('re-enables a previously disabled live channel when enableLive is true', func
 
     $channel->refresh();
     expect($channel->enabled)->toBeTrue();
-    expect($channel->last_scrubber_result)->toBe('live');
+    expect($channel->last_scrubber_live)->toBeTrue();
     expect($channel->last_scrubbed_at)->not->toBeNull();
 
     expect($this->log->fresh()->live_count)->toBe(1);

--- a/tests/Feature/ProcessChannelScrubberChunkTest.php
+++ b/tests/Feature/ProcessChannelScrubberChunkTest.php
@@ -3,6 +3,7 @@
 use App\Enums\Status;
 use App\Jobs\ProcessChannelScrubberChunk;
 use App\Models\Channel;
+use App\Models\ChannelFailover;
 use App\Models\ChannelScrubber;
 use App\Models\ChannelScrubberLog;
 use App\Models\Playlist;
@@ -260,5 +261,85 @@ it('re-enables a previously disabled live channel when enableLive is true', func
     expect($channel->last_scrubber_live)->toBeTrue();
     expect($channel->last_scrubbed_at)->not->toBeNull();
 
+    expect($this->log->fresh()->live_count)->toBe(1);
+});
+
+it('keeps a disabled live failover channel hidden when failover protection is enabled', function () {
+    $master = ($this->channel)([
+        'enabled' => true,
+    ]);
+
+    $failover = ($this->channel)([
+        'enabled' => false,
+        'url' => 'http://example.invalid/failover',
+        'url_custom' => null,
+        'stream_stats' => null,
+    ]);
+
+    ChannelFailover::create([
+        'user_id' => $this->user->id,
+        'channel_id' => $master->id,
+        'channel_failover_id' => $failover->id,
+    ]);
+
+    Http::fake([
+        'http://example.invalid/failover' => Http::response('', 200),
+    ]);
+
+    ($this->handleChunk)(new ProcessChannelScrubberChunk(
+        channelIds: [$failover->id],
+        scrubberId: $this->scrubber->id,
+        logId: $this->log->id,
+        checkMethod: 'http',
+        batchNo: $this->scrubber->uuid,
+        totalChannels: 1,
+        enableLive: true,
+        protectFailoverChannels: true,
+    ));
+
+    $failover->refresh();
+    expect($failover->enabled)->toBeFalse();
+    expect($failover->last_scrubber_live)->toBeTrue();
+    expect($failover->last_scrubbed_at)->not->toBeNull();
+    expect($this->log->fresh()->live_count)->toBe(1);
+});
+
+it('re-enables a disabled live failover channel when failover protection is disabled', function () {
+    $master = ($this->channel)([
+        'enabled' => true,
+    ]);
+
+    $failover = ($this->channel)([
+        'enabled' => false,
+        'url' => 'http://example.invalid/failover',
+        'url_custom' => null,
+        'stream_stats' => null,
+    ]);
+
+    ChannelFailover::create([
+        'user_id' => $this->user->id,
+        'channel_id' => $master->id,
+        'channel_failover_id' => $failover->id,
+    ]);
+
+    Http::fake([
+        'http://example.invalid/failover' => Http::response('', 200),
+    ]);
+
+    ($this->handleChunk)(new ProcessChannelScrubberChunk(
+        channelIds: [$failover->id],
+        scrubberId: $this->scrubber->id,
+        logId: $this->log->id,
+        checkMethod: 'http',
+        batchNo: $this->scrubber->uuid,
+        totalChannels: 1,
+        enableLive: true,
+        protectFailoverChannels: false,
+    ));
+
+    $failover->refresh();
+    expect($failover->enabled)->toBeTrue();
+    expect($failover->last_scrubber_live)->toBeTrue();
+    expect($failover->last_scrubbed_at)->not->toBeNull();
     expect($this->log->fresh()->live_count)->toBe(1);
 });

--- a/tests/Feature/ProcessChannelScrubberChunkTest.php
+++ b/tests/Feature/ProcessChannelScrubberChunkTest.php
@@ -7,20 +7,25 @@ use App\Models\ChannelScrubber;
 use App\Models\ChannelScrubberLog;
 use App\Models\Playlist;
 use App\Models\User;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
 
 beforeEach(function () {
-    $this->user = User::factory()->create();
-    $this->playlist = Playlist::factory()->for($this->user)->createQuietly();
+    Config::set('cache.default', 'array');
+    Queue::fake();
 
-    $this->scrubber = ChannelScrubber::create([
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::withoutEvents(fn () => Playlist::factory()->for($this->user)->create());
+
+    $this->scrubber = ChannelScrubber::withoutEvents(fn () => ChannelScrubber::create([
         'name' => 'Test Scrubber',
-        'uuid' => 'test-batch-uuid',
+        'uuid' => '00000000-0000-4000-8000-000000000001',
         'status' => Status::Processing,
         'user_id' => $this->user->id,
         'playlist_id' => $this->playlist->id,
         'progress' => 0,
-    ]);
+    ]));
 
     $this->log = ChannelScrubberLog::create([
         'channel_scrubber_id' => $this->scrubber->id,
@@ -28,6 +33,17 @@ beforeEach(function () {
         'playlist_id' => $this->playlist->id,
         'status' => 'processing',
     ]);
+
+    $this->channel = function (array $attributes = []): Channel {
+        return Channel::withoutEvents(fn () => Channel::factory()->create([
+            'user_id' => $this->user->id,
+            'playlist_id' => $this->playlist->id,
+            'group_id' => null,
+            ...$attributes,
+        ]));
+    };
+
+    $this->handleChunk = fn (ProcessChannelScrubberChunk $chunk): mixed => Channel::withoutEvents(fn () => $chunk->handle());
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -36,7 +52,7 @@ beforeEach(function () {
 
 it('marks a channel dead via ffprobe when ensureStreamStats returns empty', function () {
     // No URL and no stream_stats → ensureStreamStats() returns [] → dead
-    $channel = Channel::factory()->for($this->playlist)->create([
+    $channel = ($this->channel)([
         'user_id' => $this->user->id,
         'enabled' => true,
         'url' => null,
@@ -44,17 +60,19 @@ it('marks a channel dead via ffprobe when ensureStreamStats returns empty', func
         'stream_stats' => null,
     ]);
 
-    (new ProcessChannelScrubberChunk(
+    ($this->handleChunk)(new ProcessChannelScrubberChunk(
         channelIds: [$channel->id],
         scrubberId: $this->scrubber->id,
         logId: $this->log->id,
         checkMethod: 'ffprobe',
         batchNo: $this->scrubber->uuid,
         totalChannels: 1,
-    ))->handle();
+    ));
 
     $channel->refresh();
     expect($channel->enabled)->toBeFalse();
+    expect($channel->last_scrubber_result)->toBe('dead');
+    expect($channel->last_scrubbed_at)->not->toBeNull();
 
     $this->assertDatabaseHas('channel_scrubber_log_channels', [
         'channel_scrubber_log_id' => $this->log->id,
@@ -67,7 +85,7 @@ it('marks a channel dead via ffprobe even when stream_stats are cached', functio
     // producing false negatives for dead streams that had been probed before.
     // The new lightweight ffprobe probe always makes a fresh network call — cached stats
     // are irrelevant. A null URL with cached stats is still dead.
-    $channel = Channel::factory()->for($this->playlist)->create([
+    $channel = ($this->channel)([
         'user_id' => $this->user->id,
         'enabled' => true,
         'url' => null,
@@ -77,17 +95,19 @@ it('marks a channel dead via ffprobe even when stream_stats are cached', functio
         ],
     ]);
 
-    (new ProcessChannelScrubberChunk(
+    ($this->handleChunk)(new ProcessChannelScrubberChunk(
         channelIds: [$channel->id],
         scrubberId: $this->scrubber->id,
         logId: $this->log->id,
         checkMethod: 'ffprobe',
         batchNo: $this->scrubber->uuid,
         totalChannels: 1,
-    ))->handle();
+    ));
 
     $channel->refresh();
     expect($channel->enabled)->toBeFalse();
+    expect($channel->last_scrubber_result)->toBe('dead');
+    expect($channel->last_scrubbed_at)->not->toBeNull();
 
     $this->assertDatabaseHas('channel_scrubber_log_channels', [
         'channel_scrubber_log_id' => $this->log->id,
@@ -96,27 +116,27 @@ it('marks a channel dead via ffprobe even when stream_stats are cached', functio
 });
 
 it('increments dead_count on the scrubber for each dead channel', function () {
-    $dead1 = Channel::factory()->for($this->playlist)->create([
+    $dead1 = ($this->channel)([
         'user_id' => $this->user->id,
         'url' => null,
         'url_custom' => null,
         'stream_stats' => null,
     ]);
-    $dead2 = Channel::factory()->for($this->playlist)->create([
+    $dead2 = ($this->channel)([
         'user_id' => $this->user->id,
         'url' => null,
         'url_custom' => null,
         'stream_stats' => null,
     ]);
 
-    (new ProcessChannelScrubberChunk(
+    ($this->handleChunk)(new ProcessChannelScrubberChunk(
         channelIds: [$dead1->id, $dead2->id],
         scrubberId: $this->scrubber->id,
         logId: $this->log->id,
         checkMethod: 'ffprobe',
         batchNo: $this->scrubber->uuid,
         totalChannels: 2,
-    ))->handle();
+    ));
 
     expect($this->scrubber->fresh()->dead_count)->toBe(2);
     expect($this->log->fresh()->live_count)->toBe(0);
@@ -127,21 +147,21 @@ it('increments dead_count on the scrubber for each dead channel', function () {
 // ──────────────────────────────────────────────────────────────────────────────
 
 it('skips processing when the batch uuid does not match', function () {
-    $channel = Channel::factory()->for($this->playlist)->create([
+    $channel = ($this->channel)([
         'user_id' => $this->user->id,
         'enabled' => true,
         'url' => null,
         'stream_stats' => null,
     ]);
 
-    (new ProcessChannelScrubberChunk(
+    ($this->handleChunk)(new ProcessChannelScrubberChunk(
         channelIds: [$channel->id],
         scrubberId: $this->scrubber->id,
         logId: $this->log->id,
         checkMethod: 'ffprobe',
         batchNo: 'stale-uuid',
         totalChannels: 1,
-    ))->handle();
+    ));
 
     $channel->refresh();
     expect($channel->enabled)->toBeTrue();
@@ -150,21 +170,21 @@ it('skips processing when the batch uuid does not match', function () {
 it('skips processing when the scrubber is cancelled', function () {
     $this->scrubber->update(['status' => Status::Cancelled]);
 
-    $channel = Channel::factory()->for($this->playlist)->create([
+    $channel = ($this->channel)([
         'user_id' => $this->user->id,
         'enabled' => true,
         'url' => null,
         'stream_stats' => null,
     ]);
 
-    (new ProcessChannelScrubberChunk(
+    ($this->handleChunk)(new ProcessChannelScrubberChunk(
         channelIds: [$channel->id],
         scrubberId: $this->scrubber->id,
         logId: $this->log->id,
         checkMethod: 'ffprobe',
         batchNo: $this->scrubber->uuid,
         totalChannels: 1,
-    ))->handle();
+    ));
 
     $channel->refresh();
     expect($channel->enabled)->toBeTrue();
@@ -175,7 +195,7 @@ it('skips processing when the scrubber is cancelled', function () {
 // ──────────────────────────────────────────────────────────────────────────────
 
 it('does not disable dead channels when disableDead is false', function () {
-    $channel = Channel::factory()->for($this->playlist)->create([
+    $channel = ($this->channel)([
         'user_id' => $this->user->id,
         'enabled' => true,
         'url' => null,
@@ -183,7 +203,7 @@ it('does not disable dead channels when disableDead is false', function () {
         'stream_stats' => null,
     ]);
 
-    (new ProcessChannelScrubberChunk(
+    ($this->handleChunk)(new ProcessChannelScrubberChunk(
         channelIds: [$channel->id],
         scrubberId: $this->scrubber->id,
         logId: $this->log->id,
@@ -191,10 +211,12 @@ it('does not disable dead channels when disableDead is false', function () {
         batchNo: $this->scrubber->uuid,
         totalChannels: 1,
         disableDead: false,
-    ))->handle();
+    ));
 
     $channel->refresh();
     expect($channel->enabled)->toBeTrue();
+    expect($channel->last_scrubber_result)->toBe('dead');
+    expect($channel->last_scrubbed_at)->not->toBeNull();
 
     $this->assertDatabaseHas('channel_scrubber_log_channels', [
         'channel_scrubber_log_id' => $this->log->id,
@@ -210,7 +232,7 @@ it('does not disable dead channels when disableDead is false', function () {
 // ──────────────────────────────────────────────────────────────────────────────
 
 it('re-enables a previously disabled live channel when enableLive is true', function () {
-    $channel = Channel::factory()->for($this->playlist)->create([
+    $channel = ($this->channel)([
         'user_id' => $this->user->id,
         'enabled' => false,
         'url' => 'http://example.invalid/stream',
@@ -223,7 +245,7 @@ it('re-enables a previously disabled live channel when enableLive is true', func
         'http://example.invalid/stream' => Http::response('', 200),
     ]);
 
-    (new ProcessChannelScrubberChunk(
+    ($this->handleChunk)(new ProcessChannelScrubberChunk(
         channelIds: [$channel->id],
         scrubberId: $this->scrubber->id,
         logId: $this->log->id,
@@ -231,10 +253,12 @@ it('re-enables a previously disabled live channel when enableLive is true', func
         batchNo: $this->scrubber->uuid,
         totalChannels: 1,
         enableLive: true,
-    ))->handle();
+    ));
 
     $channel->refresh();
     expect($channel->enabled)->toBeTrue();
+    expect($channel->last_scrubber_result)->toBe('live');
+    expect($channel->last_scrubbed_at)->not->toBeNull();
 
     expect($this->log->fresh()->live_count)->toBe(1);
 });

--- a/tests/Feature/ProcessChannelScrubberCompleteTest.php
+++ b/tests/Feature/ProcessChannelScrubberCompleteTest.php
@@ -1,0 +1,142 @@
+<?php
+
+use App\Enums\Status;
+use App\Jobs\MergeChannels;
+use App\Jobs\ProcessChannelScrubberComplete;
+use App\Models\ChannelScrubber;
+use App\Models\ChannelScrubberLog;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    Bus::fake();
+    Notification::fake();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::withoutEvents(fn () => Playlist::factory()->for($this->user)->createQuietly([
+        'auto_merge_channels_enabled' => false,
+    ]));
+
+    $this->scrubber = function (array $attributes = []): ChannelScrubber {
+        return ChannelScrubber::withoutEvents(fn () => ChannelScrubber::create([
+            'name' => 'Post Scan Scrubber',
+            'uuid' => '00000000-0000-4000-8000-000000000101',
+            'status' => Status::Processing,
+            'user_id' => $this->user->id,
+            'playlist_id' => $this->playlist->id,
+            'channel_count' => 12,
+            'dead_count' => 2,
+            'progress' => 95,
+            'processing' => true,
+            ...$attributes,
+        ]));
+    };
+
+    $this->logFor = function (ChannelScrubber $scrubber): ChannelScrubberLog {
+        return ChannelScrubberLog::create([
+            'channel_scrubber_id' => $scrubber->id,
+            'user_id' => $this->user->id,
+            'playlist_id' => $this->playlist->id,
+            'status' => 'processing',
+            'channel_count' => 12,
+        ]);
+    };
+});
+
+it('does not dispatch native merge after scan when the scrubber setting is off', function () {
+    $this->playlist->update(['auto_merge_channels_enabled' => true]);
+    $scrubber = ($this->scrubber)(['rebuild_failovers_after_scan' => false]);
+    $log = ($this->logFor)($scrubber);
+
+    (new ProcessChannelScrubberComplete(
+        scrubberId: $scrubber->id,
+        logId: $log->id,
+        batchNo: $scrubber->uuid,
+        start: now()->subSeconds(3),
+    ))->handle();
+
+    Bus::assertNotDispatched(MergeChannels::class);
+    expect($scrubber->fresh()->status)->toBe(Status::Completed);
+    expect($log->fresh()->status)->toBe('completed');
+});
+
+it('does not dispatch native merge after scan when playlist auto merge is disabled', function () {
+    $scrubber = ($this->scrubber)(['rebuild_failovers_after_scan' => true]);
+    $log = ($this->logFor)($scrubber);
+
+    (new ProcessChannelScrubberComplete(
+        scrubberId: $scrubber->id,
+        logId: $log->id,
+        batchNo: $scrubber->uuid,
+        start: now()->subSeconds(3),
+    ))->handle();
+
+    Bus::assertNotDispatched(MergeChannels::class);
+    expect($scrubber->fresh()->status)->toBe(Status::Completed);
+});
+
+it('dispatches native merge after a successful scan when enabled', function () {
+    $this->playlist->update([
+        'auto_merge_channels_enabled' => true,
+        'auto_merge_config' => [
+            'merge_key' => 'stream_id',
+            'new_channels_only' => false,
+            'force_complete_remerge' => true,
+        ],
+    ]);
+    $scrubber = ($this->scrubber)(['rebuild_failovers_after_scan' => true]);
+    $log = ($this->logFor)($scrubber);
+
+    (new ProcessChannelScrubberComplete(
+        scrubberId: $scrubber->id,
+        logId: $log->id,
+        batchNo: $scrubber->uuid,
+        start: now()->subSeconds(3),
+    ))->handle();
+
+    Bus::assertDispatched(MergeChannels::class, function (MergeChannels $job): bool {
+        return $job->playlistId === $this->playlist->id
+            && $job->mergeKey === 'stream_id'
+            && $job->newChannelsOnly === false
+            && $job->forceCompleteRemerge === true;
+    });
+    expect($scrubber->fresh()->status)->toBe(Status::Completed);
+    expect($scrubber->fresh()->processing)->toBeFalse();
+});
+
+it('does not dispatch native merge when the scrubber completion is stale', function () {
+    $this->playlist->update(['auto_merge_channels_enabled' => true]);
+    $scrubber = ($this->scrubber)(['rebuild_failovers_after_scan' => true]);
+    $log = ($this->logFor)($scrubber);
+
+    (new ProcessChannelScrubberComplete(
+        scrubberId: $scrubber->id,
+        logId: $log->id,
+        batchNo: 'stale-batch',
+        start: now()->subSeconds(3),
+    ))->handle();
+
+    Bus::assertNotDispatched(MergeChannels::class);
+    expect($log->fresh()->status)->toBe('cancelled');
+});
+
+it('does not dispatch native merge when the scrubber was cancelled', function () {
+    $this->playlist->update(['auto_merge_channels_enabled' => true]);
+    $scrubber = ($this->scrubber)([
+        'status' => Status::Cancelled,
+        'rebuild_failovers_after_scan' => true,
+    ]);
+    $log = ($this->logFor)($scrubber);
+
+    (new ProcessChannelScrubberComplete(
+        scrubberId: $scrubber->id,
+        logId: $log->id,
+        batchNo: $scrubber->uuid,
+        start: now()->subSeconds(3),
+    ))->handle();
+
+    Bus::assertNotDispatched(MergeChannels::class);
+    expect($log->fresh()->status)->toBe('cancelled');
+});

--- a/tests/Feature/ProcessChannelScrubberCompleteTest.php
+++ b/tests/Feature/ProcessChannelScrubberCompleteTest.php
@@ -82,8 +82,6 @@ it('dispatches native merge after a successful scan when enabled', function () {
         'auto_merge_channels_enabled' => true,
         'auto_merge_config' => [
             'merge_key' => 'stream_id',
-            'new_channels_only' => false,
-            'force_complete_remerge' => true,
         ],
     ]);
     $scrubber = ($this->scrubber)(['rebuild_failovers_after_scan' => true]);

--- a/tests/Feature/RegexMergeTest.php
+++ b/tests/Feature/RegexMergeTest.php
@@ -37,6 +37,7 @@ it('merges channels matching a playlist-level regex pattern as failovers', funct
         'name' => 'CCTV-1',
         'stream_id' => 'cctv1-primary',
         'can_merge' => true,
+        'enabled' => true,
     ]);
 
     $match1 = Channel::factory()->create([
@@ -47,6 +48,7 @@ it('merges channels matching a playlist-level regex pattern as failovers', funct
         'name' => 'CCTV1',
         'stream_id' => 'cctv1-backup-a',
         'can_merge' => true,
+        'enabled' => true,
     ]);
 
     $match2 = Channel::factory()->create([
@@ -57,6 +59,7 @@ it('merges channels matching a playlist-level regex pattern as failovers', funct
         'name' => 'cctv-1',
         'stream_id' => 'cctv1-backup-b',
         'can_merge' => true,
+        'enabled' => true,
     ]);
 
     // Should NOT match — CCTV10 is beyond the regex boundary
@@ -68,6 +71,7 @@ it('merges channels matching a playlist-level regex pattern as failovers', funct
         'name' => 'CCTV10',
         'stream_id' => 'cctv10',
         'can_merge' => true,
+        'enabled' => true,
     ]);
 
     $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
@@ -100,6 +104,7 @@ it('skips channels with invalid regex patterns without crashing', function () {
         'group_id' => $this->group->id,
         'stream_id' => 'test1',
         'can_merge' => true,
+        'enabled' => true,
     ]);
 
     $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);
@@ -124,6 +129,7 @@ it('does nothing when no regex patterns are configured', function () {
             'group_id' => $this->group->id,
             'stream_id' => $id,
             'can_merge' => true,
+            'enabled' => true,
         ]);
     }
 
@@ -147,6 +153,7 @@ it('matches regex against channel name when title does not match', function () {
         'name' => 'BBC One',
         'stream_id' => 'bbc-one-primary',
         'can_merge' => true,
+        'enabled' => true,
     ]);
 
     $matchByName = Channel::factory()->create([
@@ -157,6 +164,7 @@ it('matches regex against channel name when title does not match', function () {
         'name' => 'BBC One',
         'stream_id' => 'bbc-one-other',
         'can_merge' => true,
+        'enabled' => true,
     ]);
 
     $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);

--- a/tests/Feature/XtreamApiControllerTest.php
+++ b/tests/Feature/XtreamApiControllerTest.php
@@ -442,9 +442,30 @@ class XtreamApiControllerTest extends TestCase
     public function test_merge_and_unmerge_channels_jobs()
     {
         // Create channels with the same stream_id (explicit sort order so channel1 is master)
-        $channel1 = Channel::factory()->create(['playlist_id' => $this->playlist->id, 'stream_id' => '100', 'user_id' => $this->user->id, 'sort' => 1.0]);
-        $channel2 = Channel::factory()->create(['playlist_id' => $this->playlist->id, 'stream_id' => '100', 'user_id' => $this->user->id, 'sort' => 2.0]);
-        $channel3 = Channel::factory()->create(['playlist_id' => $this->playlist->id, 'stream_id' => '100', 'user_id' => $this->user->id, 'sort' => 3.0]);
+        $channel1 = Channel::factory()->create([
+            'playlist_id' => $this->playlist->id,
+            'stream_id' => '100',
+            'user_id' => $this->user->id,
+            'sort' => 1.0,
+            'enabled' => true,
+            'can_merge' => true,
+        ]);
+        $channel2 = Channel::factory()->create([
+            'playlist_id' => $this->playlist->id,
+            'stream_id' => '100',
+            'user_id' => $this->user->id,
+            'sort' => 2.0,
+            'enabled' => true,
+            'can_merge' => true,
+        ]);
+        $channel3 = Channel::factory()->create([
+            'playlist_id' => $this->playlist->id,
+            'stream_id' => '100',
+            'user_id' => $this->user->id,
+            'sort' => 3.0,
+            'enabled' => true,
+            'can_merge' => true,
+        ]);
 
         // Run the merge job with required arguments: user, playlists (as collection with playlist_failover_id), playlistId
         $playlists = collect([['playlist_failover_id' => $this->playlist->id]]);

--- a/tests/Unit/MergeChannelsTest.php
+++ b/tests/Unit/MergeChannelsTest.php
@@ -277,7 +277,7 @@ class MergeChannelsTest extends TestCase
             'playlist_id' => $playlist1->id,
             'group_id' => null,
             'enabled' => true,
-            'last_scrubber_result' => 'live',
+            'last_scrubber_live' => true,
         ]);
 
         $deadHiddenFailover = Channel::factory()->create([
@@ -286,7 +286,7 @@ class MergeChannelsTest extends TestCase
             'playlist_id' => $playlist2->id,
             'group_id' => null,
             'enabled' => false,
-            'last_scrubber_result' => 'dead',
+            'last_scrubber_live' => false,
         ]);
 
         ChannelFailover::create([

--- a/tests/Unit/MergeChannelsTest.php
+++ b/tests/Unit/MergeChannelsTest.php
@@ -263,4 +263,53 @@ class MergeChannelsTest extends TestCase
         $this->assertFalse($disabledPreferred->refresh()->enabled);
         $this->assertDatabaseCount('channel_failovers', 0);
     }
+
+    #[Test]
+    public function scrubber_dead_hidden_failover_is_not_promoted_and_is_pruned_from_master_failovers()
+    {
+        $user = User::factory()->create();
+        $playlist1 = Playlist::factory()->for($user)->createQuietly();
+        $playlist2 = Playlist::factory()->for($user)->createQuietly();
+
+        $currentMaster = Channel::factory()->create([
+            'stream_id' => 'streamZ',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist1->id,
+            'group_id' => null,
+            'enabled' => true,
+            'last_scrubber_result' => 'live',
+        ]);
+
+        $deadHiddenFailover = Channel::factory()->create([
+            'stream_id' => 'streamZ',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'group_id' => null,
+            'enabled' => false,
+            'last_scrubber_result' => 'dead',
+        ]);
+
+        ChannelFailover::create([
+            'user_id' => $user->id,
+            'channel_id' => $currentMaster->id,
+            'channel_failover_id' => $deadHiddenFailover->id,
+        ]);
+
+        $playlists = collect([
+            ['playlist_failover_id' => $playlist1->id],
+            ['playlist_failover_id' => $playlist2->id],
+        ]);
+
+        // Playlist 2 would normally be preferred, and the disabled channel is
+        // an existing hidden failover. The scrubber-dead state makes it
+        // unavailable, so it must not be promoted or retained as a failover.
+        $this->runMergeChannels($user, $playlists, $playlist2->id, false, true);
+
+        $this->assertTrue($currentMaster->refresh()->enabled);
+        $this->assertFalse($deadHiddenFailover->refresh()->enabled);
+        $this->assertDatabaseMissing('channel_failovers', [
+            'channel_id' => $currentMaster->id,
+            'channel_failover_id' => $deadHiddenFailover->id,
+        ]);
+    }
 }

--- a/tests/Unit/MergeChannelsTest.php
+++ b/tests/Unit/MergeChannelsTest.php
@@ -37,11 +37,11 @@ class MergeChannelsTest extends TestCase
         $playlist = Playlist::factory()->for($user)->createQuietly();
 
         // Create channels for the playlist with same stream_id
-        $channel1 = Channel::factory()->create(['stream_id' => 'stream1', 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null]);
-        $channel2 = Channel::factory()->create(['stream_id' => 'stream1', 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null]);
+        $channel1 = Channel::factory()->create(['stream_id' => 'stream1', 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null, 'enabled' => true]);
+        $channel2 = Channel::factory()->create(['stream_id' => 'stream1', 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null, 'enabled' => true]);
         // Channels with empty stream_ids should not be merged
-        $channel3 = Channel::factory()->create(['stream_id' => '', 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null]);
-        $channel4 = Channel::factory()->create(['stream_id' => null, 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null]);
+        $channel3 = Channel::factory()->create(['stream_id' => '', 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null, 'enabled' => true]);
+        $channel4 = Channel::factory()->create(['stream_id' => null, 'user_id' => $user->id, 'playlist_id' => $playlist->id, 'group_id' => null, 'enabled' => true]);
 
         // Create playlists collection as expected by MergeChannels constructor
         $playlists = collect([['playlist_failover_id' => $playlist->id]]);
@@ -68,6 +68,7 @@ class MergeChannelsTest extends TestCase
             'user_id' => $user->id,
             'playlist_id' => $playlist1->id,
             'group_id' => null,
+            'enabled' => true,
         ]);
 
         $failover = Channel::factory()->create([
@@ -77,6 +78,7 @@ class MergeChannelsTest extends TestCase
             'user_id' => $user->id,
             'playlist_id' => $playlist2->id,
             'group_id' => null,
+            'enabled' => true,
         ]);
 
         $unrelatedLive = Channel::factory()->create([
@@ -86,6 +88,7 @@ class MergeChannelsTest extends TestCase
             'user_id' => $user->id,
             'playlist_id' => $playlist2->id,
             'group_id' => null,
+            'enabled' => true,
         ]);
 
         $this->runMergeChannels(
@@ -148,7 +151,7 @@ class MergeChannelsTest extends TestCase
     }
 
     #[Test]
-    public function promoted_master_is_enabled_and_old_master_is_deactivated_when_failovers_are_deactivated()
+    public function hidden_failover_can_be_promoted_to_master_and_old_master_is_deactivated()
     {
         $user = User::factory()->create();
         $playlist1 = Playlist::factory()->for($user)->createQuietly();
@@ -179,7 +182,13 @@ class MergeChannelsTest extends TestCase
             'enabled' => true,
         ]);
 
-        // Existing failover relationship (old master had a failover)
+        // Existing failover relationships. The new preferred master is disabled
+        // because it is currently hidden as a native auto-merge failover.
+        ChannelFailover::create([
+            'user_id' => $user->id,
+            'channel_id' => $oldMaster->id,
+            'channel_failover_id' => $newMaster->id,
+        ]);
         ChannelFailover::create([
             'user_id' => $user->id,
             'channel_id' => $oldMaster->id,
@@ -201,6 +210,7 @@ class MergeChannelsTest extends TestCase
 
         $this->assertTrue($newMaster->enabled, 'Promoted master should be enabled');
         $this->assertFalse($oldMaster->enabled, 'Old master should be deactivated as a failover');
+        $this->assertFalse($failover->enabled, 'Remaining failover should be deactivated');
         // Ensure failover relationships exist for the new master
         $this->assertDatabaseHas('channel_failovers', [
             'channel_id' => $newMaster->id,
@@ -210,5 +220,47 @@ class MergeChannelsTest extends TestCase
             'channel_id' => $newMaster->id,
             'channel_failover_id' => $failover->id,
         ]);
+        $this->assertDatabaseMissing('channel_failovers', [
+            'channel_id' => $oldMaster->id,
+            'channel_failover_id' => $newMaster->id,
+        ]);
+    }
+
+    #[Test]
+    public function disabled_preferred_channel_that_is_not_an_existing_failover_is_not_promoted_or_merged()
+    {
+        $user = User::factory()->create();
+        $playlist1 = Playlist::factory()->for($user)->createQuietly();
+        $playlist2 = Playlist::factory()->for($user)->createQuietly();
+
+        $enabledMaster = Channel::factory()->create([
+            'stream_id' => 'streamY',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist1->id,
+            'group_id' => null,
+            'enabled' => true,
+        ]);
+
+        $disabledPreferred = Channel::factory()->create([
+            'stream_id' => 'streamY',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'group_id' => null,
+            'enabled' => false,
+        ]);
+
+        $playlists = collect([
+            ['playlist_failover_id' => $playlist1->id],
+            ['playlist_failover_id' => $playlist2->id],
+        ]);
+
+        // The preferred playlist contains the disabled channel, but it is not
+        // an existing hidden failover. Merge should not promote/re-enable it,
+        // and should not add it as a runtime failover candidate.
+        $this->runMergeChannels($user, $playlists, $playlist2->id, false, true);
+
+        $this->assertTrue($enabledMaster->refresh()->enabled);
+        $this->assertFalse($disabledPreferred->refresh()->enabled);
+        $this->assertDatabaseCount('channel_failovers', 0);
     }
 }

--- a/tests/Unit/MergeChannelsTest.php
+++ b/tests/Unit/MergeChannelsTest.php
@@ -265,7 +265,7 @@ class MergeChannelsTest extends TestCase
     }
 
     #[Test]
-    public function scrubber_dead_hidden_failover_is_not_promoted_and_is_pruned_from_master_failovers()
+    public function scrubber_dead_hidden_failover_is_not_promoted_but_mapping_is_preserved()
     {
         $user = User::factory()->create();
         $playlist1 = Playlist::factory()->for($user)->createQuietly();
@@ -302,14 +302,109 @@ class MergeChannelsTest extends TestCase
 
         // Playlist 2 would normally be preferred, and the disabled channel is
         // an existing hidden failover. The scrubber-dead state makes it
-        // unavailable, so it must not be promoted or retained as a failover.
+        // unavailable as master, but the native failover mapping is topology
+        // and should be preserved.
         $this->runMergeChannels($user, $playlists, $playlist2->id, false, true);
 
         $this->assertTrue($currentMaster->refresh()->enabled);
         $this->assertFalse($deadHiddenFailover->refresh()->enabled);
-        $this->assertDatabaseMissing('channel_failovers', [
+        $this->assertDatabaseHas('channel_failovers', [
             'channel_id' => $currentMaster->id,
             'channel_failover_id' => $deadHiddenFailover->id,
+        ]);
+    }
+
+    #[Test]
+    public function scrubber_dead_master_rotates_to_live_failover_and_restores_when_live_again()
+    {
+        $user = User::factory()->create();
+        $playlist1 = Playlist::factory()->for($user)->createQuietly();
+        $playlist2 = Playlist::factory()->for($user)->createQuietly();
+        $playlist3 = Playlist::factory()->for($user)->createQuietly();
+
+        $oldMaster = Channel::factory()->create([
+            'stream_id' => 'streamR',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist1->id,
+            'group_id' => null,
+            'sort' => 1.0,
+            'enabled' => false,
+            'last_scrubber_live' => false,
+        ]);
+
+        $liveFailover = Channel::factory()->create([
+            'stream_id' => 'streamR',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'group_id' => null,
+            'sort' => 2.0,
+            'enabled' => false,
+            'last_scrubber_live' => true,
+        ]);
+
+        $secondaryFailover = Channel::factory()->create([
+            'stream_id' => 'streamR',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist3->id,
+            'group_id' => null,
+            'sort' => 3.0,
+            'enabled' => false,
+            'last_scrubber_live' => true,
+        ]);
+
+        ChannelFailover::create([
+            'user_id' => $user->id,
+            'channel_id' => $oldMaster->id,
+            'channel_failover_id' => $liveFailover->id,
+            'sort' => 1,
+        ]);
+        ChannelFailover::create([
+            'user_id' => $user->id,
+            'channel_id' => $oldMaster->id,
+            'channel_failover_id' => $secondaryFailover->id,
+            'sort' => 2,
+        ]);
+
+        $playlists = collect([
+            ['playlist_failover_id' => $playlist1->id],
+            ['playlist_failover_id' => $playlist2->id],
+            ['playlist_failover_id' => $playlist3->id],
+        ]);
+
+        $this->runMergeChannels($user, $playlists, $playlist1->id, false, true);
+
+        $this->assertFalse($oldMaster->refresh()->enabled);
+        $this->assertTrue($liveFailover->refresh()->enabled);
+        $this->assertFalse($secondaryFailover->refresh()->enabled);
+        $this->assertDatabaseMissing('channel_failovers', [
+            'channel_id' => $oldMaster->id,
+            'channel_failover_id' => $liveFailover->id,
+        ]);
+        $this->assertDatabaseHas('channel_failovers', [
+            'channel_id' => $liveFailover->id,
+            'channel_failover_id' => $secondaryFailover->id,
+            'sort' => 1,
+        ]);
+        $this->assertDatabaseHas('channel_failovers', [
+            'channel_id' => $liveFailover->id,
+            'channel_failover_id' => $oldMaster->id,
+            'sort' => 2,
+        ]);
+
+        $oldMaster->update(['last_scrubber_live' => true]);
+
+        $this->runMergeChannels($user, $playlists, $playlist1->id, false, true);
+
+        $this->assertTrue($oldMaster->refresh()->enabled);
+        $this->assertFalse($liveFailover->refresh()->enabled);
+        $this->assertFalse($secondaryFailover->refresh()->enabled);
+        $this->assertDatabaseHas('channel_failovers', [
+            'channel_id' => $oldMaster->id,
+            'channel_failover_id' => $liveFailover->id,
+        ]);
+        $this->assertDatabaseHas('channel_failovers', [
+            'channel_id' => $oldMaster->id,
+            'channel_failover_id' => $secondaryFailover->id,
         ]);
     }
 }

--- a/tests/Unit/MergeChannelsTest.php
+++ b/tests/Unit/MergeChannelsTest.php
@@ -268,11 +268,12 @@ class MergeChannelsTest extends TestCase
     }
 
     #[Test]
-    public function scrubber_dead_channel_that_is_not_existing_topology_is_not_added_as_new_failover()
+    public function scrubber_dead_channel_that_is_not_existing_topology_is_added_after_healthier_failovers()
     {
         $user = User::factory()->create();
         $playlist1 = Playlist::factory()->for($user)->createQuietly();
         $playlist2 = Playlist::factory()->for($user)->createQuietly();
+        $playlist3 = Playlist::factory()->for($user)->createQuietly();
 
         $enabledMaster = Channel::factory()->create([
             'stream_id' => 'streamY-dead',
@@ -283,10 +284,19 @@ class MergeChannelsTest extends TestCase
             'last_scrubber_live' => true,
         ]);
 
-        $deadCandidate = Channel::factory()->create([
+        $healthyCandidate = Channel::factory()->create([
             'stream_id' => 'streamY-dead',
             'user_id' => $user->id,
             'playlist_id' => $playlist2->id,
+            'group_id' => null,
+            'enabled' => false,
+            'last_scrubber_live' => true,
+        ]);
+
+        $deadCandidate = Channel::factory()->create([
+            'stream_id' => 'streamY-dead',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist3->id,
             'group_id' => null,
             'enabled' => false,
             'last_scrubber_live' => false,
@@ -295,15 +305,23 @@ class MergeChannelsTest extends TestCase
         $playlists = collect([
             ['playlist_failover_id' => $playlist1->id],
             ['playlist_failover_id' => $playlist2->id],
+            ['playlist_failover_id' => $playlist3->id],
         ]);
 
-        $this->runMergeChannels($user, $playlists, $playlist2->id, false, true);
+        $this->runMergeChannels($user, $playlists, $playlist3->id, false, true);
 
         $this->assertTrue($enabledMaster->refresh()->enabled);
+        $this->assertFalse($healthyCandidate->refresh()->enabled);
         $this->assertFalse($deadCandidate->refresh()->enabled);
-        $this->assertDatabaseMissing('channel_failovers', [
+        $this->assertDatabaseHas('channel_failovers', [
+            'channel_id' => $enabledMaster->id,
+            'channel_failover_id' => $healthyCandidate->id,
+            'sort' => 1,
+        ]);
+        $this->assertDatabaseHas('channel_failovers', [
             'channel_id' => $enabledMaster->id,
             'channel_failover_id' => $deadCandidate->id,
+            'sort' => 2,
         ]);
     }
 

--- a/tests/Unit/MergeChannelsTest.php
+++ b/tests/Unit/MergeChannelsTest.php
@@ -227,7 +227,7 @@ class MergeChannelsTest extends TestCase
     }
 
     #[Test]
-    public function disabled_preferred_channel_that_is_not_an_existing_failover_is_not_promoted_or_merged()
+    public function disabled_preferred_channel_that_is_not_an_existing_failover_is_not_promoted_but_can_be_failover()
     {
         $user = User::factory()->create();
         $playlist1 = Playlist::factory()->for($user)->createQuietly();
@@ -255,13 +255,56 @@ class MergeChannelsTest extends TestCase
         ]);
 
         // The preferred playlist contains the disabled channel, but it is not
-        // an existing hidden failover. Merge should not promote/re-enable it,
-        // and should not add it as a runtime failover candidate.
+        // an existing hidden failover. Merge should not promote/re-enable it
+        // as master, but it can still be linked as a hidden failover.
         $this->runMergeChannels($user, $playlists, $playlist2->id, false, true);
 
         $this->assertTrue($enabledMaster->refresh()->enabled);
         $this->assertFalse($disabledPreferred->refresh()->enabled);
-        $this->assertDatabaseCount('channel_failovers', 0);
+        $this->assertDatabaseHas('channel_failovers', [
+            'channel_id' => $enabledMaster->id,
+            'channel_failover_id' => $disabledPreferred->id,
+        ]);
+    }
+
+    #[Test]
+    public function scrubber_dead_channel_that_is_not_existing_topology_is_not_added_as_new_failover()
+    {
+        $user = User::factory()->create();
+        $playlist1 = Playlist::factory()->for($user)->createQuietly();
+        $playlist2 = Playlist::factory()->for($user)->createQuietly();
+
+        $enabledMaster = Channel::factory()->create([
+            'stream_id' => 'streamY-dead',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist1->id,
+            'group_id' => null,
+            'enabled' => true,
+            'last_scrubber_live' => true,
+        ]);
+
+        $deadCandidate = Channel::factory()->create([
+            'stream_id' => 'streamY-dead',
+            'user_id' => $user->id,
+            'playlist_id' => $playlist2->id,
+            'group_id' => null,
+            'enabled' => false,
+            'last_scrubber_live' => false,
+        ]);
+
+        $playlists = collect([
+            ['playlist_failover_id' => $playlist1->id],
+            ['playlist_failover_id' => $playlist2->id],
+        ]);
+
+        $this->runMergeChannels($user, $playlists, $playlist2->id, false, true);
+
+        $this->assertTrue($enabledMaster->refresh()->enabled);
+        $this->assertFalse($deadCandidate->refresh()->enabled);
+        $this->assertDatabaseMissing('channel_failovers', [
+            'channel_id' => $enabledMaster->id,
+            'channel_failover_id' => $deadCandidate->id,
+        ]);
     }
 
     #[Test]

--- a/tests/Unit/MergeChannelsTest.php
+++ b/tests/Unit/MergeChannelsTest.php
@@ -257,7 +257,7 @@ class MergeChannelsTest extends TestCase
         // The preferred playlist contains the disabled channel, but it is not
         // an existing hidden failover. Merge should not promote/re-enable it
         // as master, but it can still be linked as a hidden failover.
-        $this->runMergeChannels($user, $playlists, $playlist2->id, false, true);
+        $this->runMergeChannels($user, $playlists, $playlist2->id, false, true, scrubberAwareMasterSelection: true);
 
         $this->assertTrue($enabledMaster->refresh()->enabled);
         $this->assertFalse($disabledPreferred->refresh()->enabled);
@@ -308,7 +308,7 @@ class MergeChannelsTest extends TestCase
             ['playlist_failover_id' => $playlist3->id],
         ]);
 
-        $this->runMergeChannels($user, $playlists, $playlist3->id, false, true);
+        $this->runMergeChannels($user, $playlists, $playlist3->id, false, true, scrubberAwareMasterSelection: true);
 
         $this->assertTrue($enabledMaster->refresh()->enabled);
         $this->assertFalse($healthyCandidate->refresh()->enabled);
@@ -365,7 +365,7 @@ class MergeChannelsTest extends TestCase
         // an existing hidden failover. The scrubber-dead state makes it
         // unavailable as master, but the native failover mapping is topology
         // and should be preserved.
-        $this->runMergeChannels($user, $playlists, $playlist2->id, false, true);
+        $this->runMergeChannels($user, $playlists, $playlist2->id, false, true, scrubberAwareMasterSelection: true);
 
         $this->assertTrue($currentMaster->refresh()->enabled);
         $this->assertFalse($deadHiddenFailover->refresh()->enabled);
@@ -432,7 +432,7 @@ class MergeChannelsTest extends TestCase
             ['playlist_failover_id' => $playlist3->id],
         ]);
 
-        $this->runMergeChannels($user, $playlists, $playlist1->id, false, true);
+        $this->runMergeChannels($user, $playlists, $playlist1->id, false, true, scrubberAwareMasterSelection: true);
 
         $this->assertFalse($oldMaster->refresh()->enabled);
         $this->assertTrue($liveFailover->refresh()->enabled);
@@ -454,7 +454,7 @@ class MergeChannelsTest extends TestCase
 
         $oldMaster->update(['last_scrubber_live' => true]);
 
-        $this->runMergeChannels($user, $playlists, $playlist1->id, false, true);
+        $this->runMergeChannels($user, $playlists, $playlist1->id, false, true, scrubberAwareMasterSelection: true);
 
         $this->assertTrue($oldMaster->refresh()->enabled);
         $this->assertFalse($liveFailover->refresh()->enabled);


### PR DESCRIPTION
## Simple explanation

This PR makes native auto-merge/failover rebuilding aware of channel availability reported by the channel scrubber.

The change is required because native failover channels are intentionally hidden with `enabled = false`. A scrubber scan should not accidentally re-enable those hidden failovers, and a failed master channel should not cause its failover mappings to disappear.

Supersedes #1205.

## Why this is required

Native failovers use database mappings to describe failover topology. The `enabled` flag controls whether a channel is shown as a normal playlist entry, but disabled failover children may still be valid runtime failovers.

This PR separates visibility, availability, and failover topology:

- Existing failover mappings are preserved, including hidden disabled failover channels.
- Scrubber-dead channels are not promoted to master while a live or unknown candidate exists.
- When a master is marked dead, auto-merge can promote the next viable failover and move the old master behind healthier candidates.
- When the old master comes back live, a full rebuild can promote it back according to configured priority rules.
- Disabled matched channels can still be linked as hidden failovers when they are not known scrubber-dead.
- Scrubber-dead matched channels can still be linked as failovers, but are ordered after live or unknown candidates.

## Changes

- Adds `channels.last_scrubbed_at`.
- Adds nullable `channels.last_scrubber_live`.
- Records scrubber availability state during channel scrubber runs.
- Adds `channel_scrubbers.protect_failover_channels`, defaulting to enabled.
- Prevents live scrubber scans from re-enabling hidden native failover channels when protection is enabled.
- Adds `channel_scrubbers.rebuild_failovers_after_scan`.
- Dispatches a full native auto-merge rebuild after successful scrubber scans when enabled.
- Prevents scrubber-dead channels from being selected as master.
- Preserves existing failover topology instead of pruning mappings only because a channel currently probes dead.
- Allows disabled matched channels to remain hidden while still being linked as failovers.
- Sorts known-dead failover candidates after live or unknown candidates.
- Keeps configured priority/weighted scoring within each availability bucket.
- Adds regression coverage for scrubber state, hidden failover protection, failover rotation, disabled matched failovers, and merge eligibility.

## Testing

Focused tests:

- `MergeChannelsTest`
- `ProcessChannelScrubberCompleteTest`

Result:

```text
13 warnings, 42 assertions, exit 0