### PR TITLE
fix: repair network output playlist selection

### DIFF
--- a/app/Filament/Resources/Networks/NetworkResource.php
+++ b/app/Filament/Resources/Networks/NetworkResource.php
@@ -253,10 +253,15 @@ class NetworkResource extends Resource implements CopilotResource
                                         ->relationship(
                                             'networkPlaylist',
                                             'name',
-                                            fn (Builder $query) => $query->where('is_network_playlist', true)
+                                            fn (Builder $query) => $query
+                                                ->where('user_id', Auth::id())
+                                                ->where('is_network_playlist', true)
                                         )
+                                        ->searchable()
+                                        ->preload()
                                         ->required()
-                                        ->helperText(__('Assign this network to a playlist for M3U/EPG output. Create one if none exist.'))
+                                        ->helperText(__('Select a network output playlist. Only playlists created for Networks are eligible. New playlists created here are marked for network output.'))
+                                        ->noSearchResultsMessage(__('No network output playlists found. Use the plus button to create one.'))
                                         ->createOptionForm([
                                             TextInput::make('name')
                                                 ->label(__('Playlist Name'))
@@ -426,9 +431,14 @@ class NetworkResource extends Resource implements CopilotResource
                                 ->relationship(
                                     'networkPlaylist',
                                     'name',
-                                    fn (Builder $query) => $query->where('is_network_playlist', true)
+                                    fn (Builder $query) => $query
+                                        ->where('user_id', Auth::id())
+                                        ->where('is_network_playlist', true)
                                 )
-                                ->helperText(__('Assign to a network playlist for M3U/EPG output.'))
+                                ->searchable()
+                                ->preload()
+                                ->helperText(__('Select a network output playlist. Only playlists created for Networks are eligible. New playlists created here are marked for network output.'))
+                                ->noSearchResultsMessage(__('No network output playlists found. Use the plus button to create one.'))
                                 ->createOptionForm([
                                     TextInput::make('name')
                                         ->label(__('Playlist Name'))

--- a/app/Filament/Resources/Networks/NetworkResource.php
+++ b/app/Filament/Resources/Networks/NetworkResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Networks;
 
+use App\Enums\PlaylistChannelId;
 use App\Enums\TranscodeMode;
 use App\Filament\Actions\AssetPickerAction;
 use App\Filament\Concerns\HasCopilotSupport;
@@ -259,7 +260,6 @@ class NetworkResource extends Resource implements CopilotResource
                                         )
                                         ->searchable()
                                         ->preload()
-                                        ->required()
                                         ->helperText(__('Select a network output playlist. Only playlists created for Networks are eligible. New playlists created here are marked for network output.'))
                                         ->noSearchResultsMessage(__('No network output playlists found. Use the plus button to create one.'))
                                         ->createOptionForm([
@@ -274,6 +274,7 @@ class NetworkResource extends Resource implements CopilotResource
                                                 'uuid' => (string) Str::uuid(),
                                                 'user_id' => Auth::id(),
                                                 'is_network_playlist' => true,
+                                                'id_channel_by' => PlaylistChannelId::TvgId,
                                             ]);
 
                                             return $playlist->id;
@@ -451,6 +452,7 @@ class NetworkResource extends Resource implements CopilotResource
                                         'uuid' => (string) Str::uuid(),
                                         'user_id' => Auth::id(),
                                         'is_network_playlist' => true,
+                                        'id_channel_by' => PlaylistChannelId::TvgId,
                                     ]);
 
                                     return $playlist->id;

--- a/tests/Feature/NetworkOutputPlaylistSelectTest.php
+++ b/tests/Feature/NetworkOutputPlaylistSelectTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Filament\Resources\Networks\Pages\CreateNetwork;
+use App\Models\Playlist;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Filament\Forms\Components\Select;
+use Livewire\Livewire;
+use PHPUnit\Framework\Assert;
+
+beforeEach(function () {
+    $this->user = User::factory()->create([
+        'permissions' => ['use_integrations'],
+    ]);
+
+    $this->actingAs($this->user);
+});
+
+it('preloads eligible network output playlists on the create form', function () {
+    $eligiblePlaylist = Playlist::factory()->create([
+        'name' => 'Network Output',
+        'user_id' => $this->user->id,
+        'is_network_playlist' => true,
+    ]);
+
+    $regularPlaylist = Playlist::factory()->create([
+        'name' => 'Regular Playlist',
+        'user_id' => $this->user->id,
+        'is_network_playlist' => false,
+    ]);
+
+    $otherUserPlaylist = Playlist::factory()->create([
+        'name' => 'Other User Output',
+        'is_network_playlist' => true,
+    ]);
+
+    Livewire::test(CreateNetwork::class)
+        ->assertFormFieldExists('network_playlist_id', function (Select $field) use ($eligiblePlaylist, $regularPlaylist, $otherUserPlaylist): bool {
+            $encodedOptions = json_encode($field->getOptionsForJs(), JSON_THROW_ON_ERROR);
+
+            Assert::assertStringContainsString((string) $eligiblePlaylist->getKey(), $encodedOptions);
+            Assert::assertStringContainsString($eligiblePlaylist->name, $encodedOptions);
+            Assert::assertStringNotContainsString($regularPlaylist->name, $encodedOptions);
+            Assert::assertStringNotContainsString($otherUserPlaylist->name, $encodedOptions);
+
+            return true;
+        });
+});
+
+it('creates and selects a network output playlist from the create form', function () {
+    Livewire::test(CreateNetwork::class)
+        ->callAction(TestAction::make('createOption')->schemaComponent('network_playlist_id'), data: [
+            'name' => 'New Network Output',
+        ])
+        ->assertHasNoFormErrors()
+        ->assertSchemaStateSet(function (array $state): void {
+            $playlist = Playlist::query()->where('name', 'New Network Output')->first();
+
+            Assert::assertNotNull($playlist);
+            Assert::assertSame($this->user->id, $playlist->user_id);
+            Assert::assertTrue($playlist->is_network_playlist);
+            Assert::assertEquals($playlist->getKey(), $state['network_playlist_id']);
+        });
+});

--- a/tests/Feature/NetworkOutputPlaylistSelectTest.php
+++ b/tests/Feature/NetworkOutputPlaylistSelectTest.php
@@ -40,7 +40,7 @@ it('preloads eligible network output playlists on the create form', function () 
         ->assertFormFieldExists('network_playlist_id', function (Select $field) use ($eligiblePlaylist, $regularPlaylist, $otherUserPlaylist): bool {
             $encodedOptions = json_encode($field->getOptionsForJs(), JSON_THROW_ON_ERROR);
 
-            Assert::assertStringContainsString('"value":"' . $eligiblePlaylist->getKey() . '"', $encodedOptions);
+            Assert::assertStringContainsString('"value":"'.$eligiblePlaylist->getKey().'"', $encodedOptions);
             Assert::assertStringContainsString($eligiblePlaylist->name, $encodedOptions);
             Assert::assertStringNotContainsString($regularPlaylist->name, $encodedOptions);
             Assert::assertStringNotContainsString($otherUserPlaylist->name, $encodedOptions);
@@ -91,7 +91,7 @@ it('scopes network output playlists to the current user on the edit form', funct
         ->assertFormFieldExists('network_playlist_id', function (Select $field) use ($eligiblePlaylist, $regularPlaylist, $otherUserPlaylist): bool {
             $encodedOptions = json_encode($field->getOptionsForJs(), JSON_THROW_ON_ERROR);
 
-            Assert::assertStringContainsString('"value":"' . $eligiblePlaylist->getKey() . '"', $encodedOptions);
+            Assert::assertStringContainsString('"value":"'.$eligiblePlaylist->getKey().'"', $encodedOptions);
             Assert::assertStringContainsString($eligiblePlaylist->name, $encodedOptions);
             Assert::assertStringNotContainsString($regularPlaylist->name, $encodedOptions);
             Assert::assertStringNotContainsString($otherUserPlaylist->name, $encodedOptions);

--- a/tests/Feature/NetworkOutputPlaylistSelectTest.php
+++ b/tests/Feature/NetworkOutputPlaylistSelectTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Filament\Resources\Networks\Pages\CreateNetwork;
+use App\Filament\Resources\Networks\Pages\EditNetwork;
+use App\Models\Network;
 use App\Models\Playlist;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
@@ -38,7 +40,7 @@ it('preloads eligible network output playlists on the create form', function () 
         ->assertFormFieldExists('network_playlist_id', function (Select $field) use ($eligiblePlaylist, $regularPlaylist, $otherUserPlaylist): bool {
             $encodedOptions = json_encode($field->getOptionsForJs(), JSON_THROW_ON_ERROR);
 
-            Assert::assertStringContainsString((string) $eligiblePlaylist->getKey(), $encodedOptions);
+            Assert::assertStringContainsString('"value":"' . $eligiblePlaylist->getKey() . '"', $encodedOptions);
             Assert::assertStringContainsString($eligiblePlaylist->name, $encodedOptions);
             Assert::assertStringNotContainsString($regularPlaylist->name, $encodedOptions);
             Assert::assertStringNotContainsString($otherUserPlaylist->name, $encodedOptions);
@@ -60,5 +62,40 @@ it('creates and selects a network output playlist from the create form', functio
             Assert::assertSame($this->user->id, $playlist->user_id);
             Assert::assertTrue($playlist->is_network_playlist);
             Assert::assertEquals($playlist->getKey(), $state['network_playlist_id']);
+        });
+});
+
+it('scopes network output playlists to the current user on the edit form', function () {
+    $network = Network::factory()->create([
+        'user_id' => $this->user->id,
+    ]);
+
+    $eligiblePlaylist = Playlist::factory()->create([
+        'name' => 'Network Output',
+        'user_id' => $this->user->id,
+        'is_network_playlist' => true,
+    ]);
+
+    $regularPlaylist = Playlist::factory()->create([
+        'name' => 'Regular Playlist',
+        'user_id' => $this->user->id,
+        'is_network_playlist' => false,
+    ]);
+
+    $otherUserPlaylist = Playlist::factory()->create([
+        'name' => 'Other User Output',
+        'is_network_playlist' => true,
+    ]);
+
+    Livewire::test(EditNetwork::class, ['record' => $network->getKey()])
+        ->assertFormFieldExists('network_playlist_id', function (Select $field) use ($eligiblePlaylist, $regularPlaylist, $otherUserPlaylist): bool {
+            $encodedOptions = json_encode($field->getOptionsForJs(), JSON_THROW_ON_ERROR);
+
+            Assert::assertStringContainsString('"value":"' . $eligiblePlaylist->getKey() . '"', $encodedOptions);
+            Assert::assertStringContainsString($eligiblePlaylist->name, $encodedOptions);
+            Assert::assertStringNotContainsString($regularPlaylist->name, $encodedOptions);
+            Assert::assertStringNotContainsString($otherUserPlaylist->name, $encodedOptions);
+
+            return true;
         });
 });


### PR DESCRIPTION
## Summary
- Preloads and searches eligible network output playlists in the Networks form.
- Scopes output playlist choices to the current user and explains that only Network playlists are eligible.
- Adds regression coverage for option loading and create-option selection.

## Tests
- `git diff --check`
- `php artisan test --compact tests/Feature/NetworkOutputPlaylistSelectTest.php` blocked locally because `php` is not installed
- `vendor/bin/pint --dirty --format agent` blocked locally because Composer dependencies are not installed
- GitHub CI will run Pint and Pest on this PR

Closes #1231
