### PR TITLE
fix: add active live group recount bulk action

### DIFF
--- a/app/Facades/SortFacade.php
+++ b/app/Facades/SortFacade.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static null bulkSortGroupChannels(\App\Models\Group $record, string $order = 'ASC', ?string $column = null)
  * @method static null bulkRecountGroupChannels(\App\Models\Group $record, int $start = 1)
  * @method static null bulkRecountGroupsByOrder(\Illuminate\Database\Eloquent\Collection $groups, int $start = 1)
+ * @method static null bulkRecountActiveLiveGroupsByOrder(\Illuminate\Database\Eloquent\Collection $groups, int $start = 1)
  * @method static null bulkRecountChannels(\Illuminate\Database\Eloquent\Collection $channels, int $start = 1)
  * @method static null bulkRecountCustomPlaylistChannels(\App\Models\CustomPlaylist $playlist, \Illuminate\Database\Eloquent\Collection $channels, int $start = 1)
  * @method static null bulkSortAlphaCustomPlaylistChannels(\App\Models\CustomPlaylist $playlist, \Illuminate\Database\Eloquent\Collection $channels, string $order = 'ASC', string $column = 'title')

--- a/app/Filament/Resources/Groups/GroupResource.php
+++ b/app/Filament/Resources/Groups/GroupResource.php
@@ -617,6 +617,33 @@ class GroupResource extends Resource implements CopilotResource
                         ->requiresConfirmation()
                         ->modalIcon('heroicon-o-hashtag')
                         ->modalDescription(__('Recount channels across the selected groups. Groups are processed by sort order, then name, then id, while channels in each group are processed by sort.')),
+                    BulkAction::make('recount_active_channels')
+                        ->label(__('Recount Active Channels in Selected Groups'))
+                        ->icon('heroicon-o-hashtag')
+                        ->form([
+                            TextInput::make('start')
+                                ->label(__('Start Number'))
+                                ->numeric()
+                                ->default(1)
+                                ->required(),
+                        ])
+                        ->action(function (Collection $records, array $data): void {
+                            SortFacade::bulkRecountActiveLiveGroupsByOrder(
+                                $records,
+                                (int) $data['start']
+                            );
+                        })
+                        ->after(function () {
+                            Notification::make()
+                                ->success()
+                                ->title(__('Active Channels Recounted'))
+                                ->body(__('The enabled live channels in the selected groups have been recounted sequentially.'))
+                                ->send();
+                        })
+                        ->deselectRecordsAfterCompletion()
+                        ->requiresConfirmation()
+                        ->modalIcon('heroicon-o-hashtag')
+                        ->modalDescription(__('Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers.')),
                     BulkAction::make('find-replace')
                         ->label(__('Find & Replace'))
                         ->schema(fn () => FindReplaceService::getBulkActionSchema('groups'))

--- a/app/Services/SortService.php
+++ b/app/Services/SortService.php
@@ -147,6 +147,46 @@ class SortService
         }
     }
 
