### PR TITLE
fix(epg): preserve XMLTV programme identity

### DIFF
--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -385,7 +385,7 @@ class EpgGenerateController extends Controller
                                     $progXml .= '    <category>'.$this->escapeXml($programme['category']).'</category>'.PHP_EOL;
                                 }
                                 foreach (EpisodeNumberNormalizer::forProgramme($programme) as $episodeNumber) {
-                                    $systemAttribute = $episodeNumber['system'] !== null
+                                    $systemAttribute = ($episodeNumber['system'] !== null && $episodeNumber['system'] !== '')
                                         ? ' system="'.$this->escapeXml($episodeNumber['system']).'"'
                                         : '';
                                     $progXml .= '    <episode-num'.$systemAttribute.'>'.$this->escapeXml($episodeNumber['value']).'</episode-num>'.PHP_EOL;

--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -14,9 +14,11 @@ use App\Models\Playlist;
 use App\Models\PlaylistAlias;
 use App\Services\AedExtractorService;
 use App\Services\EpgCacheService;
+use App\Services\EpisodeNumberNormalizer;
 use App\Services\NetworkEpgService;
 use Carbon\Carbon;
 use DOMDocument;
+use DOMElement;
 use Exception;
 use Filament\Notifications\Notification;
 use Illuminate\Http\Response;
@@ -382,8 +384,11 @@ class EpgGenerateController extends Controller
                                 if ($programme['category']) {
                                     $progXml .= '    <category>'.$this->escapeXml($programme['category']).'</category>'.PHP_EOL;
                                 }
-                                if ($programme['episode_num']) {
-                                    $progXml .= '    <episode-num system="xmltv_ns">'.$this->escapeXml($programme['episode_num']).'</episode-num>'.PHP_EOL;
+                                foreach (EpisodeNumberNormalizer::forProgramme($programme) as $episodeNumber) {
+                                    $systemAttribute = $episodeNumber['system'] !== null
+                                        ? ' system="'.$this->escapeXml($episodeNumber['system']).'"'
+                                        : '';
+                                    $progXml .= '    <episode-num'.$systemAttribute.'>'.$this->escapeXml($episodeNumber['value']).'</episode-num>'.PHP_EOL;
                                 }
                                 if ($programme['icon']) {
                                     $icon = $logoProxyEnabled
@@ -463,7 +468,6 @@ class EpgGenerateController extends Controller
             foreach ($dummyEpgChannels as $dummyEpgChannel) {
                 $tvgId = $this->escapeXml($dummyEpgChannel['tvg_id']);
                 $title = $dummyEpgChannel['title'];
-                $icon = $dummyEpgChannel['icon'];
                 $group = $this->escapeXml($dummyEpgChannel['group']);
                 $includeCategory = $dummyEpgChannel['include_category'];
                 $aedProfileId = $dummyEpgChannel['aed_profile_id'] ?? null;
@@ -479,7 +483,7 @@ class EpgGenerateController extends Controller
 
                     $aedIcon = $aedProfile->logo_url
                         ? $this->escapeXml($aedProfile->logo_url)
-                        : $icon;
+                        : null;
                     $aedCategory = $aedProfile->category
                         ? $this->escapeXml($aedProfile->category)
                         : ($includeCategory ? $group : null);
@@ -552,7 +556,7 @@ class EpgGenerateController extends Controller
                             }
                         }
                     } else {
-                        // Extraction failed or no time — use AED title with standard repeating slots
+                        // Extraction failed or no time - use AED title with standard repeating slots
                         $aedTitle = $this->escapeXml($aedEvent->title);
                         $aedDesc = $aedEvent->description
                             ? $this->escapeXml($aedEvent->description)
@@ -583,9 +587,6 @@ class EpgGenerateController extends Controller
                     foreach ($timeSlots as $slot) {
                         $buffer .= '  <programme channel="'.$tvgId.'" start="'.$slot['start'].'" stop="'.$slot['end'].'">'.PHP_EOL;
                         $buffer .= '    <title>'.$title.'</title>'.PHP_EOL;
-                        if ($icon) {
-                            $buffer .= '    <icon src="'.$icon.'"/>'.PHP_EOL;
-                        }
                         $buffer .= '    <desc>'.$title.'</desc>'.PHP_EOL;
                         if ($includeCategory) {
                             $buffer .= '    <category lang="en">'.$group.'</category>'.PHP_EOL;
@@ -932,6 +933,7 @@ class EpgGenerateController extends Controller
 
                 // Get the item element
                 $item = $itemDom->documentElement;
+                $this->normalizeEpisodeNumbers($item);
 
                 // Save original time attributes before the loop so each iteration starts fresh
                 $originalStart = $item->getAttribute('start');
@@ -976,6 +978,34 @@ class EpgGenerateController extends Controller
         }
         // Close the XMLReader for this epg
         $programReader->close();
+    }
+
+    private function normalizeEpisodeNumbers(DOMElement $programme): void
+    {
+        $episodeNumberElements = [];
+
+        foreach ($programme->childNodes as $childNode) {
+            if ($childNode instanceof DOMElement && $childNode->tagName === 'episode-num') {
+                $episodeNumberElements[] = $childNode;
+            }
+        }
+
+        foreach ($episodeNumberElements as $episodeNumberElement) {
+            $normalizedEpisodeNumbers = EpisodeNumberNormalizer::normalize([[
+                'system' => $episodeNumberElement->hasAttribute('system')
+                    ? $episodeNumberElement->getAttribute('system')
+                    : null,
+                'value' => $episodeNumberElement->textContent,
+            ]]);
+
+            if ($normalizedEpisodeNumbers === []) {
+                $programme->removeChild($episodeNumberElement);
+
+                continue;
+            }
+
+            $episodeNumberElement->textContent = $normalizedEpisodeNumbers[0]['value'];
+        }
     }
 
     /**

--- a/app/Services/EpgCacheService.php
+++ b/app/Services/EpgCacheService.php
@@ -248,25 +248,25 @@ class EpgCacheService
                 break;
             case 'previously-shown':
                 // The <previously-shown> element may carry start/channel attributes;
-                // only the boolean presence is recorded — attributes are intentionally ignored.
+                // only the boolean presence is recorded - attributes are intentionally ignored.
                 $programme['previously_shown'] = true;
                 break;
             case 'premiere':
                 // The <premiere> element may carry text content (a description);
-                // only the boolean presence is recorded — content is intentionally ignored.
+                // only the boolean presence is recorded - content is intentionally ignored.
                 $programme['premiere'] = true;
                 break;
             case 'episode-num':
-                $episodeNumValue = trim($reader->readString() ?: '');
-                $episodeNumSystem = trim((string) ($reader->getAttribute('system') ?: ''));
-                if ($episodeNumValue !== '') {
+                $episodeNumbers = EpisodeNumberNormalizer::normalize([[
+                    'system' => $reader->getAttribute('system'),
+                    'value' => $reader->readString(),
+                ]]);
+                if ($episodeNumbers !== []) {
+                    $episodeNumber = $episodeNumbers[0];
                     if ($programme['episode_num'] === '') {
-                        $programme['episode_num'] = $episodeNumValue;
+                        $programme['episode_num'] = $episodeNumber['value'];
                     }
-                    $programme['episode_nums'][] = [
-                        'system' => $episodeNumSystem,
-                        'value' => $episodeNumValue,
-                    ];
+                    $programme['episode_nums'][] = $episodeNumber;
                 }
                 break;
             case 'url':
@@ -1218,7 +1218,7 @@ class EpgCacheService
      * Clear EPG file caches for all playlist types (source, custom, merged, aliases)
      * that contain any of the given channel IDs.
      *
-     * Executes 4 DB queries then one bulk Storage::delete — no model hydration, no N+1.
+     * Executes 4 DB queries then one bulk Storage::delete - no model hydration, no N+1.
      */
     public static function clearForChannelIds(array $channelIds): void
     {

--- a/app/Services/EpisodeNumberNormalizer.php
+++ b/app/Services/EpisodeNumberNormalizer.php
@@ -62,6 +62,6 @@ final class EpisodeNumberNormalizer
         $valueWithoutWhitespace = preg_replace('/\s+/', '', $value) ?? '';
 
         return $valueWithoutWhitespace !== '..'
-            && preg_match('/^(?:\d+(?:\/[1-9]\d*)?)?\.(?:\d+(?:\/[1-9]\d*)?)?\.(?:\d+(?:\/[1-9]\d*)?)?$/', $valueWithoutWhitespace) === 1;
+            && preg_match('/^(?:\d+(?:\/0*[1-9]\d*)?)?\.(?:\d+(?:\/0*[1-9]\d*)?)?\.(?:\d+(?:\/0*[1-9]\d*)?)?$/', $valueWithoutWhitespace) === 1;
     }
 }

--- a/app/Services/EpisodeNumberNormalizer.php
+++ b/app/Services/EpisodeNumberNormalizer.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Services;
+
+final class EpisodeNumberNormalizer
+{
+    /**
+     * @param  array<int, mixed>  $episodeNumbers
+     * @return array<int, array{system: string|null, value: string}>
+     */
+    public static function normalize(array $episodeNumbers): array
+    {
+        $normalizedEpisodeNumbers = [];
+
+        foreach ($episodeNumbers as $episodeNumber) {
+            if (! is_array($episodeNumber)) {
+                continue;
+            }
+
+            $system = array_key_exists('system', $episodeNumber)
+                ? $episodeNumber['system']
+                : null;
+            $value = trim((string) ($episodeNumber['value'] ?? ''));
+
+            if ($system !== null && ! is_string($system)) {
+                continue;
+            }
+
+            if ($value === '' || ($system === 'xmltv_ns' && ! self::isValidXmltvNamespace($value))) {
+                continue;
+            }
+
+            $normalizedEpisodeNumbers[] = [
+                'system' => $system,
+                'value' => $value,
+            ];
+        }
+
+        return $normalizedEpisodeNumbers;
+    }
+
+    /**
+     * @param  array<string, mixed>  $programme
+     * @return array<int, array{system: string|null, value: string}>
+     */
+    public static function forProgramme(array $programme): array
+    {
+        if (! array_key_exists('episode_nums', $programme)) {
+            return self::normalize([[
+                'system' => 'xmltv_ns',
+                'value' => $programme['episode_num'] ?? '',
+            ]]);
+        }
+
+        return is_array($programme['episode_nums'])
+            ? self::normalize($programme['episode_nums'])
+            : [];
+    }
+
+    private static function isValidXmltvNamespace(string $value): bool
+    {
+        $valueWithoutWhitespace = preg_replace('/\s+/', '', $value) ?? '';
+
+        return $valueWithoutWhitespace !== '..'
+            && preg_match('/^(?:\d+(?:\/[1-9]\d*)?)?\.(?:\d+(?:\/[1-9]\d*)?)?\.(?:\d+(?:\/[1-9]\d*)?)?$/', $valueWithoutWhitespace) === 1;
+    }
+}

--- a/tests/Feature/EpgGenerateControllerTest.php
+++ b/tests/Feature/EpgGenerateControllerTest.php
@@ -6,11 +6,13 @@ use App\Events\EpgUpdated;
 use App\Events\PlaylistCreated;
 use App\Events\PlaylistDeleted;
 use App\Events\PlaylistUpdated;
+use App\Models\AedProfile;
 use App\Models\Channel;
 use App\Models\Epg;
 use App\Models\EpgChannel;
 use App\Models\Playlist;
 use App\Models\User;
+use App\Services\EpgCacheService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
@@ -60,7 +62,7 @@ test('epg download does not crash when epg source file is missing', function () 
         'channel' => 1,
     ]);
 
