### PR TITLE
Add proxy auto-transition for zero-round-trip programme switching

### DIFF
--- a/app/Http/Controllers/Api/M3uProxyApiController.php
+++ b/app/Http/Controllers/Api/M3uProxyApiController.php
@@ -475,8 +475,17 @@ class M3uProxyApiController extends Controller
             // The proxy already started the next programme — update DB state atomically
             // to reflect the running broadcast without an intermediate null state that
             // the tick loop could misread as "stopped".
+            $endedProgrammeId = $network->broadcast_programme_id;
             $network->refresh();
-            $nextProgramme = $network->getCurrentProgramme() ?? $network->getNextProgramme();
+
+            // Guard: getCurrentProgramme() uses end_time > now(), so a callback that
+            // arrives before the wall clock crosses end_time returns the just-ended
+            // programme. Skip it so we always resolve the next one.
+            $nextProgramme = $network->getCurrentProgramme();
+            if ($nextProgramme?->id === $endedProgrammeId) {
+                $nextProgramme = null;
+            }
+            $nextProgramme ??= $network->getNextProgramme();
 
             $network->update([
                 'broadcast_segment_sequence' => $finalSegment + 1,
@@ -488,6 +497,7 @@ class M3uProxyApiController extends Controller
                 'broadcast_fail_count' => 0,
                 'broadcast_last_exit_code' => null,
                 'broadcast_transcode_session_id' => null,
+                'broadcast_restart_locked' => false,
             ]);
 
             $network->increment('broadcast_discontinuity_sequence');

