### PR TITLE
feat: Add plugin table headings and clear-row delete behavior

### DIFF
--- a/app/Filament/Resources/Plugins/Pages/ManagePluginTable.php
+++ b/app/Filament/Resources/Plugins/Pages/ManagePluginTable.php
@@ -243,24 +243,13 @@ class ManagePluginTable extends Page implements HasTable
     private function deleteAction(): DeleteAction
     {
         $action = DeleteAction::make();
+        $registry = app(PluginUiTableRegistry::class);
 
-        if (! app(PluginUiTableRegistry::class)->clearsRecordOnDelete($this->tableDefinition)) {
+        if (! $registry->clearsRecordOnDelete($this->tableDefinition)) {
             return $action;
         }
 
-        $label = (string) ($this->tableDefinition['delete_label'] ?? __('Clear :model', ['model' => $this->modelLabel()]));
-        $icon = (string) ($this->tableDefinition['delete_icon'] ?? 'heroicon-o-x-mark');
-
-        return $action
-            ->label($label)
-            ->icon($icon)
-            ->color((string) ($this->tableDefinition['delete_color'] ?? 'gray'))
-            ->modalHeading($label)
-            ->modalIcon($icon)
-            ->modalDescription((string) ($this->tableDefinition['delete_description'] ?? __('This will clear the saved configuration for this row without removing it from the table.')))
-            ->modalSubmitActionLabel((string) ($this->tableDefinition['delete_submit_label'] ?? __('Clear')))
-            ->successNotificationTitle((string) ($this->tableDefinition['delete_success_message'] ?? __(':model cleared', ['model' => $this->modelLabel()])))
-            ->using(fn (PluginTableRecord $record): PluginTableRecord => app(PluginUiTableRegistry::class)->clearRecordForDelete($record, $this->tableDefinition));
+        return $registry->decorateClearAction($action, $this->tableDefinition, $this->modelLabel());
     }
 
     /**

--- a/app/Filament/Resources/Plugins/Pages/ManagePluginTable.php
+++ b/app/Filament/Resources/Plugins/Pages/ManagePluginTable.php
@@ -248,10 +248,33 @@ class ManagePluginTable extends Page implements HasTable
         }
 
         if (($this->tableDefinition['delete'] ?? true) !== false) {
-            $actions[] = DeleteAction::make();
+            $actions[] = $this->deleteAction();
         }
 
         return $actions;
+    }
+
+    private function deleteAction(): DeleteAction
+    {
+        $action = DeleteAction::make();
+
+        if (! app(PluginUiTableRegistry::class)->clearsRecordOnDelete($this->tableDefinition)) {
+            return $action;
+        }
+
+        $label = (string) ($this->tableDefinition['delete_label'] ?? __('Clear :model', ['model' => $this->modelLabel()]));
+        $icon = (string) ($this->tableDefinition['delete_icon'] ?? 'heroicon-o-x-mark');
+
+        return $action
+            ->label($label)
+            ->icon($icon)
+            ->color((string) ($this->tableDefinition['delete_color'] ?? 'gray'))
+            ->modalHeading($label)
+            ->modalIcon($icon)
+            ->modalDescription((string) ($this->tableDefinition['delete_description'] ?? __('This will clear the saved configuration for this row without removing it from the table.')))
+            ->modalSubmitActionLabel((string) ($this->tableDefinition['delete_submit_label'] ?? __('Clear')))
+            ->successNotificationTitle((string) ($this->tableDefinition['delete_success_message'] ?? __(':model cleared', ['model' => $this->modelLabel()])))
+            ->using(fn (PluginTableRecord $record): PluginTableRecord => app(PluginUiTableRegistry::class)->clearRecordForDelete($record, $this->tableDefinition));
     }
 
     /**

--- a/app/Livewire/PluginTableInline.php
+++ b/app/Livewire/PluginTableInline.php
@@ -64,6 +64,8 @@ class PluginTableInline extends Component implements HasActions, HasForms, HasTa
     {
         $table = $table
             ->query(fn (): Builder => $this->tableQuery())
+            ->heading($this->tableHeading())
+            ->description($this->tableDescription())
             ->columns($this->tableColumns())
             ->headerActions($this->tableHeaderActions())
             ->recordActions($this->tableRecordActions(), position: RecordActionsPosition::BeforeCells);
@@ -275,6 +277,16 @@ class PluginTableInline extends Component implements HasActions, HasForms, HasTa
     private function tableName(): ?string
     {
         return filled($this->tableDefinition['table'] ?? null) ? (string) $this->tableDefinition['table'] : null;
+    }
+
+    private function tableHeading(): ?string
+    {
+        return filled($this->tableDefinition['label'] ?? null) ? (string) $this->tableDefinition['label'] : null;
+    }
+
+    private function tableDescription(): ?string
+    {
+        return filled($this->tableDefinition['description'] ?? null) ? (string) $this->tableDefinition['description'] : null;
     }
 
     private function modelLabel(): string

--- a/app/Livewire/PluginTableInline.php
+++ b/app/Livewire/PluginTableInline.php
@@ -230,23 +230,13 @@ class PluginTableInline extends Component implements HasActions, HasForms, HasTa
             ->hiddenLabel()
             ->size('sm');
 
-        if (! app(PluginUiTableRegistry::class)->clearsRecordOnDelete($this->tableDefinition)) {
+        $registry = app(PluginUiTableRegistry::class);
+
+        if (! $registry->clearsRecordOnDelete($this->tableDefinition)) {
             return $action;
         }
 
-        $label = (string) ($this->tableDefinition['delete_label'] ?? __('Clear :model', ['model' => $this->modelLabel()]));
-        $icon = (string) ($this->tableDefinition['delete_icon'] ?? 'heroicon-o-x-mark');
-
-        return $action
-            ->label($label)
-            ->icon($icon)
-            ->color((string) ($this->tableDefinition['delete_color'] ?? 'gray'))
-            ->modalHeading($label)
-            ->modalIcon($icon)
-            ->modalDescription((string) ($this->tableDefinition['delete_description'] ?? __('This will clear the saved configuration for this row without removing it from the table.')))
-            ->modalSubmitActionLabel((string) ($this->tableDefinition['delete_submit_label'] ?? __('Clear')))
-            ->successNotificationTitle((string) ($this->tableDefinition['delete_success_message'] ?? __(':model cleared', ['model' => $this->modelLabel()])))
-            ->using(fn (PluginTableRecord $record): PluginTableRecord => app(PluginUiTableRegistry::class)->clearRecordForDelete($record, $this->tableDefinition));
+        return $registry->decorateClearAction($action, $this->tableDefinition, $this->modelLabel());
     }
 
     /** @return array<int, mixed> */

--- a/app/Livewire/PluginTableInline.php
+++ b/app/Livewire/PluginTableInline.php
@@ -231,13 +231,36 @@ class PluginTableInline extends Component implements HasActions, HasForms, HasTa
         }
 
         if (($this->tableDefinition['delete'] ?? true) !== false) {
-            $actions[] = DeleteAction::make()
-                ->button()
-                ->hiddenLabel()
-                ->size('sm');
+            $actions[] = $this->deleteAction();
         }
 
         return $actions;
