### PR TITLE
fix: preserve selected auto-sync groups

### DIFF
--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2620,6 +2620,7 @@ class PlaylistResource extends Resource implements CopilotResource
                                         playlist: $record,
                                         customPlaylistId: $get('custom_playlist_id') ? (int) $get('custom_playlist_id') : null,
                                         type: $get('type') ?? 'live_groups',
+                                        selectedGroupIds: (array) ($get('groups') ?? []),
                                     );
                                 })
                                 ->multiple()

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -882,21 +882,29 @@ class PlaylistService
     /**
      * Get selectable source groups for auto-sync rules.
      *
+     * @param  array<int|string>  $selectedGroupIds
      * @return array<int, string>
      */
-    public static function getEligibleAutoSyncGroupOptions(Playlist $playlist, ?int $customPlaylistId, string $type): array
+    public static function getEligibleAutoSyncGroupOptions(Playlist $playlist, ?int $customPlaylistId, string $type, array $selectedGroupIds = []): array
     {
+        $selectedGroupIds = collect($selectedGroupIds)
+            ->filter(fn ($id): bool => is_numeric($id))
+            ->map(fn ($id): int => (int) $id)
+            ->values()
+            ->all();
+
         if ($type === 'series_categories') {
             return Category::query()
                 ->where('playlist_id', $playlist->id)
-                ->when($customPlaylistId, function (Builder $query) use ($customPlaylistId): void {
-                    $query->where(function (Builder $query) use ($customPlaylistId): void {
+                ->when($customPlaylistId, function (Builder $query) use ($customPlaylistId, $selectedGroupIds): void {
+                    $query->where(function (Builder $query) use ($customPlaylistId, $selectedGroupIds): void {
                         $query->whereDoesntHave('series')
                             ->orWhereHas('series', function (Builder $query) use ($customPlaylistId): void {
                                 $query->whereDoesntHave('customPlaylists', function (Builder $query) use ($customPlaylistId): void {
                                     $query->whereKey($customPlaylistId);
                                 });
-                            });
+                            })
+                            ->when($selectedGroupIds, fn (Builder $query): Builder => $query->orWhereIn('id', $selectedGroupIds));
                     });
                 })
                 ->orderBy('name')
@@ -910,14 +918,15 @@ class PlaylistService
         return Group::query()
             ->where('playlist_id', $playlist->id)
             ->where('type', $isVod ? 'vod' : 'live')
-            ->when($customPlaylistId, function (Builder $query) use ($channelRelation, $customPlaylistId): void {
-                $query->where(function (Builder $query) use ($channelRelation, $customPlaylistId): void {
+            ->when($customPlaylistId, function (Builder $query) use ($channelRelation, $customPlaylistId, $selectedGroupIds): void {
+                $query->where(function (Builder $query) use ($channelRelation, $customPlaylistId, $selectedGroupIds): void {
                     $query->whereDoesntHave($channelRelation)
                         ->orWhereHas($channelRelation, function (Builder $query) use ($customPlaylistId): void {
                             $query->whereDoesntHave('customPlaylists', function (Builder $query) use ($customPlaylistId): void {
                                 $query->whereKey($customPlaylistId);
                             });
-                        });
+                        })
+                        ->when($selectedGroupIds, fn (Builder $query): Builder => $query->orWhereIn('id', $selectedGroupIds));
                 });
             })
             ->orderBy('name')

--- a/tests/Feature/AddGroupsToCustomPlaylistTest.php
+++ b/tests/Feature/AddGroupsToCustomPlaylistTest.php
@@ -444,6 +444,84 @@ it('includes empty live groups in auto-sync options so they can be targeted befo
     expect($options)->toHaveKey($emptyLiveGroup->id);
 });
 
+it('keeps selected live groups available after their channels are already attached to the custom playlist', function () {
+    $selectedGroup = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Selected Parents',
+        'type' => 'live',
+    ]);
+    $selectedChannel = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $selectedGroup->id,
+        'is_vod' => false,
+    ]);
+    $this->customPlaylist->channels()->attach($selectedChannel->id);
+
+    $attachedUnselectedGroup = Group::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Attached Unselected',
+        'type' => 'live',
+    ]);
+    $attachedUnselectedChannel = Channel::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'group_id' => $attachedUnselectedGroup->id,
+        'is_vod' => false,
+    ]);
+    $this->customPlaylist->channels()->attach($attachedUnselectedChannel->id);
+
+    $options = PlaylistService::getEligibleAutoSyncGroupOptions(
+        $this->playlist,
+        $this->customPlaylist->id,
+        'live_groups',
+        [$selectedGroup->id]
+    );
+
+    expect($options)
+        ->toHaveKey($selectedGroup->id)
+        ->not->toHaveKey($attachedUnselectedGroup->id);
+});
+
+it('keeps selected series categories available after their series are already attached to the custom playlist', function () {
+    $selectedCategory = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Selected Series',
+    ]);
+    $selectedSeries = Series::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'category_id' => $selectedCategory->id,
+    ]);
+    $this->customPlaylist->series()->attach($selectedSeries->id);
+
+    $attachedUnselectedCategory = Category::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Attached Unselected Series',
+    ]);
+    $attachedUnselectedSeries = Series::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'category_id' => $attachedUnselectedCategory->id,
+    ]);
+    $this->customPlaylist->series()->attach($attachedUnselectedSeries->id);
+
+    $options = PlaylistService::getEligibleAutoSyncGroupOptions(
+        $this->playlist,
+        $this->customPlaylist->id,
+        'series_categories',
+        [$selectedCategory->id]
+    );
+
+    expect($options)
+        ->toHaveKey($selectedCategory->id)
+        ->not->toHaveKey($attachedUnselectedCategory->id);
+});
+
 it('includes empty series categories in auto-sync options so they can be targeted before series are synced', function () {
     $emptyCategory = Category::factory()->create([
         'user_id' => $this->user->id,


### PR DESCRIPTION
## Summary
- Keeps saved auto-sync source groups in the Groups select options, even when the group is already fully attached to the target Custom Playlist.
- Preserves the existing filter behavior for unselected fully attached groups.
- Adds regression coverage for selected live groups and selected series categories.

## Root cause
PR #1242 changed auto-sync group options to hide groups whose items are already attached to the target Custom Playlist. That is correct for new selections, but it also removed the currently saved selections after the next sync. Filament then rendered those saved group IDs as invalid values, matching issue #1251.

## Verification
- `php vendor/bin/pest --compact tests/Feature/AddGroupsToCustomPlaylistTest.php tests/Feature/AutoSyncGroupsToCustomPlaylistTest.php tests/Feature/RunCustomPlaylistProcessingTest.php`
- `php vendor/bin/pint --test --format agent`
- `php -l app/Services/PlaylistService.php`
- `php -l app/Filament/Resources/Playlists/PlaylistResource.php`
- `php -l tests/Feature/AddGroupsToCustomPlaylistTest.php`
- `git diff --check`

Fixes #1251
