### PR TITLE
feat: add OpenCode Copilot providers

### DIFF
--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -25,6 +25,7 @@ use App\Services\DateFormatService;
 use App\Services\M3uProxyService;
 use App\Services\PlaylistService;
 use App\Settings\GeneralSettings;
+use App\Support\CopilotProvider;
 use Cron\CronExpression;
 use Exception;
 use Filament\Actions\Action;
@@ -1781,35 +1782,13 @@ class Preferences extends SettingsPage
                                                 Select::make('copilot_provider')
                                                     ->label(__('Provider'))
                                                     ->searchable()
-                                                    ->options([
-                                                        'openai' => 'OpenAI',
-                                                        'anthropic' => 'Anthropic',
-                                                        'gemini' => 'Google Gemini',
-                                                        'mistral' => 'Mistral',
-                                                        'groq' => 'Groq',
-                                                        'deepseek' => 'DeepSeek',
-                                                        'xai' => 'xAI (Grok)',
-                                                        'minimax' => 'MiniMax',
-                                                        'openrouter' => 'OpenRouter',
-                                                        'ollama' => 'Ollama (Local)',
-                                                    ])
+                                                    ->options(CopilotProvider::options())
                                                     ->live()
                                                     ->required(fn (Get $get): bool => (bool) $get('copilot_enabled'))
                                                     ->helperText(__('The AI provider to use for the Copilot assistant.')),
                                                 TextInput::make('copilot_model')
                                                     ->label(__('Model'))
-                                                    ->placeholder(fn (Get $get): string => match ($get('copilot_provider')) {
-                                                        'anthropic' => 'claude-sonnet-4-6',
-                                                        'gemini' => 'gemini-2.5-flash',
-                                                        'mistral' => 'mistral-large-latest',
-                                                        'groq' => 'llama-3.3-70b-versatile',
-                                                        'deepseek' => 'deepseek-v4-flash',
-                                                        'xai' => 'grok-3',
-                                                        'minimax' => 'MiniMax-M2.7',
-                                                        'openrouter' => 'openai/gpt-5.4',
-                                                        'ollama' => 'llama3',
-                                                        default => 'gpt-5.4-mini',
-                                                    })
+                                                    ->placeholder(fn (Get $get): string => CopilotProvider::defaultModel($get('copilot_provider')))
                                                     ->helperText(__('The model to use. Leave blank to use the provider default.')),
                                             ]),
                                         TextInput::make('copilot_api_key')
@@ -1823,12 +1802,8 @@ class Preferences extends SettingsPage
                                         TextInput::make('copilot_url')
                                             ->label(__('Base URL'))
                                             ->url()
-                                            ->placeholder(fn (Get $get): string => match ($get('copilot_provider')) {
-                                                'ollama' => 'http://localhost:11434',
-                                                'minimax' => 'https://api.minimax.io/v1',
-                                                default => 'https://api.openai.com/v1',
-                                            })
-                                            ->visible(fn (Get $get): bool => in_array($get('copilot_provider'), ['openai', 'ollama', 'minimax']))
+                                            ->placeholder(fn (Get $get): string => CopilotProvider::defaultUrl($get('copilot_provider')))
+                                            ->visible(fn (Get $get): bool => CopilotProvider::supportsCustomUrl($get('copilot_provider')))
                                             ->helperText(__('Override the default API base URL. Leave blank to use the provider default. Useful for self-hosted models or proxy endpoints.')),
                                     ]),
                                 Section::make(__('System Prompt'))

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -44,6 +44,7 @@ use App\Services\PlaylistService;
 use App\Services\ProxyService;
 use App\Services\SortService;
 use App\Settings\GeneralSettings;
+use App\Support\CopilotProvider;
 use CraftForge\FilamentLanguageSwitcher\Events\LocaleChanged;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
@@ -909,7 +910,7 @@ class AppServiceProvider extends ServiceProvider
                 config(["ai.providers.{$settings->copilot_provider}.key" => $settings->copilot_api_key]);
             }
 
