### PR TITLE
feat: add dynamic plugin select options

### DIFF
--- a/app/Filament/Resources/Plugins/Pages/ManagePluginTable.php
+++ b/app/Filament/Resources/Plugins/Pages/ManagePluginTable.php
@@ -169,7 +169,7 @@ class ManagePluginTable extends Page implements HasTable
             ->label($label)
             ->placeholder($this->selectPlaceholder($column))
             ->selectablePlaceholder(! (bool) ($column['required'] ?? false))
-            ->options(fn (): array => $this->columnOptions($column))
+            ->options(fn (?PluginTableRecord $record = null): array => $this->columnOptions($column, $record))
             ->state(fn (PluginTableRecord $record): mixed => data_get($record->toArray(), $name))
             ->rules([(bool) ($column['required'] ?? false) ? 'required' : 'nullable']);
 
@@ -178,33 +178,19 @@ class ManagePluginTable extends Page implements HasTable
 
     private function columnState(PluginTableRecord $record, array $column): mixed
     {
-        if (! empty($column['lookup']) && is_array($column['lookup'])) {
-            $value = data_get($record->toArray(), (string) ($column['lookup']['source_column'] ?? $column['name']));
-
-            return app(PluginUiTableRegistry::class)->lookupLabel($this->getRecord(), $column['lookup'], $value);
-        }
-
-        $value = data_get($record->toArray(), (string) $column['name']);
-
-        if (is_scalar($value) && is_array($column['options'] ?? null)) {
-            return $column['options'][(string) $value] ?? $value;
-        }
-
-        return is_array($value) ? json_encode($value, JSON_UNESCAPED_SLASHES) : $value;
+        return app(PluginUiTableRegistry::class)->columnDisplayState($this->pluginRecord(), $record, $column);
     }
 
     /**
      * @return array<string, string>
      */
-    private function columnOptions(array $column): array
+    private function columnOptions(array $column, ?PluginTableRecord $record = null): array
     {
-        if (is_array($column['options'] ?? null)) {
-            return $column['options'];
-        }
-
-        return is_array($column['lookup'] ?? null)
-            ? app(PluginUiTableRegistry::class)->lookupOptions($this->getRecord(), $column['lookup'])
-            : [];
+        return app(PluginUiTableRegistry::class)->columnOptions(
+            $this->pluginRecord(),
+            $column,
+            $record?->toArray() ?? [],
+        );
     }
 
     private function selectPlaceholder(array $column): string
@@ -298,5 +284,13 @@ class ManagePluginTable extends Page implements HasTable
     private function modelLabel(): string
     {
         return (string) ($this->tableDefinition['model_label'] ?? Str::singular($this->getTitle()));
+    }
+
+    private function pluginRecord(): Plugin
+    {
+        /** @var Plugin $plugin */
+        $plugin = $this->getRecord();
+
+        return $plugin;
     }
 }

--- a/app/Livewire/PluginTableInline.php
+++ b/app/Livewire/PluginTableInline.php
@@ -151,38 +151,24 @@ class PluginTableInline extends Component implements HasActions, HasForms, HasTa
             ->label($label)
             ->placeholder($this->selectPlaceholder($column))
             ->selectablePlaceholder(! (bool) ($column['required'] ?? false))
-            ->options(fn (): array => $this->columnOptions($column))
+            ->options(fn (?PluginTableRecord $record = null): array => $this->columnOptions($column, $record))
             ->state(fn (PluginTableRecord $record): mixed => data_get($record->toArray(), $name))
             ->rules([(bool) ($column['required'] ?? false) ? 'required' : 'nullable']);
     }
 
     private function columnState(PluginTableRecord $record, array $column): mixed
     {
-        if (! empty($column['lookup']) && is_array($column['lookup'])) {
-            $value = data_get($record->toArray(), (string) ($column['lookup']['source_column'] ?? $column['name']));
-
-            return app(PluginUiTableRegistry::class)->lookupLabel($this->record, $column['lookup'], $value);
-        }
-
-        $value = data_get($record->toArray(), (string) $column['name']);
-
-        if (is_scalar($value) && is_array($column['options'] ?? null)) {
-            return $column['options'][(string) $value] ?? $value;
-        }
-
-        return is_array($value) ? json_encode($value, JSON_UNESCAPED_SLASHES) : $value;
+        return app(PluginUiTableRegistry::class)->columnDisplayState($this->pluginRecord(), $record, $column);
     }
 
     /** @return array<string, string> */
-    private function columnOptions(array $column): array
+    private function columnOptions(array $column, ?PluginTableRecord $record = null): array
     {
-        if (is_array($column['options'] ?? null)) {
-            return $column['options'];
-        }
-
-        return is_array($column['lookup'] ?? null)
-            ? app(PluginUiTableRegistry::class)->lookupOptions($this->record, $column['lookup'])
-            : [];
+        return app(PluginUiTableRegistry::class)->columnOptions(
+            $this->pluginRecord(),
+            $column,
+            $record?->toArray() ?? [],
+        );
     }
 
     private function selectPlaceholder(array $column): string
@@ -280,5 +266,13 @@ class PluginTableInline extends Component implements HasActions, HasForms, HasTa
     private function modelLabel(): string
     {
         return (string) ($this->tableDefinition['model_label'] ?? Str::singular($this->tableDefinition['label'] ?? Str::headline($this->tableId)));
+    }
+
+    private function pluginRecord(): Plugin
+    {
+        /** @var Plugin $plugin */
+        $plugin = $this->record;
+
+        return $plugin;
     }
 }

--- a/app/Plugins/Contracts/PluginSelectOptionsProviderInterface.php
+++ b/app/Plugins/Contracts/PluginSelectOptionsProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Plugins\Contracts;
+
+use App\Plugins\Support\PluginSelectOptionsContext;
+
+interface PluginSelectOptionsProviderInterface
+{
+    /**
+     * @return array<string, string>
+     */
+    public function selectOptions(string $provider, PluginSelectOptionsContext $context): array;
+}

