### PR TITLE
fix: add guest release date sorting

### DIFF
--- a/app/Filament/GuestPanel/Resources/Series/SeriesResource.php
+++ b/app/Filament/GuestPanel/Resources/Series/SeriesResource.php
@@ -29,6 +29,11 @@ class SeriesResource extends Resource
 
     protected static ?string $slug = 'series';
 
+    public static function canViewAny(): bool
+    {
+        return true;
+    }
+
     public static function getNavigationBadge(): ?string
     {
         $playlist = PlaylistFacade::resolvePlaylistByUuid(static::getCurrentUuid());
@@ -169,7 +174,8 @@ class SeriesResource extends Resource
                     ->openUrlInNewTab()
                     ->icon('heroicon-s-play'),
                 Tables\Columns\TextColumn::make('release_date')
-                    ->searchable(),
+                    ->searchable()
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('rating')
                     ->badge()
                     ->color('success')

--- a/app/Filament/GuestPanel/Resources/Vods/VodResource.php
+++ b/app/Filament/GuestPanel/Resources/Vods/VodResource.php
@@ -36,6 +36,11 @@ class VodResource extends Resource
 
     protected static ?string $slug = 'vod';
 
+    public static function canViewAny(): bool
+    {
+        return true;
+    }
+
     public static function getNavigationBadge(): ?string
     {
         $playlist = PlaylistFacade::resolvePlaylistByUuid(static::getCurrentUuid());
@@ -234,6 +239,16 @@ class VodResource extends Resource
                         return $query->orWhereRaw("LOWER({$urlExpr}) LIKE ?", ['%'.strtolower($search).'%']);
                     })
                     ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('release_date')
+                    ->label(__('Release Date'))
+                    ->getStateUsing(fn (Channel $record): string => static::getVodReleaseDate($record))
+                    ->sortable(
+                        query: fn (Builder $query, string $direction): Builder => static::sortByVodReleaseDate(
+                            $query,
+                            $direction
+                        )
+                    )
+                    ->toggleable(),
 
                 Tables\Columns\TextColumn::make('created_at')
                     ->formatStateUsing(fn ($state) => app(DateFormatService::class)->format($state))
@@ -265,6 +280,57 @@ class VodResource extends Resource
             ->toolbarActions([
                 //
             ]);
+    }
+
+    private static function getVodReleaseDate(Channel $record): string
+    {
+        return (string) (
+            $record->info['release_date']
+            ?? $record->info['releasedate']
+            ?? $record->movie_data['release_date']
+            ?? $record->movie_data['releasedate']
+            ?? $record->year
+            ?? ''
+        );
+    }
+
+    private static function sortByVodReleaseDate(Builder $query, string $direction): Builder
+    {
+        $direction = strtolower($direction) === 'desc' ? 'desc' : 'asc';
+        $driver = $query->getConnection()->getDriverName();
+
+        $expressions = match ($driver) {
+            'pgsql' => [
+                'NULLIF(channels.info->>\'release_date\', \'\')',
+                'NULLIF(channels.info->>\'releasedate\', \'\')',
+                'NULLIF(channels.movie_data->>\'release_date\', \'\')',
+                'NULLIF(channels.movie_data->>\'releasedate\', \'\')',
+                'channels.year::text',
+                "''",
+            ],
+            'mysql', 'mariadb' => [
+                'NULLIF(JSON_UNQUOTE(JSON_EXTRACT(channels.info, \'$.release_date\')), \'\')',
+                'NULLIF(JSON_UNQUOTE(JSON_EXTRACT(channels.info, \'$.releasedate\')), \'\')',
+                'NULLIF(JSON_UNQUOTE(JSON_EXTRACT(channels.movie_data, \'$.release_date\')), \'\')',
+                'NULLIF(JSON_UNQUOTE(JSON_EXTRACT(channels.movie_data, \'$.releasedate\')), \'\')',
+                'CAST(channels.year AS CHAR)',
+                "''",
+            ],
+            default => [
+                'NULLIF(json_extract(channels.info, \'$.release_date\'), \'\')',
+                'NULLIF(json_extract(channels.info, \'$.releasedate\'), \'\')',
+                'NULLIF(json_extract(channels.movie_data, \'$.release_date\'), \'\')',
+                'NULLIF(json_extract(channels.movie_data, \'$.releasedate\'), \'\')',
+                'CAST(channels.year AS TEXT)',
+                "''",
+            ],
+        };
+        $expression = 'COALESCE('.implode(', ', $expressions).')';
+
+        return $query
+            ->orderBy(DB::raw($expression), $direction)
+            ->orderBy('channels.title', $direction)
+            ->orderBy('channels.id', $direction);
     }
 
     public static function getRelations(): array

