### PR TITLE
fix: apply Xtream auto channel increment to series

### DIFF
--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -856,6 +856,7 @@ class XtreamApiController extends Controller
 
             return response()->stream(function () use ($seriesIterable, $playlist, $baseUrl, $isCustomPlaylist, $tagUuid) {
                 $num = 0;
+                $channelNumber = $playlist->auto_channel_increment ? $playlist->channel_start - 1 : 0;
                 echo '[';
                 $first = true;
                 foreach ($seriesIterable as $seriesItem) {
@@ -863,6 +864,7 @@ class XtreamApiController extends Controller
                         echo ',';
                     }
                     $num++;
+                    $seriesNumber = $playlist->auto_channel_increment ? ++$channelNumber : $num;
 
                     $seriesCategoryId = 'all';
                     if ($isCustomPlaylist) {
@@ -894,7 +896,7 @@ class XtreamApiController extends Controller
                     }
 
                     echo json_encode([
-                        'num' => $num,
+                        'num' => $seriesNumber,
                         'name' => $seriesItem->name,
                         'series_id' => (int) $seriesItem->id,
                         'cover' => $cover,

--- a/tests/Feature/XtreamAutoChannelIncrementTest.php
+++ b/tests/Feature/XtreamAutoChannelIncrementTest.php
@@ -3,6 +3,7 @@
 use App\Models\Channel;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Models\Series;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
@@ -74,4 +75,30 @@ it('Xtream API get_vod_streams uses auto channel increment before imported provi
 
     expect($streams)->toBeArray()->toHaveCount(2)
         ->and(array_column($streams, 'num'))->toBe([6000, 6001]);
+});
+
+it('Xtream API get_series uses auto channel increment from the configured channel start', function () {
+    $this->playlist->update([
+        'auto_channel_increment' => true,
+        'channel_start' => 7000,
+    ]);
+
+    Series::factory()->for($this->user)->for($this->playlist)->create([
+        'enabled' => true,
+        'sort' => 1,
+        'name' => 'Series One',
+    ]);
+    Series::factory()->for($this->user)->for($this->playlist)->create([
+        'enabled' => true,
+        'sort' => 2,
+        'name' => 'Series Two',
+    ]);
+
+    $response = $this->getJson('/player_api.php?username='.urlencode($this->user->name).'&password='.urlencode($this->playlist->uuid).'&action=get_series');
+
+    $response->assertStatus(200);
+    $series = $response->json();
+
+    expect($series)->toBeArray()->toHaveCount(2)
+        ->and(array_column($series, 'num'))->toBe([7000, 7001]);
 });


### PR DESCRIPTION
## Summary
- Apply `auto_channel_increment` and `channel_start` to Xtream `get_series` `num` output.
- Add regression coverage for series numbering alongside live and VOD streams.

## Testing
- `docker compose -f docker-compose.dev.yml --profile test run --rm --build m3u-editor-dev-test tests/Feature/XtreamAutoChannelIncrementTest.php`
- `docker compose -f docker-compose.dev.yml --profile test run --rm m3u-editor-dev-test tests/Feature/XtreamAutoChannelIncrementTest.php`
- `docker compose -f docker-compose.dev.yml --profile test run --rm --entrypoint /bin/bash m3u-editor-dev-test -lc './vendor/bin/pint --test app/Http/Controllers/XtreamApiController.php tests/Feature/XtreamAutoChannelIncrementTest.php'`
- `docker compose -f docker-compose.dev.yml --profile test run --rm --entrypoint /bin/bash m3u-editor-dev-test -lc 'php -l app/Http/Controllers/XtreamApiController.php && php -l tests/Feature/XtreamAutoChannelIncrementTest.php'`

Follow-up to #1153.