-            if (! empty($settings->copilot_url) && in_array($settings->copilot_provider, ['openai', 'ollama'], true)) {
+            if (! empty($settings->copilot_url) && CopilotProvider::supportsCustomUrl($settings->copilot_provider)) {
                 config(["ai.providers.{$settings->copilot_provider}.url" => $settings->copilot_url]);
             }
         } catch (Throwable) {

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -56,6 +56,7 @@ use App\Http\Middleware\DashboardMiddleware;
 // use App\Filament\Widgets\PayPalDonateWidget;
 use App\Http\Middleware\SeedLocaleFromUser;
 use App\Settings\GeneralSettings;
+use App\Support\CopilotProvider;
 use CraftForge\FilamentLanguageSwitcher\FilamentLanguageSwitcherPlugin;
 use EslamRedaDiv\FilamentCopilot\FilamentCopilotPlugin;
 use EslamRedaDiv\FilamentCopilot\Tools\GetToolsTool;
@@ -396,24 +397,6 @@ class AdminPanelProvider extends PanelProvider
      * Build the Copilot plugin from database settings.
      * Returns null when the plugin is disabled or not fully configured.
      */
-    /** Default models used when the model field is left blank. */
-    private const COPILOT_DEFAULT_MODELS = [
-        'openai' => 'gpt-5.4-mini',
-        'anthropic' => 'claude-sonnet-4-6',
-        'gemini' => 'gemini-2.5-flash',
-        'mistral' => 'mistral-large-latest',
-        'ollama' => 'llama3',
-        'groq' => 'llama-3.3-70b-versatile',
-        'deepseek' => 'deepseek-v4-flash',
-        'xai' => 'grok-3',
-        'openrouter' => 'openai/gpt-5.4',
-        'minimax' => 'MiniMax-M2.7',
-    ];
-
-    /**
-     * Build the Copilot plugin from database settings.
-     * Returns null when the plugin is disabled or not fully configured.
-     */
     private function buildCopilotPlugin(array $s): ?FilamentCopilotPlugin
     {
         // Skip during tests — the settings table is not yet created when panel() runs
@@ -432,7 +415,7 @@ class AdminPanelProvider extends PanelProvider
             }
 
             $model = $s['copilot_model']
-                ?: (self::COPILOT_DEFAULT_MODELS[$s['copilot_provider']] ?? 'gpt-4o');
+                ?: CopilotProvider::defaultModel($s['copilot_provider']);
 
             $provider = $s['copilot_provider'];
 
@@ -443,8 +426,9 @@ class AdminPanelProvider extends PanelProvider
                 config(["ai.providers.{$provider}.key" => $s['copilot_api_key']]);
             }
 
