### PR TITLE
fix: gate Plex DVR sync dispatch

### DIFF
--- a/app/Console/Commands/SyncPlexDvr.php
+++ b/app/Console/Commands/SyncPlexDvr.php
@@ -2,7 +2,7 @@
 
 namespace App\Console\Commands;
 
-use App\Jobs\SyncPlexDvrJob;
+use App\Models\MediaServerIntegration;
 use App\Services\PlexManagementService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
@@ -30,9 +30,9 @@ class SyncPlexDvr extends Command
     {
         $integrationId = $this->argument('integration');
 
-        $query = SyncPlexDvrJob::eligibleIntegrationsQuery($integrationId ? (int) $integrationId : null);
-
-        $integrations = $query->get();
+        $integrations = MediaServerIntegration::query()
+            ->eligibleForPlexDvr($integrationId ? (int) $integrationId : null)
+            ->get();
 
         if ($integrations->isEmpty()) {
             $this->info('No Plex integrations with active DVR found.');

--- a/app/Console/Commands/SyncPlexDvr.php
+++ b/app/Console/Commands/SyncPlexDvr.php
@@ -2,7 +2,7 @@
 
 namespace App\Console\Commands;
 
-use App\Models\MediaServerIntegration;
+use App\Jobs\SyncPlexDvrJob;
 use App\Services\PlexManagementService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
@@ -30,15 +30,7 @@ class SyncPlexDvr extends Command
     {
         $integrationId = $this->argument('integration');
 
-        $query = MediaServerIntegration::query()
-            ->where('enabled', true)
-            ->where('plex_management_enabled', true)
-            ->whereNotNull('plex_dvr_id')
-            ->whereNotNull('plex_dvr_tuners');
-
-        if ($integrationId) {
-            $query->where('id', $integrationId);
-        }
+        $query = SyncPlexDvrJob::eligibleIntegrationsQuery($integrationId ? (int) $integrationId : null);
 
         $integrations = $query->get();
 

--- a/app/Filament/Resources/Channels/ChannelResource.php
+++ b/app/Filament/Resources/Channels/ChannelResource.php
@@ -222,7 +222,7 @@ class ChannelResource extends Resource implements CopilotResource
                 ->toggleable()
                 ->sortable()
                 ->afterStateUpdated(function (): void {
-                    dispatch(new SyncPlexDvrJob(trigger: 'channel_toggle'));
+                    SyncPlexDvrJob::dispatchIfConfigured(trigger: 'channel_toggle');
                 }),
             ToggleColumn::make('can_merge')
                 ->label(__('Merge Enabled'))
@@ -574,7 +574,7 @@ class ChannelResource extends Resource implements CopilotResource
                         ->action(function (Collection $records, array $data): void {
                             $start = (int) $data['start'];
                             SortFacade::bulkRecountChannels($records, $start);
-                            dispatch(new SyncPlexDvrJob(trigger: 'channel_recount'));
+                            SyncPlexDvrJob::dispatchIfConfigured(trigger: 'channel_recount');
                         })
                         ->after(function ($livewire) {
                             Notification::make()
@@ -1241,7 +1241,7 @@ class ChannelResource extends Resource implements CopilotResource
                             ->title(__('Selected channels enabled'))
                             ->body(__('The selected channels have been enabled.'))
                             ->send();
-                        dispatch(new SyncPlexDvrJob(trigger: 'channel_bulk_enable'));
+                        SyncPlexDvrJob::dispatchIfConfigured(trigger: 'channel_bulk_enable');
                     })
                     ->color('success')
                     ->deselectRecordsAfterCompletion()
@@ -1262,7 +1262,7 @@ class ChannelResource extends Resource implements CopilotResource
                             ->title(__('Selected channels disabled'))
                             ->body(__('The selected channels have been disabled.'))
                             ->send();
-                        dispatch(new SyncPlexDvrJob(trigger: 'channel_bulk_disable'));
+                        SyncPlexDvrJob::dispatchIfConfigured(trigger: 'channel_bulk_disable');
                     })
                     ->color('danger')
                     ->deselectRecordsAfterCompletion()

--- a/app/Filament/Resources/CustomPlaylists/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylists/RelationManagers/ChannelsRelationManager.php
@@ -324,7 +324,7 @@ class ChannelsRelationManager extends RelationManager
                     ->action(function (Collection $records, array $data) use ($ownerRecord): void {
                         $start = (int) $data['start'];
                         SortFacade::bulkRecountCustomPlaylistChannels($ownerRecord, $records, $start);
-                        dispatch(new SyncPlexDvrJob(trigger: 'custom_playlist_recount'));
+                        SyncPlexDvrJob::dispatchIfConfigured(trigger: 'custom_playlist_recount');
                     })
                     ->after(function () {
                         Notification::make()

--- a/app/Filament/Resources/CustomPlaylists/RelationManagers/VodRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylists/RelationManagers/VodRelationManager.php
@@ -313,7 +313,7 @@ class VodRelationManager extends RelationManager
                     ->action(function (Collection $records, array $data) use ($ownerRecord): void {
                         $start = (int) $data['start'];
                         SortFacade::bulkRecountCustomPlaylistChannels($ownerRecord, $records, $start);
-                        dispatch(new SyncPlexDvrJob(trigger: 'custom_playlist_recount'));
+                        SyncPlexDvrJob::dispatchIfConfigured(trigger: 'custom_playlist_recount');
                     })
                     ->after(function () {
                         Notification::make()

--- a/app/Filament/Resources/Groups/GroupResource.php
+++ b/app/Filament/Resources/Groups/GroupResource.php
@@ -348,7 +348,7 @@ class GroupResource extends Resource implements CopilotResource
 
                             SortFacade::bulkRecountGroupChannels($record, $maxChannel + 1);
                         })->after(function () {
-                            dispatch(new SyncPlexDvrJob(trigger: 'group_enable'));
+                            SyncPlexDvrJob::dispatchIfConfigured(trigger: 'group_enable');
                             Notification::make()
                                 ->success()
                                 ->title(__('Group channels enabled'))
@@ -368,7 +368,7 @@ class GroupResource extends Resource implements CopilotResource
                                 'enabled' => false,
                             ]);
                         })->after(function () {
-                            dispatch(new SyncPlexDvrJob(trigger: 'group_disable'));
+                            SyncPlexDvrJob::dispatchIfConfigured(trigger: 'group_disable');
                             Notification::make()
                                 ->success()
                                 ->title(__('Group channels disabled'))
@@ -509,7 +509,7 @@ class GroupResource extends Resource implements CopilotResource
                                 SortFacade::bulkRecountGroupChannels($record, $maxChannel + 1);
                             }
                         })->after(function () {
-                            dispatch(new SyncPlexDvrJob(trigger: 'group_bulk_enable'));
+                            SyncPlexDvrJob::dispatchIfConfigured(trigger: 'group_bulk_enable');
                             Notification::make()
                                 ->success()
                                 ->title(__('Selected group channels enabled'))
@@ -531,7 +531,7 @@ class GroupResource extends Resource implements CopilotResource
                                 ]);
                             }
                         })->after(function () {
-                            dispatch(new SyncPlexDvrJob(trigger: 'group_bulk_disable'));
+                            SyncPlexDvrJob::dispatchIfConfigured(trigger: 'group_bulk_disable');
                             Notification::make()
                                 ->success()
                                 ->title(__('Selected group channels disabled'))
@@ -553,7 +553,7 @@ class GroupResource extends Resource implements CopilotResource
                                 ]);
                             }
                         })->after(function () {
-                            dispatch(new SyncPlexDvrJob(trigger: 'group_bulk_enable_groups'));
+                            SyncPlexDvrJob::dispatchIfConfigured(trigger: 'group_bulk_enable_groups');
                             Notification::make()
                                 ->success()
                                 ->title(__('Selected groups enabled'))
@@ -576,7 +576,7 @@ class GroupResource extends Resource implements CopilotResource
                                 ]);
                             }
                         })->after(function () {
-                            dispatch(new SyncPlexDvrJob(trigger: 'group_bulk_disable_groups'));
+                            SyncPlexDvrJob::dispatchIfConfigured(trigger: 'group_bulk_disable_groups');
                             Notification::make()
                                 ->success()
                                 ->title(__('Selected groups disabled'))

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -1432,7 +1432,7 @@ class VodResource extends Resource implements CopilotResource
                             Channel::whereIn('id', $chunk->pluck('id'))->update(['enabled' => true]);
                         }
                     })->after(function () {
-                        dispatch(new SyncPlexDvrJob(trigger: 'vod_bulk_enable'));
+                        SyncPlexDvrJob::dispatchIfConfigured(trigger: 'vod_bulk_enable');
                         Notification::make()
                             ->success()
                             ->title(__('Selected channels enabled'))
@@ -1453,7 +1453,7 @@ class VodResource extends Resource implements CopilotResource
                             Channel::whereIn('id', $chunk->pluck('id'))->update(['enabled' => false]);
                         }
                     })->after(function () {
-                        dispatch(new SyncPlexDvrJob(trigger: 'vod_bulk_disable'));
+                        SyncPlexDvrJob::dispatchIfConfigured(trigger: 'vod_bulk_disable');
                         Notification::make()
                             ->success()
                             ->title(__('Selected channels disabled'))

--- a/app/Jobs/SyncPlexDvrJob.php
+++ b/app/Jobs/SyncPlexDvrJob.php
@@ -6,6 +6,7 @@ use App\Models\MediaServerIntegration;
 use App\Services\PlexManagementService;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 
@@ -42,19 +43,36 @@ class SyncPlexDvrJob implements ShouldBeUnique, ShouldQueue
         return 120;
     }
 
-    public function handle(): void
+    public static function dispatchIfConfigured(?int $integrationId = null, string $trigger = 'unknown'): bool
+    {
+        if (! self::eligibleIntegrationsQuery($integrationId)->exists()) {
+            return false;
+        }
+
+        dispatch(new self(integrationId: $integrationId, trigger: $trigger));
+
+        return true;
+    }
+
+    public static function eligibleIntegrationsQuery(?int $integrationId = null): Builder
     {
         $query = MediaServerIntegration::query()
+            ->where('type', 'plex')
             ->where('enabled', true)
             ->where('plex_management_enabled', true)
             ->whereNotNull('plex_dvr_id')
             ->whereNotNull('plex_dvr_tuners');
 
-        if ($this->integrationId) {
-            $query->where('id', $this->integrationId);
+        if ($integrationId) {
+            $query->where('id', $integrationId);
         }
 
-        $integrations = $query->get();
+        return $query;
+    }
+
+    public function handle(): void
+    {
+        $integrations = self::eligibleIntegrationsQuery($this->integrationId)->get();
 
         if ($integrations->isEmpty()) {
             return;

--- a/app/Jobs/SyncPlexDvrJob.php
+++ b/app/Jobs/SyncPlexDvrJob.php
@@ -6,7 +6,6 @@ use App\Models\MediaServerIntegration;
 use App\Services\PlexManagementService;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 
@@ -45,7 +44,12 @@ class SyncPlexDvrJob implements ShouldBeUnique, ShouldQueue
 
     public static function dispatchIfConfigured(?int $integrationId = null, string $trigger = 'unknown'): bool
     {
-        if (! self::eligibleIntegrationsQuery($integrationId)->exists()) {
+        if (! MediaServerIntegration::query()->eligibleForPlexDvr($integrationId)->exists()) {
+            Log::debug('SyncPlexDvrJob: skipped dispatch, no eligible Plex DVR integration', [
+                'integration_id' => $integrationId,
+                'trigger' => $trigger,
+            ]);
+
             return false;
         }
 
@@ -54,25 +58,9 @@ class SyncPlexDvrJob implements ShouldBeUnique, ShouldQueue
         return true;
     }
 
-    public static function eligibleIntegrationsQuery(?int $integrationId = null): Builder
-    {
-        $query = MediaServerIntegration::query()
-            ->where('type', 'plex')
-            ->where('enabled', true)
-            ->where('plex_management_enabled', true)
-            ->whereNotNull('plex_dvr_id')
-            ->whereNotNull('plex_dvr_tuners');
-
-        if ($integrationId) {
-            $query->where('id', $integrationId);
-        }
-
-        return $query;
-    }
-
     public function handle(): void
     {
-        $integrations = self::eligibleIntegrationsQuery($this->integrationId)->get();
+        $integrations = MediaServerIntegration::query()->eligibleForPlexDvr($this->integrationId)->get();
 
         if ($integrations->isEmpty()) {
             return;

--- a/app/Listeners/SyncListener.php
+++ b/app/Listeners/SyncListener.php
@@ -62,7 +62,7 @@ class SyncListener
                 }
 
                 // Sync Plex DVR channel maps (lineup may have changed)
-                dispatch(new SyncPlexDvrJob(trigger: 'playlist_sync'));
+                SyncPlexDvrJob::dispatchIfConfigured(trigger: 'playlist_sync');
             }
 
             // Handle Playlist post-processes
@@ -94,7 +94,7 @@ class SyncListener
                 $this->postProcessEpg($event->model);
 
                 // Sync Plex DVR (EPG data changed, guide needs refresh)
-                dispatch(new SyncPlexDvrJob(trigger: 'epg_sync'));
+                SyncPlexDvrJob::dispatchIfConfigured(trigger: 'epg_sync');
             }
         }
     }

--- a/app/Models/MediaServerIntegration.php
+++ b/app/Models/MediaServerIntegration.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -239,6 +240,24 @@ class MediaServerIntegration extends Model
     public function scopeEnabled($query)
     {
         return $query->where('enabled', true);
+    }
+
+    /**
+     * Scope to integrations eligible for Plex DVR sync.
+     */
+    public function scopeEligibleForPlexDvr(Builder $query, ?int $integrationId = null)
+    {
+        $query->where('type', 'plex')
+            ->where('enabled', true)
+            ->where('plex_management_enabled', true)
+            ->whereNotNull('plex_dvr_id')
+            ->whereNotNull('plex_dvr_tuners');
+
+        if ($integrationId) {
+            $query->where('id', $integrationId);
+        }
+
+        return $query;
     }
 
     /**

--- a/app/Observers/ChannelObserver.php
+++ b/app/Observers/ChannelObserver.php
@@ -40,7 +40,7 @@ class ChannelObserver
     public function updated(Channel $channel): void
     {
         if ($channel->wasChanged('enabled')) {
-            dispatch(new SyncPlexDvrJob(trigger: 'channel_observer'));
+            SyncPlexDvrJob::dispatchIfConfigured(trigger: 'channel_observer');
         }
     }
 }

--- a/tests/Feature/ChannelObserverTest.php
+++ b/tests/Feature/ChannelObserverTest.php
@@ -3,7 +3,6 @@
 use App\Jobs\SyncPlexDvrJob;
 use App\Models\Channel;
 use App\Models\Group;
-use App\Models\MediaServerIntegration;
 use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Support\Facades\Bus;
@@ -21,21 +20,7 @@ beforeEach(function () {
         'playlist_id' => $this->playlist->id,
     ]);
 
-    MediaServerIntegration::withoutEvents(function () {
-        return MediaServerIntegration::create([
-            'name' => 'Managed Plex',
-            'type' => 'plex',
-            'host' => 'plex.example.com',
-            'port' => 32400,
-            'ssl' => false,
-            'api_key' => 'test-token',
-            'enabled' => true,
-            'user_id' => $this->user->id,
-            'plex_management_enabled' => true,
-            'plex_dvr_id' => 1,
-            'plex_dvr_tuners' => [['device_key' => 'dev1', 'playlist_uuid' => 'uuid1']],
-        ]);
-    });
+    createEligiblePlexDvrIntegration($this->user->id);
 });
 
 it('dispatches SyncPlexDvrJob when channel enabled status changes', function () {

--- a/tests/Feature/ChannelObserverTest.php
+++ b/tests/Feature/ChannelObserverTest.php
@@ -3,6 +3,7 @@
 use App\Jobs\SyncPlexDvrJob;
 use App\Models\Channel;
 use App\Models\Group;
+use App\Models\MediaServerIntegration;
 use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Support\Facades\Bus;
@@ -19,6 +20,22 @@ beforeEach(function () {
         'user_id' => $this->user->id,
         'playlist_id' => $this->playlist->id,
     ]);
+
+    MediaServerIntegration::withoutEvents(function () {
+        return MediaServerIntegration::create([
+            'name' => 'Managed Plex',
+            'type' => 'plex',
+            'host' => 'plex.example.com',
+            'port' => 32400,
+            'ssl' => false,
+            'api_key' => 'test-token',
+            'enabled' => true,
+            'user_id' => $this->user->id,
+            'plex_management_enabled' => true,
+            'plex_dvr_id' => 1,
+            'plex_dvr_tuners' => [['device_key' => 'dev1', 'playlist_uuid' => 'uuid1']],
+        ]);
+    });
 });
 
 it('dispatches SyncPlexDvrJob when channel enabled status changes', function () {

--- a/tests/Feature/SyncListenerTest.php
+++ b/tests/Feature/SyncListenerTest.php
@@ -29,6 +29,7 @@ use App\Listeners\SyncListener;
 use App\Models\ChannelScrubber;
 use App\Models\CustomPlaylist;
 use App\Models\Epg;
+use App\Models\MediaServerIntegration;
 use App\Models\Playlist;
 use App\Models\SyncRun;
 use App\Models\User;
@@ -50,6 +51,22 @@ beforeEach(function () {
         'sort_alpha_config' => null,
         'auto_merge_channels_enabled' => false,
     ]);
+
+    MediaServerIntegration::withoutEvents(function () {
+        return MediaServerIntegration::create([
+            'name' => 'Managed Plex',
+            'type' => 'plex',
+            'host' => 'plex.example.com',
+            'port' => 32400,
+            'ssl' => false,
+            'api_key' => 'test-token',
+            'enabled' => true,
+            'user_id' => $this->user->id,
+            'plex_management_enabled' => true,
+            'plex_dvr_id' => 1,
+            'plex_dvr_tuners' => [['device_key' => 'dev1', 'playlist_uuid' => 'uuid1']],
+        ]);
+    });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/tests/Feature/SyncListenerTest.php
+++ b/tests/Feature/SyncListenerTest.php
@@ -29,7 +29,6 @@ use App\Listeners\SyncListener;
 use App\Models\ChannelScrubber;
 use App\Models\CustomPlaylist;
 use App\Models\Epg;
-use App\Models\MediaServerIntegration;
 use App\Models\Playlist;
 use App\Models\SyncRun;
 use App\Models\User;
@@ -52,21 +51,7 @@ beforeEach(function () {
         'auto_merge_channels_enabled' => false,
     ]);
 
-    MediaServerIntegration::withoutEvents(function () {
-        return MediaServerIntegration::create([
-            'name' => 'Managed Plex',
-            'type' => 'plex',
-            'host' => 'plex.example.com',
-            'port' => 32400,
-            'ssl' => false,
-            'api_key' => 'test-token',
-            'enabled' => true,
-            'user_id' => $this->user->id,
-            'plex_management_enabled' => true,
-            'plex_dvr_id' => 1,
-            'plex_dvr_tuners' => [['device_key' => 'dev1', 'playlist_uuid' => 'uuid1']],
-        ]);
-    });
+    createEligiblePlexDvrIntegration($this->user->id);
 });
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/tests/Feature/SyncPlexDvrJobTest.php
+++ b/tests/Feature/SyncPlexDvrJobTest.php
@@ -4,7 +4,9 @@ use App\Jobs\SyncPlexDvrJob;
 use App\Models\MediaServerIntegration;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 uses(RefreshDatabase::class);
 
@@ -42,6 +44,57 @@ it('skips when no eligible integrations exist', function () {
     $job->handle();
 
     expect(true)->toBeTrue();
+});
+
+it('does not dispatch when no eligible Plex DVR integration exists', function () {
+    Bus::fake();
+
+    MediaServerIntegration::withoutEvents(function () {
+        return MediaServerIntegration::create([
+            'name' => 'Unmanaged Plex',
+            'type' => 'plex',
+            'host' => 'plex.example.com',
+            'port' => 32400,
+            'ssl' => false,
+            'api_key' => 'test-token',
+            'enabled' => true,
+            'user_id' => $this->user->id,
+            'plex_management_enabled' => false,
+            'plex_dvr_id' => 1,
+            'plex_dvr_tuners' => [['device_key' => 'dev1', 'playlist_uuid' => 'uuid1']],
+        ]);
+    });
+
+    expect(SyncPlexDvrJob::dispatchIfConfigured(trigger: 'test'))->toBeFalse();
+
+    Bus::assertNotDispatched(SyncPlexDvrJob::class);
+});
+
+it('dispatches when an eligible Plex DVR integration exists', function () {
+    Bus::fake();
+
+    MediaServerIntegration::withoutEvents(function () {
+        return MediaServerIntegration::create([
+            'name' => 'Managed Plex',
+            'type' => 'plex',
+            'host' => 'plex.example.com',
+            'port' => 32400,
+            'ssl' => false,
+            'api_key' => 'test-token',
+            'enabled' => true,
+            'user_id' => $this->user->id,
+            'plex_management_enabled' => true,
+            'plex_dvr_id' => 1,
+            'plex_dvr_tuners' => [['device_key' => 'dev1', 'playlist_uuid' => 'uuid1']],
+        ]);
+    });
+
+    expect(SyncPlexDvrJob::dispatchIfConfigured(trigger: 'test'))->toBeTrue();
+
+    Bus::assertDispatched(
+        SyncPlexDvrJob::class,
+        fn (SyncPlexDvrJob $job): bool => $job->trigger === 'test'
+    );
 });
 
 it('skips disabled integrations', function () {
@@ -92,6 +145,31 @@ it('skips integrations without plex management enabled', function () {
     $job->handle();
 
     expect(true)->toBeTrue();
+});
+
+it('skips non-plex integrations even when dvr fields are present', function () {
+    MediaServerIntegration::withoutEvents(function () {
+        return MediaServerIntegration::create([
+            'name' => 'Jellyfin with DVR fields',
+            'type' => 'jellyfin',
+            'host' => 'jellyfin.example.com',
+            'port' => 8096,
+            'ssl' => false,
+            'api_key' => 'test-token',
+            'enabled' => true,
+            'user_id' => $this->user->id,
+            'plex_management_enabled' => true,
+            'plex_dvr_id' => 1,
+            'plex_dvr_tuners' => [['device_key' => 'dev1', 'playlist_uuid' => 'uuid1']],
+        ]);
+    });
+
+    Log::spy();
+
+    $job = new SyncPlexDvrJob(trigger: 'test');
+    $job->handle();
+
+    Log::shouldNotHaveReceived('error');
 });
 
 it('skips integrations without dvr id', function () {

--- a/tests/Feature/SyncPlexDvrJobTest.php
+++ b/tests/Feature/SyncPlexDvrJobTest.php
@@ -73,21 +73,7 @@ it('does not dispatch when no eligible Plex DVR integration exists', function ()
 it('dispatches when an eligible Plex DVR integration exists', function () {
     Bus::fake();
 
-    MediaServerIntegration::withoutEvents(function () {
-        return MediaServerIntegration::create([
-            'name' => 'Managed Plex',
-            'type' => 'plex',
-            'host' => 'plex.example.com',
-            'port' => 32400,
-            'ssl' => false,
-            'api_key' => 'test-token',
-            'enabled' => true,
-            'user_id' => $this->user->id,
-            'plex_management_enabled' => true,
-            'plex_dvr_id' => 1,
-            'plex_dvr_tuners' => [['device_key' => 'dev1', 'playlist_uuid' => 'uuid1']],
-        ]);
-    });
+    createEligiblePlexDvrIntegration($this->user->id);
 
     expect(SyncPlexDvrJob::dispatchIfConfigured(trigger: 'test'))->toBeTrue();
 
@@ -95,6 +81,14 @@ it('dispatches when an eligible Plex DVR integration exists', function () {
         SyncPlexDvrJob::class,
         fn (SyncPlexDvrJob $job): bool => $job->trigger === 'test'
     );
+});
+
+it('does not dispatch when the specified integration id has no eligible integration', function () {
+    Bus::fake();
+
+    expect(SyncPlexDvrJob::dispatchIfConfigured(integrationId: 99999, trigger: 'test'))->toBeFalse();
+
+    Bus::assertNotDispatched(SyncPlexDvrJob::class);
 });
 
 it('skips disabled integrations', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\MediaServerIntegration;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -47,4 +48,23 @@ expect()->extend('toBeOne', function () {
 function something()
 {
     // ..
+}
+
+function createEligiblePlexDvrIntegration(int $userId): MediaServerIntegration
+{
+    return MediaServerIntegration::withoutEvents(function () use ($userId) {
+        return MediaServerIntegration::create([
+            'name' => 'Managed Plex',
+            'type' => 'plex',
+            'host' => 'plex.example.com',
+            'port' => 32400,
+            'ssl' => false,
+            'api_key' => 'test-token',
+            'enabled' => true,
+            'user_id' => $userId,
+            'plex_management_enabled' => true,
+            'plex_dvr_id' => 1,
+            'plex_dvr_tuners' => [['device_key' => 'dev1', 'playlist_uuid' => 'uuid1']],
+        ]);
+    });
 }


### PR DESCRIPTION
## Summary
- Prevent Plex DVR sync jobs from being queued unless an eligible Plex DVR integration exists.
- Centralize Plex DVR integration eligibility for the queued job and artisan command.
- Exclude non-Plex media server integrations from Plex DVR sync processing.
- Add regression coverage for gated dispatch behavior.

## Tests
- `docker compose -f docker-compose.dev.yml --profile test run --rm m3u-editor-dev-test tests/Feature/SyncPlexDvrJobTest.php tests/Feature/ChannelObserverTest.php tests/Feature/SyncListenerTest.php --compact`
- `docker compose -f docker-compose.dev.yml --profile test run --rm --entrypoint /bin/bash m3u-editor-dev-test -lc 'vendor/bin/pint --test app/Jobs/SyncPlexDvrJob.php app/Console/Commands/SyncPlexDvr.php app/Listeners/SyncListener.php app/Observers/ChannelObserver.php app/Filament/Resources/Channels/ChannelResource.php app/Filament/Resources/Groups/GroupResource.php app/Filament/Resources/Vods/VodResource.php app/Filament/Resources/CustomPlaylists/RelationManagers/ChannelsRelationManager.php app/Filament/Resources/CustomPlaylists/RelationManagers/VodRelationManager.php tests/Feature/SyncPlexDvrJobTest.php tests/Feature/ChannelObserverTest.php tests/Feature/SyncListenerTest.php'`