--- a/app/Filament/Resources/Series/SeriesResource.php
+++ b/app/Filament/Resources/Series/SeriesResource.php
@@ -259,7 +259,8 @@ class SeriesResource extends Resource implements CopilotResource
                 ->openUrlInNewTab()
                 ->icon('heroicon-s-play'),
             TextColumn::make('release_date')
-                ->searchable(),
+                ->searchable()
+                ->sortable(),
             TextColumn::make('rating')
                 ->badge()
                 ->color('success')

--- a/app/Filament/Resources/Vods/VodResource.php
+++ b/app/Filament/Resources/Vods/VodResource.php
@@ -420,6 +420,17 @@ class VodResource extends Resource implements CopilotResource
                 })
                 ->toggleable(isToggledHiddenByDefault: true),
 
+            TextColumn::make('release_date')
+                ->label(__('Release Date'))
+                ->getStateUsing(fn (Channel $record): string => static::getVodReleaseDate($record))
+                ->sortable(
+                    query: fn (Builder $query, string $direction): Builder => static::sortByVodReleaseDate(
+                        $query,
+                        $direction
+                    )
+                )
+                ->toggleable(),
+
             TextColumn::make('created_at')
                 ->formatStateUsing(fn ($state) => app(DateFormatService::class)->format($state))
                 ->sortable()
@@ -2202,6 +2213,57 @@ class VodResource extends Resource implements CopilotResource
      * @throws QueryException
      * @throws Exception
      */