+    /**
+     * Bulk recount enabled live channel numbers across multiple groups in deterministic sort order.
+     */
+    public function bulkRecountActiveLiveGroupsByOrder(Collection $groups, int $start = 1): void
+    {
+        $currentStart = max(1, $start);
+
+        $orderedGroups = $groups
+            ->sort(function (Group $first, Group $second): int {
+                $sortOrderComparison = ((float) $first->sort_order) <=> ((float) $second->sort_order);
+
+                if ($sortOrderComparison !== 0) {
+                    return $sortOrderComparison;
+                }
+
+                $nameComparison = strcasecmp($first->name, $second->name);
+
+                if ($nameComparison !== 0) {
+                    return $nameComparison;
+                }
+
+                return $first->id <=> $second->id;
+            })
+            ->values();
+
+        foreach ($orderedGroups as $record) {
+            $channels = $record->live_channels()
+                ->where('enabled', true)
+                ->orderBy('sort')
+                ->get();
+
+            if ($channels->isEmpty()) {
+                continue;
+            }
+
+            $this->bulkRecountChannels($channels, $currentStart);
+            $currentStart += $channels->count();
+        }
+    }
+
     public function bulkRecountChannels(Collection $channels, $start = 1): void
     {
         $offset = max(0, $start - 1);

--- a/lang/de.json
+++ b/lang/de.json
@@ -2954,5 +2954,9 @@
     "YYYY or YYYY-MM-DD": "JJJJ oder JJJJ-MM-TT",
     "YYYY-MM-DD": "JJJJ-MM-TT",
     "Z to A or 9 to 0": "Z bis A oder 9 bis 0",
-    "—": "—"
+    "—": "—",
+    "Recount Active Channels in Selected Groups": "Recount Active Channels in Selected Groups",
+    "Active Channels Recounted": "Active Channels Recounted",
+    "The enabled live channels in the selected groups have been recounted sequentially.": "The enabled live channels in the selected groups have been recounted sequentially.",
+    "Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers.": "Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2954,5 +2954,9 @@
     "YYYY or YYYY-MM-DD": "YYYY or YYYY-MM-DD",
     "YYYY-MM-DD": "YYYY-MM-DD",
     "Z to A or 9 to 0": "Z to A or 9 to 0",
-    "—": "—"
+    "—": "—",
+    "Recount Active Channels in Selected Groups": "Recount Active Channels in Selected Groups",
+    "Active Channels Recounted": "Active Channels Recounted",
+    "The enabled live channels in the selected groups have been recounted sequentially.": "The enabled live channels in the selected groups have been recounted sequentially.",
+    "Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers.": "Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -2954,5 +2954,9 @@
     "YYYY or YYYY-MM-DD": "AAAA o AAAA-MM-DD",
     "YYYY-MM-DD": "AAAA-MM-DD",
     "Z to A or 9 to 0": "Z a A o 9 a 0",
-    "—": "—"
+    "—": "—",
+    "Recount Active Channels in Selected Groups": "Recount Active Channels in Selected Groups",
+    "Active Channels Recounted": "Active Channels Recounted",
+    "The enabled live channels in the selected groups have been recounted sequentially.": "The enabled live channels in the selected groups have been recounted sequentially.",
+    "Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers.": "Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2954,5 +2954,9 @@
     "YYYY or YYYY-MM-DD": "AAAA ou AAAA-MM-JJ",
     "YYYY-MM-DD": "AAAA-MM-JJ",
     "Z to A or 9 to 0": "Z à A ou 9 à 0",
-    "—": "—"
+    "—": "—",
+    "Recount Active Channels in Selected Groups": "Recount Active Channels in Selected Groups",
+    "Active Channels Recounted": "Active Channels Recounted",
+    "The enabled live channels in the selected groups have been recounted sequentially.": "The enabled live channels in the selected groups have been recounted sequentially.",
+    "Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers.": "Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers."
 }

--- a/lang/zh_CN.json
+++ b/lang/zh_CN.json
@@ -2954,5 +2954,9 @@
     "YYYY or YYYY-MM-DD": "YYYY 或 YYYY-MM-DD",
     "YYYY-MM-DD": "YYYY-MM-DD",
     "Z to A or 9 to 0": "Z 到 A 或 9 到 0",
-    "—": "—"
+    "—": "—",
+    "Recount Active Channels in Selected Groups": "Recount Active Channels in Selected Groups",
+    "Active Channels Recounted": "Active Channels Recounted",
+    "The enabled live channels in the selected groups have been recounted sequentially.": "The enabled live channels in the selected groups have been recounted sequentially.",
+    "Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers.": "Recount only enabled live channels across the selected groups. Groups are processed by sort order, then name, then id, while enabled live channels in each group are processed by sort. Disabled channels keep their current numbers."
 }

--- a/tests/Feature/GroupEnableChannelRecountTest.php
+++ b/tests/Feature/GroupEnableChannelRecountTest.php
@@ -159,7 +159,7 @@ it('starts at 1 when no other enabled channels exist in the playlist', function 
         ]);
     }
 
-    // Enable group — no other enabled channels exist
+    // Enable group. No other enabled channels exist.
     $group->channels()->update(['enabled' => true]);
 
     $maxChannel = Channel::query()