+    }
+
+    private function deleteAction(): DeleteAction
+    {
+        $action = DeleteAction::make()
+            ->button()
+            ->hiddenLabel()
+            ->size('sm');
+
+        if (! app(PluginUiTableRegistry::class)->clearsRecordOnDelete($this->tableDefinition)) {
+            return $action;
+        }
+
+        $label = (string) ($this->tableDefinition['delete_label'] ?? __('Clear :model', ['model' => $this->modelLabel()]));
+        $icon = (string) ($this->tableDefinition['delete_icon'] ?? 'heroicon-o-x-mark');
+
+        return $action
+            ->label($label)
+            ->icon($icon)
+            ->color((string) ($this->tableDefinition['delete_color'] ?? 'gray'))
+            ->modalHeading($label)
+            ->modalIcon($icon)
+            ->modalDescription((string) ($this->tableDefinition['delete_description'] ?? __('This will clear the saved configuration for this row without removing it from the table.')))
+            ->modalSubmitActionLabel((string) ($this->tableDefinition['delete_submit_label'] ?? __('Clear')))
+            ->successNotificationTitle((string) ($this->tableDefinition['delete_success_message'] ?? __(':model cleared', ['model' => $this->modelLabel()])))
+            ->using(fn (PluginTableRecord $record): PluginTableRecord => app(PluginUiTableRegistry::class)->clearRecordForDelete($record, $this->tableDefinition));
     }
 
     /** @return array<int, mixed> */

