### PR TITLE
feat(epg): add dummy epg fallback ids

### DIFF
--- a/app/Filament/Resources/CustomPlaylists/CustomPlaylistResource.php
+++ b/app/Filament/Resources/CustomPlaylists/CustomPlaylistResource.php
@@ -414,6 +414,20 @@ class CustomPlaylistResource extends Resource implements CopilotResource
                         ->required()
                         ->default('stream_id') // Default to stream_id
                         ->columnSpan(1),
+                    Select::make('dummy_epg_id_fallbacks')
+                        ->label(__('Additional Dummy EPG IDs'))
+                        ->helperText(__('Generate matching dummy EPG channel and programme entries for these additional IDs, so clients can fall back between channel name, title, number, channel ID, or TVG/stream ID.'))
+                        ->options([
+                            'stream_id' => 'TVG ID/Stream ID',
+                            'channel_id' => 'Channel ID',
+                            'number' => 'Channel Number',
+                            'name' => 'Channel Name',
+                            'title' => 'Channel Title',
+                        ])
+                        ->multiple()
+                        ->preload()
+                        ->hidden(fn (Get $get): bool => ! $get('dummy_epg'))
+                        ->columnSpan(1),
                     TextInput::make('dummy_epg_length')
                         ->label(__('Dummy program length (in minutes)'))
                         ->columnSpan(1)

--- a/app/Filament/Resources/MergedPlaylists/MergedPlaylistResource.php
+++ b/app/Filament/Resources/MergedPlaylists/MergedPlaylistResource.php
@@ -322,6 +322,20 @@ class MergedPlaylistResource extends Resource implements CopilotResource
                         ->required()
                         ->default('stream_id') // Default to stream_id
                         ->columnSpan(1),
+                    Select::make('dummy_epg_id_fallbacks')
+                        ->label(__('Additional Dummy EPG IDs'))
+                        ->helperText(__('Generate matching dummy EPG channel and programme entries for these additional IDs, so clients can fall back between channel name, title, number, channel ID, or TVG/stream ID.'))
+                        ->options([
+                            'stream_id' => 'TVG ID/Stream ID',
+                            'channel_id' => 'Channel ID',
+                            'number' => 'Channel Number',
+                            'name' => 'Channel Name',
+                            'title' => 'Channel Title',
+                        ])
+                        ->multiple()
+                        ->preload()
+                        ->hidden(fn (Get $get): bool => ! $get('dummy_epg'))
+                        ->columnSpan(1),
                     TextInput::make('dummy_epg_length')
                         ->label(__('Dummy program length (in minutes)'))
                         ->columnSpan(1)

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -3016,6 +3016,20 @@ class PlaylistResource extends Resource implements CopilotResource
                         ->required()
                         ->default('stream_id') // Default to stream_id
                         ->columnSpan(1),
+                    Select::make('dummy_epg_id_fallbacks')
+                        ->label(__('Additional Dummy EPG IDs'))
+                        ->helperText(__('Generate matching dummy EPG channel and programme entries for these additional IDs, so clients can fall back between channel name, title, number, channel ID, or TVG/stream ID.'))
+                        ->options([
+                            'stream_id' => 'TVG ID/Stream ID',
+                            'channel_id' => 'Channel ID',
+                            'number' => 'Channel Number',
+                            'name' => 'Channel Name',
+                            'title' => 'Channel Title',
+                        ])
+                        ->multiple()
+                        ->preload()
+                        ->hidden(fn (Get $get): bool => ! $get('dummy_epg'))
+                        ->columnSpan(1),
                     Toggle::make('dummy_epg_category')
                         ->label(__('Channel group as category'))
                         ->columnSpan(1)

--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Enums\ChannelLogoType;
 use App\Enums\PlaylistChannelId;
 use App\Facades\PlaylistFacade;
+use App\Models\Channel;
 use App\Models\CustomPlaylist;
 use App\Models\Epg;
 use App\Models\MergedPlaylist;
@@ -134,32 +135,14 @@ class EpgGenerateController extends Controller
                 $channelNo = ++$channelNumber;
             }
 
