### PR TITLE
feat: add Plex network track preferences

### DIFF
--- a/app/Filament/Resources/Networks/NetworkResource.php
+++ b/app/Filament/Resources/Networks/NetworkResource.php
@@ -797,6 +797,26 @@ class NetworkResource extends Resource implements CopilotResource
                                             ->nullable(),
                                     ])->visible(fn (Get $get): bool => $get('transcode_mode') === TranscodeMode::Local->value),
 
+                                    Grid::make(2)->schema([
+                                        TextInput::make('preferred_audio_track')
+                                            ->label(__('Preferred Audio Track'))
+                                            ->helperText(__(
+                                                'Plex only. Enter a language code such as eng or jpn, or a Plex stream ID.'
+                                            ))
+                                            ->placeholder(__('eng'))
+                                            ->maxLength(64)
+                                            ->nullable(),
+
+                                        TextInput::make('preferred_subtitle_track')
+                                            ->label(__('Preferred Subtitle Track'))
+                                            ->helperText(__(
+                                                'Plex only. Enter a language code such as eng or jpn, or a Plex stream ID.'
+                                            ))
+                                            ->placeholder(__('eng'))
+                                            ->maxLength(64)
+                                            ->nullable(),
+                                    ]),
+
                                     Select::make('hwaccel')
                                         ->label(__('Hardware Acceleration'))
                                         ->placeholder(__('Auto/Default'))

--- a/app/Models/Network.php
+++ b/app/Models/Network.php
@@ -35,6 +35,8 @@ class Network extends Model
         'transcode_mode' => TranscodeMode::class,
         'video_bitrate' => 'integer',
         'audio_bitrate' => 'integer',
+        'preferred_audio_track' => 'string',
+        'preferred_subtitle_track' => 'string',
         'broadcast_started_at' => 'datetime',
         'broadcast_pid' => 'integer',
         'broadcast_programme_id' => 'integer',

--- a/app/Services/NetworkBroadcastService.php
+++ b/app/Services/NetworkBroadcastService.php
@@ -757,6 +757,14 @@ class NetworkBroadcastService
             $request->merge(['static' => 'true']); // static stream for HLS
         }
 
+        if (! empty($network->preferred_audio_track)) {
+            $request->merge(['PreferredAudioTrack' => $network->preferred_audio_track]);
+        }
+
+        if (! empty($network->preferred_subtitle_track)) {
+            $request->merge(['PreferredSubtitleTrack' => $network->preferred_subtitle_track]);
+        }
+
         // Use media server's native seeking if we need to seek
         if ($seekSeconds > 0) {
             // Jellyfin/Emby use ticks (100-nanosecond intervals)

--- a/app/Services/PlexService.php
+++ b/app/Services/PlexService.php
@@ -418,6 +418,45 @@ class PlexService implements MediaServer
         );
     }
 
