### PR TITLE
Fix local media 403 for symlinked library files

### DIFF
--- a/app/Http/Controllers/MediaServerProxyController.php
+++ b/app/Http/Controllers/MediaServerProxyController.php
@@ -325,6 +325,19 @@ class MediaServerProxyController extends Controller
                     $isAllowed = true;
                     break;
                 }
+
+                // Also allow entries that are symlinks located inside a configured path
+                // but resolving outside it (e.g. *arr libraries symlinked into a
+                // debrid/cloud mount). Only the final path component may be a symlink:
+                // the parent directory is resolved with realpath(), so `..` traversal
+                // and symlinked directories cannot escape the configured paths.
+                $linkDir = realpath(dirname($filePath));
+
+                if ($allowedPath && $linkDir && is_file($filePath)
+                    && (str_starts_with($linkDir.DIRECTORY_SEPARATOR, $allowedPath.DIRECTORY_SEPARATOR) || $linkDir === $allowedPath)) {
+                    $isAllowed = true;
+                    break;
+                }
             }
 
             if (! $isAllowed) {


### PR DESCRIPTION
## Summary

Fixes #1249 — since `experimental-0.12.36`, every local-media library entry that is a **symlink** returns `403 Access denied` on the stream routes (`/local-media/{integration}/stream/{id}` and Xtream `/movie/...`), because the security check in `MediaServerProxyController` validates `realpath($filePath)`, which resolves symlinks to their target outside the configured path.

This breaks *arr + debrid/cloud-mount setups (Radarr/Sonarr + Decypharr/rclone/zurg etc.) where the whole library consists of symlinks like:

```
/media/movies/Movie (2026)/Movie (2026).mkv -> /mnt/decypharr/__all__/Movie.2026.1080p.../file.mkv
```

## Change

In addition to the existing `realpath` check, accept files whose **link location** is inside a configured path: resolve only the parent directory (`realpath(dirname($filePath))`) and require it to be within the allowed path. Only the final path component may be a symlink, so `..` traversal and symlinked directories still cannot escape the configured paths.

## Testing

- Running this exact patch on top of `experimental-0.12.36` (Docker, arm64): symlinked movies/series stream again with `206` + Range support on both the local-media route and the Xtream movie route.
- Regular (non-symlink) files: unchanged behavior.
- Files genuinely outside configured paths (including via `..`): still `403`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)