--- a/app/Http/Controllers/Api/M3uProxyApiController.php
+++ b/app/Http/Controllers/Api/M3uProxyApiController.php
@@ -446,23 +446,65 @@ class M3uProxyApiController extends Controller
 
     /**
      * Handle programme ended callback - transition to next programme.
+     *
+     * When the proxy includes `auto_transitioned=true` it has already started the
+     * next FFmpeg process (zero-round-trip transition). In that case we update DB
+     * state atomically to reflect the new running programme without calling start()
+     * again. For the normal path we set `broadcast_restart_locked` to prevent the
+     * tick loop from racing while start() is in flight.
      */
     protected function handleProgrammeEnded(Network $network, array $data, NetworkBroadcastService $service): void
     {
         $finalSegment = $data['final_segment_number'] ?? 0;
         $durationStreamed = $data['duration_streamed'] ?? 0;
+        $autoTransitioned = $data['auto_transitioned'] ?? false;
+        $newPid = $data['new_pid'] ?? null;
 
         Log::info('Programme completed via proxy', [
             'network_id' => $network->id,
             'network_name' => $network->name,
             'final_segment' => $finalSegment,
             'duration_streamed' => $durationStreamed,
+            'auto_transitioned' => $autoTransitioned,
         ]);
 
         // Clean up Plex transcode session before transitioning to next programme
         $service->cleanupTranscodeSession($network);
 
-        // Update segment sequence for next programme
+        if ($autoTransitioned && $newPid !== null) {
+            // The proxy already started the next programme — update DB state atomically
+            // to reflect the running broadcast without an intermediate null state that
+            // the tick loop could misread as "stopped".
+            $network->refresh();
+            $nextProgramme = $network->getCurrentProgramme() ?? $network->getNextProgramme();
+
+            $network->update([
+                'broadcast_segment_sequence' => $finalSegment + 1,
+                'broadcast_started_at' => now(),
+                'broadcast_pid' => $newPid,
+                'broadcast_programme_id' => $nextProgramme?->id,
+                'broadcast_initial_offset_seconds' => 0,
+                'broadcast_error' => null,
+                'broadcast_fail_count' => 0,
+                'broadcast_last_exit_code' => null,
+                'broadcast_transcode_session_id' => null,
+            ]);
+
+            $network->increment('broadcast_discontinuity_sequence');
+
+            Log::info('Auto-transitioned to next programme', [
+                'network_id' => $network->id,
+                'new_pid' => $newPid,
+                'next_programme_id' => $nextProgramme?->id,
+                'next_programme_title' => $nextProgramme?->title,
+            ]);
+
+            return;
+        }
+
+        // Normal transition: clear current programme state and start next.
+        // Set restart lock to prevent tick loop from also trying to start while
+        // this handler's start() call is in flight.
         $network->update([
             'broadcast_segment_sequence' => $finalSegment + 1,
             'broadcast_started_at' => null,
@@ -473,29 +515,32 @@ class M3uProxyApiController extends Controller
             'broadcast_fail_count' => 0,
             'broadcast_last_exit_code' => null,
             'broadcast_transcode_session_id' => null,
+            'broadcast_restart_locked' => true,
         ]);
 
         // Increment discontinuity sequence for transition
         $network->increment('broadcast_discontinuity_sequence');
 
-        // Check if there's a next programme to broadcast
         $network->refresh();
         $nextProgramme = $network->getCurrentProgramme() ?? $network->getNextProgramme();
 
-        if ($nextProgramme && $network->broadcast_requested) {
-            Log::info('Starting next programme via proxy', [
-                'network_id' => $network->id,
-                'programme_id' => $nextProgramme->id,
-                'programme_title' => $nextProgramme->title,
-            ]);
+        try {
+            if ($nextProgramme && $network->broadcast_requested) {
+                Log::info('Starting next programme via proxy', [
+                    'network_id' => $network->id,
+                    'programme_id' => $nextProgramme->id,
+                    'programme_title' => $nextProgramme->title,
+                ]);
 
-            // Start next programme
-            $service->start($network);
-        } else {
-            Log::info('No next programme to broadcast', [
-                'network_id' => $network->id,
-                'broadcast_requested' => $network->broadcast_requested,
-            ]);
+                $service->start($network);
+            } else {
+                Log::info('No next programme to broadcast', [
+                    'network_id' => $network->id,
+                    'broadcast_requested' => $network->broadcast_requested,
+                ]);
+            }
+        } finally {
+            $network->update(['broadcast_restart_locked' => false]);
         }
     }
 

--- a/app/Services/NetworkBroadcastService.php
+++ b/app/Services/NetworkBroadcastService.php
@@ -1395,6 +1395,17 @@ class NetworkBroadcastService
                         $headers['X-Plex-Token'] = $qs['X-Plex-Token'];
                     }
 