@@ -362,4 +362,145 @@ it('uses stable name and id fallback when sort_order is the same for selected gr
     expect($alphaChannels)->toBe([10]);
     expect($alphaDuplicateChannels)->toBe([11]);
     expect($zuluChannels)->toBe([12]);
+});
+
+it('recounts only active live channels across selected groups in group order', function () {
+    $groupA = Group::factory()->for($this->playlist)->for($this->user)->create([
+        'name' => 'Group A',
+        'sort_order' => 1,
+        'type' => 'live',
+    ]);
+    $groupB = Group::factory()->for($this->playlist)->for($this->user)->create([
+        'name' => 'Group B',
+        'sort_order' => 2,
+        'type' => 'live',
+    ]);
+
+    $groupADisabled = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $groupA->id,
+        'enabled' => false,
+        'is_vod' => false,
+        'sort' => 1,
+        'channel' => 674,
+    ]);
+    foreach ([2, 3] as $sort) {
+        Channel::factory()->create([
+            'user_id' => $this->user->id,
+            'playlist_id' => $this->playlist->id,
+            'group_id' => $groupA->id,
+            'enabled' => true,
+            'is_vod' => false,
+            'sort' => $sort,
+            'channel' => 900 + $sort,
+        ]);
+    }
+
+    $groupBDisabled = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $groupB->id,
+        'enabled' => false,
+        'is_vod' => false,
+        'sort' => 1,
+        'channel' => 981,
+    ]);
+    foreach ([2, 3, 4] as $sort) {
+        Channel::factory()->create([
+            'user_id' => $this->user->id,
+            'playlist_id' => $this->playlist->id,
+            'group_id' => $groupB->id,
+            'enabled' => true,
+            'is_vod' => false,
+            'sort' => $sort,
+            'channel' => 800 + $sort,
+        ]);
+    }
+
+    $groups = Group::query()
+        ->whereIn('id', [$groupB->id, $groupA->id])
+        ->get();
+
+    SortFacade::bulkRecountActiveLiveGroupsByOrder($groups, 1);
+
+    expect(Channel::query()
+        ->where('group_id', $groupA->id)
+        ->where('enabled', true)
+        ->orderBy('sort')
+        ->pluck('channel')
+        ->all())->toBe([1, 2]);
+
+    expect(Channel::query()
+        ->where('group_id', $groupB->id)
+        ->where('enabled', true)
+        ->orderBy('sort')
+        ->pluck('channel')
+        ->all())->toBe([3, 4, 5]);
+
+    expect($groupADisabled->refresh()->channel)->toBe(674);
+    expect($groupBDisabled->refresh()->channel)->toBe(981);
+});
+
+it('runs the active channels table bulk recount across selected groups by group order', function () {
+    $groupA = Group::factory()->for($this->playlist)->for($this->user)->create([
+        'name' => 'Group A',
+        'sort_order' => 20,
+        'type' => 'live',
+    ]);
+    $groupB = Group::factory()->for($this->playlist)->for($this->user)->create([
+        'name' => 'Group B',
+        'sort_order' => 10,
+        'type' => 'live',
+    ]);
+
+    Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $groupA->id,
+        'enabled' => false,
+        'is_vod' => false,
+        'sort' => 1,
+        'channel' => 777,
+    ]);
+    Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $groupA->id,
+        'enabled' => true,
+        'is_vod' => false,
+        'sort' => 2,
+        'channel' => 900,
+    ]);
+
+    foreach ([1, 2] as $sort) {
+        Channel::factory()->create([
+            'user_id' => $this->user->id,
+            'playlist_id' => $this->playlist->id,
+            'group_id' => $groupB->id,
+            'enabled' => true,
+            'is_vod' => false,
+            'sort' => $sort,
+            'channel' => 800 + $sort,
+        ]);
+    }
+
+    Livewire::test(ListGroups::class)
+        ->callTableBulkAction('recount_active_channels', collect([$groupA, $groupB]), [
+            'start' => 100,
+        ]);
+
+    expect(Channel::query()
+        ->where('group_id', $groupB->id)
+        ->where('enabled', true)
+        ->orderBy('sort')
+        ->pluck('channel')
+        ->all())->toBe([100, 101]);
+
+    expect(Channel::query()
+        ->where('group_id', $groupA->id)
+        ->where('enabled', true)
+        ->orderBy('sort')
+        ->pluck('channel')
+        ->all())->toBe([102]);
 });


### PR DESCRIPTION
## Summary
- Add a separate Live Groups bulk action, `Recount Active Channels in Selected Groups`.
- Recount selected live groups by `groups.sort_order`, then name, then id.
- Number only enabled live channels in each group by `channels.sort`; disabled channels keep their existing channel numbers.
- Keep the existing `Recount Selected Groups` action unchanged.

## Testing
- `python3 -m json.tool lang/en.json lang/de.json lang/es.json lang/fr.json lang/zh_CN.json`
- `git diff --check`
- Docker test container PHP lint for changed PHP/test files
- `vendor/bin/pint --test tests/Feature/GroupEnableChannelRecountTest.php`
- `vendor/bin/pint --test`
- `tests/Feature/GroupEnableChannelRecountTest.php` in Docker test profile: 8 warnings, 24 assertions, exit code 0
- Full Docker Pest suite with embedded Redis: 1523 passed, 29 skipped, 4019 assertions
- `composer audit --locked --format=summary`: no security vulnerability advisories found
- `npm audit --audit-level=high`: 0 vulnerabilities

## Local build note
- Retried local `docker build` twice. Both attempts were blocked before application build by transient GitHub codeload HTTP/2 400 errors while Composer downloaded dist archives, first `igorw/evenement`, then `symfony/polyfill-php84` / `php-fig/log`. The Docker test image build, frontend build inside that image, focused tests, full suite, Pint, and audits passed.