--- a/app/Plugins/PluginUiTableRegistry.php
+++ b/app/Plugins/PluginUiTableRegistry.php
@@ -4,6 +4,7 @@ namespace App\Plugins;
 
 use App\Models\Plugin;
 use App\Models\PluginTableRecord;
+use Filament\Actions\DeleteAction;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -103,6 +104,23 @@ class PluginUiTableRegistry
         $record->update($this->expandedPayload($payload));
 
         return $record;
+    }
+
+    public function decorateClearAction(DeleteAction $action, array $definition, string $modelLabel): DeleteAction
+    {
+        $label = (string) ($definition['delete_label'] ?? __('Clear :model', ['model' => $modelLabel]));
+        $icon = (string) ($definition['delete_icon'] ?? 'heroicon-o-x-mark');
+
+        return $action
+            ->label($label)
+            ->icon($icon)
+            ->color((string) ($definition['delete_color'] ?? 'gray'))
+            ->modalHeading($label)
+            ->modalIcon($icon)
+            ->modalDescription((string) ($definition['delete_description'] ?? __('This will clear the saved configuration for this row without removing it from the table.')))
+            ->modalSubmitActionLabel((string) ($definition['delete_submit_label'] ?? __('Clear')))
+            ->successNotificationTitle((string) ($definition['delete_success_message'] ?? __(':model cleared', ['model' => $modelLabel])))
+            ->using(fn (PluginTableRecord $record): PluginTableRecord => $this->clearRecordForDelete($record, $definition));
     }
 
     public function columnDisplayState(Plugin $plugin, PluginTableRecord $record, array $column): mixed

--- a/app/Plugins/PluginUiTableRegistry.php
+++ b/app/Plugins/PluginUiTableRegistry.php
@@ -87,6 +87,22 @@ class PluginUiTableRegistry
             ->all();
     }
 
+    public function clearsRecordOnDelete(array $definition): bool
+    {
+        return ($definition['delete_behavior'] ?? null) === 'clear';
+    }
+
+    public function clearRecordForDelete(PluginTableRecord $record, array $definition): PluginTableRecord
+    {
+        $payload = is_array($definition['delete_payload'] ?? null)
+            ? $definition['delete_payload']
+            : [];
+
+        $record->update($this->expandedPayload($payload));
+
+        return $record;
+    }
+
     public function prefillRows(Plugin $plugin, array $definition): void
     {
         $prefill = $definition['prefill'] ?? null;
@@ -182,6 +198,21 @@ class PluginUiTableRegistry
                 (bool) ($lookup['enabled_only'] ?? false) && Schema::hasColumn($tableName, 'enabled'),
                 fn (QueryBuilder $query) => $query->where('enabled', true),
             );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function expandedPayload(array $payload): array
+    {
+        $expanded = [];
+
+        foreach ($payload as $key => $value) {
+            data_set($expanded, (string) $key, $value);
+        }
+
+        return $expanded;
     }
 
     private function columnsFor(Plugin $plugin, string $tableName): Collection

--- a/app/Plugins/PluginValidator.php
+++ b/app/Plugins/PluginValidator.php
@@ -742,6 +742,18 @@ class PluginValidator
                 $errors[] = "{$path} requires [label].";
             }
 
