### PR TITLE
fix: filter custom playlist VOD group options

### DIFF
--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -29,7 +29,6 @@ use App\Livewire\PlaylistInfo;
 use App\Livewire\PlaylistM3uUrl;
 use App\Livewire\XtreamApiInfo;
 use App\Livewire\XtreamDnsStatus;
-use App\Models\Category;
 use App\Models\CustomPlaylist;
 use App\Models\Group;
 use App\Models\MediaServerIntegration;
@@ -45,6 +44,7 @@ use App\Rules\UrlIsAllowed;
 use App\Services\DateFormatService;
 use App\Services\EpgCacheService;
 use App\Services\M3uProxyService;
+use App\Services\PlaylistService;
 use App\Services\ProfileService;
 use App\Services\SyncPipelineService;
 use App\Services\XtreamService;
@@ -2615,21 +2615,12 @@ class PlaylistResource extends Resource implements CopilotResource
                                     if (! $record) {
                                         return [];
                                     }
-                                    $type = $get('type') ?? 'live_groups';
-                                    if ($type === 'series_categories') {
-                                        return Category::where('playlist_id', $record->id)
-                                            ->orderBy('name')
-                                            ->pluck('name', 'id')
-                                            ->toArray();
-                                    }
 
-                                    $groupType = $type === 'vod_groups' ? 'vod' : 'live';
-
-                                    return Group::where('playlist_id', $record->id)
-                                        ->where('type', $groupType)
-                                        ->orderBy('name')
-                                        ->pluck('name', 'id')
-                                        ->toArray();
+                                    return PlaylistService::getEligibleAutoSyncGroupOptions(
+                                        playlist: $record,
+                                        customPlaylistId: $get('custom_playlist_id') ? (int) $get('custom_playlist_id') : null,
+                                        type: $get('type') ?? 'live_groups',
+                                    );
                                 })
                                 ->multiple()
                                 ->searchable()

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2641,6 +2641,7 @@ class PlaylistResource extends Resource implements CopilotResource
                                     $set('mode', 'original');
                                     $set('category', null);
                                     $set('new_category', null);
+                                    $set('groups', []);
                                 })
                                 ->columnSpan(3),
                             Select::make('sync_mode')