-            // Get the `tvg-id` based on the playlist setting
-            switch ($idChannelBy) {
-                case PlaylistChannelId::ChannelId:
-                    $tvgId = $channel->id;
-                    break;
-                case PlaylistChannelId::Number:
-                    $tvgId = $channelNo;
-                    break;
-                case PlaylistChannelId::Name:
-                    $tvgId = $channel->name_custom ?? $channel->name;
-                    break;
-                case PlaylistChannelId::Title:
-                    $tvgId = $channel->title_custom ?? $channel->title;
-                    break;
-                default:
-                    $tvgId = $channel->stream_id_custom ?? $channel->source_id ?? $channel->stream_id;
-                    break;
-            }
+            $tvgId = $this->getChannelIdentifier($channel, $channelNo, $idChannelBy);
 
             // If no TVG ID still, fallback to the channel source ID or internal ID as a last resort
             if (empty($tvgId)) {
                 $tvgId = $channel->source_id ?? $channel->id;
             }
 
-            // Make sure TVG ID only contains characters and numbers
-            $tvgId = preg_replace(config('dev.tvgid.regex'), '', $tvgId);
+            $tvgId = $this->sanitizeChannelIdentifier($tvgId);
 
             // Output the <channel> tag
             $title = $channel->title_custom ?? $channel->title;
@@ -223,7 +206,7 @@ class EpgGenerateController extends Controller
                 // Keep track of which channels need a dummy EPG program
                 // Need this to output the <programme> tags later
                 $dummyEpgChannels[] = [
-                    'tvg_id' => $tvgId,
+                    'tvg_ids' => $this->getDummyEpgChannelIds($channel, $channelNo, $tvgId, $playlist->dummy_epg_id_fallbacks ?? []),
                     'channel_id' => $channel->id,
                     'channel_no' => $channelNo,
                     'title' => $title,
@@ -232,16 +215,17 @@ class EpgGenerateController extends Controller
                     'include_category' => $playlist->dummy_epg_category,
                 ];
 
-                // Output the <channel> tag
-                echo '  <channel id="'.$tvgId.'">'.PHP_EOL;
-                echo '    <display-name>'.$title.'</display-name>';
-                if ($channelNo !== null) {
-                    echo PHP_EOL.'    <display-name>'.$channelNo.'</display-name>';
+                foreach ($dummyEpgChannels[array_key_last($dummyEpgChannels)]['tvg_ids'] as $dummyTvgId) {
+                    echo '  <channel id="'.$dummyTvgId.'">'.PHP_EOL;
+                    echo '    <display-name>'.$title.'</display-name>';
+                    if ($channelNo !== null) {
+                        echo PHP_EOL.'    <display-name>'.$channelNo.'</display-name>';
+                    }
+                    if ($icon) {
+                        echo PHP_EOL.'    <icon src="'.$icon.'"/>';
+                    }
+                    echo PHP_EOL.'  </channel>'.PHP_EOL;
                 }
-                if ($icon) {
-                    echo PHP_EOL.'    <icon src="'.$icon.'"/>';
-                }
-                echo PHP_EOL.'  </channel>'.PHP_EOL;
             }
         }
 