+            if (array_key_exists('delete_behavior', $uiTable)
+                && ! in_array($uiTable['delete_behavior'], ['delete', 'clear'], true)) {
+                $errors[] = "{$path}.delete_behavior must be one of [delete, clear].";
+            }
+
+            if (($uiTable['delete_behavior'] ?? null) === 'clear'
+                && ! is_array($uiTable['delete_payload'] ?? null)) {
+                $errors[] = "{$path}.delete_payload must be an object when delete_behavior is [clear].";
+            } elseif (array_key_exists('delete_payload', $uiTable) && ! is_array($uiTable['delete_payload'])) {
+                $errors[] = "{$path}.delete_payload must be an object.";
+            }
+
             if (array_key_exists('prefill', $uiTable)) {
                 $prefill = $uiTable['prefill'];
                 $prefillPath = "{$path}.prefill";

--- a/docs/plugin-dev.md
+++ b/docs/plugin-dev.md
@@ -406,6 +406,11 @@ Example:
 | `create` | no | Set `false` to hide the create action (default: `true`) |
 | `edit` | no | Set `false` to hide per-row edit action (default: `true`) |
 | `delete` | no | Set `false` to hide per-row delete action (default: `true`) |
+| `delete_behavior` | no | Set to `"clear"` to update the row with `delete_payload` instead of deleting it |
+| `delete_payload` | no | Object of values to save when `delete_behavior` is `"clear"`; dot-notation sets nested `json` keys |
+| `delete_label` | no | Label used for a clear-style delete action |
+| `delete_icon` | no | Icon used for a clear-style delete action (default: `heroicon-o-x-mark`) |
+| `delete_color` | no | Button color used for a clear-style delete action (default: `gray`) |
 | `columns` | no | Column definitions for the list view |
 | `fields` | no | Field definitions for the create/edit form — uses the same field types as `settings` |
 | `prefill` | no | Auto-populate rows from a source table on page mount |
@@ -472,6 +477,18 @@ Example:
 - `defaults`: static defaults to write on each new row; dot-notation sets nested `json` keys
 
 The prefill source is capped at `config('plugins.prefill_max_source_rows')` rows (default: 1000).
+
+For prefilled tables where the source row should remain visible, use `delete_behavior: "clear"` to make the row action reset configuration instead of deleting the physical row:
+
+```json
+"delete_behavior": "clear",
+"delete_label": "Clear Assignment",
+"delete_payload": {
+  "extension_plugin_profile_id": null,
+  "enabled": false,
+  "settings.run_sync": true
+}
+```
 
 ## Capabilities
 

--- a/docs/plugin-dev.md
+++ b/docs/plugin-dev.md
@@ -407,10 +407,13 @@ Example:
 | `edit` | no | Set `false` to hide per-row edit action (default: `true`) |
 | `delete` | no | Set `false` to hide per-row delete action (default: `true`) |
 | `delete_behavior` | no | Set to `"clear"` to update the row with `delete_payload` instead of deleting it |
-| `delete_payload` | no | Object of values to save when `delete_behavior` is `"clear"`; dot-notation sets nested `json` keys |
+| `delete_payload` | no | Object of values to save when `delete_behavior` is `"clear"`; dot-notation keys (e.g. `settings.key`) write the **entire** parent JSON column — include every key you want to preserve |
 | `delete_label` | no | Label used for a clear-style delete action |
 | `delete_icon` | no | Icon used for a clear-style delete action (default: `heroicon-o-x-mark`) |
 | `delete_color` | no | Button color used for a clear-style delete action (default: `gray`) |
+| `delete_description` | no | Modal body text for a clear-style delete action |
+| `delete_submit_label` | no | Modal submit button label for a clear-style delete action (default: `Clear`) |
+| `delete_success_message` | no | Success notification title after a clear action completes |
 | `columns` | no | Column definitions for the list view |
 | `fields` | no | Field definitions for the create/edit form — uses the same field types as `settings` |
 | `prefill` | no | Auto-populate rows from a source table on page mount |

--- a/tests/Feature/PluginDeclaredTableUiTest.php
+++ b/tests/Feature/PluginDeclaredTableUiTest.php
@@ -2,6 +2,7 @@
 
 use App\Filament\Resources\Plugins\Pages\ManagePluginTable;
 use App\Filament\Resources\Plugins\PluginResource;
+use App\Livewire\PluginTableInline;
 use App\Models\Playlist;
 use App\Models\Plugin;
 use App\Models\User;
@@ -292,6 +293,18 @@ it('prefills plugin-declared table rows from an owned source table', function ()
             'run_availability' => true,
             'run_sync' => true,
         ]);