+                    if (! empty($qs['session'])) {
+                        $headers['X-Plex-Session-Identifier'] = $qs['session'];
+                        $headers['X-Plex-Playback-Session-Id'] = $qs['session'];
+                    }
+
+                    if (str_contains($nextStreamUrl, 'start.mpd')) {
+                        $headers['Accept'] = 'application/dash+xml';
+                    } else {
+                        $headers['Accept'] = 'application/vnd.apple.mpegurl';
+                    }
+
                     $config['headers'] = $headers;
                 } else {
                     $headers = [];

--- a/app/Services/NetworkBroadcastService.php
+++ b/app/Services/NetworkBroadcastService.php
@@ -345,6 +345,10 @@ class NetworkBroadcastService
             'preset' => $network->transcode_preset,
             'hwaccel' => $network->hwaccel,
             'callback_url' => $callbackUrl,
+            // Pre-compute next programme config for zero-round-trip auto-transition.
+            // The proxy will start the next programme immediately when the current
+            // FFmpeg exits with code 0, without waiting for a Laravel callback.
+            'next_stream_config' => $this->computeNextStreamConfig($network, $programme),
             // Tell the proxy exactly where to write broadcast segments.
             // Honors BROADCAST_TEMP_DIR (default /dev/shm) so ephemeral .ts files
             // are written to RAM and never touch persistent disk.
@@ -1319,5 +1323,98 @@ class NetworkBroadcastService
         Log::warning('BOOT RECOVERY: Proxy did not become ready within timeout — cleanup calls may fail');
 
         return false;
+    }
+
+    /**
+     * Compute the next programme's stream configuration for proxy auto-transition.
+     *
+     * Returns a payload array suitable for the `next_stream_config` key in the
+     * broadcast start request. The proxy uses it to immediately start the next
+     * FFmpeg process when the current one exits with code 0, eliminating the
+     * Laravel callback round-trip and reducing the inter-programme gap.
+     *
+     * Returns null when no next programme exists or its stream URL cannot be resolved.
+     */
+    protected function computeNextStreamConfig(Network $network, NetworkProgramme $currentProgramme): ?array
+    {
+        $nextProgramme = $network->getNextProgramme();
+
+        if (! $nextProgramme) {
+            return null;
+        }
+
+        $nextStreamUrl = $this->getStreamUrl($network, $nextProgramme, 0);
+
+        if (! $nextStreamUrl) {
+            Log::debug('computeNextStreamConfig: could not resolve next stream URL', [
+                'network_id' => $network->id,
+                'next_programme_id' => $nextProgramme->id,
+            ]);
+
+            return null;
+        }
+
+        $nextDuration = (int) $nextProgramme->start_time->diffInSeconds($nextProgramme->end_time);
+        $callbackUrl = $this->getProxyService()->getBroadcastCallbackUrl();
+
+        $config = [
+            'stream_url' => $nextStreamUrl,
+            'seek_seconds' => 0,
+            'duration_seconds' => $nextDuration,
+            'segment_duration' => $network->segment_duration ?? 6,
+            'hls_list_size' => $network->hls_list_size ?? 20,
+            'transcode' => ($network->transcode_mode ?? null) === TranscodeMode::Local,
+            'video_bitrate' => $network->video_bitrate ? (string) $network->video_bitrate : null,
+            'audio_bitrate' => $network->audio_bitrate ?? 192,
+            'video_resolution' => $network->video_resolution,
+            'video_codec' => $network->video_codec,
+            'audio_codec' => $network->audio_codec,
+            'preset' => $network->transcode_preset,
+            'hwaccel' => $network->hwaccel,
+            'callback_url' => $callbackUrl,
+        ];
+
+        // Attach provider-specific headers (same logic as startViaProxy).
+        try {
+            $integration = $network->mediaServerIntegration;
+
+            if ($integration && $integration->isPlex()) {
+                $parsed = parse_url($nextStreamUrl);
+                parse_str($parsed['query'] ?? '', $qs);
+                $isServerTranscode = ($network->transcode_mode ?? null) === TranscodeMode::Server;
+
+                if ($isServerTranscode) {
+                    $headers = [
+                        'X-Plex-Product' => 'Plex Web',
+                        'X-Plex-Client-Identifier' => 'm3u-proxy',
+                        'X-Plex-Platform' => 'Chrome',
+                        'X-Plex-Device' => 'OSX',
+                    ];
+
+                    if (! empty($qs['X-Plex-Token'])) {
+                        $headers['X-Plex-Token'] = $qs['X-Plex-Token'];
+                    }
+
+                    $config['headers'] = $headers;
+                } else {
+                    $headers = [];
+
+                    if (! empty($qs['X-Plex-Token'])) {
+                        $headers['X-Plex-Token'] = $qs['X-Plex-Token'];
+                    }
+
+                    if (! empty($headers)) {
+                        $config['headers'] = $headers;
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+            Log::warning('computeNextStreamConfig: failed to attach provider headers', [
+                'network_id' => $network->id,
+                'exception' => $e->getMessage(),
+            ]);
+        }
+
+        return $config;
     }
 }

--- a/tests/Feature/NetworkBroadcastTransitionTest.php
+++ b/tests/Feature/NetworkBroadcastTransitionTest.php
@@ -1,0 +1,285 @@
+<?php
+
+use App\Models\Network;
+use App\Models\NetworkProgramme;
+use App\Services\NetworkBroadcastService;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::fake([
+        '*/broadcast/*/status' => Http::response(['status' => 'stopped'], 404),
+        '*/broadcast/*/stop' => Http::response(['status' => 'stopped', 'final_segment_number' => 0], 200),
+        '*/broadcast/*/start' => Http::response(['status' => 'started', 'ffmpeg_pid' => 12345], 200),
+        '*' => Http::response([], 200),
+    ]);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Auto-transition (proxy-side seamless programme switch)
+|--------------------------------------------------------------------------
+*/
+
+it('auto_transitioned callback updates DB with new pid without starting a new broadcast', function () {
+    Carbon::setTestNow(now());
+
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => 5678,
+        'broadcast_started_at' => now()->subMinutes(60),
+        'broadcast_fail_count' => 2,
+        'broadcast_segment_sequence' => 100,
+    ]);
+
+    // Next programme available for the reference update.
+    NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now(),
+        'end_time' => now()->addMinutes(60),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class);
+    $service->shouldReceive('cleanupTranscodeSession')->once();
+    $service->shouldNotReceive('start');
+    app()->instance(NetworkBroadcastService::class, $service);
+
+    $response = $this->postJson('/api/m3u-proxy/broadcast/callback', [
+        'network_id' => $network->uuid,
+        'event' => 'programme_ended',
+        'data' => [
+            'final_segment_number' => 100,
+            'auto_transitioned' => true,
+            'new_pid' => 99999,
+        ],
+    ]);
+
+    $response->assertOk();
+
+    $network->refresh();
+    expect($network->broadcast_pid)->toBe(99999);
+    expect($network->broadcast_started_at)->not->toBeNull();
+    expect($network->broadcast_segment_sequence)->toBe(101);
+    expect($network->broadcast_fail_count)->toBe(0);
+    expect($network->broadcast_transcode_session_id)->toBeNull();
+    expect($network->broadcast_error)->toBeNull();
+
+    Carbon::setTestNow();
+});
+
+it('auto_transitioned callback records next programme reference', function () {
+    Carbon::setTestNow(now());
+
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => 5678,
+        'broadcast_started_at' => now()->subMinutes(60),
+    ]);
+
+    $nextProgramme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now(),
+        'end_time' => now()->addMinutes(60),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class);
+    $service->shouldReceive('cleanupTranscodeSession')->once();
+    $service->shouldNotReceive('start');
+    app()->instance(NetworkBroadcastService::class, $service);
+
+    $this->postJson('/api/m3u-proxy/broadcast/callback', [
+        'network_id' => $network->uuid,
+        'event' => 'programme_ended',
+        'data' => [
+            'final_segment_number' => 50,
+            'auto_transitioned' => true,
+            'new_pid' => 11111,
+        ],
+    ])->assertOk();
+
+    $network->refresh();
+    expect($network->broadcast_programme_id)->toBe($nextProgramme->id);
+
+    Carbon::setTestNow();
+});
+
+it('auto_transitioned callback increments discontinuity sequence', function () {
+    Carbon::setTestNow(now());
+
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => 5678,
+        'broadcast_started_at' => now(),
+        'broadcast_discontinuity_sequence' => 3,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class);
+    $service->shouldReceive('cleanupTranscodeSession')->once();
+    $service->shouldNotReceive('start');
+    app()->instance(NetworkBroadcastService::class, $service);
+
+    $this->postJson('/api/m3u-proxy/broadcast/callback', [
+        'network_id' => $network->uuid,
+        'event' => 'programme_ended',
+        'data' => [
+            'final_segment_number' => 0,
+            'auto_transitioned' => true,
+            'new_pid' => 22222,
+        ],
+    ])->assertOk();
+
+    expect($network->fresh()->broadcast_discontinuity_sequence)->toBe(4);
+
+    Carbon::setTestNow();
+});
+
+/*
+|--------------------------------------------------------------------------
+| Normal programme transition (callback round-trip path)
+|--------------------------------------------------------------------------
+*/
+
+it('normal programme_ended callback sets restart lock while starting next broadcast', function () {
+    Carbon::setTestNow(now());
+
+    $locked = false;
+
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => 5678,
+        'broadcast_started_at' => now()->subMinutes(60),
+    ]);
+
+    NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now(),
+        'end_time' => now()->addMinutes(60),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class);
+    $service->shouldReceive('cleanupTranscodeSession')->once();
+    $service->shouldReceive('start')->once()->andReturnUsing(function (Network $n) use (&$locked) {
+        $locked = $n->fresh()->broadcast_restart_locked;
+
+        return true;
+    });
+    app()->instance(NetworkBroadcastService::class, $service);
+
+    $this->postJson('/api/m3u-proxy/broadcast/callback', [
+        'network_id' => $network->uuid,
+        'event' => 'programme_ended',
+        'data' => ['final_segment_number' => 100],
+    ])->assertOk();
+
+    expect($locked)->toBeTrue('restart lock should be held while start() runs');
+    expect($network->fresh()->broadcast_restart_locked)->toBeFalse('lock should be released after start()');
+
+    Carbon::setTestNow();
+});
+
+it('normal programme_ended callback releases restart lock even if start throws', function () {
+    Carbon::setTestNow(now());
+
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => 5678,
+        'broadcast_started_at' => now(),
+    ]);
+
+    NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now(),
+        'end_time' => now()->addMinutes(60),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class);
+    $service->shouldReceive('cleanupTranscodeSession')->once();
+    $service->shouldReceive('start')->once()->andThrow(new RuntimeException('proxy unavailable'));
+    app()->instance(NetworkBroadcastService::class, $service);
+
+    $response = $this->postJson('/api/m3u-proxy/broadcast/callback', [
+        'network_id' => $network->uuid,
+        'event' => 'programme_ended',
+        'data' => ['final_segment_number' => 10],
+    ]);
+
+    // Callback itself reports the exception.
+    $response->assertStatus(500);
+
+    // Lock must be released regardless.
+    expect($network->fresh()->broadcast_restart_locked)->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+/*
+|--------------------------------------------------------------------------
+| computeNextStreamConfig
+|--------------------------------------------------------------------------
+*/
+
+it('computeNextStreamConfig returns null when no next programme exists', function () {
+    $network = Network::factory()->create(['broadcast_enabled' => true]);
+
+    $programme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinutes(55),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = app(NetworkBroadcastService::class);
+    $method = new ReflectionMethod(NetworkBroadcastService::class, 'computeNextStreamConfig');
+    $result = $method->invoke($service, $network, $programme);
+
+    expect($result)->toBeNull();
+});
+
+it('next_stream_config key is always present in the broadcast start payload', function () {
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => null,
+        'broadcast_started_at' => null,
+    ]);
+
+    $programme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinutes(55),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = app(NetworkBroadcastService::class);
+    $method = new ReflectionMethod(NetworkBroadcastService::class, 'startViaProxy');
+    $method->invoke($service, $network, 'http://example.com/stream.ts', 0, 3300, $programme);
+
+    $captured = [];
+    Http::assertSent(function ($request) use (&$captured) {
+        if (str_contains($request->url(), '/broadcast/') && str_contains($request->url(), '/start')) {
+            $captured = $request->data();
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // Key must always be present (null when no next programme).
+    expect($captured)->toHaveKey('next_stream_config');
+});

--- a/tests/Feature/NetworkBroadcastTransitionTest.php
+++ b/tests/Feature/NetworkBroadcastTransitionTest.php
@@ -141,6 +141,92 @@ it('auto_transitioned callback increments discontinuity sequence', function () {
     Carbon::setTestNow();
 });
 
+it('auto_transitioned callback clears broadcast_restart_locked even if it was stuck true', function () {
+    Carbon::setTestNow(now());
+
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => 5678,
+        'broadcast_started_at' => now()->subMinutes(60),
+        'broadcast_restart_locked' => true,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class);
+    $service->shouldReceive('cleanupTranscodeSession')->once();
+    $service->shouldNotReceive('start');
+    app()->instance(NetworkBroadcastService::class, $service);
+
+    $this->postJson('/api/m3u-proxy/broadcast/callback', [
+        'network_id' => $network->uuid,
+        'event' => 'programme_ended',
+        'data' => [
+            'final_segment_number' => 10,
+            'auto_transitioned' => true,
+            'new_pid' => 33333,
+        ],
+    ])->assertOk();
+
+    expect($network->fresh()->broadcast_restart_locked)->toBeFalse('auto-transition must clear a stuck restart lock');
+
+    Carbon::setTestNow();
+});
+
+it('auto_transitioned callback resolves correct next programme when callback arrives before wall clock crosses end_time', function () {
+    // Simulate a fast callback: the ended programme's end_time is still in the future
+    // (i.e. the stream ended a couple of seconds early), so getCurrentProgramme() would
+    // naively return the ended programme. The fix must skip it and find the real next one.
+    Carbon::setTestNow(now());
+
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => 5678,
+        'broadcast_started_at' => now()->subMinutes(60),
+    ]);
+
+    // Ended programme: end_time is 10 seconds in the future (callback arrived early)
+    $endedProgramme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(60),
+        'end_time' => now()->addSeconds(10),
+        'duration_seconds' => 3610,
+    ]);
+
+    // Actual next programme
+    $nextProgramme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->addSeconds(10),
+        'end_time' => now()->addMinutes(70),
+        'duration_seconds' => 3600,
+    ]);
+
+    // Set network's current broadcast_programme_id to the ended programme
+    $network->update(['broadcast_programme_id' => $endedProgramme->id]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class);
+    $service->shouldReceive('cleanupTranscodeSession')->once();
+    $service->shouldNotReceive('start');
+    app()->instance(NetworkBroadcastService::class, $service);
+
+    $this->postJson('/api/m3u-proxy/broadcast/callback', [
+        'network_id' => $network->uuid,
+        'event' => 'programme_ended',
+        'data' => [
+            'final_segment_number' => 100,
+            'auto_transitioned' => true,
+            'new_pid' => 44444,
+        ],
+    ])->assertOk();
+
+    // Must resolve to the *next* programme, not the ended one
+    expect($network->fresh()->broadcast_programme_id)->toBe($nextProgramme->id);
+
+    Carbon::setTestNow();
+});
+
 /*
 |--------------------------------------------------------------------------
 | Normal programme transition (callback round-trip path)


### PR DESCRIPTION
When a network broadcast transitions between programmes, there's currently a gap between the current FFmpeg exiting and the next one starting — caused by the proxy calling back to Laravel, which then issues a new `start()` to the proxy.

This PR eliminates that gap by sending the next programme's full stream config to the proxy in the initial broadcast-start payload. The proxy starts the next FFmpeg as soon as the current one exits cleanly, then notifies Laravel via callback so DB state can be updated atomically.

**Changes:**
- `M3uProxyApiController::handleProgrammeEnded` now branches on `auto_transitioned`:
  - **Auto path** — updates DB state for the already-running next programme (new pid, fresh `started_at`, reset fail count, increment discontinuity sequence). No second `start()` call.
  - **Normal path** — sets `broadcast_restart_locked=true` around `start()` to prevent the tick loop from racing, released in `finally`.
- `NetworkBroadcastService::computeNextStreamConfig` pre-computes the next programme's config (stream URL, transcode settings, Plex headers) and attaches it as `next_stream_config` to every broadcast-start payload.
- 7 new feature tests covering both paths, lock release on success/exception, and null-safety of the new payload key.

**Test:** `php artisan test --compact --filter=NetworkBroadcastTransitionTest`