+    private static function getVodReleaseDate(Channel $record): string
+    {
+        return (string) (
+            $record->info['release_date']
+            ?? $record->info['releasedate']
+            ?? $record->movie_data['release_date']
+            ?? $record->movie_data['releasedate']
+            ?? $record->year
+            ?? ''
+        );
+    }
+
+    private static function sortByVodReleaseDate(Builder $query, string $direction): Builder
+    {
+        $direction = strtolower($direction) === 'desc' ? 'desc' : 'asc';
+        $driver = $query->getConnection()->getDriverName();
+
+        $expressions = match ($driver) {
+            'pgsql' => [
+                'NULLIF(channels.info->>\'release_date\', \'\')',
+                'NULLIF(channels.info->>\'releasedate\', \'\')',
+                'NULLIF(channels.movie_data->>\'release_date\', \'\')',
+                'NULLIF(channels.movie_data->>\'releasedate\', \'\')',
+                'channels.year::text',
+                "''",
+            ],
+            'mysql', 'mariadb' => [
+                'NULLIF(JSON_UNQUOTE(JSON_EXTRACT(channels.info, \'$.release_date\')), \'\')',
+                'NULLIF(JSON_UNQUOTE(JSON_EXTRACT(channels.info, \'$.releasedate\')), \'\')',
+                'NULLIF(JSON_UNQUOTE(JSON_EXTRACT(channels.movie_data, \'$.release_date\')), \'\')',
+                'NULLIF(JSON_UNQUOTE(JSON_EXTRACT(channels.movie_data, \'$.releasedate\')), \'\')',
+                'CAST(channels.year AS CHAR)',
+                "''",
+            ],
+            default => [
+                'NULLIF(json_extract(channels.info, \'$.release_date\'), \'\')',
+                'NULLIF(json_extract(channels.info, \'$.releasedate\'), \'\')',
+                'NULLIF(json_extract(channels.movie_data, \'$.release_date\'), \'\')',
+                'NULLIF(json_extract(channels.movie_data, \'$.releasedate\'), \'\')',
+                'CAST(channels.year AS TEXT)',
+                "''",
+            ],
+        };
+        $expression = 'COALESCE('.implode(', ', $expressions).')';
+
+        return $query
+            ->orderBy(DB::raw($expression), $direction)
+            ->orderBy('channels.title', $direction)
+            ->orderBy('channels.id', $direction);
+    }
+
     public static function createCustomChannel(array $data, string $model): Model
     {
         $data['user_id'] = auth()->id();

--- a/tests/Feature/GuestPanelReleaseDateSortingTest.php
+++ b/tests/Feature/GuestPanelReleaseDateSortingTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Filament\GuestPanel\Resources\Series\Pages\ListSeries as GuestListSeries;
+use App\Filament\GuestPanel\Resources\Vods\Pages\ListVod as GuestListVod;
+use App\Http\Middleware\GuestPlaylistAuth;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\PlaylistAuth;
+use App\Models\Series;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('playlist'));
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create();
+    $this->username = 'guest-sort-user';
+    $this->password = 'guest-sort-pass';
+
+    $playlistAuth = PlaylistAuth::create([
+        'name' => 'Guest Sort Auth',
+        'username' => $this->username,
+        'password' => $this->password,
+        'enabled' => true,
+        'user_id' => $this->user->id,
+    ]);
+    $playlistAuth->assignTo($this->playlist);
+
+    $prefix = base64_encode($this->playlist->uuid).'_';
+    session([
+        "{$prefix}guest_auth_username" => $this->username,
+        "{$prefix}guest_auth_password" => $this->password,
+    ]);
+
+    $this->withCookie('playlist_uuid', $this->playlist->uuid);
+    $this->withoutMiddleware(GuestPlaylistAuth::class);
+});
+
+it('allows guest series lists to sort by release date', function () {
+    $newerSeries = Series::factory()->for($this->user)->for($this->playlist)->create([
+        'enabled' => true,
+        'name' => 'Newer Series',
+        'release_date' => '2024-01-10',
+    ]);
+    $olderSeries = Series::factory()->for($this->user)->for($this->playlist)->create([
+        'enabled' => true,
+        'name' => 'Older Series',
+        'release_date' => '1999-03-31',
+    ]);
+
+    Livewire::withHeaders(['Referer' => url("/playlist/v/{$this->playlist->uuid}/series")])
+        ->test(GuestListSeries::class)
+        ->assertOk()
+        ->loadTable()
+        ->sortTable('release_date')
+        ->assertCanSeeTableRecords([$olderSeries, $newerSeries], inOrder: true);
+});
+
+it('allows guest VOD lists to show and sort by release date', function () {
+    $newerVod = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'enabled' => true,
+        'is_vod' => true,
+        'title' => 'Newer Movie',
+        'year' => 2024,
+        'info' => ['release_date' => '2024-01-10'],
+    ]);
+    $olderVod = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'enabled' => true,
+        'is_vod' => true,
+        'title' => 'Older Movie',
+        'year' => 1999,
+        'info' => ['release_date' => '1999-03-31'],
+    ]);
+
+    Livewire::withHeaders(['Referer' => url("/playlist/v/{$this->playlist->uuid}/vod")])
+        ->test(GuestListVod::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertTableColumnExists('release_date')
+        ->sortTable('release_date')
+        ->assertCanSeeTableRecords([$olderVod, $newerVod], inOrder: true);
+});


### PR DESCRIPTION
## Summary
- Adds sorting to the guest Series Release Date column.
- Adds a sortable Release Date column to the guest VOD list.
- Uses VOD info release_date, releasedate, movie_data dates, then year as a fallback for sorting and display.

## Tests
- Added tests/Feature/GuestPanelReleaseDateSortingTest.php for guest Series and VOD release date sorting.
- Not run locally: php is not installed in this environment.
- Not run locally: vendor/bin/pint is unavailable because dependencies are not installed in this environment.
- Not run locally: Docker daemon is not running, so the project test container could not be used.

Closes #1235