--- a/app/Plugins/PluginManager.php
+++ b/app/Plugins/PluginManager.php
@@ -10,9 +10,11 @@ use App\Models\User;
 use App\Plugins\Contracts\HookablePluginInterface;
 use App\Plugins\Contracts\LifecyclePluginInterface;
 use App\Plugins\Contracts\PluginInterface;
+use App\Plugins\Contracts\PluginSelectOptionsProviderInterface;
 use App\Plugins\Contracts\ScheduledPluginInterface;
 use App\Plugins\Support\PluginActionResult;
 use App\Plugins\Support\PluginExecutionContext;
+use App\Plugins\Support\PluginSelectOptionsContext;
 use App\Plugins\Support\PluginUninstallContext;
 use App\Plugins\Support\PluginValidationResult;
 use Carbon\CarbonInterface;
@@ -765,12 +767,46 @@ class PluginManager
             ->values();
     }
 
+    /**
+     * @param  array<string, mixed>  $state
+     * @param  array<string, mixed>  $field
+     * @return array<string, string>
+     */
+    public function selectOptions(Plugin $plugin, string $provider, array $state = [], array $field = []): array
+    {
+        $plugin = $this->validate($plugin);
+        $this->assertPluginLoadable($plugin, requireEnabled: false);
+        $this->assertPluginTrustedForUi($plugin);
+
+        $instance = $this->resolvePluginInstance($plugin);
+
+        if (! $instance instanceof PluginSelectOptionsProviderInterface) {
+            throw new RuntimeException("Plugin [{$plugin->plugin_id}] does not provide dynamic select options.");
+        }
+
+        return $this->normalizeSelectOptions($instance->selectOptions(
+            $provider,
+            new PluginSelectOptionsContext(
+                plugin: $plugin->fresh() ?? $plugin,
+                user: auth()->user(),
+                settings: $this->resolvedSettings($plugin),
+                state: $state,
+                field: $field,
+            ),
+        ));
+    }
+
     public function instantiate(Plugin $plugin): PluginInterface
     {
         $plugin = $this->validate($plugin);
         $this->assertPluginLoadable($plugin, requireEnabled: false);
         $this->assertPluginRunnable($plugin);
 
+        return $this->resolvePluginInstance($plugin);
+    }
+
+    private function resolvePluginInstance(Plugin $plugin): PluginInterface
+    {
         $entrypoint = rtrim((string) $plugin->path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$plugin->entrypoint;
         if (! class_exists($plugin->class_name, false)) {
             require_once $entrypoint;
@@ -782,6 +818,25 @@ class PluginManager
         }
 
         return $instance;
+    }
+
+    /**
+     * @param  array<mixed>  $options
+     * @return array<string, string>
+     */
+    private function normalizeSelectOptions(array $options): array
+    {
+        $normalized = [];
+
+        foreach ($options as $value => $label) {
+            if (! is_scalar($value) || ! is_scalar($label)) {
+                continue;
+            }
+
+            $normalized[(string) $value] = (string) $label;
+        }
+
+        return $normalized;
     }
 
     public function trust(Plugin $plugin, ?int $userId = null, ?string $reason = null): Plugin
@@ -1170,7 +1225,7 @@ class PluginManager
                 }
             }
 
-            if ($plugin->isInstalled() || ($plugin->last_cleanup_mode ?? null) !== 'purge') {
+            if ($plugin->isInstalled() || ($plugin->last_cleanup_mode ?? null) === 'preserve') {
                 foreach ($this->schemaManager->diagnostics($plugin->plugin_id, $plugin->schema_definition ?? []) as $diagnostic) {
                     $issues[] = [
                         'plugin_id' => $plugin->plugin_id,
@@ -2062,6 +2117,11 @@ class PluginManager
             throw new RuntimeException("Plugin [{$plugin->plugin_id}] is disabled.");
         }
 
+        $this->assertPluginTrustedForUi($plugin);
+    }
+
+    private function assertPluginTrustedForUi(Plugin $plugin): void
+    {
         if ($plugin->isBlocked()) {
             throw new RuntimeException("Plugin [{$plugin->plugin_id}] has been blocked by an administrator.");
         }

--- a/app/Plugins/PluginSchemaMapper.php
+++ b/app/Plugins/PluginSchemaMapper.php
@@ -11,12 +11,14 @@ use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Exists;
+use Illuminate\Validation\Rules\In;
 use InvalidArgumentException;
 use Throwable;
 
@@ -349,7 +351,7 @@ class PluginSchemaMapper
     }
 
     /**
-     * @return array<int, string|\Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Validation\Rules\In>
+     * @return array<int, string|ValidationRule|In>
      */
     private function selectValueRules(array $field): array
     {

--- a/app/Plugins/PluginSchemaMapper.php
+++ b/app/Plugins/PluginSchemaMapper.php
@@ -14,6 +14,7 @@ use Filament\Schemas\Components\Utilities\Set;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
@@ -390,7 +391,13 @@ class PluginSchemaMapper
                 $this->optionProviderState($field, $prefix, $get),
                 $field,
             );
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            Log::warning('Plugin dynamic select options failed.', [
+                'plugin_id' => $plugin->plugin_id,
+                'provider' => $provider,
+                'error' => $e->getMessage(),
+            ]);
+
             return [];
         }
     }

--- a/app/Plugins/PluginSchemaMapper.php
+++ b/app/Plugins/PluginSchemaMapper.php
@@ -9,6 +9,8 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Schema;
@@ -16,6 +18,7 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Exists;
 use InvalidArgumentException;
+use Throwable;
 
 class PluginSchemaMapper
 {
@@ -81,21 +84,23 @@ class PluginSchemaMapper
         return $defaults;
     }
 
-    private function componentsForFields(array $fields, string $prefix = '', array $existing = [], ?Plugin $plugin = null): array
+    private function componentsForFields(array $fields, string $prefix = '', array $existing = [], ?Plugin $plugin = null, ?array $dependencyResetTargets = null): array
     {
+        $dependencyResetTargets ??= $this->dependencyResetTargets($fields, $prefix);
+
         return collect($fields)
             ->filter(fn (array $field): bool => ($field['type'] ?? null) === 'section' || filled($field['id'] ?? null))
-            ->map(fn (array $field) => $this->componentForField($field, $prefix, $existing, $plugin))
+            ->map(fn (array $field) => $this->componentForField($field, $prefix, $existing, $plugin, $dependencyResetTargets))
             ->values()
             ->all();
     }
 