-    // The EPG source file does not exist — should return valid XML without crashing
+    // The EPG source file does not exist - should return valid XML without crashing
     $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
 
     $response->assertStatus(200);
@@ -115,6 +117,80 @@ test('epg download does not crash when epg source file is corrupted', function (
     Storage::disk('local')->delete($epg->file_path);
 });
 
+test('xmlreader fallback preserves programme identities and artwork while omitting invalid identities', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => false,
+    ]);
+    $epg = Epg::factory()->for($user)->create([
+        'url' => 'https://example.com/fallback-identity.xml',
+        'is_cached' => false,
+    ]);
+    $epgChannel = EpgChannel::factory()->for($user)->for($epg)->create([
+        'channel_id' => 'source.fallback.identity',
+        'display_name' => 'Fallback Identity Channel',
+        'lang' => 'en',
+    ]);
+
+    Channel::factory()->for($user)->for($playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'epg_channel_id' => $epgChannel->id,
+        'stream_id' => 'fallback-identity-channel',
+        'title' => 'Fallback Identity Channel',
+        'channel' => 1,
+    ]);
+
+    $start = now()->startOfDay()->addHour()->format('YmdHis O');
+    $stop = now()->startOfDay()->addHours(2)->format('YmdHis O');
+    $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="source.fallback.identity"><display-name>Fallback Identity Channel</display-name></channel>
+  <programme start="{$start}" stop="{$stop}" channel="source.fallback.identity">
+    <title>Fallback Identity Programme</title>
+    <icon src="https://example.com/fallback-programme-artwork.jpg" />
+    <episode-num system="xmltv_ns">1 . 4/10 .</episode-num>
+    <episode-num system="provider-counter">0</episode-num>
+    <episode-num system="dd_progid">EP012345670089</episode-num>
+    <episode-num system="onscreen">S02E05</episode-num>
+    <episode-num system="provider.example/id">series-0</episode-num>
+    <episode-num>Unclassified 7</episode-num>
+    <episode-num system="xmltv_ns">1..2..3</episode-num>
+    <episode-num system="xmltv_ns">   </episode-num>
+    <episode-num system="provider-counter">   </episode-num>
+  </programme>
+</tv>
+XML;
+
+    Storage::disk('local')->put($epg->file_path, gzencode($xml));
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertOk()->assertHeader('Content-Type', 'application/gzip');
+
+    $document = new DOMDocument;
+    expect($document->loadXML(gzdecode($response->getContent())))->toBeTrue();
+
+    $xpath = new DOMXPath($document);
+    $episodeNumbers = [];
+    foreach ($xpath->query('//programme[@channel="fallback-identity-channel"]/episode-num') as $episodeNumber) {
+        $episodeNumbers[] = [
+            'system' => $episodeNumber->hasAttribute('system') ? $episodeNumber->getAttribute('system') : null,
+            'value' => $episodeNumber->textContent,
+        ];
+    }
+
+    expect($episodeNumbers)->toBe([
+        ['system' => 'xmltv_ns', 'value' => '1 . 4/10 .'],
+        ['system' => 'provider-counter', 'value' => '0'],
+        ['system' => 'dd_progid', 'value' => 'EP012345670089'],
+        ['system' => 'onscreen', 'value' => 'S02E05'],
+        ['system' => 'provider.example/id', 'value' => 'series-0'],
+        ['system' => null, 'value' => 'Unclassified 7'],
+    ])->and($xpath->query('//programme[@channel="fallback-identity-channel"]/icon[@src="https://example.com/fallback-programme-artwork.jpg"]'))->toHaveCount(1);
+});
+
 test('epg xml generation preserves albanian characters with explicit utf8 escaping', function () {
     $previousCharset = ini_get('default_charset');
     ini_set('default_charset', 'ISO-8859-1');
@@ -149,4 +225,232 @@ test('epg xml generation preserves albanian characters with explicit utf8 escapi
     } finally {
         ini_set('default_charset', $previousCharset ?: 'UTF-8');
     }
+});
+
+test('cached epg generation preserves ordered episode number identities from source xml', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => false,
+    ]);
+    $epg = Epg::factory()->for($user)->create([
+        'url' => 'https://example.com/identity.xml',
+    ]);
+    $epgChannel = EpgChannel::factory()->for($user)->for($epg)->create([
+        'channel_id' => 'source.identity',
+        'display_name' => 'Identity Channel',
+        'lang' => 'en',
+    ]);
+
+    Channel::factory()->for($user)->for($playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'epg_channel_id' => $epgChannel->id,
+        'stream_id' => 'identity-channel',
+        'title' => 'Identity Channel',
+        'channel' => 1,
+    ]);
+
+    $date = now()->format('Y-m-d');
+    $start = now()->startOfDay()->addHour()->format('YmdHis O');
+    $stop = now()->startOfDay()->addHours(2)->format('YmdHis O');
+    $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="source.identity"><display-name>Identity Channel</display-name></channel>
+  <programme start="{$start}" stop="{$stop}" channel="source.identity">
+    <title>Identity Programme</title>
+    <icon src="https://example.com/programme-artwork.jpg" />
+    <episode-num system="xmltv_ns">1 . 4/10 .</episode-num>
+    <episode-num system="dd_progid">EP012345670089</episode-num>
+    <episode-num system="onscreen">S02E05</episode-num>
+    <episode-num system="provider.example/id">series-0</episode-num>
+    <episode-num>Unclassified 7</episode-num>
+    <episode-num system=" xmltv_ns ">0</episode-num>
+    <episode-num system="xmltv_ns">0</episode-num>
+    <episode-num system="xmltv_ns">1..2..3</episode-num>
+    <episode-num system="onscreen">   </episode-num>
+  </programme>
+</tv>
+XML;
+
+    Storage::disk('local')->put($epg->file_path, gzencode($xml));
+
+    expect(app(EpgCacheService::class)->cacheEpgData($epg))->toBeTrue();
+
+    $cacheLine = Storage::disk('local')->get("epg-cache/{$epg->uuid}/v2/programmes-{$date}.jsonl");
+    $cachedProgramme = json_decode(trim($cacheLine), true, flags: JSON_THROW_ON_ERROR)['programme'];
+    $expectedEpisodeNumbers = [
+        ['system' => 'xmltv_ns', 'value' => '1 . 4/10 .'],
+        ['system' => 'dd_progid', 'value' => 'EP012345670089'],
+        ['system' => 'onscreen', 'value' => 'S02E05'],
+        ['system' => 'provider.example/id', 'value' => 'series-0'],
+        ['system' => null, 'value' => 'Unclassified 7'],
+        ['system' => ' xmltv_ns ', 'value' => '0'],
+    ];
+
+    expect($cachedProgramme['episode_nums'])->toBe($expectedEpisodeNumbers)
+        ->and($cachedProgramme['icon'])->toBe('https://example.com/programme-artwork.jpg');
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertOk()->assertHeader('Content-Type', 'application/gzip');
+
+    $document = new DOMDocument;
+    expect($document->loadXML(gzdecode($response->getContent())))->toBeTrue();
+
+    $episodeNumbers = [];
+    foreach ($document->getElementsByTagName('episode-num') as $episodeNumber) {
+        $episodeNumbers[] = [
+            'system' => $episodeNumber->hasAttribute('system') ? $episodeNumber->getAttribute('system') : null,
+            'value' => $episodeNumber->textContent,
+        ];
+    }
+
+    $xpath = new DOMXPath($document);
+
+    expect($episodeNumbers)->toBe($expectedEpisodeNumbers)
+        ->and($xpath->query('//programme[@channel="identity-channel"]/icon[@src="https://example.com/programme-artwork.jpg"]'))->toHaveCount(1);
+});
+
+test('legacy scalar episode numbers emit only valid xmltv namespace identities', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => false,
+    ]);
+    $epg = Epg::factory()->for($user)->create([
+        'url' => 'https://example.com/legacy.xml',
+        'is_cached' => true,
+    ]);
+    $epgChannel = EpgChannel::factory()->for($user)->for($epg)->create([
+        'channel_id' => 'source.legacy',
+        'display_name' => 'Legacy Channel',
+        'lang' => 'en',
+    ]);
+
+    Channel::factory()->for($user)->for($playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'epg_channel_id' => $epgChannel->id,
+        'stream_id' => 'legacy-channel',
+        'title' => 'Legacy Channel',
+        'channel' => 1,
+    ]);
+
+    $date = now()->format('Y-m-d');
+    $cacheDirectory = "epg-cache/{$epg->uuid}/v2";
+    Storage::disk('local')->put("{$cacheDirectory}/metadata.json", json_encode([
+        'cache_created' => time(),
+        'cache_version' => 'v2',
+    ], JSON_THROW_ON_ERROR));
+
+    $records = collect([
+        ['title' => 'Valid Legacy', 'episode_num' => '0.4.'],
+        ['title' => 'Provider Legacy', 'episode_num' => 'EP012345670089'],
+        ['title' => 'Zero Legacy', 'episode_num' => '0'],
+        ['title' => 'Malformed Legacy', 'episode_num' => '1..2..3'],
+    ])->map(function (array $programme, int $index): string {
+        return json_encode([
+            'channel' => 'source.legacy',
+            'programme' => array_merge([
+                'start' => now()->startOfDay()->addHours($index + 1)->toISOString(),
+                'stop' => now()->startOfDay()->addHours($index + 2)->toISOString(),
+                'subtitle' => '',
+                'desc' => '',
+                'category' => '',
+                'rating' => '',
+                'icon' => '',
+                'images' => [],
+                'new' => false,
+            ], $programme),
+        ], JSON_THROW_ON_ERROR);
+    })->implode("\n")."\n";
+
+    Storage::disk('local')->put("{$cacheDirectory}/programmes-{$date}.jsonl", $records);
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertOk()->assertHeader('Content-Type', 'application/gzip');
+
+    $document = new DOMDocument;
+    expect($document->loadXML(gzdecode($response->getContent())))->toBeTrue();
+
+    $episodeNumbers = [];
+    foreach ($document->getElementsByTagName('episode-num') as $episodeNumber) {
+        $episodeNumbers[] = [
+            'system' => $episodeNumber->getAttribute('system'),
+            'value' => $episodeNumber->textContent,
+        ];
+    }
+
+    expect($episodeNumbers)->toBe([
+        ['system' => 'xmltv_ns', 'value' => '0.4.'],
+    ]);
+});
+
+test('standard dummy programmes do not copy channel branding into programme artwork', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => true,
+        'dummy_epg_length' => 7200,
+    ]);
+
+    Channel::factory()->for($user)->for($playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'stream_id' => 'dummy-channel',
+        'title' => 'Dummy Channel',
+        'logo' => 'https://example.com/channel-logo.png',
+        'channel' => 1,
+        'aed_profile_id' => null,
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertOk()->assertHeader('Content-Type', 'application/gzip');
+
+    $document = new DOMDocument;
+    expect($document->loadXML(gzdecode($response->getContent())))->toBeTrue();
+
+    $xpath = new DOMXPath($document);
+
+    expect($xpath->query('//channel[@id="dummy-channel"]/icon'))->toHaveCount(1)
+        ->and($xpath->query('//programme[@channel="dummy-channel"]'))->toHaveCount(1)
+        ->and($xpath->query('//programme[@channel="dummy-channel"]/icon'))->toHaveCount(0);
+});
+
+test('aed dummy programmes do not fall back to channel branding for programme artwork', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => true,
+    ]);
+    $aedProfile = new AedProfile;
+    $aedProfile->forceFill([
+        'user_id' => $user->id,
+        'name' => 'No Artwork',
+        'logo_url' => null,
+        'event_duration_minutes' => 7200,
+    ])->save();
+
+    Channel::factory()->for($user)->for($playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'stream_id' => 'aed-dummy-channel',
+        'title' => 'AED Dummy Channel',
+        'logo' => 'https://example.com/channel-logo.png',
+        'channel' => 1,
+        'aed_profile_id' => $aedProfile->id,
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertOk()->assertHeader('Content-Type', 'application/gzip');
+
+    $document = new DOMDocument;
+    expect($document->loadXML(gzdecode($response->getContent())))->toBeTrue();
+
+    $xpath = new DOMXPath($document);
+
+    expect($xpath->query('//channel[@id="aed-dummy-channel"]/icon'))->toHaveCount(1)
+        ->and($xpath->query('//programme[@channel="aed-dummy-channel"]'))->toHaveCount(1)
+        ->and($xpath->query('//programme[@channel="aed-dummy-channel"]/icon'))->toHaveCount(0);
 });