@@ -412,7 +396,7 @@ class EpgGenerateController extends Controller
 
             // Generate programmes for each channel using pre-calculated time slots
             foreach ($dummyEpgChannels as $dummyEpgChannel) {
-                $tvgId = $this->escapeXml($dummyEpgChannel['tvg_id']);
+                $tvgIds = array_map(fn (string $tvgId): string => $this->escapeXml($tvgId), $dummyEpgChannel['tvg_ids']);
                 $title = $dummyEpgChannel['title'];
                 $icon = $dummyEpgChannel['icon'];
                 $group = $this->escapeXml($dummyEpgChannel['group']);
@@ -420,17 +404,19 @@ class EpgGenerateController extends Controller
 
                 // Build all programmes for this channel in one string buffer
                 $buffer = '';
-                foreach ($timeSlots as $slot) {
-                    $buffer .= '  <programme channel="'.$tvgId.'" start="'.$slot['start'].'" stop="'.$slot['end'].'">'.PHP_EOL;
-                    $buffer .= '    <title>'.$title.'</title>'.PHP_EOL;
-                    if ($icon) {
-                        $buffer .= '    <icon src="'.$icon.'"/>'.PHP_EOL;
+                foreach ($tvgIds as $tvgId) {
+                    foreach ($timeSlots as $slot) {
+                        $buffer .= '  <programme channel="'.$tvgId.'" start="'.$slot['start'].'" stop="'.$slot['end'].'">'.PHP_EOL;
+                        $buffer .= '    <title>'.$title.'</title>'.PHP_EOL;
+                        if ($icon) {
+                            $buffer .= '    <icon src="'.$icon.'"/>'.PHP_EOL;
+                        }
+                        $buffer .= '    <desc>'.$title.'</desc>'.PHP_EOL;
+                        if ($includeCategory) {
+                            $buffer .= '    <category lang="en">'.$group.'</category>'.PHP_EOL;
+                        }
+                        $buffer .= '  </programme>'.PHP_EOL;
                     }
-                    $buffer .= '    <desc>'.$title.'</desc>'.PHP_EOL;
-                    if ($includeCategory) {
-                        $buffer .= '    <category lang="en">'.$group.'</category>'.PHP_EOL;
-                    }
-                    $buffer .= '  </programme>'.PHP_EOL;
                 }
                 // Single echo per channel instead of 600+ echoes
                 echo $buffer;
@@ -695,6 +681,45 @@ class EpgGenerateController extends Controller
         } catch (Exception $e) {
             return null;
         }
+    }
+
+    private function getChannelIdentifier(Channel $channel, int|string|null $channelNo, PlaylistChannelId|string|null $strategy): mixed
+    {
+        $strategyValue = $strategy instanceof PlaylistChannelId ? $strategy->value : $strategy;
+
+        return match ($strategyValue) {
+            PlaylistChannelId::ChannelId->value => $channel->id,
+            PlaylistChannelId::Number->value => $channelNo,
+            PlaylistChannelId::Name->value => $channel->name_custom ?? $channel->name,
+            PlaylistChannelId::Title->value => $channel->title_custom ?? $channel->title,
+            default => $channel->stream_id_custom ?? $channel->source_id ?? $channel->stream_id,
+        };
+    }
+
+    private function sanitizeChannelIdentifier(mixed $identifier): string
+    {
+        return (string) preg_replace(config('dev.tvgid.regex'), '', (string) $identifier);
+    }
+
+    /**
+     * @param  array<int, string>  $fallbackStrategies
+     * @return array<int, string>
+     */
+    private function getDummyEpgChannelIds(Channel $channel, int|string|null $channelNo, string $primaryTvgId, array $fallbackStrategies): array
+    {
+        $channelIds = [$primaryTvgId];
+
+        foreach ($fallbackStrategies as $fallbackStrategy) {
+            $fallbackId = $this->sanitizeChannelIdentifier(
+                $this->getChannelIdentifier($channel, $channelNo, $fallbackStrategy)
+            );
+
+            if ($fallbackId !== '') {
+                $channelIds[] = $fallbackId;
+            }
+        }
+
+        return array_values(array_unique($channelIds));
     }
 
     /**

--- a/app/Models/CustomPlaylist.php
+++ b/app/Models/CustomPlaylist.php
@@ -32,6 +32,7 @@ class CustomPlaylist extends Model
         'id' => 'integer',
         'user_id' => 'integer',
         'dummy_epg' => 'boolean',
+        'dummy_epg_id_fallbacks' => 'array',
         'output_tvg_type' => 'boolean',
         'short_urls' => 'array',
         'proxy_options' => 'array',

--- a/app/Models/MergedPlaylist.php
+++ b/app/Models/MergedPlaylist.php
@@ -28,6 +28,7 @@ class MergedPlaylist extends Model
         'id' => 'integer',
         'user_id' => 'integer',
         'dummy_epg' => 'boolean',
+        'dummy_epg_id_fallbacks' => 'array',
         'output_tvg_type' => 'boolean',
         'short_urls' => 'array',
         'proxy_options' => 'array',

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -38,6 +38,7 @@ class Playlist extends Model
         'sync_time' => 'float',
         'processing' => 'array',
         'dummy_epg' => 'boolean',
+        'dummy_epg_id_fallbacks' => 'array',
         'output_tvg_type' => 'boolean',
         'import_prefs' => 'array',
         'groups' => 'array',

--- a/app/Models/PlaylistAlias.php
+++ b/app/Models/PlaylistAlias.php
@@ -280,6 +280,13 @@ class PlaylistAlias extends Model
         return $effectivePlaylist ? (bool) $effectivePlaylist->dummy_epg_category : false;
     }
 
+    public function getDummyEpgIdFallbacksAttribute(): array
+    {
+        $effectivePlaylist = $this->getEffectivePlaylist();
+
+        return $effectivePlaylist ? (array) ($effectivePlaylist->dummy_epg_id_fallbacks ?? []) : [];
+    }
+
     /**
      * Get groups through the effective playlist
      */

--- a/database/migrations/2026_06_27_103300_add_dummy_epg_id_fallbacks_to_playlists.php
+++ b/database/migrations/2026_06_27_103300_add_dummy_epg_id_fallbacks_to_playlists.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        foreach (['playlists', 'custom_playlists', 'merged_playlists'] as $tableName) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->json('dummy_epg_id_fallbacks')
+                    ->nullable()
+                    ->after('dummy_epg');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (['playlists', 'custom_playlists', 'merged_playlists'] as $tableName) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->dropColumn('dummy_epg_id_fallbacks');
+            });
+        }
+    }
+};