-    private function componentForField(array $field, string $prefix = '', array $existing = [], ?Plugin $plugin = null)
+    private function componentForField(array $field, string $prefix = '', array $existing = [], ?Plugin $plugin = null, array $dependencyResetTargets = [])
     {
         $type = $field['type'] ?? 'text';
 
         if ($type === 'section') {
-            return $this->sectionComponent($field, $prefix, $existing, $plugin);
+            return $this->sectionComponent($field, $prefix, $existing, $plugin, $dependencyResetTargets);
         }
 
         $label = $field['label'] ?? Str::headline((string) ($field['id'] ?? 'value'));
@@ -111,7 +116,7 @@ class PluginSchemaMapper
             'number' => TextInput::make($name)->numeric(),
             'textarea' => Textarea::make($name)->rows(4),
             'tags' => TagsInput::make($name)->splitKeys(['Tab', 'Return']),
-            'select' => $this->staticSelectComponent($name, $field),
+            'select' => $this->selectComponent($name, $field, $plugin, $prefix),
             'model_select' => $this->modelSelectComponent($name, $field),
             'table_select' => $this->tableSelectComponent($name, $field, $plugin),
             'text' => TextInput::make($name),
@@ -120,6 +125,15 @@ class PluginSchemaMapper
 
         if ($type === 'text' && (bool) ($field['secret'] ?? false)) {
             $component->password()->revealable();
+        }
+
+        if (($targets = $dependencyResetTargets[$name] ?? []) !== []) {
+            $component->live();
+            $component->afterStateUpdated(function (Set $set) use ($targets): void {
+                foreach ($targets as $target) {
+                    $set($target, null);
+                }
+            });
         }
 
         return $component
@@ -135,7 +149,7 @@ class PluginSchemaMapper
      * `fields` array is processed recursively through componentsForFields(), so any depth
      * of nesting works for both rendering and defaults/rules flattening.
      */
-    private function sectionComponent(array $field, string $prefix = '', array $existing = [], ?Plugin $plugin = null): Section
+    private function sectionComponent(array $field, string $prefix = '', array $existing = [], ?Plugin $plugin = null, array $dependencyResetTargets = []): Section
     {
         $label = $field['label'] ?? Str::headline((string) ($field['id'] ?? 'Section'));
         $description = $field['description'] ?? $field['helper_text'] ?? null;
@@ -143,7 +157,7 @@ class PluginSchemaMapper
 
         $section = Section::make($label)
             ->compact((bool) ($field['compact'] ?? true)) // Sections default to compact mode since they are often used for logical grouping within a form, but allow this to be overridden for more visual separation when needed.
-            ->schema($this->componentsForFields($field['fields'] ?? [], $prefix, $existing, $plugin))
+            ->schema($this->componentsForFields($field['fields'] ?? [], $prefix, $existing, $plugin, $dependencyResetTargets))
             ->columnSpanFull();
 
         if (filled($description)) {
@@ -166,13 +180,21 @@ class PluginSchemaMapper
         return $section;
     }
 
-    private function staticSelectComponent(string $name, array $field): Select
+    private function selectComponent(string $name, array $field, ?Plugin $plugin, string $prefix): Select
     {
+        $optionsProvider = trim((string) ($field['options_provider'] ?? ''));
+
         $select = Select::make($name)
-            ->options($field['options'] ?? [])
+            ->options($optionsProvider !== ''
+                ? fn (Get $get): array => $this->dynamicSelectOptions($plugin, $optionsProvider, $field, $prefix, $get)
+                : $this->staticSelectOptions($field))
             ->searchable()
             ->placeholder($this->selectPlaceholder($field))
             ->selectablePlaceholder(! (bool) ($field['required'] ?? false));
+
+        if ($optionsProvider !== '') {
+            $select->live();
+        }
 
         if ((bool) ($field['multiple'] ?? false)) {
             $select->multiple();
@@ -292,7 +314,7 @@ class PluginSchemaMapper
                 if ($required) {
                     $rules[$name][] = 'min:1';
                 }
-                $rules[$name.'.*'] = ['string', Rule::in(array_keys($field['options'] ?? []))];
+                $rules[$name.'.*'] = $this->selectValueRules($field);
 
                 continue;
             }
@@ -312,7 +334,7 @@ class PluginSchemaMapper
                     'boolean' => ['boolean'],
                     'number' => ['numeric'],
                     'textarea', 'text' => ['string'],
-                    'select' => ['string', Rule::in(array_keys($field['options'] ?? []))],
+                    'select' => $this->selectValueRules($field),
                     'model_select' => ['integer', $this->modelSelectExistsRule($field)],
                     'table_select' => $plugin ? ['integer', $this->tableSelectExistsRule($field, $plugin)] : ['integer'],
                     'tags' => ['string'],
@@ -324,6 +346,128 @@ class PluginSchemaMapper
         }
 
         return $rules;
+    }
+
+    /**
+     * @return array<int, string|\Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Validation\Rules\In>
+     */
+    private function selectValueRules(array $field): array
+    {
+        $rules = ['string'];
+
+        if (blank($field['options_provider'] ?? null)) {
+            $rules[] = Rule::in(array_keys($this->staticSelectOptions($field)));
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function staticSelectOptions(array $field): array
+    {
+        return collect($field['options'] ?? [])
+            ->mapWithKeys(fn (mixed $label, mixed $value): array => [(string) $value => (string) $label])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function dynamicSelectOptions(?Plugin $plugin, string $provider, array $field, string $prefix, Get $get): array
+    {
+        if (! $plugin) {
+            return [];
+        }
+
+        try {
+            return app(PluginManager::class)->selectOptions(
+                $plugin,
+                $provider,
+                $this->optionProviderState($field, $prefix, $get),
+                $field,
+            );
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function optionProviderState(array $field, string $prefix, Get $get): array
+    {
+        $state = [];
+
+        foreach ($this->dependsOn($field, $prefix) as $dependency) {
+            $value = $get($dependency);
+
+            $state[$dependency] = $value;
+            Arr::set($state, $dependency, $value);
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    private function dependencyResetTargets(array $fields, string $prefix): array
+    {
+        $targets = [];
+
+        $this->collectDependencyResetTargets($fields, $prefix, $targets);
+
+        return collect($targets)
+            ->map(fn (array $values): array => array_values(array_unique($values)))
+            ->all();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $fields
+     * @param  array<string, array<int, string>>  $targets
+     */
+    private function collectDependencyResetTargets(array $fields, string $prefix, array &$targets): void
+    {
+        foreach ($fields as $field) {
+            if (($field['type'] ?? null) === 'section') {
+                $this->collectDependencyResetTargets($field['fields'] ?? [], $prefix, $targets);
+
+                continue;
+            }
+
+            $fieldId = $field['id'] ?? null;
+            if (! $fieldId || blank($field['options_provider'] ?? null)) {
+                continue;
+            }
+
+            $fieldName = $prefix.$fieldId;
+            foreach ($this->dependsOn($field, $prefix) as $dependency) {
+                $targets[$dependency][] = $fieldName;
+            }
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function dependsOn(array $field, string $prefix): array
+    {
+        return collect(Arr::wrap($field['depends_on'] ?? []))
+            ->filter(fn (mixed $dependency): bool => is_string($dependency) && trim($dependency) !== '')
+            ->map(fn (string $dependency): string => $this->qualifiedDependencyName(trim($dependency), $prefix))
+            ->values()
+            ->all();
+    }
+
+    private function qualifiedDependencyName(string $dependency, string $prefix): string
+    {
+        if ($prefix !== '' && ! str_contains($dependency, '.') && ! str_starts_with($dependency, $prefix)) {
+            return $prefix.$dependency;
+        }
+
+        return $dependency;
     }
 
     private function modelSelectExistsRule(array $field): Exists

--- a/app/Plugins/PluginUiTableRegistry.php
+++ b/app/Plugins/PluginUiTableRegistry.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Throwable;
 
 class PluginUiTableRegistry
 {
@@ -85,6 +86,48 @@ class PluginUiTableRegistry
             ->pluck($labelColumn, $keyColumn)
             ->mapWithKeys(fn (mixed $label, mixed $value): array => [(string) $value => (string) $label])
             ->all();
+    }
+
+    public function columnDisplayState(Plugin $plugin, PluginTableRecord $record, array $column): mixed
+    {
+        if (! empty($column['lookup']) && is_array($column['lookup'])) {
+            $value = data_get($record->toArray(), (string) ($column['lookup']['source_column'] ?? $column['name']));
+
+            return $this->lookupLabel($plugin, $column['lookup'], $value);
+        }
+
+        $value = data_get($record->toArray(), (string) $column['name']);
+
+        if (is_scalar($value)) {
+            $options = $this->columnOptions($plugin, $column, $record->toArray());
+
+            if ($options !== []) {
+                return $options[(string) $value] ?? $value;
+            }
+        }
+
+        return is_array($value) ? json_encode($value, JSON_UNESCAPED_SLASHES) : $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $recordState
+     * @return array<string, string>
+     */
+    public function columnOptions(Plugin $plugin, array $column, array $recordState = []): array
+    {
+        $optionsProvider = trim((string) ($column['options_provider'] ?? ''));
+
+        if ($optionsProvider !== '') {
+            return $this->dynamicColumnOptions($plugin, $optionsProvider, $column, $recordState);
+        }
+
+        if (is_array($column['options'] ?? null)) {
+            return $this->staticOptions($column['options']);
+        }
+
+        return is_array($column['lookup'] ?? null)
+            ? $this->lookupOptions($plugin, $column['lookup'])
+            : [];
     }
 
     public function prefillRows(Plugin $plugin, array $definition): void
@@ -182,6 +225,68 @@ class PluginUiTableRegistry
                 (bool) ($lookup['enabled_only'] ?? false) && Schema::hasColumn($tableName, 'enabled'),
                 fn (QueryBuilder $query) => $query->where('enabled', true),
             );
+    }
+
+    /**
+     * @param  array<mixed>  $options
+     * @return array<string, string>
+     */
+    private function staticOptions(array $options): array
+    {
+        return collect($options)
+            ->mapWithKeys(fn (mixed $label, mixed $value): array => [(string) $value => (string) $label])
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $column
+     * @param  array<string, mixed>  $recordState
+     * @return array<string, string>
+     */
+    private function dynamicColumnOptions(Plugin $plugin, string $provider, array $column, array $recordState): array
+    {
+        try {
+            return app(PluginManager::class)->selectOptions(
+                $plugin,
+                $provider,
+                $this->columnOptionProviderState($column, $recordState),
+                $column,
+            );
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $column
+     * @param  array<string, mixed>  $recordState
+     * @return array<string, mixed>
+     */
+    private function columnOptionProviderState(array $column, array $recordState): array
+    {
+        $state = [];
+
+        foreach ($this->dependsOn($column) as $dependency) {
+            $value = data_get($recordState, $dependency);
+
+            $state[$dependency] = $value;
+            Arr::set($state, $dependency, $value);
+        }
+
+        return $state;
+    }
+
+    /**
+     * @param  array<string, mixed>  $column
+     * @return array<int, string>
+     */
+    private function dependsOn(array $column): array
+    {
+        return collect(Arr::wrap($column['depends_on'] ?? []))
+            ->filter(fn (mixed $dependency): bool => is_string($dependency) && trim($dependency) !== '')
+            ->map(fn (string $dependency): string => trim($dependency))
+            ->values()
+            ->all();
     }
 
     private function columnsFor(Plugin $plugin, string $tableName): Collection

--- a/app/Plugins/PluginUiTableRegistry.php
+++ b/app/Plugins/PluginUiTableRegistry.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Throwable;
 
@@ -252,7 +253,13 @@ class PluginUiTableRegistry
                 $this->columnOptionProviderState($column, $recordState),
                 $column,
             );
-        } catch (Throwable) {
+        } catch (Throwable $e) {
+            Log::warning('Plugin dynamic column options failed.', [
+                'plugin_id' => $plugin->plugin_id,
+                'provider' => $provider,
+                'error' => $e->getMessage(),
+            ]);
+
             return [];
         }
     }

--- a/app/Plugins/PluginValidator.php
+++ b/app/Plugins/PluginValidator.php
@@ -589,8 +589,27 @@ class PluginValidator
             $errors[] = "{$group}.{$fieldId} should define a human-friendly [label]";
         }
 
-        if ($type === 'select' && empty($field['options'])) {
-            $errors[] = "{$group}.{$fieldId} select fields require [options]";
+        if ($type === 'select' && empty($field['options']) && blank($field['options_provider'] ?? null)) {
+            $errors[] = "{$group}.{$fieldId} select fields require [options] or [options_provider]";
+        }
+
+        if (array_key_exists('options_provider', $field)
+            && (! is_string($field['options_provider']) || blank($field['options_provider']))) {
+            $errors[] = "{$group}.{$fieldId} options_provider must be a non-empty string";
+        }
+
+        if (array_key_exists('depends_on', $field)) {
+            if (! is_array($field['depends_on'])) {
+                $errors[] = "{$group}.{$fieldId} depends_on must be a list of field names";
+            } else {
+                foreach ($field['depends_on'] as $dependency) {
+                    if (! is_string($dependency) || blank($dependency)) {
+                        $errors[] = "{$group}.{$fieldId} depends_on must contain only non-empty strings";
+
+                        break;
+                    }
+                }
+            }
         }
 
         if ($type === 'model_select' && blank($field['model'] ?? null)) {

--- a/app/Plugins/PluginValidator.php
+++ b/app/Plugins/PluginValidator.php
@@ -593,24 +593,10 @@ class PluginValidator
             $errors[] = "{$group}.{$fieldId} select fields require [options] or [options_provider]";
         }
 
-        if (array_key_exists('options_provider', $field)
-            && (! is_string($field['options_provider']) || blank($field['options_provider']))) {
-            $errors[] = "{$group}.{$fieldId} options_provider must be a non-empty string";
-        }
-
-        if (array_key_exists('depends_on', $field)) {
-            if (! is_array($field['depends_on'])) {
-                $errors[] = "{$group}.{$fieldId} depends_on must be a list of field names";
-            } else {
-                foreach ($field['depends_on'] as $dependency) {
-                    if (! is_string($dependency) || blank($dependency)) {
-                        $errors[] = "{$group}.{$fieldId} depends_on must contain only non-empty strings";
-
-                        break;
-                    }
-                }
-            }
-        }
+        $errors = [
+            ...$errors,
+            ...$this->validateOptionsProviderDefinition($field, "{$group}.{$fieldId}"),
+        ];
 
         if ($type === 'model_select' && blank($field['model'] ?? null)) {
             $errors[] = "{$group}.{$fieldId} model_select fields require [model]";
@@ -792,6 +778,11 @@ class PluginValidator
                 foreach ($uiTable['columns'] ?? [] as $columnIndex => $column) {
                     if (! is_array($column) || blank($column['name'] ?? null)) {
                         $errors[] = "{$path}.columns.{$columnIndex} requires [name].";
+                    } elseif (is_array($column)) {
+                        $errors = [
+                            ...$errors,
+                            ...$this->validateOptionsProviderDefinition($column, "{$path}.columns.{$columnIndex}"),
+                        ];
                     }
                 }
             }
@@ -811,6 +802,40 @@ class PluginValidator
                         ...$this->validateFieldDefinition($field, $fieldTypes, "{$path}.fields"),
                     ];
                 }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param  array<string, mixed>  $definition
+     * @return array<int, string>
+     */
+    private function validateOptionsProviderDefinition(array $definition, string $path): array
+    {
+        $errors = [];
+
+        if (array_key_exists('options_provider', $definition)
+            && (! is_string($definition['options_provider']) || blank($definition['options_provider']))) {
+            $errors[] = "{$path} options_provider must be a non-empty string";
+        }
+
+        if (! array_key_exists('depends_on', $definition)) {
+            return $errors;
+        }
+
+        if (! is_array($definition['depends_on'])) {
+            $errors[] = "{$path} depends_on must be a list of field names";
+
+            return $errors;
+        }
+
+        foreach ($definition['depends_on'] as $dependency) {
+            if (! is_string($dependency) || blank($dependency)) {
+                $errors[] = "{$path} depends_on must contain only non-empty strings";
+
+                break;
             }
         }
 

--- a/app/Plugins/PluginValidator.php
+++ b/app/Plugins/PluginValidator.php
@@ -778,7 +778,7 @@ class PluginValidator
                 foreach ($uiTable['columns'] ?? [] as $columnIndex => $column) {
                     if (! is_array($column) || blank($column['name'] ?? null)) {
                         $errors[] = "{$path}.columns.{$columnIndex} requires [name].";
-                    } elseif (is_array($column)) {
+                    } else {
                         $errors = [
                             ...$errors,
                             ...$this->validateOptionsProviderDefinition($column, "{$path}.columns.{$columnIndex}"),
@@ -823,6 +823,10 @@ class PluginValidator
 
         if (! array_key_exists('depends_on', $definition)) {
             return $errors;
+        }
+
+        if (array_key_exists('depends_on', $definition) && blank($definition['options_provider'] ?? null)) {
+            $errors[] = "{$path} depends_on has no effect without options_provider";
         }
 
         if (! is_array($definition['depends_on'])) {

--- a/app/Plugins/Support/PluginSelectOptionsContext.php
+++ b/app/Plugins/Support/PluginSelectOptionsContext.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Plugins\Support;
+
+use App\Models\Plugin;
+use App\Models\User;
+use Illuminate\Support\Arr;
+
+class PluginSelectOptionsContext
+{
+    /**
+     * @param  array<string, mixed>  $settings
+     * @param  array<string, mixed>  $state
+     * @param  array<string, mixed>  $field
+     */
+    public function __construct(
+        public readonly Plugin $plugin,
+        public readonly ?User $user,
+        public readonly array $settings,
+        public readonly array $state,
+        public readonly array $field,
+    ) {}
+
+    public function value(string $key, mixed $default = null): mixed
+    {
+        if (array_key_exists($key, $this->state)) {
+            return $this->state[$key];
+        }
+
+        return Arr::get($this->state, $key, Arr::get($this->settings, $key, $default));
+    }
+}

--- a/tests/Feature/PluginDeclaredTableUiTest.php
+++ b/tests/Feature/PluginDeclaredTableUiTest.php
@@ -5,12 +5,14 @@ use App\Filament\Resources\Plugins\PluginResource;
 use App\Models\Playlist;
 use App\Models\Plugin;
 use App\Models\User;
+use App\Plugins\PluginIntegrityService;
 use App\Plugins\PluginSchemaManager;
 use App\Plugins\PluginSchemaMapper;
 use App\Plugins\PluginUiTableRegistry;
 use App\Plugins\PluginValidator;
 use App\Plugins\Support\PluginManifest;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Exists;
@@ -94,6 +96,156 @@ function declaredTableUiPlugin(): Plugin
     ]);
 
     return $plugin;
+}
+
+function declaredDynamicOptionsTableUiPlugin(): array
+{
+    $suffix = Str::lower(Str::random(6));
+    $pluginId = "dynamic-table-ui-{$suffix}";
+    $classSegment = Str::studly(str_replace('-', ' ', $pluginId));
+    $tablePrefix = "plugin_dynamic_table_ui_{$suffix}_";
+    $tableName = "{$tablePrefix}profiles";
+    $sourcePath = storage_path("app/testing-plugin-sources/{$pluginId}");
+
+    $schema = [
+        'tables' => [[
+            'name' => $tableName,
+            'columns' => [
+                ['type' => 'id', 'name' => 'id'],
+                ['type' => 'foreignId', 'name' => 'extension_plugin_id', 'references' => 'extension_plugins', 'on_delete' => 'cascade'],
+                ['type' => 'string', 'name' => 'name'],
+                ['type' => 'json', 'name' => 'settings', 'nullable' => true],
+                ['type' => 'timestamps'],
+            ],
+            'indexes' => [],
+        ]],
+        'ui_tables' => [[
+            'id' => 'profiles',
+            'label' => 'Profiles',
+            'model_label' => 'Profile',
+            'table' => $tableName,
+            'columns' => [
+                ['name' => 'name', 'label' => 'Name'],
+                [
+                    'name' => 'settings.provider_source',
+                    'label' => 'Provider Source',
+                    'options_provider' => 'fixture_sources',
+                    'depends_on' => ['settings.provider', 'settings.country'],
+                ],
+            ],
+            'fields' => [],
+        ]],
+    ];
+
+    $manifest = [
+        'id' => $pluginId,
+        'name' => 'Dynamic Table UI',
+        'version' => '1.0.0',
+        'api_version' => config('plugins.api_version'),
+        'description' => 'Declarative table UI dynamic options fixture.',
+        'entrypoint' => 'Plugin.php',
+        'class' => "AppLocalPlugins\\{$classSegment}\\Plugin",
+        'capabilities' => [],
+        'hooks' => [],
+        'permissions' => ['schema_manage'],
+        'settings' => [],
+        'actions' => [],
+        'schema' => $schema,
+        'data_ownership' => [
+            'plugin_id' => $pluginId,
+            'table_prefix' => $tablePrefix,
+            'tables' => [$tableName],
+            'directories' => [],
+            'files' => [],
+            'default_cleanup_policy' => 'preserve',
+        ],
+    ];
+
+    $pluginSource = <<<PHP
+<?php
+
+namespace AppLocalPlugins\\{$classSegment};
+
+use App\\Plugins\\Contracts\\PluginInterface;
+use App\\Plugins\\Contracts\\PluginSelectOptionsProviderInterface;
+use App\\Plugins\\Support\\PluginActionResult;
+use App\\Plugins\\Support\\PluginExecutionContext;
+use App\\Plugins\\Support\\PluginSelectOptionsContext;
+
+class Plugin implements PluginInterface, PluginSelectOptionsProviderInterface
+{
+    public function runAction(string \$action, array \$payload, PluginExecutionContext \$context): PluginActionResult
+    {
+        return PluginActionResult::success('Fixture plugin action completed.');
+    }
+
+    public function selectOptions(string \$provider, PluginSelectOptionsContext \$context): array
+    {
+        if (\$provider !== 'fixture_sources') {
+            return [];
+        }
+
+        return [
+            'viewersvault' => 'ViewersVault '.\$context->value('settings.provider', 'unknown').'/'.\$context->value('settings.country', 'unknown'),
+        ];
+    }
+}
+PHP;
+
+    File::deleteDirectory($sourcePath);
+    File::ensureDirectoryExists($sourcePath);
+    File::put(
+        "{$sourcePath}/plugin.json",
+        json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL,
+    );
+    File::put("{$sourcePath}/Plugin.php", $pluginSource);
+
+    $hashes = app(PluginIntegrityService::class)->hashesForPlugin($sourcePath, 'Plugin.php');
+
+    $plugin = Plugin::query()->create([
+        'plugin_id' => $pluginId,
+        'name' => 'Dynamic Table UI',
+        'version' => '1.0.0',
+        'api_version' => config('plugins.api_version'),
+        'description' => 'Declarative table UI dynamic options fixture.',
+        'entrypoint' => 'Plugin.php',
+        'class_name' => "AppLocalPlugins\\{$classSegment}\\Plugin",
+        'capabilities' => [],
+        'hooks' => [],
+        'permissions' => ['schema_manage'],
+        'schema_definition' => $schema,
+        'actions' => [],
+        'settings_schema' => [],
+        'settings' => [],
+        'data_ownership' => $manifest['data_ownership'],
+        'source_type' => 'local_directory',
+        'path' => $sourcePath,
+        'available' => true,
+        'enabled' => true,
+        'installation_status' => 'installed',
+        'trust_state' => 'trusted',
+        'integrity_status' => 'verified',
+        'trusted_hashes' => $hashes,
+        'manifest_hash' => $hashes['manifest_hash'] ?? null,
+        'entrypoint_hash' => $hashes['entrypoint_hash'] ?? null,
+        'plugin_hash' => $hashes['plugin_hash'] ?? null,
+    ]);
+
+    app(PluginSchemaManager::class)->apply($schema);
+
+    DB::table($tableName)->insert([
+        'extension_plugin_id' => $plugin->id,
+        'name' => 'Dynamic Profile',
+        'settings' => json_encode([
+            'provider' => 'sky',
+            'country' => 'uk',
+            'provider_source' => 'viewersvault',
+        ], JSON_THROW_ON_ERROR),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return [$plugin, $sourcePath];
 }
 
 function declaredPrefilledTableUiPlugin(): array
@@ -222,6 +374,21 @@ it('renders plugin-declared table UIs through the generic plugin table page', fu
         ->assertSee('Native Playlist');
 });
 
+it('renders plugin-declared table column options from a dynamic provider', function () {
+    $this->actingAs(User::factory()->admin()->create());
+
+    [$plugin, $sourcePath] = declaredDynamicOptionsTableUiPlugin();
+
+    try {
+        Livewire::test(ManagePluginTable::class, ['record' => $plugin->getRouteKey(), 'table' => 'profiles'])
+            ->assertOk()
+            ->assertSee('Dynamic Profile')
+            ->assertSee('ViewersVault sky/uk');
+    } finally {
+        File::deleteDirectory($sourcePath);
+    }
+});
+
 it('applies declared cascade actions to plugin table foreign keys', function () {
     $plugin = declaredTableUiPlugin();
     $tableName = 'plugin_declared_table_ui_profiles';
@@ -330,6 +497,38 @@ it('returns validation errors (not TypeError) when ui_table columns or fields is
 
     expect($errors)->toContain('schema.ui_tables.0.columns must be a list.')
         ->and($errors)->toContain('schema.ui_tables.0.fields must be a list.');
+});
+
+it('validates dynamic option provider declarations on ui_table columns', function () {
+    $suffix = Str::lower(Str::random(6));
+    $tableName = "plugin_test_{$suffix}_items";
+
+    $manifest = PluginManifest::fromArray([
+        'id' => "test-{$suffix}",
+        'name' => 'Test Plugin',
+        'permissions' => [],
+        'schema' => [
+            'tables' => [['name' => $tableName, 'columns' => [['type' => 'id', 'name' => 'id']]]],
+            'ui_tables' => [[
+                'id' => 'items',
+                'table' => $tableName,
+                'label' => 'Items',
+                'columns' => [[
+                    'name' => 'source',
+                    'options_provider' => '',
+                    'depends_on' => ['provider', ''],
+                ]],
+                'fields' => [],
+            ]],
+        ],
+    ], '/tmp/test-plugin');
+
+    $validator = app(PluginValidator::class);
+    $method = new ReflectionMethod($validator, 'validateSchema');
+    $errors = $method->invoke($validator, $manifest);
+
+    expect($errors)->toContain('schema.ui_tables.0.columns.0 options_provider must be a non-empty string')
+        ->and($errors)->toContain('schema.ui_tables.0.columns.0 depends_on must contain only non-empty strings');
 });
 
 it('generates an exists rule for table_select settings fields', function () {

--- a/tests/Feature/PluginSettingsSchemaGroupingTest.php
+++ b/tests/Feature/PluginSettingsSchemaGroupingTest.php
@@ -6,6 +6,7 @@ use App\Plugins\PluginValidator;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Section;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
 it('renders a text field with secret true as a password input', function () {
@@ -140,6 +141,46 @@ it('rejects a section containing a non-array nested field', function () {
         ], $fieldTypes, 'settings');
 
     expect($errors)->toContain('settings.my_section section fields must be objects');
+});
+
+it('allows select fields backed by plugin option providers', function () {
+    $validator = app(PluginValidator::class);
+
+    $fieldTypes = config('plugins.field_types');
+
+    $errors = (new ReflectionMethod($validator, 'validateFieldDefinition'))
+        ->invoke($validator, [
+            'id' => 'provider_source',
+            'type' => 'select',
+            'label' => 'Provider Source',
+            'options_provider' => 'fixture_sources',
+            'depends_on' => ['provider', 'country'],
+        ], $fieldTypes, 'settings');
+
+    expect($errors)->toBe([]);
+});
+
+it('does not apply static option validation to provider backed select fields', function () {
+    $plugin = new Plugin([
+        'settings_schema' => [
+            [
+                'id' => 'provider_source',
+                'type' => 'select',
+                'label' => 'Provider Source',
+                'options_provider' => 'fixture_sources',
+                'depends_on' => ['provider', 'country'],
+            ],
+        ],
+        'settings' => [],
+    ]);
+
+    $rules = app(PluginSchemaMapper::class)->settingsRules($plugin);
+
+    expect(Validator::make([
+        'settings' => [
+            'provider_source' => 'dynamic-value',
+        ],
+    ], $rules)->passes())->toBeTrue();
 });
 
 it('allows a section without an id, using the label as the error path identifier', function () {

--- a/tests/Feature/PluginSystemTest.php
+++ b/tests/Feature/PluginSystemTest.php
@@ -242,6 +242,102 @@ it('discovers and validates a generated local plugin fixture', function () {
     }
 });
 
+it('resolves dynamic select options from a trusted disabled plugin', function () {
+    $pluginId = 'select-options-'.Str::lower(Str::random(6));
+    $paths = pluginReviewFixturePaths($pluginId);
+    $classSegment = Str::studly(str_replace('-', ' ', $pluginId));
+
+    File::deleteDirectory($paths['source']);
+    File::ensureDirectoryExists($paths['source']);
+
+    $manifest = [
+        'id' => $pluginId,
+        'name' => 'Select Options Fixture',
+        'version' => '0.1.0',
+        'description' => 'Temporary dynamic select options fixture.',
+        'api_version' => config('plugins.api_version'),
+        'entrypoint' => 'Plugin.php',
+        'class' => "AppLocalPlugins\\{$classSegment}\\Plugin",
+        'capabilities' => [],
+        'hooks' => [],
+        'permissions' => [],
+        'settings' => [[
+            'id' => 'provider_source',
+            'label' => 'Provider Source',
+            'type' => 'select',
+            'options_provider' => 'fixture_sources',
+            'depends_on' => ['country'],
+        ]],
+        'actions' => [],
+        'schema' => [
+            'tables' => [],
+        ],
+        'data_ownership' => [
+            'plugin_id' => $pluginId,
+            'table_prefix' => 'plugin_'.str_replace('-', '_', $pluginId).'_',
+            'tables' => [],
+            'directories' => [],
+            'files' => [],
+            'default_cleanup_policy' => 'preserve',
+        ],
+    ];
+
+    $pluginSource = <<<PHP
+<?php
+
+namespace AppLocalPlugins\\{$classSegment};
+
+use App\\Plugins\\Contracts\\PluginInterface;
+use App\\Plugins\\Contracts\\PluginSelectOptionsProviderInterface;
+use App\\Plugins\\Support\\PluginActionResult;
+use App\\Plugins\\Support\\PluginExecutionContext;
+use App\\Plugins\\Support\\PluginSelectOptionsContext;
+
+class Plugin implements PluginInterface, PluginSelectOptionsProviderInterface
+{
+    public function runAction(string \$action, array \$payload, PluginExecutionContext \$context): PluginActionResult
+    {
+        return PluginActionResult::success('Fixture plugin action completed.');
+    }
+
+    public function selectOptions(string \$provider, PluginSelectOptionsContext \$context): array
+    {
+        if (\$provider !== 'fixture_sources') {
+            return [];
+        }
+
+        return [
+            'alpha' => 'Alpha '.\$context->value('country', 'unknown'),
+        ];
+    }
+}
+PHP;
+
+    File::put(
+        $paths['source'].'/plugin.json',
+        json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL,
+    );
+    File::put($paths['source'].'/Plugin.php', $pluginSource);
+
+    try {
+        approvePluginReviewForTests($paths['source']);
+        $plugin = app(PluginManager::class)->findPluginById($pluginId);
+
+        expect($plugin)->not->toBeNull()
+            ->and($plugin->enabled)->toBeFalse();
+
+        $options = app(PluginManager::class)->selectOptions(
+            $plugin,
+            'fixture_sources',
+            ['country' => 'uk'],
+        );
+
+        expect($options)->toBe(['alpha' => 'Alpha uk']);
+    } finally {
+        cleanupReviewFixturePlugin($pluginId);
+    }
+});
+
 it('rejects top-level executable plugin php while staging a directory review', function () {
     $pluginId = 'review-safety-'.Str::lower(Str::random(6));
     $paths = createReviewFixturePlugin($pluginId, withSideEffect: true);


### PR DESCRIPTION
## Simple explanation

This PR adds host support for plugin-backed dynamic select options in plugin schemas.

The change is required because plugin `select` fields and plugin-declared table option labels were limited to static option lists in `plugin.json`. That meant one field or table display column could not adjust its available options based on another value, such as a provider source list that depends on the selected provider and country.

## Why this is required

Some plugin settings are naturally dependent on other settings.

For example, a plugin may need:

- A source list that changes when `provider` changes.
- A region/source list that changes when `country` changes.
- Options that come from plugin code or registry metadata instead of a fixed manifest list.
- Plugin table columns that display saved option values using the same provider-aware labels as the edit form.

This PR lets the host keep `plugin.json` declarative while allowing trusted plugins to provide dynamic option lists at render time.

Plugins can now declare something like:

```json
{
  "id": "settings.provider_source",
  "type": "select",
  "options_provider": "channel_guardian_sources",
  "depends_on": [
    "settings.provider",
    "settings.country"
  ]
}
```

Plugin-declared table columns can also use the same dynamic provider contract:

```json
{
  "name": "settings.provider_source",
  "label": "Provider Source",
  "options_provider": "channel_guardian_sources",
  "depends_on": [
    "settings.provider",
    "settings.country"
  ]
}
```

## Changes

- Adds `PluginSelectOptionsProviderInterface`.
- Adds `PluginSelectOptionsContext` with plugin, user, saved settings, current form state, and field metadata.
- Adds `PluginManager::selectOptions()` for resolving dynamic options from trusted, loadable plugins.
- Allows schema `select` fields to use either static `options` or an `options_provider`.
- Adds `depends_on` support so dynamic selects can react to related form fields.
- Clears dependent dynamic select values when their dependencies change.
- Skips static `Rule::in(...)` validation for provider-backed selects.
- Keeps static `options` support unchanged for existing plugins.
- Adds dynamic `options_provider` support to plugin-declared table columns.
- Resolves plugin table column display labels through dynamic providers using the current row state.
- Supports dynamic option lists for editable plugin table select columns.
- Validates `options_provider` and `depends_on` metadata on plugin table columns.
- Adds regression coverage for provider-backed select fields, disabled-but-trusted plugin option resolution, and provider-backed plugin table columns.
- Avoids schema-table diagnostics for discovered but never-installed plugins unless cleanup was explicitly preserved.

## Testing

Focused tests previously run:

- `PluginSettingsSchemaGroupingTest`
- `PluginSystemTest`
- Channel Guardian manifest/source option coverage
- Channel Guardian source cache persistence coverage

Result:

`48 passed, 225 assertions`

Additional local verification for the table-column follow-up:

- PHP syntax checks for the modified host files.
- `git diff --check`

Note: the available local container image has production-only dependencies, so Pest was not available there to rerun the new table-column feature test.