--- a/app/Filament/Resources/VodGroups/Pages/EditVodGroup.php
+++ b/app/Filament/Resources/VodGroups/Pages/EditVodGroup.php
@@ -26,7 +26,7 @@ class EditVodGroup extends EditRecord
     {
         return [
             ActionGroup::make([
-                PlaylistService::getAddGroupsToPlaylistAction('add', 'channel'),
+                PlaylistService::getAddGroupsToPlaylistAction('add', 'vod'),
                 Action::make('move')
                     ->label(__('Move to Group'))
                     ->schema([

--- a/app/Filament/Resources/VodGroups/VodGroupResource.php
+++ b/app/Filament/Resources/VodGroups/VodGroupResource.php
@@ -173,7 +173,7 @@ class VodGroupResource extends Resource implements CopilotResource
             ])
             ->recordActions([
                 ActionGroup::make([
-                    PlaylistService::getAddGroupsToPlaylistAction('add', 'channel'),
+                    PlaylistService::getAddGroupsToPlaylistAction('add', 'vod'),
                     Action::make('move')
                         ->label(__('Move Channels to Group'))
                         ->schema([
@@ -422,7 +422,7 @@ class VodGroupResource extends Resource implements CopilotResource
             ], position: RecordActionsPosition::BeforeCells)
             ->toolbarActions([
                 BulkActionGroup::make([
-                    PlaylistService::getAddGroupsToPlaylistBulkAction('add', 'channel'),
+                    PlaylistService::getAddGroupsToPlaylistBulkAction('add', 'vod'),
                     BulkAction::make('move')
                         ->label(__('Move Channels to Group'))
                         ->schema([

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -7,6 +7,7 @@ use App\Jobs\MergeChannels;
 use App\Jobs\MergeEpisodes;
 use App\Jobs\UnmergeChannels;
 use App\Jobs\UnmergeEpisodes;
+use App\Models\Category;
 use App\Models\CustomPlaylist;
 use App\Models\Group;
 use App\Models\MergedPlaylist;
@@ -876,6 +877,46 @@ class PlaylistService
                 ->required(fn (Get $get) => $get('mode') === 'create')
                 ->visible(fn (Get $get) => $get('playlist') && $get('mode') === 'create'),
         ];
+    }
+
+    /**
+     * Get selectable source groups for auto-sync rules.
+     *
+     * @return array<int, string>
+     */
+    public static function getEligibleAutoSyncGroupOptions(Playlist $playlist, ?int $customPlaylistId, string $type): array
+    {
+        if ($type === 'series_categories') {
+            return Category::query()
+                ->where('playlist_id', $playlist->id)
+                ->when($customPlaylistId, function (Builder $query) use ($customPlaylistId): void {
+                    $query->whereHas('series', function (Builder $query) use ($customPlaylistId): void {
+                        $query->whereDoesntHave('customPlaylists', function (Builder $query) use ($customPlaylistId): void {
+                            $query->whereKey($customPlaylistId);
+                        });
+                    });
+                })
+                ->orderBy('name')
+                ->pluck('name', 'id')
+                ->toArray();
+        }
+
+        $isVod = $type === 'vod_groups';
+        $channelRelation = $isVod ? 'vod_channels' : 'live_channels';
+
+        return Group::query()
+            ->where('playlist_id', $playlist->id)
+            ->where('type', $isVod ? 'vod' : 'live')
+            ->when($customPlaylistId, function (Builder $query) use ($channelRelation, $customPlaylistId): void {
+                $query->whereHas($channelRelation, function (Builder $query) use ($customPlaylistId): void {
+                    $query->whereDoesntHave('customPlaylists', function (Builder $query) use ($customPlaylistId): void {
+                        $query->whereKey($customPlaylistId);
+                    });
+                });
+            })
+            ->orderBy('name')
+            ->pluck('name', 'id')
+            ->toArray();
     }
 
     /**

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -890,10 +890,13 @@ class PlaylistService
             return Category::query()
                 ->where('playlist_id', $playlist->id)
                 ->when($customPlaylistId, function (Builder $query) use ($customPlaylistId): void {
-                    $query->whereHas('series', function (Builder $query) use ($customPlaylistId): void {
-                        $query->whereDoesntHave('customPlaylists', function (Builder $query) use ($customPlaylistId): void {
-                            $query->whereKey($customPlaylistId);
-                        });
+                    $query->where(function (Builder $query) use ($customPlaylistId): void {
+                        $query->whereDoesntHave('series')
+                            ->orWhereHas('series', function (Builder $query) use ($customPlaylistId): void {
+                                $query->whereDoesntHave('customPlaylists', function (Builder $query) use ($customPlaylistId): void {
+                                    $query->whereKey($customPlaylistId);
+                                });
+                            });
                     });
                 })
                 ->orderBy('name')
@@ -908,10 +911,13 @@ class PlaylistService
             ->where('playlist_id', $playlist->id)
             ->where('type', $isVod ? 'vod' : 'live')
             ->when($customPlaylistId, function (Builder $query) use ($channelRelation, $customPlaylistId): void {
-                $query->whereHas($channelRelation, function (Builder $query) use ($customPlaylistId): void {
-                    $query->whereDoesntHave('customPlaylists', function (Builder $query) use ($customPlaylistId): void {
-                        $query->whereKey($customPlaylistId);
-                    });
+                $query->where(function (Builder $query) use ($channelRelation, $customPlaylistId): void {
+                    $query->whereDoesntHave($channelRelation)
+                        ->orWhereHas($channelRelation, function (Builder $query) use ($customPlaylistId): void {
+                            $query->whereDoesntHave('customPlaylists', function (Builder $query) use ($customPlaylistId): void {
+                                $query->whereKey($customPlaylistId);
+                            });
+                        });
                 });
             })
             ->orderBy('name')

--- a/tests/Feature/AddGroupsToCustomPlaylistTest.php
+++ b/tests/Feature/AddGroupsToCustomPlaylistTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Events\PlaylistCreated;
+use App\Events\PlaylistUpdated;
 use App\Jobs\AddGroupsToCustomPlaylist;
 use App\Models\Category;
 use App\Models\Channel;
@@ -8,11 +10,17 @@ use App\Models\Group;
 use App\Models\Playlist;
 use App\Models\Series;
 use App\Models\User;
+use App\Services\PlaylistService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    Event::fake([PlaylistCreated::class, PlaylistUpdated::class]);
+    Notification::fake();
+
     $this->user = User::factory()->create();
     $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
     $this->customPlaylist = CustomPlaylist::factory()->create(['user_id' => $this->user->id]);
@@ -252,4 +260,160 @@ it('skips missing group ids gracefully', function () {
     ))->handle();
 
     expect($this->customPlaylist->channels()->count())->toBe(0);
+});
+
+it('only offers eligible unattached VOD groups for auto-sync group options', function () {
+    $liveGroup = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Live News',
+        'type' => 'live',
+    ]);
+    Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $liveGroup->id,
+        'is_vod' => false,
+    ]);
+
+    $attachedVodGroup = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Already Added VOD',
+        'type' => 'vod',
+    ]);
+    $attachedVodChannel = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $attachedVodGroup->id,
+        'is_vod' => true,
+    ]);
+    $this->customPlaylist->channels()->attach($attachedVodChannel->id);
+
+    $eligibleVodGroup = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Eligible VOD',
+        'type' => 'vod',
+    ]);
+    Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $eligibleVodGroup->id,
+        'is_vod' => true,
+    ]);
+
+    $options = PlaylistService::getEligibleAutoSyncGroupOptions($this->playlist, $this->customPlaylist->id, 'vod_groups');
+
+    expect($options)
+        ->toHaveKey($eligibleVodGroup->id)
+        ->not->toHaveKey($attachedVodGroup->id)
+        ->not->toHaveKey($liveGroup->id);
+});
+
+it('keeps partially attached VOD groups eligible when they still contain unattached VOD channels', function () {
+    $group = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Partially Added VOD',
+        'type' => 'vod',
+    ]);
+
+    $attachedChannel = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $group->id,
+        'is_vod' => true,
+    ]);
+    Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $group->id,
+        'is_vod' => true,
+    ]);
+    $this->customPlaylist->channels()->attach($attachedChannel->id);
+
+    $options = PlaylistService::getEligibleAutoSyncGroupOptions($this->playlist, $this->customPlaylist->id, 'vod_groups');
+
+    expect($options)->toHaveKey($group->id);
+});
+
+it('only offers eligible unattached live groups for auto-sync group options', function () {
+    $attachedLiveGroup = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Already Added Live',
+        'type' => 'live',
+    ]);
+    $attachedLiveChannel = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $attachedLiveGroup->id,
+        'is_vod' => false,
+    ]);
+    $this->customPlaylist->channels()->attach($attachedLiveChannel->id);
+
+    $eligibleLiveGroup = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Eligible Live',
+        'type' => 'live',
+    ]);
+    Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $eligibleLiveGroup->id,
+        'is_vod' => false,
+    ]);
+
+    $vodGroup = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'VOD Movies',
+        'type' => 'vod',
+    ]);
+    Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $vodGroup->id,
+        'is_vod' => true,
+    ]);
+
+    $options = PlaylistService::getEligibleAutoSyncGroupOptions($this->playlist, $this->customPlaylist->id, 'live_groups');
+
+    expect($options)
+        ->toHaveKey($eligibleLiveGroup->id)
+        ->not->toHaveKey($attachedLiveGroup->id)
+        ->not->toHaveKey($vodGroup->id);
+});
+
+it('only offers eligible unattached series categories for auto-sync group options', function () {
+    $attachedCategory = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Already Added Series',
+    ]);
+    $attachedSeries = Series::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'category_id' => $attachedCategory->id,
+    ]);
+    $this->customPlaylist->series()->attach($attachedSeries->id);
+
+    $eligibleCategory = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Eligible Series',
+    ]);
+    Series::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'category_id' => $eligibleCategory->id,
+    ]);
+
+    $options = PlaylistService::getEligibleAutoSyncGroupOptions($this->playlist, $this->customPlaylist->id, 'series_categories');
+
+    expect($options)
+        ->toHaveKey($eligibleCategory->id)
+        ->not->toHaveKey($attachedCategory->id);
 });

--- a/tests/Feature/AddGroupsToCustomPlaylistTest.php
+++ b/tests/Feature/AddGroupsToCustomPlaylistTest.php
@@ -417,3 +417,41 @@ it('only offers eligible unattached series categories for auto-sync group option
         ->toHaveKey($eligibleCategory->id)
         ->not->toHaveKey($attachedCategory->id);
 });
+
+it('includes empty VOD groups in auto-sync options so they can be targeted before channels are synced', function () {
+    $emptyVodGroup = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'PPV Events',
+        'type' => 'vod',
+    ]);
+
+    $options = PlaylistService::getEligibleAutoSyncGroupOptions($this->playlist, $this->customPlaylist->id, 'vod_groups');
+
+    expect($options)->toHaveKey($emptyVodGroup->id);
+});
+
+it('includes empty live groups in auto-sync options so they can be targeted before channels are synced', function () {
+    $emptyLiveGroup = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Sports Events',
+        'type' => 'live',
+    ]);
+
+    $options = PlaylistService::getEligibleAutoSyncGroupOptions($this->playlist, $this->customPlaylist->id, 'live_groups');
+
+    expect($options)->toHaveKey($emptyLiveGroup->id);
+});
+
+it('includes empty series categories in auto-sync options so they can be targeted before series are synced', function () {
+    $emptyCategory = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Upcoming Shows',
+    ]);
+
+    $options = PlaylistService::getEligibleAutoSyncGroupOptions($this->playlist, $this->customPlaylist->id, 'series_categories');
+
+    expect($options)->toHaveKey($emptyCategory->id);
+});


### PR DESCRIPTION
## Summary
- Filter custom-playlist auto-add source options so fully attached VOD, live and series groups are not offered again
- Keep partially attached source groups eligible when they still contain unattached items
- Route VOD group row, bulk and edit-page add actions through VOD mode instead of channel mode

## Testing
- `docker compose -f docker-compose.dev.yml --profile test build m3u-editor-dev-test`
- `docker compose -f docker-compose.dev.yml --profile test run --rm m3u-editor-dev-test tests/Feature/AddGroupsToCustomPlaylistTest.php`
- `docker run --rm -v "$PWD":/var/www/html -w /var/www/html --entrypoint sh m3u-editor-m3u-editor-dev-test -lc 'vendor/bin/pint --test app/Services/PlaylistService.php app/Filament/Resources/Playlists/PlaylistResource.php app/Filament/Resources/VodGroups/VodGroupResource.php app/Filament/Resources/VodGroups/Pages/EditVodGroup.php tests/Feature/AddGroupsToCustomPlaylistTest.php'`
- `docker compose -f docker-compose.dev.yml --profile test run --rm --entrypoint php m3u-editor-dev-test -l app/Services/PlaylistService.php app/Filament/Resources/Playlists/PlaylistResource.php app/Filament/Resources/VodGroups/VodGroupResource.php app/Filament/Resources/VodGroups/Pages/EditVodGroup.php tests/Feature/AddGroupsToCustomPlaylistTest.php`

Fixes #1240