-            // Custom base URL — supported for OpenAI-compatible, Ollama, and MiniMax endpoints.
-            if (! empty($s['copilot_url']) && in_array($provider, ['openai', 'ollama', 'minimax'], true)) {
+            // Custom base URL is only the API root. The selected gateway appends
+            // /responses or /chat/completions depending on the provider driver.
+            if (! empty($s['copilot_url']) && CopilotProvider::supportsCustomUrl($provider)) {
                 config(["ai.providers.{$provider}.url" => $s['copilot_url']]);
             }
 

--- a/app/Support/CopilotProvider.php
+++ b/app/Support/CopilotProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Support;
+
+final class CopilotProvider
+{
+    private const DEFAULT_OPENAI_URL = 'https://api.openai.com/v1';
+
+    private const OPENCODE_URL = 'https://opencode.ai/zen/v1';
+
+    /**
+     * @return array<string, string>
+     */
+    public static function options(): array
+    {
+        return [
+            'openai' => 'OpenAI',
+            'opencode_zen' => 'OpenCode Zen',
+            'opencode_go' => 'OpenCode Go',
+            'anthropic' => 'Anthropic',
+            'gemini' => 'Google Gemini',
+            'mistral' => 'Mistral',
+            'groq' => 'Groq',
+            'deepseek' => 'DeepSeek',
+            'xai' => 'xAI (Grok)',
+            'minimax' => 'MiniMax',
+            'openrouter' => 'OpenRouter',
+            'ollama' => 'Ollama (Local)',
+        ];
+    }
+
+    public static function driver(string $provider): string
+    {
+        return match ($provider) {
+            'opencode_zen' => 'openai',
+            'opencode_go' => 'deepseek',
+            default => $provider,
+        };
+    }
+
+    public static function defaultModel(?string $provider): string
+    {
+        return match ($provider) {
+            'anthropic' => 'claude-sonnet-4-6',
+            'gemini' => 'gemini-2.5-flash',
+            'mistral' => 'mistral-large-latest',
+            'groq' => 'llama-3.3-70b-versatile',
+            'deepseek' => 'deepseek-v4-flash',
+            'opencode_go' => 'deepseek-v4-flash',
+            'xai' => 'grok-3',
+            'minimax' => 'MiniMax-M2.7',
+            'openrouter' => 'openai/gpt-5.4',
+            'ollama' => 'llama3',
+            'opencode_zen' => 'gpt-5.4-mini',
+            default => 'gpt-5.4-mini',
+        };
+    }
+
+    public static function defaultUrl(?string $provider): string
+    {
+        return match ($provider) {
+            'ollama' => 'http://localhost:11434',
+            'minimax' => 'https://api.minimax.io/v1',
+            'opencode_zen', 'opencode_go' => self::OPENCODE_URL,
+            default => self::DEFAULT_OPENAI_URL,
+        };
+    }
+
+    public static function supportsCustomUrl(?string $provider): bool
+    {
+        return in_array($provider, ['openai', 'opencode_zen', 'opencode_go', 'ollama', 'minimax'], true);
+    }
+}

--- a/config/ai.php
+++ b/config/ai.php
@@ -74,6 +74,12 @@ return [
             'key' => env('DEEPSEEK_API_KEY'),
         ],
 
+        'opencode_go' => [
+            'driver' => 'deepseek',
+            'key' => env('OPENCODE_GO_API_KEY'),
+            'url' => env('OPENCODE_GO_URL', 'https://opencode.ai/zen/v1'),
+        ],
+
         'eleven' => [
             'driver' => 'eleven',
             'key' => env('ELEVENLABS_API_KEY'),
@@ -115,6 +121,12 @@ return [
             'driver' => 'openai',
             'key' => env('OPENAI_API_KEY'),
             'url' => env('OPENAI_URL', 'https://api.openai.com/v1'),
+        ],
+
+        'opencode_zen' => [
+            'driver' => 'openai',
+            'key' => env('OPENCODE_ZEN_API_KEY'),
+            'url' => env('OPENCODE_ZEN_URL', 'https://opencode.ai/zen/v1'),
         ],
 
         'openrouter' => [

--- a/tests/Unit/CopilotProviderTest.php
+++ b/tests/Unit/CopilotProviderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Support\CopilotProvider;
+
+it('defines OpenCode provider aliases with the correct drivers and endpoints', function (): void {
+    expect(CopilotProvider::options())
+        ->toHaveKey('opencode_zen', 'OpenCode Zen')
+        ->toHaveKey('opencode_go', 'OpenCode Go');
+
+    expect(CopilotProvider::driver('opencode_zen'))->toBe('openai')
+        ->and(CopilotProvider::defaultUrl('opencode_zen'))->toBe('https://opencode.ai/zen/v1')
+        ->and(CopilotProvider::defaultModel('opencode_zen'))->toBe('gpt-5.4-mini');
+
+    expect(CopilotProvider::driver('opencode_go'))->toBe('deepseek')
+        ->and(CopilotProvider::defaultUrl('opencode_go'))->toBe('https://opencode.ai/zen/v1')
+        ->and(CopilotProvider::defaultModel('opencode_go'))->toBe('deepseek-v4-flash');
+});
+
+it('keeps OpenCode Go on a chat completions compatible driver instead of OpenAI responses', function (): void {
+    expect(CopilotProvider::driver('opencode_go'))->not->toBe('openai');
+});
+
+it('lists providers whose base URL can be overridden in Copilot settings', function (): void {
+    expect(CopilotProvider::supportsCustomUrl('opencode_zen'))->toBeTrue()
+        ->and(CopilotProvider::supportsCustomUrl('opencode_go'))->toBeTrue()
+        ->and(CopilotProvider::supportsCustomUrl('deepseek'))->toBeFalse();
+});
+
+it('registers OpenCode aliases in Laravel AI config with endpoint root URLs', function (): void {
+    expect(config('ai.providers.opencode_zen.driver'))->toBe('openai')
+        ->and(config('ai.providers.opencode_zen.url'))->toBe('https://opencode.ai/zen/v1')
+        ->and(config('ai.providers.opencode_go.driver'))->toBe('deepseek')
+        ->and(config('ai.providers.opencode_go.url'))->toBe('https://opencode.ai/zen/v1');
+});


### PR DESCRIPTION
## Summary
- Add OpenCode Zen and OpenCode Go provider aliases to AI Copilot settings
- Route OpenCode Zen through the OpenAI Responses driver and OpenCode Go through the DeepSeek chat-completions driver
- Keep OpenCode Base URL values at the API root, with endpoint paths appended by the underlying gateway
- Add focused tests for OpenCode provider mapping and config defaults

## Testing
- `docker compose -f docker-compose.dev.yml --profile test run --rm --entrypoint /bin/bash m3u-editor-dev-test -lc 'cd /var/www/html && vendor/bin/pint --test app/Support/CopilotProvider.php app/Filament/Pages/Preferences.php app/Providers/Filament/AdminPanelProvider.php app/Providers/AppServiceProvider.php config/ai.php tests/Unit/CopilotProviderTest.php'`
- `docker compose -f docker-compose.dev.yml --profile test run --rm --build m3u-editor-dev-test tests/Unit/CopilotProviderTest.php`