+});
+
+it('renders inline plugin table headings from manifest labels', function () {
+    $user = User::factory()->admin()->create();
+    $this->actingAs($user);
+
+    $plugin = declaredTableUiPlugin();
+
+    Livewire::test(PluginTableInline::class, ['record' => $plugin, 'tableId' => 'profiles'])
+        ->assertOk()
+        ->assertSee('Profiles')
+        ->assertSee('Reusable test profiles.');
 });
 
 it('throws when ui_tables is not a list in the manifest', function () {

--- a/tests/Feature/PluginDeclaredTableUiTest.php
+++ b/tests/Feature/PluginDeclaredTableUiTest.php
@@ -562,6 +562,14 @@ it('returns validation errors (not TypeError) when ui_table columns or fields is
         ->and($errors)->toContain('schema.ui_tables.0.fields must be a list.');
 });
 
+it('treats delete_behavior delete as a standard delete with no clear applied', function () {
+    $plugin = declaredTableUiPlugin();
+    $definition = data_get($plugin->schema_definition, 'ui_tables.0');
+    $definition['delete_behavior'] = 'delete';
+
+    expect(app(PluginUiTableRegistry::class)->clearsRecordOnDelete($definition))->toBeFalse();
+});
+
 it('validates clear delete behavior declarations on ui_tables', function () {
     $suffix = Str::lower(Str::random(6));
     $tableName = "plugin_test_{$suffix}_items";

--- a/tests/Feature/PluginDeclaredTableUiTest.php
+++ b/tests/Feature/PluginDeclaredTableUiTest.php
@@ -307,6 +307,56 @@ it('renders inline plugin table headings from manifest labels', function () {
         ->assertSee('Reusable test profiles.');
 });
 
+it('can clear a plugin table record instead of deleting it', function () {
+    $user = User::factory()->admin()->create();
+    $this->actingAs($user);
+
+    $playlist = Playlist::withoutEvents(fn (): Playlist => Playlist::factory()->for($user)->create(['name' => 'Assigned Playlist']));
+    [$plugin, $profilesTable, $linksTable] = declaredPrefilledTableUiPlugin();
+    $profileId = DB::table($profilesTable)->value('id');
+
+    $definition = data_get($plugin->schema_definition, 'ui_tables.0');
+    $definition['delete_behavior'] = 'clear';
+    $definition['delete_payload'] = [
+        'extension_plugin_profile_id' => null,
+        'enabled' => false,
+        'settings.run_availability' => true,
+        'settings.run_sync' => true,
+    ];
+
+    app(PluginUiTableRegistry::class)->prefillRows($plugin, $definition);
+
+    $row = DB::table($linksTable)->where('playlist_id', $playlist->id)->first();
+
+    DB::table($linksTable)->where('id', $row->id)->update([
+        'extension_plugin_profile_id' => $profileId,
+        'enabled' => true,
+        'settings' => json_encode([
+            'run_availability' => false,
+            'run_sync' => false,
+        ], JSON_THROW_ON_ERROR),
+        'updated_at' => now(),
+    ]);
+
+    $record = app(PluginUiTableRegistry::class)
+        ->newModel($plugin, $linksTable)
+        ->newQuery()
+        ->findOrFail($row->id);
+
+    app(PluginUiTableRegistry::class)->clearRecordForDelete($record, $definition);
+
+    $cleared = DB::table($linksTable)->where('id', $row->id)->first();
+
+    expect(DB::table($linksTable)->count())->toBe(1)
+        ->and((int) $cleared->playlist_id)->toBe($playlist->id)
+        ->and($cleared->extension_plugin_profile_id)->toBeNull()
+        ->and((bool) $cleared->enabled)->toBeFalse()
+        ->and(json_decode((string) $cleared->settings, true))->toMatchArray([
+            'run_availability' => true,
+            'run_sync' => true,
+        ]);
+});
+
 it('throws when ui_tables is not a list in the manifest', function () {
     expect(fn () => PluginManifest::fromArray([
         'id' => 'test-plugin',
@@ -343,6 +393,34 @@ it('returns validation errors (not TypeError) when ui_table columns or fields is
 
     expect($errors)->toContain('schema.ui_tables.0.columns must be a list.')
         ->and($errors)->toContain('schema.ui_tables.0.fields must be a list.');
+});
+
+it('validates clear delete behavior declarations on ui_tables', function () {
+    $suffix = Str::lower(Str::random(6));
+    $tableName = "plugin_test_{$suffix}_items";
+
+    $manifest = PluginManifest::fromArray([
+        'id' => "test-{$suffix}",
+        'name' => 'Test Plugin',
+        'permissions' => [],
+        'schema' => [
+            'tables' => [['name' => $tableName, 'columns' => [['type' => 'id', 'name' => 'id']]]],
+            'ui_tables' => [[
+                'id' => 'items',
+                'table' => $tableName,
+                'label' => 'Items',
+                'delete_behavior' => 'clear',
+                'columns' => [],
+                'fields' => [],
+            ]],
+        ],
+    ], '/tmp/test-plugin');
+
+    $validator = app(PluginValidator::class);
+    $method = new ReflectionMethod($validator, 'validateSchema');
+    $errors = $method->invoke($validator, $manifest);
+
+    expect($errors)->toContain('schema.ui_tables.0.delete_payload must be an object when delete_behavior is [clear].');
 });
 
 it('generates an exists rule for table_select settings fields', function () {


### PR DESCRIPTION


## Simple explanation

This PR improves host support for plugin-declared Data tab tables.

It does two related things:

- Shows the plugin-declared table label and description above inline plugin tables.
- Allows a plugin table delete action to clear/reset a row instead of physically deleting it.

This is useful for plugin tables that are prefilled from host data, such as one row per playlist. In those cases, deleting the row is not the right model because the row represents an existing host object. The plugin may only want to clear its own configuration for that row.

## Why this is required

Plugin manifests can already declare `label` and `description` for `schema.ui_tables`.

Standalone plugin table pages use those values as the page title/subheading, but inline tables rendered inside a plugin's Data tab did not show them. When a plugin has multiple Data tab tables, this makes the UI hard to scan because users see several table panels without visible section names.

Some plugin tables are also naturally source-backed or prefilled.

For example, a plugin may need:

- A row for every playlist owned by the user.
- The row to remain visible even when plugin configuration is cleared.
- A clear/reset action that disables the plugin's assignment for that playlist.
- The host playlist row to remain intact and be reconfigurable later.

Previously, the generic table UI only supported hiding delete or permanently deleting the row. This PR adds an explicit manifest-driven clear behavior for that use case.

Plugins can now declare:

```json
{
  "id": "playlist_assignments",
  "label": "Playlist Assignments",
  "description": "Assign profiles to playlists.",
  "table": "plugin_example_links",
  "create": false,
  "delete_behavior": "clear",
  "delete_label": "Clear Assignment",
  "delete_payload": {
    "extension_plugin_profile_id": null,
    "enabled": false,
    "settings.run_sync": true
  }
}
```

When the row action runs, the host updates the row with `delete_payload` using dot-notation for nested JSON values instead of deleting the row.

## Changes

- Renders `schema.ui_tables[].label` as the heading for inline plugin Data tab tables.
- Renders `schema.ui_tables[].description` as the description for inline plugin Data tab tables.
- Adds `delete_behavior: "clear"` support for plugin-declared tables.
- Adds `delete_payload` support for clear-style row actions.
- Supports dot-notation in `delete_payload` so plugins can reset nested JSON settings.
- Adds optional clear-action presentation fields:
  - `delete_label`
  - `delete_icon`
  - `delete_color`
  - `delete_description`
  - `delete_submit_label`
  - `delete_success_message`
- Keeps default delete behavior unchanged for existing plugin tables.
- Applies the clear behavior consistently on standalone plugin table pages and inline Data tab tables.
- Adds manifest validation for invalid `delete_behavior` values.
- Requires `delete_payload` when `delete_behavior` is `clear`.
- Documents the new manifest fields in `docs/plugin-dev.md`.
- Adds regression coverage for inline table headings.
- Adds regression coverage for clear-on-delete behavior.
- Adds regression coverage for clear delete behavior manifest validation.

## Testing

Focused tests run on the PR branch:

- `PluginDeclaredTableUiTest`

Result:

`11 passed, 42 assertions`

Additional local verification after replaying these commits onto the current development branch:

- `PluginDeclaredTableUiTest`
- Channel Guardian `ManifestRegistryTest`

Result:

`13 passed, 47 assertions`

`5 passed, 15 assertions`