+    /**
+     * Resolve a Plex audio or subtitle stream ID from a user preference.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    protected function resolvePreferredStreamId(array $metadata, int $streamType, string $preference): ?string
+    {
+        $preference = trim($preference);
+
+        if ($preference === '') {
+            return null;
+        }
+
+        if (ctype_digit($preference)) {
+            return $preference;
+        }
+
+        $normalizedPreference = strtolower($preference);
+        $streams = $metadata['Media'][0]['Part'][0]['Stream'] ?? [];
+
+        foreach ($streams as $stream) {
+            if ((int) ($stream['streamType'] ?? 0) !== $streamType) {
+                continue;
+            }
+
+            foreach (['languageCode', 'language', 'title', 'displayTitle', 'extendedDisplayTitle'] as $key) {
+                $value = strtolower((string) ($stream[$key] ?? ''));
+
+                if ($value === $normalizedPreference || str_contains($value, $normalizedPreference)) {
+                    $id = (string) ($stream['id'] ?? '');
+
+                    return $id !== '' ? $id : null;
+                }
+            }
+        }
+
+        return null;
+    }
+
     public function getDirectStreamUrl(Request $request, string $itemId, string $container = 'ts', array $transcodeOptions = []): string
     {
         try {
@@ -449,6 +488,30 @@ class PlexService implements MediaServer
                         $params['subtitleStreamID'] = $request->input('SubtitleStreamIndex');
                     }
 
+                    if ($request->has('PreferredAudioTrack')) {
+                        $audioStreamId = $this->resolvePreferredStreamId(
+                            $metadata,
+                            2,
+                            (string) $request->input('PreferredAudioTrack')
+                        );
+
+                        if ($audioStreamId !== null) {
+                            $params['audioStreamID'] = $audioStreamId;
+                        }
+                    }
+
+                    if ($request->has('PreferredSubtitleTrack')) {
+                        $subtitleStreamId = $this->resolvePreferredStreamId(
+                            $metadata,
+                            3,
+                            (string) $request->input('PreferredSubtitleTrack')
+                        );
+
+                        if ($subtitleStreamId !== null) {
+                            $params['subtitleStreamID'] = $subtitleStreamId;
+                        }
+                    }
+
                     // If transcode options are provided use Plex's transcode endpoint
                     // UNLESS the caller explicitly requests to skip Plex transcoding via the
                     // 'skip_plex_transcode' flag. This allows direct file access for better
@@ -473,6 +536,8 @@ class PlexService implements MediaServer
                             'videoBitrate' => $videoBitrate,
                             'audioBitrate' => $audioBitrate,
                             'videoResolution' => $resolution,
+                            'audioStreamID' => $params['audioStreamID'] ?? null,
+                            'subtitleStreamID' => $params['subtitleStreamID'] ?? null,
                         ]);
 
                         // Preferred flow: ask Plex's universal decision endpoint for the correct

--- a/database/factories/NetworkFactory.php
+++ b/database/factories/NetworkFactory.php
@@ -41,6 +41,8 @@ class NetworkFactory extends Factory
             'audio_bitrate' => 192,
             'video_codec' => null,
             'audio_codec' => null,
+            'preferred_audio_track' => null,
+            'preferred_subtitle_track' => null,
             'transcode_preset' => null,
             'hwaccel' => null,
         ];

--- a/database/migrations/2026_07_04_000001_add_track_preferences_to_networks_table.php
+++ b/database/migrations/2026_07_04_000001_add_track_preferences_to_networks_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('networks', function (Blueprint $table) {
+            if (! Schema::hasColumn('networks', 'preferred_audio_track')) {
+                $table->string('preferred_audio_track')->nullable()->after('audio_codec');
+            }
+
+            if (! Schema::hasColumn('networks', 'preferred_subtitle_track')) {
+                $table->string('preferred_subtitle_track')->nullable()->after('preferred_audio_track');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('networks', function (Blueprint $table) {
+            $columns = [];
+
+            if (Schema::hasColumn('networks', 'preferred_audio_track')) {
+                $columns[] = 'preferred_audio_track';
+            }
+
+            if (Schema::hasColumn('networks', 'preferred_subtitle_track')) {
+                $columns[] = 'preferred_subtitle_track';
+            }
+
+            if ($columns !== []) {
+                $table->dropColumn($columns);
+            }
+        });
+    }
+};

--- a/tests/Feature/PlexTrackPreferenceTest.php
+++ b/tests/Feature/PlexTrackPreferenceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Models\MediaServerIntegration;
+use App\Services\PlexService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+function makePlexTrackPreferenceService(): PlexService
+{
+    return PlexService::make(new MediaServerIntegration([
+        'type' => 'plex',
+        'host' => 'plex.local',
+        'port' => 32400,
+        'ssl' => false,
+        'api_key' => 'plex-token',
+    ]));
+}
+
+function fakePlexMetadataWithStreams(): void
+{
+    Http::fake([
+        'http://plex.local:32400/library/metadata/item-1' => Http::response([
+            'MediaContainer' => [
+                'Metadata' => [[
+                    'Media' => [[
+                        'Part' => [[
+                            'key' => '/library/parts/file.ts',
+                            'Stream' => [
+                                [
+                                    'id' => 101,
+                                    'streamType' => 2,
+                                    'languageCode' => 'eng',
+                                    'displayTitle' => 'English AAC 2.0',
+                                ],
+                                [
+                                    'id' => 102,
+                                    'streamType' => 2,
+                                    'languageCode' => 'jpn',
+                                    'displayTitle' => 'Japanese AAC 2.0',
+                                ],
+                                [
+                                    'id' => 201,
+                                    'streamType' => 3,
+                                    'languageCode' => 'eng',
+                                    'displayTitle' => 'English Forced',
+                                ],
+                            ],
+                        ]],
+                    ]],
+                ]],
+            ],
+        ], 200),
+    ]);
+}
+
+it('adds preferred Plex audio and subtitle stream ids to direct URLs', function () {
+    fakePlexMetadataWithStreams();
+
+    $request = new Request;
+    $request->merge([
+        'PreferredAudioTrack' => 'jpn',
+        'PreferredSubtitleTrack' => 'eng',
+    ]);
+
+    $url = makePlexTrackPreferenceService()->getDirectStreamUrl($request, 'item-1');
+
+    expect($url)->toContain('audioStreamID=102')
+        ->and($url)->toContain('subtitleStreamID=201');
+});
+
+it('allows exact Plex stream ids as track preferences', function () {
+    fakePlexMetadataWithStreams();
+
+    $request = new Request;
+    $request->merge([
+        'PreferredAudioTrack' => '102',
+        'PreferredSubtitleTrack' => '201',
+    ]);
+
+    $url = makePlexTrackPreferenceService()->getDirectStreamUrl($request, 'item-1');
+
+    expect($url)->toContain('audioStreamID=102')
+        ->and($url)->toContain('subtitleStreamID=201');
+});


### PR DESCRIPTION
## Summary
- Adds per-network Plex audio and subtitle track preferences.
- Resolves language codes or exact Plex stream IDs to Plex stream IDs before building broadcast stream URLs.
- Adds coverage for language and exact stream ID preferences.

Closes #1211
