### PR TITLE
fix: stream backup downloads outside Livewire

### DIFF
--- a/app/Http/Controllers/BackupDownloadController.php
+++ b/app/Http/Controllers/BackupDownloadController.php
@@ -20,20 +20,21 @@ class BackupDownloadController extends Controller
         $stream = Storage::disk($disk)->readStream($decodedPath);
         abort_if($stream === false, 404);
 
+        $contentType = str_ends_with($decodedPath, '.tar.gz') ? 'application/gzip' : 'application/zip';
+
         $headers = [
-            'Content-Type' => 'application/zip',
+            'Content-Type' => $contentType,
+            'Content-Length' => (string) Storage::disk($disk)->size($decodedPath),
         ];
-
-        $size = Storage::disk($disk)->size($decodedPath);
-
-        if ($size !== null) {
-            $headers['Content-Length'] = (string) $size;
-        }
 
         return response()->streamDownload(function () use ($stream): void {
             try {
                 while (! feof($stream)) {
-                    echo fread($stream, 1024 * 1024);
+                    $chunk = fread($stream, 1024 * 1024);
+                    if ($chunk === false) {
+                        break;
+                    }
+                    echo $chunk;
                     flush();
                 }
             } finally {
@@ -49,7 +50,7 @@ class BackupDownloadController extends Controller
         $paddedPath = str_pad(strtr($path, '-_', '+/'), strlen($path) % 4 === 0 ? strlen($path) : strlen($path) + 4 - (strlen($path) % 4), '=', STR_PAD_RIGHT);
         $decodedPath = base64_decode($paddedPath, true);
 
-        if ($decodedPath === false || $decodedPath === '' || str_contains($decodedPath, "\0")) {
+        if ($decodedPath === false || $decodedPath === '' || str_contains($decodedPath, "\0") || str_contains($decodedPath, '..')) {
             return null;
         }
 

--- a/app/Http/Controllers/BackupDownloadController.php
+++ b/app/Http/Controllers/BackupDownloadController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackup;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class BackupDownloadController extends Controller
+{
+    public function __invoke(Request $request, string $disk, string $path): StreamedResponse
+    {
+        abort_unless($request->user()?->can('download-backup'), 403);
+        abort_unless(in_array($disk, FilamentSpatieLaravelBackup::getDisks(), true), 404);
+
+        $decodedPath = $this->decodePath($path);
+        abort_if($decodedPath === null || ! Storage::disk($disk)->exists($decodedPath), 404);
+
+        $stream = Storage::disk($disk)->readStream($decodedPath);
+        abort_if($stream === false, 404);
+
+        $headers = [
+            'Content-Type' => 'application/zip',
+        ];
+
+        $size = Storage::disk($disk)->size($decodedPath);
+
+        if ($size !== null) {
+            $headers['Content-Length'] = (string) $size;
+        }
+
+        return response()->streamDownload(function () use ($stream): void {
+            try {
+                while (! feof($stream)) {
+                    echo fread($stream, 1024 * 1024);
+                    flush();
+                }
+            } finally {
+                if (is_resource($stream)) {
+                    fclose($stream);
+                }
+            }
+        }, basename($decodedPath), $headers);
+    }
+
+    private function decodePath(string $path): ?string
+    {
+        $paddedPath = str_pad(strtr($path, '-_', '+/'), strlen($path) % 4 === 0 ? strlen($path) : strlen($path) + 4 - (strlen($path) % 4), '=', STR_PAD_RIGHT);
+        $decodedPath = base64_decode($paddedPath, true);
+
+        if ($decodedPath === false || $decodedPath === '' || str_contains($decodedPath, "\0")) {
+            return null;
+        }
+
+        return $decodedPath;
+    }
+}

--- a/app/Livewire/BackupDestinationListRecords.php
+++ b/app/Livewire/BackupDestinationListRecords.php
@@ -128,7 +128,8 @@ class BackupDestinationListRecords extends Component implements HasActions, HasF
                     ->url(fn (array $record): string => route('backups.download', [
                         'disk' => $record['disk'],
                         'path' => rtrim(strtr(base64_encode($record['path']), '+/', '-_'), '='),
-                    ])),
+                    ]))
+                    ->openUrlInNewTab(),
             ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Livewire/BackupDestinationListRecords.php
+++ b/app/Livewire/BackupDestinationListRecords.php
@@ -17,7 +17,6 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
@@ -126,7 +125,10 @@ class BackupDestinationListRecords extends Component implements HasActions, HasF
                     ->icon('heroicon-o-arrow-down-tray')
                     ->visible(auth()->user()->can('download-backup'))
                     ->button()->hiddenLabel()->size('sm')
-                    ->action(fn (array $record) => Storage::disk($record['disk'])->download($record['path'])),
+                    ->url(fn (array $record): string => route('backups.download', [
+                        'disk' => $record['disk'],
+                        'path' => rtrim(strtr(base64_encode($record['path']), '+/', '-_'), '='),
+                    ])),
             ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\DispatcharrController;
 use App\Http\Controllers\AssetPreviewController;
 use App\Http\Controllers\Auth\OidcController;
+use App\Http\Controllers\BackupDownloadController;
 use App\Http\Controllers\ChannelController;
 use App\Http\Controllers\EpgController;
 use App\Http\Controllers\EpgFileController;
@@ -108,6 +109,11 @@ Route::get('/logo-proxy/{encodedUrl}/{filename?}', [LogoProxyController::class, 
 Route::get('/assets/{asset}/preview', AssetPreviewController::class)
     ->middleware(['auth'])
     ->name('assets.preview');
+
+Route::get('/admin/backups/download/{disk}/{path}', BackupDownloadController::class)
+    ->middleware(['auth'])
+    ->where('path', '[A-Za-z0-9\-_]+')
+    ->name('backups.download');
 
 Route::get('/extension-plugins/{plugin}/runs/{run}/report', PluginRunReportController::class)
     ->middleware(['auth'])

--- a/tests/Feature/BackupDownloadTest.php
+++ b/tests/Feature/BackupDownloadTest.php
@@ -9,6 +9,7 @@ function encodedBackupPath(string $path): string
 }
 
 it('streams backup downloads through an authenticated admin route', function () {
+    config(['backup.backup.destination.disks' => ['local']]);
     Storage::fake('local');
 
     $backupPath = 'm3u-editor-backups/large-backup.zip';
@@ -42,12 +43,25 @@ it('prevents non-admin users from downloading backups', function () {
 });
 
 it('returns not found for missing backup files', function () {
+    config(['backup.backup.destination.disks' => ['local']]);
     Storage::fake('local');
 
     $this->actingAs(User::factory()->admin()->create())
         ->get(route('backups.download', [
             'disk' => 'local',
             'path' => encodedBackupPath('m3u-editor-backups/missing.zip'),
+        ]))
+        ->assertNotFound();
+});
+
+it('rejects path traversal sequences', function () {
+    config(['backup.backup.destination.disks' => ['local']]);
+    Storage::fake('local');
+
+    $this->actingAs(User::factory()->admin()->create())
+        ->get(route('backups.download', [
+            'disk' => 'local',
+            'path' => encodedBackupPath('../../etc/passwd'),
         ]))
         ->assertNotFound();
 });

--- a/tests/Feature/BackupDownloadTest.php
+++ b/tests/Feature/BackupDownloadTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+
+function encodedBackupPath(string $path): string
+{
+    return rtrim(strtr(base64_encode($path), '+/', '-_'), '=');
+}
+
+it('streams backup downloads through an authenticated admin route', function () {
+    Storage::fake('local');
+
+    $backupPath = 'm3u-editor-backups/large-backup.zip';
+    $backupContents = str_repeat('backup-payload-', 128);
+    Storage::disk('local')->put($backupPath, $backupContents);
+
+    $this->actingAs(User::factory()->admin()->create())
+        ->get(route('backups.download', [
+            'disk' => 'local',
+            'path' => encodedBackupPath($backupPath),
+        ]))
+        ->assertOk()
+        ->assertHeader('content-type', 'application/zip')
+        ->assertHeader('content-length', (string) strlen($backupContents))
+        ->assertHeader('content-disposition', 'attachment; filename=large-backup.zip')
+        ->assertStreamedContent($backupContents);
+});
+
+it('prevents non-admin users from downloading backups', function () {
+    Storage::fake('local');
+
+    $backupPath = 'm3u-editor-backups/large-backup.zip';
+    Storage::disk('local')->put($backupPath, 'backup-payload');
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('backups.download', [
+            'disk' => 'local',
+            'path' => encodedBackupPath($backupPath),
+        ]))
+        ->assertForbidden();
+});
+
+it('returns not found for missing backup files', function () {
+    Storage::fake('local');
+
+    $this->actingAs(User::factory()->admin()->create())
+        ->get(route('backups.download', [
+            'disk' => 'local',
+            'path' => encodedBackupPath('m3u-editor-backups/missing.zip'),
+        ]))
+        ->assertNotFound();
+});


### PR DESCRIPTION
## Summary
- Move backup downloads out of the Livewire table action response path.
- Add an authenticated admin-only download route that streams backup files from storage.
- Encode backup paths into the URL safely and keep disk validation limited to configured backup disks.
- Add feature coverage for successful admin downloads, non-admin denial, and missing backup files.

Fixes #1166

## Testing
- `vendor/bin/pint --test app/Http/Controllers/BackupDownloadController.php app/Livewire/BackupDestinationListRecords.php routes/web.php tests/Feature/BackupDownloadTest.php`
- `vendor/bin/pint --test`
- `tests/Feature/BackupDownloadTest.php` in Docker test profile: 3 warnings, 10 assertions, exit code 0
- `git diff --check`