--- a/tests/Unit/EpgCacheServiceXmltvSignalsTest.php
+++ b/tests/Unit/EpgCacheServiceXmltvSignalsTest.php
@@ -84,6 +84,67 @@ XML;
         ->and($programme['production_year'])->toBe(2024);
 });
 
+it('preserves episode number systems while omitting invalid xmltv namespace identities', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <programme start="20260421080000 +0000" stop="20260421084500 +0000" channel="demo.channel">
+    <title>Identity Test</title>
+    <episode-num system="xmltv_ns">1 . 4/10 .</episode-num>
+    <episode-num system="dd_progid">EP012345670089</episode-num>
+    <episode-num system="onscreen">S02E05</episode-num>
+    <episode-num system="provider.example/id">series-0</episode-num>
+    <episode-num>Unclassified 7</episode-num>
+    <episode-num system=" xmltv_ns ">0</episode-num>
+    <episode-num system="xmltv_ns">0</episode-num>
+    <episode-num system="xmltv_ns">1..2..3</episode-num>
+    <episode-num system="xmltv_ns">..</episode-num>
+    <episode-num system="onscreen">   </episode-num>
+  </programme>
+</tv>
+XML;
+
+    file_put_contents($this->testGzPath, gzencode($xml));
+
+    $service = makeTestEpgCacheService();
+    $programmes = iterator_to_array($service->exposeParseProgrammesStream($this->testGzPath), false);
+
+    expect($programmes)->toHaveCount(1)
+        ->and($programmes[0]['episode_num'])->toBe('1 . 4/10 .')
+        ->and($programmes[0]['episode_nums'])->toBe([
+            ['system' => 'xmltv_ns', 'value' => '1 . 4/10 .'],
+            ['system' => 'dd_progid', 'value' => 'EP012345670089'],
+            ['system' => 'onscreen', 'value' => 'S02E05'],
+            ['system' => 'provider.example/id', 'value' => 'series-0'],
+            ['system' => null, 'value' => 'Unclassified 7'],
+            ['system' => ' xmltv_ns ', 'value' => '0'],
+        ]);
+});
+
+it('preserves a zero episode number when its provider system gives it identity', function () {
+    $xml = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <programme start="20260421080000 +0000" stop="20260421084500 +0000" channel="demo.channel">
+    <title>Provider Zero</title>
+    <episode-num system="provider-counter">0</episode-num>
+    <episode-num system="xmltv_ns">0</episode-num>
+  </programme>
+</tv>
+XML;
+
+    file_put_contents($this->testGzPath, gzencode($xml));
+
+    $service = makeTestEpgCacheService();
+    $programmes = iterator_to_array($service->exposeParseProgrammesStream($this->testGzPath), false);
+
+    expect($programmes)->toHaveCount(1)
+        ->and($programmes[0]['episode_num'])->toBe('0')
+        ->and($programmes[0]['episode_nums'])->toBe([
+            ['system' => 'provider-counter', 'value' => '0'],
+        ]);
+});
+
 it('rejects malformed or unsafe url values from epg feeds', function () {
     $xml = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

- preserve ordered, non-empty `<episode-num>` values with their original `system` in cached EPG generation and the XMLReader fallback
- validate only identifiers whose exact system is `xmltv_ns`, while retaining provider-specific, system-less, onscreen, and provider-owned zero values
- preserve real programme artwork and avoid using channel logos as artwork for standard or AED dummy programmes
- cover cached output and the forced XMLReader fallback with deterministic regressions

## Verification

- Pint: 1,314 files passed
- changed PHP files: syntax clean
- focused cache, generator, and fallback tests: 13 passed, 71 assertions
- broader EPG suite: 54 passed, 280 assertions
- full practical suite with Redis: 1,585 passed, 29 skipped, 4,232 assertions
- Composer audit: no advisories
- npm audit: 0 vulnerabilities
- Vite build: passed
- diff and forbidden Unicode dash scans: clean

Closes #1258