--- a/tests/Feature/EpgApiControllerTest.php
+++ b/tests/Feature/EpgApiControllerTest.php
@@ -2,6 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Events\EpgCreated;
+use App\Events\EpgDeleted;
+use App\Events\EpgUpdated;
+use App\Events\PlaylistCreated;
+use App\Events\PlaylistDeleted;
+use App\Events\PlaylistUpdated;
 use App\Models\Channel;
 use App\Models\Epg;
 use App\Models\EpgChannel;
@@ -10,6 +16,9 @@ use App\Models\Playlist;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 class EpgApiControllerTest extends TestCase
@@ -23,6 +32,19 @@ class EpgApiControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        Event::fake([
+            EpgCreated::class,
+            EpgDeleted::class,
+            EpgUpdated::class,
+            PlaylistCreated::class,
+            PlaylistDeleted::class,
+            PlaylistUpdated::class,
+        ]);
+        $this->withoutMiddleware([
+            ThrottleRequests::class,
+            ThrottleRequestsWithRedis::class,
+        ]);
 
         $this->user = User::factory()->create();
         $this->playlist = Playlist::factory()->for($this->user)->create([

--- a/tests/Feature/EpgGenerateControllerTest.php
+++ b/tests/Feature/EpgGenerateControllerTest.php
@@ -150,3 +150,38 @@ test('epg xml generation preserves albanian characters with explicit utf8 escapi
         ini_set('default_charset', $previousCharset ?: 'UTF-8');
     }
 });
+
+test('dummy epg can generate fallback channel ids for title and stream id', function () {
+    $user = User::factory()->create();
+
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => true,
+        'dummy_epg_length' => 60,
+        'id_channel_by' => 'name',
+        'dummy_epg_id_fallbacks' => ['title', 'stream_id'],
+    ]);
+
+    Channel::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $user->id,
+        'enabled' => true,
+        'is_vod' => false,
+        'name' => 'News Name',
+        'title' => 'News Title',
+        'stream_id' => 'news-stream-id',
+        'channel' => 7,
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertStatus(200);
+    $content = gzdecode($response->getContent());
+
+    expect($content)
+        ->toContain('<channel id="NewsName">')
+        ->toContain('<channel id="NewsTitle">')
+        ->toContain('<channel id="news-stream-id">')
+        ->toContain('<programme channel="NewsName"')
+        ->toContain('<programme channel="NewsTitle"')
+        ->toContain('<programme channel="news-stream-id"');
+});


### PR DESCRIPTION
## Summary
- Add `dummy_epg_id_fallbacks` to playlist, custom playlist, and merged playlist EPG settings.
- Generate Dummy EPG channel and programme aliases for the selected additional ID strategies.
- Add the UI select for Additional Dummy EPG IDs in all EPG Output forms.
- Isolate existing EPG API tests from playlist event side effects and Redis-backed throttling.

## Testing
- `docker compose -f docker-compose.dev.yml --profile test run --rm m3u-editor-dev-test tests/Feature/EpgGenerateControllerTest.php tests/Feature/EpgApiControllerTest.php`
- `docker run --rm --user "$(id -u):$(id -g)" -v "$PWD":/work -w /work --entrypoint /bin/bash m3u-editor-m3u-editor-dev-test -lc 'php /var/www/html/vendor/bin/pint --test'`

Closes #465
