### PR TITLE
feat: add capability-aware TV stream resolution

### DIFF
--- a/app/DataObjects/ClientCapabilities.php
+++ b/app/DataObjects/ClientCapabilities.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\DataObjects;
+
+class ClientCapabilities
+{
+    private const CODEC_ALIASES = [
+        'hevc' => 'hevc',
+        'h265' => 'hevc',
+        'h.265' => 'hevc',
+        'h264' => 'h264',
+        'avc' => 'h264',
+        'h.264' => 'h264',
+        'mpeg4 avc' => 'h264',
+        'mpeg2video' => 'mpeg2video',
+        'mpeg2' => 'mpeg2video',
+        'mpeg-2' => 'mpeg2video',
+        'mpeg 2 video' => 'mpeg2video',
+        'av1' => 'av1',
+        'vp9' => 'vp9',
+        'vp8' => 'vp8',
+    ];
+
+    private const CONTAINER_ALIASES = [
+        'mpegts' => 'mpegts',
+        'mpegtsraw' => 'mpegts',
+        'ts' => 'mpegts',
+        'm2ts' => 'mpegts',
+        'hls' => 'hls',
+        'm3u8' => 'hls',
+        'dash' => 'dash',
+        'mpd' => 'dash',
+        'mp4' => 'mp4',
+        'mkv' => 'mkv',
+        'matroska' => 'mkv',
+        'flv' => 'flv',
+    ];
+
+    public function __construct(
+        public readonly string $profile,
+        public readonly string $platform,
+        public readonly string $backend,
+        public readonly array $videoCodecs,
+        public readonly array $audioCodecs,
+        public readonly array $containers,
+        public readonly ?int $maxHeight = null,
+        public readonly ?int $maxBitrateKbps = null,
+        public readonly ?bool $hdr = null,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            profile: self::normalizeString($data['profile'] ?? ''),
+            platform: self::normalizeString($data['platform'] ?? ''),
+            backend: self::normalizeString($data['backend'] ?? ''),
+            videoCodecs: self::normalizeCodecList($data['video_codecs'] ?? []),
+            audioCodecs: self::normalizeStringList($data['audio_codecs'] ?? []),
+            containers: self::normalizeContainerList($data['containers'] ?? []),
+            maxHeight: isset($data['max_height']) && is_numeric($data['max_height'])
+                ? (int) $data['max_height']
+                : null,
+            maxBitrateKbps: isset($data['max_bitrate_kbps']) && is_numeric($data['max_bitrate_kbps'])
+                ? (int) $data['max_bitrate_kbps']
+                : null,
+            hdr: isset($data['hdr']) ? filter_var($data['hdr'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) : null,
+        );
+    }
+
+    public static function normalizeCodec(string $codec): string
+    {
+        $clean = strtolower(trim($codec));
+
+        return self::CODEC_ALIASES[$clean] ?? $clean;
+    }
+
+    public static function normalizeContainer(string $container): string
+    {
+        $clean = strtolower(trim($container));
+
+        return self::CONTAINER_ALIASES[$clean] ?? $clean;
+    }
+
+    private static function normalizeString(string $value): string
+    {
+        return trim($value);
+    }
+
+    private static function normalizeStringList(array $list): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            fn ($item) => strtolower(trim((string) $item)),
+            $list
+        ), fn (string $v) => $v !== '')));
+    }
+
+    private static function normalizeCodecList(array $list): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            fn ($item) => self::normalizeCodec((string) $item),
+            $list
+        ), fn (string $v) => $v !== '')));
+    }
+
+    private static function normalizeContainerList(array $list): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            fn ($item) => self::normalizeContainer((string) $item),
+            $list
+        ), fn (string $v) => $v !== '')));
+    }
+}

--- a/app/Http/Controllers/Api/TvApiController.php
+++ b/app/Http/Controllers/Api/TvApiController.php
@@ -2,13 +2,32 @@
 
 namespace App\Http\Controllers\Api;
 
+use App\DataObjects\ClientCapabilities;
 use App\Facades\PlaylistFacade;
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\XtreamStreamController;
+use App\Models\Channel;
+use App\Models\CustomPlaylist;
+use App\Models\Episode;
+use App\Models\MergedPlaylist;
+use App\Models\Playlist;
+use App\Models\PlaylistAlias;
+use App\Models\PlaylistAuth;
+use App\Models\StreamProfile;
 use App\Models\TvNotification;
+use App\Services\M3uProxyService;
+use App\Services\PlaybackCapabilityService;
+use App\Services\StreamProfileRuleEvaluator;
+use App\Services\StreamStatsService;
 use App\Settings\GeneralSettings;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\URL;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 class TvApiController extends Controller
 {
@@ -109,18 +128,442 @@ class TvApiController extends Controller
         ]);
     }
 
+    public function playStream(
+        Request $request,
+        string $playlistType,
+        int $playlistId,
+        string $type,
+        int $streamId,
+    ): Response {
+        $playlistClass = match ($playlistType) {
+            'playlist' => Playlist::class,
+            'merged' => MergedPlaylist::class,
+            'custom' => CustomPlaylist::class,
+            'alias' => PlaylistAlias::class,
+        };
+        $playlist = $playlistClass::findOrFail($playlistId);
+        abort_if($playlist instanceof PlaylistAlias && $playlist->isExpired(), 403);
+        abort_if($this->loadStream($playlist, $streamId, $type) === null, 404);
+
+        $authMethod = (string) $request->query('auth_method');
+        abort_unless(in_array($authMethod, ['owner_auth', 'playlist_auth', 'alias_auth'], true), 403);
+        $playlistAuthId = $request->integer('auth');
+        $playlistAuth = $authMethod === 'playlist_auth' && $playlistAuthId > 0
+            ? PlaylistAuth::query()
+                ->whereKey($playlistAuthId)
+                ->where('enabled', true)
+                ->whereHas('assignedPlaylist', fn ($query) => $query
+                    ->where('authenticatable_type', $playlist->getMorphClass())
+                    ->where('authenticatable_id', $playlist->id))
+                ->first()
+            : null;
+        abort_if($authMethod === 'playlist_auth' && ($playlistAuth === null || $playlistAuth->isExpired()), 403);
+        abort_if($authMethod === 'alias_auth' && ! $playlist instanceof PlaylistAlias, 403);
+
+        $username = match ($authMethod) {
+            'playlist_auth' => $playlistAuth->username,
+            'alias_auth' => $playlist->username,
+            default => $playlist->user->name,
+        };
+        $password = match ($authMethod) {
+            'playlist_auth' => $playlistAuth->password,
+            'alias_auth' => $playlist->password,
+            default => $playlist->uuid,
+        };
+        abort_if(! $username || ! $password, 403);
+        abort_unless($playlist->user?->canUseProxy() && filled(config('proxy.m3u_proxy_host')), 503);
+
+        $format = $request->query('format');
+        $request->merge(['proxy' => 'true']);
+        $controller = app(XtreamStreamController::class);
+
+        try {
+            return match ($type) {
+                'live' => $controller->handleLive(
+                    $request,
+                    $username,
+                    $password,
+                    $streamId,
+                    $format,
+                ),
+                'vod' => $controller->handleVod(
+                    $request,
+                    $username,
+                    $password,
+                    $streamId,
+                    $format,
+                ),
+                'series' => $controller->handleSeries(
+                    $request,
+                    $username,
+                    $password,
+                    $streamId,
+                    $format,
+                ),
+                'catchup' => $controller->handleTimeshift(
+                    $request,
+                    $username,
+                    $password,
+                    $request->integer('duration'),
+                    (string) $request->query('start'),
+                    $streamId,
+                    $format,
+                ),
+            };
+        } catch (Throwable) {
+            abort(503);
+        }
+    }
+
+    public function resolveStream(Request $request): JsonResponse
+    {
+        $auth = $this->resolveAuth($request);
+        $playlist = $auth['playlist'];
+
+        $validated = $request->validate([
+            'type' => 'required|in:live,vod,series,catchup',
+            'stream_id' => 'required|integer|min:1',
+            'catchup_start' => 'required_if:type,catchup|date',
+            'catchup_duration_minutes' => 'required_if:type,catchup|integer|min:1|max:10080',
+            'catchup_format' => 'sometimes|string|in:ts,m3u8',
+            'extension' => 'prohibited',
+            'client_capabilities' => 'sometimes|array',
+            'client_capabilities.profile' => 'sometimes|string|max:255',
+            'client_capabilities.platform' => 'sometimes|string|max:255',
+            'client_capabilities.backend' => 'sometimes|string|max:255',
+            'client_capabilities.video_codecs' => 'sometimes|array',
+            'client_capabilities.video_codecs.*' => 'string|max:50',
+            'client_capabilities.audio_codecs' => 'sometimes|array',
+            'client_capabilities.audio_codecs.*' => 'string|max:50',
+            'client_capabilities.containers' => 'sometimes|array',
+            'client_capabilities.containers.*' => 'string|max:50',
+            'client_capabilities.max_height' => 'sometimes|integer|min:1',
+            'client_capabilities.max_bitrate_kbps' => 'sometimes|integer|min:1',
+            'client_capabilities.hdr' => 'sometimes|boolean',
+        ]);
+
+        $type = $validated['type'];
+        $streamId = (int) $validated['stream_id'];
+        $directContext = $type === 'catchup' ? [
+            'start' => Carbon::parse($validated['catchup_start'])->utc()->format('Y-m-d:H-i-s'),
+            'duration' => (int) $validated['catchup_duration_minutes'],
+            'format' => $validated['catchup_format'] ?? 'ts',
+        ] : [];
+
+        $stream = $this->loadStream($playlist, $streamId, $type);
+
+        if (! $stream) {
+            return response()->json(['error' => 'Stream not found'], 404);
+        }
+
+        $streamStats = $stream->stream_stats;
+        $sourceInfo = $this->extractSourceInfo($streamStats);
+
+        if (! $request->has('client_capabilities') || ! is_array($request->input('client_capabilities'))) {
+            $url = $this->getDirectStreamUrl(
+                $stream,
+                $playlist,
+                $type,
+                $auth['auth_method'],
+                $auth['playlist_auth_id'],
+                $directContext,
+            );
+
+            Log::info('TV stream resolve (no capabilities)', [
+                'type' => $type,
+                'stream_id' => $streamId,
+                'mode' => 'direct_play',
+                'reason' => 'No client capabilities provided',
+            ]);
+
+            return response()->json([
+                'mode' => 'direct_play',
+                'url' => $url,
+                'reason' => 'No client capabilities provided',
+                'source' => $sourceInfo,
+            ]);
+        }
+
+        $capabilities = ClientCapabilities::fromArray($request->input('client_capabilities'));
+        $profile = $this->resolveStreamProfile($stream, $playlist);
+        $transcodeOutput = PlaybackCapabilityService::inspectTranscodeOutput($profile);
+        $canTranscode = $type !== 'catchup'
+            && $profile !== null
+            && $playlist->user?->canUseProxy()
+            && ! empty(config('proxy.m3u_proxy_host'));
+
+        $decision = PlaybackCapabilityService::decide(
+            $capabilities,
+            $streamStats,
+            $canTranscode,
+            $transcodeOutput,
+        );
+
+        $result = match ($decision['mode']) {
+            'direct_play' => [
+                'mode' => 'direct_play',
+                'url' => $this->getDirectStreamUrl(
+                    $stream,
+                    $playlist,
+                    $type,
+                    $auth['auth_method'],
+                    $auth['playlist_auth_id'],
+                    $directContext,
+                ),
+                'reason' => $decision['reason'],
+                'source' => $decision['source'],
+            ],
+            'transcode' => $this->tryCreateTranscodedStream($stream, $playlist, $profile, $request, $decision),
+            'unsupported' => [
+                'mode' => 'unsupported',
+                'url' => null,
+                'reason' => $decision['reason'],
+                'source' => $decision['source'],
+            ],
+        };
+
+        Log::info('TV stream resolve', [
+            'type' => $type,
+            'stream_id' => $streamId,
+            'mode' => $result['mode'],
+            'reason' => $result['reason'],
+            'source_video_codec' => $sourceInfo['video_codec'],
+            'source_audio_codec' => $sourceInfo['audio_codec'],
+            'source_container' => $sourceInfo['container'],
+        ]);
+
+        return response()->json($result);
+    }
+
+    private function loadStream(Model $playlist, int $streamId, string $type): Channel|Episode|null
+    {
+        if ($type === 'live' || $type === 'vod' || $type === 'catchup') {
+            $channel = $playlist->channels()
+                ->where('channels.id', $streamId)
+                ->where('enabled', true)
+                ->where('is_vod', $type === 'vod')
+                ->first();
+
+            if ($type === 'catchup' && (! $channel || ! $this->supportsCatchup($channel))) {
+                return null;
+            }
+
+            return $channel;
+        }
+
+        if ($type === 'series') {
+            $episode = Episode::with('series')->find($streamId);
+            if (! $episode || ! $episode->enabled) {
+                return null;
+            }
+
+            $series = $episode->series;
+            if (! $series || ! $series->enabled) {
+                return null;
+            }
+
+            $isMember = $playlist->series()
+                ->where('series.id', $series->id)
+                ->exists();
+
+            return $isMember ? $episode : null;
+        }
+
+        return null;
+    }
+
+    private function supportsCatchup(Channel $channel): bool
+    {
+        if ($channel->playlist?->disable_catchup) {
+            return false;
+        }
+
+        if ((! empty($channel->catchup) && $channel->catchup !== '0') || (int) $channel->shift > 0) {
+            return true;
+        }
+
+        return $channel->failoverChannels()
+            ->with('playlist')
+            ->where('enabled', true)
+            ->get()
+            ->contains(fn (Channel $failover): bool => ! $failover->playlist?->disable_catchup
+                && ((! empty($failover->catchup) && $failover->catchup !== '0') || (int) $failover->shift > 0));
+    }
+
+    private function resolveStreamProfile(Channel|Episode $stream, Model $playlist): ?StreamProfile
+    {
+        if ($stream instanceof Channel) {
+            $playlist->loadMissing('streamProfile', 'vodStreamProfile');
+
+            $profile = $stream->streamProfile
+                ?? ($stream->is_vod ? $playlist->vodStreamProfile : $playlist->streamProfile);
+
+            if (! $profile) {
+                $defaultId = $stream->is_vod
+                    ? app(GeneralSettings::class)->default_vod_stream_profile_id
+                    : app(GeneralSettings::class)->default_stream_profile_id;
+
+                if ($defaultId) {
+                    $profile = StreamProfile::find($defaultId);
+                }
+            }
+
+            return app(StreamProfileRuleEvaluator::class)->unwrap($profile, $stream->stream_stats);
+        }
+
+        $playlist->loadMissing('vodStreamProfile');
+        $profile = $playlist->vodStreamProfile;
+
+        if (! $profile) {
+            $defaultId = app(GeneralSettings::class)->default_vod_stream_profile_id;
+            if ($defaultId) {
+                $profile = StreamProfile::find($defaultId);
+            }
+        }
+
+        return app(StreamProfileRuleEvaluator::class)->unwrap($profile, $stream->stream_stats);
+    }
+
+    private function getDirectStreamUrl(
+        Channel|Episode $stream,
+        Model $playlist,
+        string $type,
+        string $authMethod,
+        ?int $playlistAuthId,
+        array $context = [],
+    ): string {
+        $format = $context['format'] ?? ($stream instanceof Channel && ! $stream->is_vod
+            ? 'ts'
+            : ($stream->container_extension ?? 'mkv'));
+
+        return URL::temporarySignedRoute('tv.stream.play', now()->addMinutes(15), [
+            'playlistType' => match (true) {
+                $playlist instanceof Playlist => 'playlist',
+                $playlist instanceof MergedPlaylist => 'merged',
+                $playlist instanceof CustomPlaylist => 'custom',
+                $playlist instanceof PlaylistAlias => 'alias',
+            },
+            'playlistId' => $playlist->id,
+            'type' => $type,
+            'streamId' => $stream->id,
+            'format' => $format,
+            'auth_method' => $authMethod,
+            'auth' => $playlistAuthId,
+            ...$context,
+        ]);
+    }
+
+    private function createTranscodedStreamUrl(
+        Channel|Episode $stream,
+        Model $playlist,
+        ?StreamProfile $profile,
+        Request $request,
+    ): string {
+        $username = $request->attributes->get('tv_username');
+        $password = $request->attributes->get('tv_password');
+
+        $playlistAuthId = null;
+
+        $playlistAuth = PlaylistAuth::where('username', $username)
+            ->where('password', $password)
+            ->where('enabled', true)
+            ->whereHas('assignedPlaylist', fn ($query) => $query
+                ->where('authenticatable_type', $playlist->getMorphClass())
+                ->where('authenticatable_id', $playlist->id))
+            ->first();
+
+        if ($playlistAuth && ! $playlistAuth->isExpired()) {
+            $playlistAuthId = $playlistAuth->id;
+        }
+
+        $service = app(M3uProxyService::class);
+
+        if ($stream instanceof Channel) {
+            return $service->getChannelUrl(
+                $playlist,
+                $stream,
+                $request,
+                $profile,
+                null,
+                $playlistAuthId,
+            );
+        }
+
+        return $service->getEpisodeUrl(
+            $playlist,
+            $stream,
+            $profile,
+            null,
+            $request,
+            $playlistAuthId,
+        );
+    }
+
+    private function tryCreateTranscodedStream(
+        Channel|Episode $stream,
+        Model $playlist,
+        ?StreamProfile $profile,
+        Request $request,
+        array $decision,
+    ): array {
+        try {
+            return [
+                'mode' => 'transcode',
+                'url' => $this->createTranscodedStreamUrl($stream, $playlist, $profile, $request),
+                'reason' => $decision['reason'],
+                'source' => $decision['source'],
+                'output' => $decision['output'],
+            ];
+        } catch (Throwable $e) {
+            Log::warning('TV stream transcode failed', [
+                'type' => $stream instanceof Episode ? 'series' : ($stream->is_vod ? 'vod' : 'live'),
+                'stream_id' => $stream->id,
+                'error_type' => $e::class,
+            ]);
+
+            return [
+                'mode' => 'unsupported',
+                'url' => null,
+                'reason' => 'Transcoding unavailable',
+                'source' => $decision['source'],
+            ];
+        }
+    }
+
+    private function extractSourceInfo(?array $streamStats): array
+    {
+        $stats = StreamStatsService::normalize($streamStats ?? []);
+
+        return [
+            'video_codec' => $stats['video_codec'] ?? null,
+            'audio_codec' => $stats['audio_codec'] ?? null,
+            'container' => PlaybackCapabilityService::detectContainer($streamStats),
+            'width' => is_numeric($stats['width'] ?? null) ? (int) $stats['width'] : null,
+            'height' => is_numeric($stats['height'] ?? null) ? (int) $stats['height'] : null,
+            'bitrate_kbps' => is_numeric($stats['bit_rate'] ?? null)
+                ? (int) round((int) $stats['bit_rate'] / 1000)
+                : null,
+            'hdr' => PlaybackCapabilityService::detectHdrState($stats),
+        ];
+    }
+
     /**
-     * Resolve the playlist and auth scope from Xtream credentials in the URL path.
+     * Resolve the playlist and auth scope from Xtream credentials.
      * Returns playlist model, isAdmin flag, and the expected WebSocket channel name.
      *
-     * @return array{playlist: Model, isAdmin: bool, channel: string}
+     * @return array{playlist: Model, isAdmin: bool, channel: string, username: string, password: string, auth_method: string, playlist_auth_id: int|null}
      */
     private function resolveAuth(Request $request): array
     {
-        $username = $request->route('username');
-        $password = $request->route('password');
+        $username = $request->route('username') ?? $request->getUser();
+        $password = $request->route('password') ?? $request->getPassword();
 
         abort_if(! $username || ! $password, 401, 'Missing credentials.');
+
+        $username = (string) $username;
+        $password = (string) $password;
+        $request->attributes->set('tv_username', $username);
+        $request->attributes->set('tv_password', $password);
 
         $result = PlaylistFacade::authenticate($username, $password);
 
@@ -129,6 +572,17 @@ class TvApiController extends Controller
         [$playlist, $authMethod] = $result;
 
         $isAdmin = $authMethod === 'owner_auth' && $playlist->user?->isAdmin();
+        $playlistAuth = $authMethod === 'playlist_auth'
+            ? PlaylistAuth::query()
+                ->where('username', $username)
+                ->where('password', $password)
+                ->where('enabled', true)
+                ->whereHas('assignedPlaylist', fn ($query) => $query
+                    ->where('authenticatable_type', $playlist->getMorphClass())
+                    ->where('authenticatable_id', $playlist->id))
+                ->first()
+            : null;
+        abort_if($authMethod === 'playlist_auth' && ($playlistAuth === null || $playlistAuth->isExpired()), 401);
         $type = $playlist->getMorphClass();
         $uuid = $playlist->uuid;
 
@@ -138,6 +592,10 @@ class TvApiController extends Controller
             'channel' => $isAdmin
                 ? "private-tv.{$type}-admin.{$uuid}"
                 : "private-tv.{$type}.{$uuid}",
+            'username' => $username,
+            'password' => $password,
+            'auth_method' => $authMethod,
+            'playlist_auth_id' => $playlistAuth?->id,
         ];
     }
 }

--- a/app/Http/Controllers/XtreamStreamController.php
+++ b/app/Http/Controllers/XtreamStreamController.php
@@ -379,12 +379,13 @@ class XtreamStreamController extends Controller
         // If the primary channel doesn't support catchup, defer to the first failover that does.
         // This allows an HD primary (no catchup) to fall back to a lower-res failover for timeshift.
         $timeshiftChannel = $channel;
-        if (! $channel->catchup || $channel->catchup == 0) {
+        $channel->loadMissing('playlist');
+        if (! $this->supportsTimeshift($channel)) {
             $failoverWithCatchup = $channel->failoverChannels()
-                ->whereNotNull('catchup')
-                ->where('catchup', '!=', '0')
-                ->where('catchup', '!=', '')
-                ->first();
+                ->with('playlist')
+                ->where('enabled', true)
+                ->get()
+                ->first(fn (Channel $failover): bool => $this->supportsTimeshift($failover));
 
             if ($failoverWithCatchup) {
                 $timeshiftChannel = $failoverWithCatchup;
@@ -429,6 +430,12 @@ class XtreamStreamController extends Controller
         }
 
         return $streamUrl;
+    }
+
+    private function supportsTimeshift(Channel $channel): bool
+    {
+        return ! $channel->playlist?->disable_catchup
+            && ((! empty($channel->catchup) && $channel->catchup !== '0') || (int) $channel->shift > 0);
     }
 
     /**

--- a/app/Http/Controllers/XtreamStreamController.php
+++ b/app/Http/Controllers/XtreamStreamController.php
@@ -405,7 +405,7 @@ class XtreamStreamController extends Controller
         }
         $request->merge($mergeData);
 
-        if ($playlist->enable_proxy && $playlist->user->canUseProxy()) {
+        if (($playlist->enable_proxy || $request->input('proxy') === 'true') && $playlist->user->canUseProxy()) {
             return app()->call([app(M3uProxyApiController::class), 'channel'], [
                 'id' => $timeshiftChannel->id,
                 'uuid' => $playlist->uuid,

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -1272,7 +1272,6 @@ class M3uProxyService
                 'stream_profile_id' => $profile->id,
                 'provider_profile_id' => $selectedProfile?->id,
                 'is_failover' => $isFailover,
-                'primary_url' => $primaryUrl,
                 'failover_count' => is_array($failovers) ? count($failovers) : ($failovers ? 'using_resolver' : 0),
             ]);
 
@@ -1307,7 +1306,6 @@ class M3uProxyService
                 'is_vod' => $actualChannel->is_vod ?? false,
                 'provider_profile_id' => $selectedProfile?->id,
                 'provider_profile_name' => $selectedProfile?->name,
-                'primary_url' => preg_replace('#/[^/]+/[^/]+/(live|series|movie)/#', '/***/***/\1/', $primaryUrl),
                 'url_transformed' => $selectedProfile !== null,
             ]);
 
@@ -2208,7 +2206,6 @@ class M3uProxyService
                 if (isset($data['stream_id'])) {
                     Log::debug('m3u-proxy stream created/updated successfully', [
                         'stream_id' => $data['stream_id'],
-                        'url' => $url,
                     ]);
 
                     return $data['stream_id'];
@@ -2217,11 +2214,10 @@ class M3uProxyService
                 throw new Exception('Stream ID not found in API response');
             }
 
-            throw new Exception('Failed to create stream: '.$response->body());
+            throw new Exception('Failed to create stream');
         } catch (Exception $e) {
             Log::error('Error creating/updating stream on m3u-proxy', [
-                'error' => $e->getMessage(),
-                'url' => $url,
+                'error_type' => $e::class,
             ]);
             throw $e;
         }
@@ -2347,7 +2343,6 @@ class M3uProxyService
                     Log::debug('Created transcoded stream on m3u-proxy', [
                         'stream_id' => $data['stream_id'],
                         'format' => $profile->format,
-                        'payload' => $payload,
                     ]);
 
                     return $data['stream_id'];
@@ -2356,12 +2351,10 @@ class M3uProxyService
                 throw new Exception('Stream ID not found in transcoding API response');
             }
 
-            throw new Exception('Failed to create transcoded stream: '.$response->body());
+            throw new Exception('Failed to create transcoded stream');
         } catch (Exception $e) {
             Log::error('Error creating transcoded stream on m3u-proxy', [
-                'error' => $e->getMessage(),
-                'profile' => $profile->getProfileIdentifier(),
-                'url' => $url,
+                'error_type' => $e::class,
             ]);
             throw $e;
         }
@@ -2398,27 +2391,7 @@ class M3uProxyService
             $url = $baseUrl.'/stream/'.$streamId;
         }
 
-        // Append trace parameters if provided
-        return $this->appendProxyTraceParams($url, $username);
-    }
-
-    /**
-     * Append traceability parameters to a proxy URL.
-     * Adds username as query parameter for client tracking.
-     *
-     * @param  string  $url  The base proxy URL
-     * @param  string|null  $username  Optional Xtream username for client tracking
-     * @return string URL with appended trace parameters
-     */
-    protected function appendProxyTraceParams(string $url, ?string $username = null): string
-    {
-        if (! $username) {
-            return $url;
-        }
-
-        $separator = parse_url($url, PHP_URL_QUERY) ? '&' : '?';
-
-        return $url.$separator.http_build_query(['username' => $username]);
+        return $url;
     }
 
     private function getFormatFromUrl(?string $url): string
@@ -2475,13 +2448,22 @@ class M3uProxyService
         // 2) resolver URL if set - this is the most explicit and reliable method to ensure correct URL resolution
         $publicUrl = config('proxy.m3u_proxy_public_url');
         if (! empty($publicUrl)) {
-            return rtrim($publicUrl, '/').'/m3u-proxy';
+            return $this->credentialFreeProxyUrl($publicUrl);
         }
 
         // 3) Smart fallback: Use APP_URL + /m3u-proxy if available (works with reverse proxy)
         // This allows the proxy to work without requiring explicit resolver URL configuration.
         // Works automatically in Docker containers with NGINX reverse proxy.
-        return ProxyFacade::getBaseUrl().'/m3u-proxy';
+        return $this->credentialFreeProxyUrl(ProxyFacade::getBaseUrl());
+    }
+
+    private function credentialFreeProxyUrl(string $url): string
+    {
+        if (parse_url($url, PHP_URL_USER) !== null || parse_url($url, PHP_URL_PASS) !== null) {
+            throw new Exception('Proxy public URL must not contain credentials');
+        }
+
+        return rtrim($url, '/').'/m3u-proxy';
     }
 
     /**

--- a/app/Services/PlaybackCapabilityService.php
+++ b/app/Services/PlaybackCapabilityService.php
@@ -1,0 +1,381 @@
+<?php
+
+namespace App\Services;
+
+use App\DataObjects\ClientCapabilities;
+use App\Models\StreamProfile;
+
+class PlaybackCapabilityService
+{
+    private const FORMAT_NAME_ALIASES = [
+        'mpegts' => 'mpegts',
+        'mpegtsraw' => 'mpegts',
+        'ts' => 'mpegts',
+        'mpeg' => 'mpegts',
+        'hls' => 'hls',
+        'm3u8' => 'hls',
+        'dash' => 'dash',
+        'mp4' => 'mp4',
+        'mov' => 'mp4',
+        'matroska' => 'mkv',
+        'mkv' => 'mkv',
+        'flv' => 'flv',
+        'avi' => 'avi',
+    ];
+
+    private const VIDEO_ENCODER_ALIASES = [
+        'libx264' => 'h264',
+        'h264' => 'h264',
+        'h264_nvenc' => 'h264',
+        'h264_qsv' => 'h264',
+        'h264_vaapi' => 'h264',
+        'libx265' => 'hevc',
+        'hevc' => 'hevc',
+        'hevc_nvenc' => 'hevc',
+        'hevc_qsv' => 'hevc',
+        'hevc_vaapi' => 'hevc',
+        'libaom-av1' => 'av1',
+        'libsvtav1' => 'av1',
+        'av1' => 'av1',
+        'libvpx-vp9' => 'vp9',
+        'vp9' => 'vp9',
+    ];
+
+    private const AUDIO_ENCODER_ALIASES = [
+        'aac' => 'aac',
+        'libfdk_aac' => 'aac',
+        'libmp3lame' => 'mp3',
+        'mp3' => 'mp3',
+        'ac3' => 'ac3',
+        'eac3' => 'eac3',
+        'libopus' => 'opus',
+        'opus' => 'opus',
+        'flac' => 'flac',
+    ];
+
+    public static function decide(
+        ClientCapabilities $client,
+        ?array $streamStats,
+        bool $canTranscode = false,
+        ?array $transcodeOutput = null,
+    ): array {
+        $stats = StreamStatsService::normalize($streamStats ?? []);
+
+        $sourceVideoCodec = self::normalizeCodec($stats['video_codec'] ?? '');
+        $sourceAudioCodec = strtolower((string) ($stats['audio_codec'] ?? ''));
+        $sourceHeight = is_numeric($stats['height'] ?? null) ? (int) $stats['height'] : null;
+        $sourceWidth = is_numeric($stats['width'] ?? null) ? (int) $stats['width'] : null;
+        $sourceBitrate = is_numeric($stats['bit_rate'] ?? null) ? (int) $stats['bit_rate'] : null;
+        $sourceHdr = self::detectHdrState($stats);
+
+        $reasons = self::incompatibilityReasons(
+            $client,
+            $sourceVideoCodec,
+            $sourceAudioCodec,
+            self::detectContainer($streamStats),
+            $sourceHeight,
+            $sourceBitrate === null ? null : (int) round($sourceBitrate / 1000),
+            $sourceHdr,
+        );
+
+        $source = [
+            'video_codec' => $stats['video_codec'] ?? null,
+            'audio_codec' => $stats['audio_codec'] ?? null,
+            'container' => self::detectContainer($streamStats),
+            'width' => $sourceWidth,
+            'height' => $sourceHeight,
+            'bitrate_kbps' => $sourceBitrate === null ? null : (int) round($sourceBitrate / 1000),
+            'hdr' => $sourceHdr,
+        ];
+
+        if (empty($reasons)) {
+            return [
+                'mode' => 'direct_play',
+                'reason' => 'Client supports all stream codecs and container',
+                'source' => $source,
+            ];
+        }
+
+        $reason = implode('; ', $reasons);
+
+        if ($canTranscode && $transcodeOutput !== null && self::outputIsCompatible(
+            $client,
+            $transcodeOutput,
+            $sourceHeight,
+            $sourceBitrate === null ? null : (int) round($sourceBitrate / 1000),
+            $sourceHdr,
+        )) {
+            return [
+                'mode' => 'transcode',
+                'reason' => $reason,
+                'source' => $source,
+                'output' => $transcodeOutput,
+            ];
+        }
+
+        return [
+            'mode' => 'unsupported',
+            'reason' => $reason.' and no compatible transcode profile available',
+            'source' => $source,
+        ];
+    }
+
+    public static function inspectTranscodeOutput(?StreamProfile $profile): ?array
+    {
+        if (! $profile || $profile->backend !== 'ffmpeg') {
+            return null;
+        }
+
+        $args = (string) $profile->args;
+        $videoEncoder = self::extractOption($args, ['-c:v', '-codec:v', '-vcodec']);
+        $audioEncoder = self::extractOption($args, ['-c:a', '-codec:a', '-acodec']);
+        $format = self::extractOption($args, ['-f']) ?? (string) $profile->format;
+
+        $videoCodec = self::VIDEO_ENCODER_ALIASES[strtolower((string) $videoEncoder)] ?? null;
+        $audioCodec = self::AUDIO_ENCODER_ALIASES[strtolower((string) $audioEncoder)] ?? null;
+        $container = ClientCapabilities::normalizeContainer($format);
+
+        if ($videoCodec === null || $audioCodec === null || $container === '') {
+            return null;
+        }
+
+        return [
+            'video_codec' => $videoCodec,
+            'audio_codec' => $audioCodec,
+            'container' => $container !== '' ? $container : null,
+            'max_height' => self::extractMaxHeight($args),
+            'max_bitrate_kbps' => self::extractBitrateKbps($args),
+            'hdr' => self::inferSdrOutput($args),
+        ];
+    }
+
+    public static function detectContainer(?array $streamStats): ?string
+    {
+        if (! is_array($streamStats)) {
+            return null;
+        }
+
+        foreach ($streamStats as $entry) {
+            if (isset($entry['format']['format_name'])) {
+                $names = explode(',', (string) $entry['format']['format_name']);
+                $primary = strtolower(trim($names[0]));
+
+                return self::FORMAT_NAME_ALIASES[$primary] ?? $primary;
+            }
+        }
+
+        return null;
+    }
+
+    public static function detectHdrState(array $stats): ?bool
+    {
+        if (StreamStatsService::detectHdr($stats) !== '') {
+            return true;
+        }
+
+        $hdr = $stats['hdr'] ?? null;
+        if (is_bool($hdr)) {
+            return $hdr;
+        }
+
+        if (is_numeric($hdr)) {
+            return (bool) $hdr;
+        }
+
+        $normalizedHdr = strtolower(trim((string) $hdr));
+        if (in_array($normalizedHdr, ['sdr', 'false', 'no', 'none'], true)) {
+            return false;
+        }
+
+        $colorTransfer = strtolower(trim((string) ($stats['color_transfer'] ?? '')));
+        if ($colorTransfer !== '' && ! in_array($colorTransfer, ['unknown', 'unspecified', 'reserved'], true)) {
+            return false;
+        }
+
+        return null;
+    }
+
+    private static function incompatibilityReasons(
+        ClientCapabilities $client,
+        ?string $videoCodec,
+        ?string $audioCodec,
+        ?string $container,
+        ?int $height,
+        ?int $bitrateKbps,
+        ?bool $hdr,
+    ): array {
+        $reasons = [];
+
+        if (! empty($client->videoCodecs) && ($videoCodec === null || $videoCodec === '')) {
+            $reasons[] = 'Source video codec is unknown';
+        }
+
+        if (! empty($client->videoCodecs) && $videoCodec !== null && $videoCodec !== ''
+            && ! in_array(self::normalizeCodec($videoCodec), $client->videoCodecs, true)) {
+            $reasons[] = "Video codec '{$videoCodec}' not supported by client";
+        }
+
+        if (! empty($client->audioCodecs) && ($audioCodec === null || $audioCodec === '')) {
+            $reasons[] = 'Source audio codec is unknown';
+        }
+
+        if (! empty($client->audioCodecs) && $audioCodec !== null && $audioCodec !== ''
+            && ! in_array(strtolower($audioCodec), $client->audioCodecs, true)) {
+            $reasons[] = "Audio codec '{$audioCodec}' not supported by client";
+        }
+
+        if (! empty($client->containers) && ($container === null || $container === '')) {
+            $reasons[] = 'Source container is unknown';
+        }
+
+        if ($container !== null && ! empty($client->containers)
+            && ! in_array(ClientCapabilities::normalizeContainer($container), $client->containers, true)) {
+            $reasons[] = "Container '{$container}' not supported by client";
+        }
+
+        if ($client->maxHeight !== null) {
+            if ($height === null) {
+                $reasons[] = 'Source height is unknown';
+            } elseif ($height > $client->maxHeight) {
+                $reasons[] = "Source height {$height}px exceeds client max {$client->maxHeight}px";
+            }
+        }
+
+        if ($client->maxBitrateKbps !== null) {
+            if ($bitrateKbps === null) {
+                $reasons[] = 'Source bitrate is unknown';
+            } elseif ($bitrateKbps > $client->maxBitrateKbps) {
+                $reasons[] = "Source bitrate {$bitrateKbps}kbps exceeds client max {$client->maxBitrateKbps}kbps";
+            }
+        }
+
+        if ($client->hdr === false) {
+            if ($hdr === null) {
+                $reasons[] = 'Source HDR status is unknown';
+            } elseif ($hdr === true) {
+                $reasons[] = 'Source is HDR but client does not support HDR';
+            }
+        }
+
+        return $reasons;
+    }
+
+    private static function outputIsCompatible(
+        ClientCapabilities $client,
+        array $output,
+        ?int $sourceHeight,
+        ?int $sourceBitrateKbps,
+        ?bool $sourceHdr,
+    ): bool {
+        $videoCodec = $output['video_codec'] ?? null;
+        $audioCodec = $output['audio_codec'] ?? null;
+        $container = $output['container'] ?? null;
+
+        if (! is_string($videoCodec) || ! is_string($audioCodec) || ! is_string($container)) {
+            return false;
+        }
+
+        if (! empty($client->videoCodecs)
+            && ! in_array(self::normalizeCodec($videoCodec), $client->videoCodecs, true)) {
+            return false;
+        }
+
+        if (! empty($client->audioCodecs)
+            && ! in_array(strtolower($audioCodec), $client->audioCodecs, true)) {
+            return false;
+        }
+
+        if (! empty($client->containers)
+            && ! in_array(ClientCapabilities::normalizeContainer($container), $client->containers, true)) {
+            return false;
+        }
+
+        if ($client->maxHeight !== null) {
+            $outputHeight = $output['max_height'] ?? null;
+            if (is_int($outputHeight) && $outputHeight > $client->maxHeight) {
+                return false;
+            }
+
+            if (($sourceHeight === null || $sourceHeight > $client->maxHeight) && ! is_int($outputHeight)) {
+                return false;
+            }
+        }
+
+        if ($client->maxBitrateKbps !== null) {
+            $outputBitrate = $output['max_bitrate_kbps'] ?? null;
+            if (is_int($outputBitrate) && $outputBitrate > $client->maxBitrateKbps) {
+                return false;
+            }
+
+            if (($sourceBitrateKbps === null || $sourceBitrateKbps > $client->maxBitrateKbps)
+                && ! is_int($outputBitrate)) {
+                return false;
+            }
+        }
+
+        if ($client->hdr === false && $sourceHdr !== false && ($output['hdr'] ?? null) !== false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function extractOption(string $args, array $options): ?string
+    {
+        $pattern = '/(?:^|\s)(?:'.implode('|', array_map(fn (string $option) => preg_quote($option, '/'), $options)).')(?:=|\s+)([^\s]+)/i';
+        if (! preg_match_all($pattern, $args, $matches) || empty($matches[1])) {
+            return null;
+        }
+
+        return trim((string) end($matches[1]), "\"'");
+    }
+
+    private static function extractMaxHeight(string $args): ?int
+    {
+        if (preg_match('/(?:^|\s)-s(?:=|\s+)(\d+)x(\d+)/i', $args, $matches)) {
+            return (int) $matches[2];
+        }
+
+        if (preg_match('/scale(?:=|[^\s,]*:)[^\s,]*[x:](-?\d+)/i', $args, $matches)) {
+            $height = (int) $matches[1];
+
+            return $height > 0 ? $height : null;
+        }
+
+        return null;
+    }
+
+    private static function extractBitrateKbps(string $args): ?int
+    {
+        $value = self::extractOption($args, ['-maxrate:v', '-maxrate', '-b:v', '-vb']);
+        if ($value === null || ! preg_match('/^(\d+(?:\.\d+)?)([kmg])?$/i', $value, $matches)) {
+            return null;
+        }
+
+        $multiplier = match (strtolower($matches[2] ?? '')) {
+            'm' => 1000,
+            'g' => 1000000,
+            default => 1,
+        };
+
+        return (int) round((float) $matches[1] * $multiplier);
+    }
+
+    private static function inferSdrOutput(string $args): ?bool
+    {
+        $normalized = strtolower($args);
+        $hasToneMapping = str_contains($normalized, 'tonemap');
+        $hasBt709Transfer = preg_match('/(?:-color_trc\s+bt709|transfer(?:=|:)bt709)/', $normalized) === 1;
+        $hasBt709Primaries = preg_match('/(?:-color_primaries\s+bt709|primaries(?:=|:)bt709)/', $normalized) === 1;
+        $hasBt709Matrix = preg_match('/(?:-colorspace\s+bt709|matrix(?:=|:)bt709)/', $normalized) === 1;
+
+        return $hasToneMapping && $hasBt709Transfer && $hasBt709Primaries && $hasBt709Matrix
+            ? false
+            : null;
+    }
+
+    private static function normalizeCodec(string $codec): string
+    {
+        return ClientCapabilities::normalizeCodec($codec);
+    }
+}

--- a/app/Services/PlaylistService.php
+++ b/app/Services/PlaylistService.php
@@ -780,16 +780,9 @@ class PlaylistService
 
             $streamUrl = $rewrite($streamUrl, $stamp, $offset);
 
-            // Helpful debug for verification
-            Log::debug(sprintf(
-                '[TIMESHIFT-M3U] utc=%d lutc=%d tz=%s start=%s offset(min)=%d final_url=%s',
-                $utc,
-                $lutc,
-                $providerTz,
-                $stamp,
-                $offset,
-                $streamUrl
-            ));
+            Log::debug('Generated M3U timeshift URL', [
+                'duration_minutes' => $offset,
+            ]);
         } elseif ($xtreamTimeshiftPresent) {
             // Convert Xtream API date format to timeshift URL format
             // Input: YYYY-MM-DD:HH-MM-SS, Output: YYYY-MM-DD:HH-MM
@@ -808,14 +801,9 @@ class PlaylistService
 
             $streamUrl = $rewrite($streamUrl, $stamp, $duration);
 
-            // Helpful debug for verification
-            Log::debug(sprintf(
-                '[TIMESHIFT-XTREAM] duration=%d date=%s converted_stamp=%s final_url=%s',
-                $duration,
-                $date,
-                $stamp,
-                $streamUrl
-            ));
+            Log::debug('Generated Xtream timeshift URL', [
+                'duration_minutes' => $duration,
+            ]);
         }
 
         return $streamUrl;

--- a/app/Services/StreamStatsService.php
+++ b/app/Services/StreamStatsService.php
@@ -25,6 +25,7 @@ class StreamStatsService
 
         $video = null;
         $audio = null;
+        $format = null;
 
         foreach ($stats as $entry) {
             if (! is_array($entry)) {
@@ -42,6 +43,10 @@ class StreamStatsService
 
             if (($stream['codec_type'] ?? null) === 'audio' && $audio === null) {
                 $audio = $stream;
+            }
+
+            if (isset($entry['format']) && is_array($entry['format']) && $format === null) {
+                $format = $entry['format'];
             }
         }
 
@@ -62,6 +67,7 @@ class StreamStatsService
             'codec_tag_string' => $video['codec_tag_string'] ?? null,
             'side_data_list' => $video['side_data_list'] ?? null,
             'bit_depth' => self::extractBitDepth($video),
+            'bit_rate' => $video['bit_rate'] ?? $audio['bit_rate'] ?? $format['bit_rate'] ?? null,
             'audio_codec' => $audio['codec_name'] ?? null,
             'audio_profile' => $audio['profile'] ?? null,
             'audio_channels' => $audio['channels'] ?? $audio['channel_layout'] ?? null,

--- a/routes/api.php
+++ b/routes/api.php
@@ -72,8 +72,19 @@ Route::prefix('vod')->middleware('dispatcharr.auth')->group(function () {
 });
 
 /*
- * TV app API routes (authenticated via Xtream credentials in URL path — no Sanctum)
+ * TV app API routes
  */
+Route::post('tv/stream/resolve', [TvApiController::class, 'resolveStream'])
+    ->middleware('throttle:60,1')
+    ->name('tv.stream.resolve.basic');
+Route::get('tv/stream/{playlistType}/{playlistId}/{type}/{streamId}', [TvApiController::class, 'playStream'])
+    ->middleware(['signed', 'throttle:60,1'])
+    ->whereIn('type', ['live', 'vod', 'series', 'catchup'])
+    ->whereIn('playlistType', ['playlist', 'merged', 'custom', 'alias'])
+    ->whereNumber('streamId')
+    ->whereNumber('playlistId')
+    ->name('tv.stream.play');
+
 Route::prefix('tv/{username}/{password}')->middleware('throttle:60,1')->group(function () {
     Route::get('notifications', [TvApiController::class, 'notifications'])
         ->name('tv.notifications');
@@ -81,4 +92,5 @@ Route::prefix('tv/{username}/{password}')->middleware('throttle:60,1')->group(fu
         ->name('tv.notifications.read');
     Route::post('broadcasting/auth', [TvApiController::class, 'broadcastingAuth'])
         ->name('tv.broadcasting.auth');
+
 });

--- a/tests/Feature/TimeshiftUrlRewritingTest.php
+++ b/tests/Feature/TimeshiftUrlRewritingTest.php
@@ -101,6 +101,7 @@ it('uses failover channel URL when primary channel has no catchup support', func
         'enabled' => true,
         'url' => 'https://provider.domain/live/user/pass/hd-stream.ts',
         'catchup' => null,
+        'shift' => 0,
     ]);
 
     $failoverChannel = Channel::factory()->create([

--- a/tests/Feature/TvStreamResolveTest.php
+++ b/tests/Feature/TvStreamResolveTest.php
@@ -1118,6 +1118,7 @@ describe('catchup stream resolve', function () {
         $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
         $this->user = tvCreateUser('catchupuser');
         $this->playlist = tvCreatePlaylist($this->user, 'Catchup Playlist');
+        $this->playlist->update(['server_timezone' => 'Etc/UTC']);
         tvCreateAuth($this->user, $this->playlist, 'catchup_user', 'catchup_pass');
         $this->channel = tvCreateChannel($this->user, $this->playlist, [
             'name' => 'Catchup Channel',
@@ -1195,6 +1196,53 @@ describe('catchup stream resolve', function () {
             ->not->toContain('example.com');
 
         $this->get($url)->assertOk()->assertSee('timeshift');
+    });
+
+    it('forces configured proxy mediation across the signed catchup response chain', function () {
+        $providerSecrets = [
+            'provider.example.test',
+            'provider_user',
+            'provider_pass',
+            'account_secret',
+            'provider_secret',
+        ];
+        $this->playlist->update(['enable_proxy' => false]);
+        expect($this->user->canUseProxy())->toBeTrue()
+            ->and($this->playlist->enable_proxy)->toBeFalse();
+        $this->channel->update([
+            'url' => 'https://provider_user:provider_pass@provider.example.test/live/account_secret/123.ts?token=provider_secret',
+        ]);
+        config([
+            'proxy.m3u_proxy_host' => 'https://proxy.example.test',
+            'proxy.m3u_proxy_port' => null,
+        ]);
+        Http::fake(['*' => Http::response('Proxy unavailable', 500)]);
+        Log::spy();
+
+        $url = $this->postJson($this->resolveUrl, [
+            'type' => 'catchup',
+            'stream_id' => $this->channel->id,
+            'catchup_start' => '2026-07-10T12:30:00+00:00',
+            'catchup_duration_minutes' => 30,
+        ])->assertOk()->json('url');
+
+        expect(URL::hasValidSignature(Request::create($url)))->toBeTrue();
+        foreach ($providerSecrets as $providerSecret) {
+            expect($url)->not->toContain($providerSecret);
+        }
+
+        $playbackResponse = $this->get($url);
+
+        $playbackResponse->assertServiceUnavailable();
+        expect($playbackResponse->headers->get('Location'))->toBeNull();
+        foreach ($providerSecrets as $providerSecret) {
+            expect($playbackResponse->getContent())->not->toContain($providerSecret);
+        }
+
+        $containsProviderSecret = fn (...$arguments): bool => Str::contains((string) json_encode($arguments), $providerSecrets);
+        foreach (['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'] as $level) {
+            Log::shouldNotHaveReceived($level, $containsProviderSecret);
+        }
     });
 
     it('rejects cross-playlist and VOD catchup streams', function () {
@@ -1281,16 +1329,17 @@ describe('catchup stream resolve', function () {
                 'metadata' => [],
             ]);
         }
-        $url = $this->postJson($this->resolveUrl, [
-            'type' => 'catchup',
-            'stream_id' => $this->channel->id,
-            'catchup_start' => '2026-07-10T12:30:00+00:00',
-            'catchup_duration_minutes' => 30,
-        ])->json('url');
+        $response = app(XtreamStreamController::class)->handleTimeshift(
+            Request::create('/timeshift', 'GET'),
+            'catchup_user',
+            'catchup_pass',
+            30,
+            '2026-07-10:12-30-00',
+            $this->channel->id,
+            'ts',
+        );
 
-        $this->get($url)
-            ->assertRedirect()
-            ->assertRedirectContains('eligible.ts');
+        expect($response->getTargetUrl())->toContain('eligible.ts');
     });
 
     it('keeps a shift-only primary instead of replacing it with a failover', function () {

--- a/tests/Feature/TvStreamResolveTest.php
+++ b/tests/Feature/TvStreamResolveTest.php
@@ -1,0 +1,1902 @@
+<?php
+
+use App\DataObjects\ClientCapabilities;
+use App\Http\Controllers\XtreamStreamController;
+use App\Models\Channel;
+use App\Models\ChannelFailover;
+use App\Models\Episode;
+use App\Models\Playlist;
+use App\Models\PlaylistAlias;
+use App\Models\PlaylistAuth;
+use App\Models\Season;
+use App\Models\Series;
+use App\Models\StreamProfile;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use App\Services\PlaybackCapabilityService;
+use App\Services\PlaylistService;
+use App\Settings\GeneralSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+/*
+|--------------------------------------------------------------------------
+| Fixture Helpers
+|--------------------------------------------------------------------------
+*/
+
+function tvMakeClient(array $overrides = []): ClientCapabilities
+{
+    return ClientCapabilities::fromArray(array_merge([
+        'profile' => 'default',
+        'platform' => 'android',
+        'backend' => 'exoplayer',
+        'video_codecs' => ['h264'],
+        'audio_codecs' => ['aac'],
+        'containers' => ['mpegts'],
+    ], $overrides));
+}
+
+function tvMakeStats(array $video = [], string $audioCodec = 'aac', string $format = 'mpegts'): array
+{
+    return [
+        ['stream' => array_merge(['codec_type' => 'video', 'codec_name' => 'h264', 'width' => 1920, 'height' => 1080], $video)],
+        ['stream' => ['codec_type' => 'audio', 'codec_name' => $audioCodec]],
+        ['format' => ['format_name' => $format]],
+    ];
+}
+
+function tvCreateUser(string $name = 'testuser', array $overrides = []): User
+{
+    return User::factory()->admin()->create(array_merge(['name' => $name], $overrides));
+}
+
+function tvCreatePlaylist(User $user, string $name = 'Test Playlist'): Playlist
+{
+    DB::table('playlists')->insert([
+        'user_id' => $user->id,
+        'name' => $name,
+        'uuid' => Str::uuid()->toString(),
+        'id_channel_by' => 'stream_id',
+        'status' => 'completed',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return Playlist::find(DB::getPdo()->lastInsertId());
+}
+
+function tvCreateAuth(User $user, Playlist $playlist, string $username, string $password): PlaylistAuth
+{
+    $auth = PlaylistAuth::factory()->for($user)->create([
+        'username' => $username,
+        'password' => $password,
+        'enabled' => true,
+    ]);
+    $auth->assignTo($playlist);
+
+    return $auth;
+}
+
+function tvCreateAlias(User $user, Playlist $playlist, array $overrides = []): PlaylistAlias
+{
+    return PlaylistAlias::create(array_merge([
+        'name' => 'TV Alias',
+        'uuid' => Str::uuid()->toString(),
+        'user_id' => $user->id,
+        'playlist_id' => $playlist->id,
+        'username' => 'alias_user',
+        'password' => 'alias_pass',
+    ], $overrides));
+}
+
+function tvCreateChannel(User $user, Playlist $playlist, array $overrides = []): Channel
+{
+    $defaults = [
+        'user_id' => $user->id,
+        'playlist_id' => $playlist->id,
+        'name' => 'Test Channel',
+        'enabled' => true,
+        'uuid' => Str::uuid()->toString(),
+        'url' => 'https://example.com/stream/123.ts',
+        'stream_stats' => json_encode(tvMakeStats()),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ];
+
+    $id = DB::table('channels')->insertGetId(array_merge($defaults, $overrides));
+
+    return Channel::find($id);
+}
+
+function tvCreateSeries(User $user, Playlist $playlist, string $name = 'Test Series'): Series
+{
+    $id = DB::table('series')->insertGetId([
+        'user_id' => $user->id,
+        'playlist_id' => $playlist->id,
+        'name' => $name,
+        'enabled' => true,
+        'import_batch_no' => 'test-batch',
+        'cover' => '',
+        'backdrop_path' => '{}',
+        'metadata' => '{}',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return Series::find($id);
+}
+
+function tvCreateSeason(User $user, Playlist $playlist, Series $series, string $name = 'Season 1'): Season
+{
+    $id = DB::table('seasons')->insertGetId([
+        'user_id' => $user->id,
+        'playlist_id' => $playlist->id,
+        'series_id' => $series->id,
+        'name' => $name,
+        'import_batch_no' => 'test-batch',
+        'season_number' => 1,
+        'episode_count' => 1,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return Season::find($id);
+}
+
+function tvCreateEpisode(
+    User $user,
+    Playlist $playlist,
+    Series $series,
+    Season $season,
+    string $title = 'Test Episode',
+    array $overrides = [],
+): Episode {
+    $defaults = [
+        'user_id' => $user->id,
+        'playlist_id' => $playlist->id,
+        'series_id' => $series->id,
+        'season_id' => $season->id,
+        'title' => $title,
+        'enabled' => true,
+        'import_batch_no' => 'test-batch',
+        'container_extension' => 'mkv',
+        'episode_num' => 1,
+        'season' => 1,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ];
+
+    $id = DB::table('episodes')->insertGetId(array_merge($defaults, $overrides));
+
+    return Episode::find($id);
+}
+
+function tvIncompatibleCaps(array $overrides = []): array
+{
+    return array_merge([
+        'profile' => 'default',
+        'platform' => 'android',
+        'backend' => 'exoplayer',
+        'video_codecs' => ['hevc'],
+        'audio_codecs' => ['aac'],
+        'containers' => ['mpegts'],
+    ], $overrides);
+}
+
+function tvCreateTranscodeProfile(User $user, array $overrides = []): StreamProfile
+{
+    return StreamProfile::factory()->for($user)->create(array_merge([
+        'backend' => 'ffmpeg',
+        'format' => 'ts',
+        'args' => '-c:v libx265 -c:a aac -f mpegts',
+    ], $overrides));
+}
+
+function tvTranscodeOutput(array $overrides = []): array
+{
+    return array_merge([
+        'video_codec' => 'h264',
+        'audio_codec' => 'aac',
+        'container' => 'mpegts',
+        'max_height' => null,
+        'max_bitrate_kbps' => null,
+        'hdr' => null,
+    ], $overrides);
+}
+
+/*
+|--------------------------------------------------------------------------
+| Datasets
+|--------------------------------------------------------------------------
+*/
+
+dataset('special_credentials', [
+    'slash' => ['my/user', 'my/pass'],
+    'space' => ['my user', 'my pass'],
+    'plus' => ['user+name', 'pass+word'],
+    'percent' => ['user%name', 'pass%word'],
+    'at' => ['user@test', 'pass@word'],
+    'unicode' => ['usér', 'pässword'],
+    'reserved' => ['user?name', 'pass#word:part'],
+]);
+
+/*
+|--------------------------------------------------------------------------
+| PlaybackCapabilityService
+|--------------------------------------------------------------------------
+*/
+
+describe('PlaybackCapabilityService', function () {
+    it('returns direct_play when all video/audio/container match', function () {
+        $result = PlaybackCapabilityService::decide(tvMakeClient(), tvMakeStats(), canTranscode: false);
+
+        expect($result['mode'])->toBe('direct_play');
+    });
+
+    it('returns unsupported when capabilities cannot be proven from missing metadata', function () {
+        $result = PlaybackCapabilityService::decide(tvMakeClient(), null, canTranscode: false);
+
+        expect($result['mode'])->toBe('unsupported')
+            ->and($result['reason'])->toContain('unknown');
+    });
+
+    it('fails closed when a declared source constraint is unknown', function (array $capabilities, callable $removeMetadata, string $reason) {
+        $stats = tvMakeStats();
+        $removeMetadata($stats);
+
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient($capabilities),
+            $stats,
+            canTranscode: false,
+        );
+
+        expect($result['mode'])->toBe('unsupported')
+            ->and($result['reason'])->toContain($reason);
+    })->with([
+        'height' => [
+            ['max_height' => 720],
+            function (array &$stats): void {
+                unset($stats[0]['stream']['height']);
+            },
+            'Source height is unknown',
+        ],
+        'bitrate' => [
+            ['max_bitrate_kbps' => 5000],
+            function (array &$stats): void {
+                unset($stats[0]['stream']['bit_rate'], $stats[1]['stream']['bit_rate'], $stats[2]['format']['bit_rate']);
+            },
+            'Source bitrate is unknown',
+        ],
+        'HDR' => [
+            ['hdr' => false],
+            function (array &$stats): void {
+                unset(
+                    $stats[0]['stream']['hdr'],
+                    $stats[0]['stream']['color_transfer'],
+                    $stats[0]['stream']['color_primaries'],
+                );
+            },
+            'Source HDR status is unknown',
+        ],
+    ]);
+
+    it('requires concrete transcode limits when constrained source metadata is unknown', function () {
+        $stats = tvMakeStats();
+        unset($stats[0]['stream']['height']);
+
+        $unknownOutput = PlaybackCapabilityService::decide(
+            tvMakeClient(['max_height' => 720]),
+            $stats,
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput(),
+        );
+        $boundedOutput = PlaybackCapabilityService::decide(
+            tvMakeClient(['max_height' => 720]),
+            $stats,
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput(['max_height' => 720]),
+        );
+
+        expect($unknownOutput['mode'])->toBe('unsupported')
+            ->and($boundedOutput['mode'])->toBe('transcode');
+    });
+
+    it('returns transcode when video codec not supported and transcode available', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(),
+            tvMakeStats(['codec_name' => 'hevc']),
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput(),
+        );
+
+        expect($result['mode'])->toBe('transcode');
+    });
+
+    it('returns unsupported when video codec not supported and no transcode', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(),
+            tvMakeStats(['codec_name' => 'vp9']),
+            canTranscode: false,
+        );
+
+        expect($result['mode'])->toBe('unsupported');
+    });
+
+    it('returns transcode when audio codec not supported', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(),
+            tvMakeStats(audioCodec: 'ac3'),
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput(),
+        );
+
+        expect($result['mode'])->toBe('transcode');
+    });
+
+    it('returns transcode when container not supported', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['containers' => ['mp4']]),
+            tvMakeStats(),
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput(['container' => 'mp4']),
+        );
+
+        expect($result['mode'])->toBe('transcode');
+    });
+
+    it('returns transcode when height exceeds client max_height', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['max_height' => 720]),
+            tvMakeStats(['height' => 1080]),
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput(['max_height' => 720]),
+        );
+
+        expect($result['mode'])->toBe('transcode');
+    });
+
+    it('returns direct_play when height within client max_height', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['max_height' => 1080]),
+            tvMakeStats(['height' => 720]),
+            canTranscode: false,
+        );
+
+        expect($result['mode'])->toBe('direct_play');
+    });
+
+    it('returns transcode when bitrate exceeds client max_bitrate_kbps', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['max_bitrate_kbps' => 5000]),
+            tvMakeStats(['bit_rate' => '8000000']),
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput(['max_bitrate_kbps' => 5000]),
+        );
+
+        expect($result['mode'])->toBe('transcode');
+    });
+
+    it('returns transcode when client does not support HDR and source is HDR', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['hdr' => false]),
+            tvMakeStats(['hdr' => 'HDR10']),
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput(['hdr' => false]),
+        );
+
+        expect($result['mode'])->toBe('transcode');
+    });
+
+    it('returns direct_play when persisted metadata proves the source is SDR', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['hdr' => false]),
+            tvMakeStats(['color_transfer' => 'bt709']),
+            canTranscode: false,
+        );
+
+        expect($result['mode'])->toBe('direct_play')
+            ->and($result['source']['hdr'])->toBeFalse();
+    });
+
+    it('detects HDR from standard ffprobe metadata', function () {
+        $stats = tvMakeStats([
+            'color_transfer' => 'smpte2084',
+            'side_data_list' => [
+                ['side_data_type' => 'Mastering display metadata'],
+            ],
+        ]);
+
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['hdr' => false]),
+            $stats,
+            canTranscode: false,
+        );
+
+        expect($result['mode'])->toBe('unsupported')
+            ->and($result['source']['hdr'])->toBeTrue();
+    });
+
+    it('uses format bitrate when stream bitrate is absent', function () {
+        $stats = tvMakeStats();
+        $stats[2]['format']['bit_rate'] = '8000000';
+
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['max_bitrate_kbps' => 5000]),
+            $stats,
+            canTranscode: false,
+        );
+
+        expect($result['mode'])->toBe('unsupported')
+            ->and($result['source']['bitrate_kbps'])->toBe(8000);
+    });
+
+    it('requires a transcode profile with compatible declared output', function () {
+        $profile = new StreamProfile([
+            'backend' => 'ffmpeg',
+            'format' => 'ts',
+            'args' => '-c:v libx265 -c:a aac -f mpegts',
+        ]);
+        $output = PlaybackCapabilityService::inspectTranscodeOutput($profile);
+
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['video_codecs' => ['hevc']]),
+            tvMakeStats(['codec_name' => 'h264']),
+            canTranscode: true,
+            transcodeOutput: $output,
+        );
+
+        expect($result['mode'])->toBe('transcode')
+            ->and($result['output']['video_codec'])->toBe('hevc')
+            ->and($result['output']['audio_codec'])->toBe('aac')
+            ->and($result['output']['container'])->toBe('mpegts');
+    });
+
+    it('only declares SDR output for an explicit complete tone mapping recipe', function () {
+        $incomplete = new StreamProfile([
+            'backend' => 'ffmpeg',
+            'format' => 'ts',
+            'args' => '-c:v libx264 -vf tonemap -c:a aac -f mpegts',
+        ]);
+        $complete = new StreamProfile([
+            'backend' => 'ffmpeg',
+            'format' => 'ts',
+            'args' => '-c:v libx264 -vf tonemap -color_trc bt709 -color_primaries bt709 -colorspace bt709 -c:a aac -f mpegts',
+        ]);
+
+        expect(PlaybackCapabilityService::inspectTranscodeOutput($incomplete)['hdr'])->toBeNull()
+            ->and(PlaybackCapabilityService::inspectTranscodeOutput($complete)['hdr'])->toBeFalse();
+    });
+
+    it('rejects ambiguous or incomplete FFmpeg output metadata', function () {
+        $missingAudio = new StreamProfile([
+            'backend' => 'ffmpeg',
+            'format' => 'ts',
+            'args' => '-c:v libx264 -f mpegts',
+        ]);
+        $overriddenWithCopy = new StreamProfile([
+            'backend' => 'ffmpeg',
+            'format' => 'ts',
+            'args' => '-c:v libx264 -c:v copy -c:a aac -f mpegts',
+        ]);
+
+        expect(PlaybackCapabilityService::inspectTranscodeOutput($missingAudio))->toBeNull()
+            ->and(PlaybackCapabilityService::inspectTranscodeOutput($overriddenWithCopy))->toBeNull();
+    });
+
+    it('requires concrete codecs and container for output compatibility', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient([
+                'video_codecs' => [],
+                'audio_codecs' => [],
+                'containers' => [],
+                'max_height' => 720,
+            ]),
+            tvMakeStats(['height' => 1080]),
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput([
+                'video_codec' => null,
+                'audio_codec' => null,
+                'container' => null,
+                'max_height' => 720,
+            ]),
+        );
+
+        expect($result['mode'])->toBe('unsupported');
+    });
+
+    it('rejects explicit output limits above client capabilities', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient([
+                'max_height' => 720,
+                'max_bitrate_kbps' => 5000,
+            ]),
+            tvMakeStats(['height' => 480, 'bit_rate' => '1000000']),
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput([
+                'max_height' => 1080,
+                'max_bitrate_kbps' => 8000,
+            ]),
+        );
+
+        expect($result['mode'])->toBe('direct_play');
+
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient([
+                'video_codecs' => ['hevc'],
+                'max_height' => 720,
+                'max_bitrate_kbps' => 5000,
+            ]),
+            tvMakeStats(['height' => 480, 'bit_rate' => '1000000']),
+            canTranscode: true,
+            transcodeOutput: tvTranscodeOutput([
+                'video_codec' => 'hevc',
+                'max_height' => 1080,
+                'max_bitrate_kbps' => 8000,
+            ]),
+        );
+
+        expect($result['mode'])->toBe('unsupported');
+    });
+
+    it('is case-insensitive when matching codecs', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['video_codecs' => ['H264', 'HEVC'], 'audio_codecs' => ['AAC'], 'containers' => ['MPEGTS']]),
+            tvMakeStats(format: 'mpegts,mpegtsraw'),
+            canTranscode: false,
+        );
+
+        expect($result['mode'])->toBe('direct_play');
+    });
+
+    it('understands codec aliases (hevc/h265)', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['video_codecs' => ['h265']]),
+            tvMakeStats(['codec_name' => 'hevc']),
+            canTranscode: false,
+        );
+
+        expect($result['mode'])->toBe('direct_play');
+    });
+
+    it('understands container aliases (ts/mpegts)', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(['containers' => ['ts']]),
+            tvMakeStats(),
+            canTranscode: false,
+        );
+
+        expect($result['mode'])->toBe('direct_play');
+    });
+
+    it('understands mpegtsraw format_name as mpegts container', function () {
+        $result = PlaybackCapabilityService::decide(
+            tvMakeClient(),
+            tvMakeStats(format: 'mpegtsraw'),
+            canTranscode: false,
+        );
+
+        expect($result['mode'])->toBe('direct_play');
+    });
+
+    it('returns source metadata in the response', function () {
+        $result = PlaybackCapabilityService::decide(tvMakeClient(), tvMakeStats(), canTranscode: false);
+
+        expect($result['source']['video_codec'])->toBe('h264');
+        expect($result['source']['audio_codec'])->toBe('aac');
+        expect($result['source']['container'])->toBe('mpegts');
+        expect($result['source']['width'])->toBe(1920);
+        expect($result['source']['height'])->toBe(1080);
+        expect($result['source']['hdr'])->toBeNull();
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| ClientCapabilities
+|--------------------------------------------------------------------------
+*/
+
+describe('ClientCapabilities', function () {
+    it('normalizes codec aliases', function () {
+        expect(ClientCapabilities::normalizeCodec('hevc'))->toBe('hevc');
+        expect(ClientCapabilities::normalizeCodec('h265'))->toBe('hevc');
+        expect(ClientCapabilities::normalizeCodec('H.265'))->toBe('hevc');
+        expect(ClientCapabilities::normalizeCodec('h264'))->toBe('h264');
+        expect(ClientCapabilities::normalizeCodec('avc'))->toBe('h264');
+        expect(ClientCapabilities::normalizeCodec('mpeg2video'))->toBe('mpeg2video');
+    });
+
+    it('normalizes container aliases', function () {
+        expect(ClientCapabilities::normalizeContainer('mpegts'))->toBe('mpegts');
+        expect(ClientCapabilities::normalizeContainer('mpegtsraw'))->toBe('mpegts');
+        expect(ClientCapabilities::normalizeContainer('ts'))->toBe('mpegts');
+        expect(ClientCapabilities::normalizeContainer('hls'))->toBe('hls');
+        expect(ClientCapabilities::normalizeContainer('m3u8'))->toBe('hls');
+    });
+
+    it('parses from array', function () {
+        $capabilities = ClientCapabilities::fromArray([
+            'profile' => 'default',
+            'platform' => 'android',
+            'backend' => 'exoplayer',
+            'video_codecs' => ['h264', 'h265'],
+            'audio_codecs' => ['aac', 'ac3'],
+            'containers' => ['mpegts', 'mp4'],
+            'max_height' => 1080,
+            'max_bitrate_kbps' => 10000,
+            'hdr' => true,
+        ]);
+
+        expect($capabilities->profile)->toBe('default');
+        expect($capabilities->platform)->toBe('android');
+        expect($capabilities->backend)->toBe('exoplayer');
+        expect($capabilities->videoCodecs)->toBe(['h264', 'hevc']);
+        expect($capabilities->audioCodecs)->toBe(['aac', 'ac3']);
+        expect($capabilities->containers)->toBe(['mpegts', 'mp4']);
+        expect($capabilities->maxHeight)->toBe(1080);
+        expect($capabilities->maxBitrateKbps)->toBe(10000);
+        expect($capabilities->hdr)->toBeTrue();
+    });
+
+    it('handles empty capabilities gracefully', function () {
+        $capabilities = ClientCapabilities::fromArray([
+            'profile' => 'default',
+            'platform' => 'android',
+            'backend' => 'exoplayer',
+        ]);
+
+        expect($capabilities->videoCodecs)->toBe([]);
+        expect($capabilities->audioCodecs)->toBe([]);
+        expect($capabilities->containers)->toBe([]);
+        expect($capabilities->maxHeight)->toBeNull();
+        expect($capabilities->maxBitrateKbps)->toBeNull();
+        expect($capabilities->hdr)->toBeNull();
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| POST stream/resolve endpoint
+|--------------------------------------------------------------------------
+*/
+
+describe('POST stream/resolve endpoint', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+        $this->user = tvCreateUser();
+        $this->playlist = tvCreatePlaylist($this->user);
+        tvCreateAuth($this->user, $this->playlist, 'tv_user', 'tv_pass');
+        $this->channel = tvCreateChannel($this->user, $this->playlist);
+        $this->resolveUrl = route('tv.stream.resolve.basic');
+        $this->withBasicAuth('tv_user', 'tv_pass');
+    });
+
+    it('authenticates the credential-free route with HTTP Basic auth', function () {
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+        ]);
+
+        $response->assertOk()->assertJsonPath('mode', 'direct_play');
+        expect($this->resolveUrl)->not->toContain('tv_user')->not->toContain('tv_pass');
+    });
+
+    it('returns 401 with invalid credentials', function () {
+        $this->withBasicAuth('wrong', 'wrong')->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => 1,
+        ])->assertUnauthorized();
+    });
+
+    it('returns 401 without HTTP Basic credentials', function () {
+        $this->withHeaders(['Authorization' => ''])->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+        ])->assertUnauthorized();
+    });
+
+    it('returns 404 for non-existent stream', function () {
+        $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => 99999,
+        ])->assertNotFound();
+    });
+
+    it('returns direct_play mode when no client_capabilities sent', function () {
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'direct_play')
+            ->assertJsonPath('reason', 'No client capabilities provided')
+            ->assertJsonStructure(['mode', 'url', 'reason', 'source']);
+    });
+
+    it('returns direct_play when client capabilities are compatible', function () {
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+            'client_capabilities' => [
+                'profile' => 'default',
+                'platform' => 'android',
+                'backend' => 'exoplayer',
+                'video_codecs' => ['h264'],
+                'audio_codecs' => ['aac'],
+                'containers' => ['mpegts'],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'direct_play')
+            ->assertJsonStructure(['mode', 'url', 'reason', 'source']);
+        expect($response->json('source'))->toHaveKeys([
+            'video_codec', 'audio_codec', 'container', 'width', 'height', 'hdr',
+        ]);
+    });
+
+    it('returns unsupported when client capabilities incompatible and no profile', function () {
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+            'client_capabilities' => tvIncompatibleCaps(),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'unsupported')
+            ->assertJsonPath('url', null);
+    });
+
+    it('returns transcode when client capabilities incompatible and profile available', function () {
+        $profile = tvCreateTranscodeProfile($this->user);
+        $this->channel->update(['stream_profile_id' => $profile->id]);
+        $this->channel->load('streamProfile');
+
+        $mockUrl = 'https://proxy.example.com/hls/abc123/playlist.m3u8';
+        $this->mock(M3uProxyService::class, function ($mock) use ($mockUrl) {
+            $mock->shouldReceive('getChannelUrl')->once()->andReturn($mockUrl);
+        });
+
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+            'client_capabilities' => tvIncompatibleCaps(),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'transcode')
+            ->assertJsonPath('url', $mockUrl);
+    });
+
+    it('returns unsupported when user cannot use proxy', function () {
+        $this->user->update(['is_admin' => false, 'permissions' => []]);
+        $profile = tvCreateTranscodeProfile($this->user);
+        $this->channel->update(['stream_profile_id' => $profile->id]);
+
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+            'client_capabilities' => tvIncompatibleCaps(),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'unsupported')
+            ->assertJsonPath('url', null);
+    });
+
+    it('returns 422 for invalid client_capabilities types', function () {
+        $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+            'client_capabilities' => 'not-an-array',
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['client_capabilities']);
+
+        $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+            'client_capabilities' => ['video_codecs' => 'not-an-array'],
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['client_capabilities.video_codecs']);
+
+        $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+            'client_capabilities' => ['max_height' => 'not-an-integer'],
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['client_capabilities.max_height']);
+    });
+
+    it('returns editor Xtream URL for direct_play (not upstream provider URL)', function () {
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $this->channel->id,
+        ]);
+
+        $url = $response->json('url');
+        expect(parse_url($url, PHP_URL_PATH))
+            ->toBe("/api/tv/stream/playlist/{$this->playlist->id}/live/{$this->channel->id}")
+            ->and(URL::hasValidSignature(Request::create($url)))->toBeTrue();
+        expect($url)->not->toContain('tv_user')->not->toContain('tv_pass');
+        expect($url)->not->toContain('example.com/stream/123.ts');
+    });
+
+    it('validates required fields', function () {
+        $this->postJson($this->resolveUrl, [])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['type', 'stream_id']);
+    });
+
+    it('validates type must be live/vod/series', function () {
+        $this->postJson($this->resolveUrl, [
+            'type' => 'invalid',
+            'stream_id' => 1,
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['type']);
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| VOD stream resolve
+|--------------------------------------------------------------------------
+*/
+
+describe('VOD stream resolve', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+        $this->user = tvCreateUser();
+        $this->playlist = tvCreatePlaylist($this->user, 'VOD Playlist');
+        tvCreateAuth($this->user, $this->playlist, 'vod_user', 'vod_pass');
+        $this->vodChannel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'VOD Channel',
+            'is_vod' => true,
+            'url' => 'https://example.com/movie/456.mp4',
+            'stream_stats' => json_encode(tvMakeStats(format: 'mp4')),
+        ]);
+        $this->vodUrl = route('tv.stream.resolve.basic');
+        $this->withBasicAuth('vod_user', 'vod_pass');
+    });
+
+    it('resolves VOD channel with compatible capabilities', function () {
+        $response = $this->postJson($this->vodUrl, [
+            'type' => 'vod',
+            'stream_id' => $this->vodChannel->id,
+            'client_capabilities' => [
+                'profile' => 'default',
+                'platform' => 'ios',
+                'backend' => 'avplayer',
+                'video_codecs' => ['h264'],
+                'audio_codecs' => ['aac'],
+                'containers' => ['mp4'],
+            ],
+        ]);
+
+        $response->assertOk()->assertJsonPath('mode', 'direct_play');
+    });
+
+    it('uses editor Xtream URL for VOD direct_play', function () {
+        $response = $this->postJson($this->vodUrl, [
+            'type' => 'vod',
+            'stream_id' => $this->vodChannel->id,
+        ]);
+
+        $url = $response->json('url');
+        expect(parse_url($url, PHP_URL_PATH))
+            ->toBe("/api/tv/stream/playlist/{$this->playlist->id}/vod/{$this->vodChannel->id}")
+            ->and(URL::hasValidSignature(Request::create($url)))->toBeTrue();
+        expect($url)->not->toContain('vod_user')->not->toContain('vod_pass');
+        expect($url)->not->toContain('example.com/movie/456.mp4');
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| HTTP Basic credentials
+|--------------------------------------------------------------------------
+*/
+
+describe('HTTP Basic credentials', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+        $this->user = tvCreateUser();
+        $this->playlist = tvCreatePlaylist($this->user, 'Cred Playlist');
+    });
+
+    it('fails closed without exposing provider credentials', function (string $username, string $password) {
+        tvCreateAuth($this->user, $this->playlist, $username, $password);
+        $channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Cred Channel',
+            'url' => 'https://provider_user:provider_pass@provider.example/live/account/secret/123.ts?token=provider_secret',
+        ]);
+
+        $response = $this->withBasicAuth($username, $password)->postJson(route('tv.stream.resolve.basic'), [
+            'type' => 'live',
+            'stream_id' => $channel->id,
+        ]);
+
+        $response->assertOk();
+        $responseUrl = $response->json('url');
+        expect($responseUrl)
+            ->not->toContain($username)
+            ->not->toContain($password)
+            ->and(URL::hasValidSignature(Request::create($responseUrl)))->toBeTrue();
+
+        $playbackResponse = $this->withBasicAuth($username, $password)->get($responseUrl);
+        $playbackResponse->assertServiceUnavailable();
+        expect($playbackResponse->headers->get('Location'))->toBeNull()
+            ->and($playbackResponse->getContent())->not->toContain('provider.example')
+            ->not->toContain('provider_user')
+            ->not->toContain('provider_pass')
+            ->not->toContain('provider_secret');
+    })->with('special_credentials');
+
+    it('returns a credential-free VOD playback URL', function () {
+        tvCreateAuth($this->user, $this->playlist, 'a b', 'c+d');
+        $channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'VOD Cred Channel',
+            'is_vod' => true,
+            'container_extension' => 'mkv',
+            'url' => 'https://example.com/movie.mkv',
+        ]);
+
+        $response = $this->withBasicAuth('a b', 'c+d')->postJson(route('tv.stream.resolve.basic'), [
+            'type' => 'vod',
+            'stream_id' => $channel->id,
+        ]);
+
+        $response->assertOk();
+        $responseUrl = $response->json('url');
+        expect($responseUrl)
+            ->not->toContain('a b')
+            ->not->toContain('c+d')
+            ->and(URL::hasValidSignature(Request::create($responseUrl)))->toBeTrue();
+    });
+
+    it('never exposes provider credentials across playback response chains', function () {
+        tvCreateAuth($this->user, $this->playlist, 'chain_user', 'chain_pass');
+        $providerUrl = 'https://provider_user:provider_pass@provider.example/live/account/secret/123.ts?token=provider_secret';
+        $live = tvCreateChannel($this->user, $this->playlist, ['url' => $providerUrl]);
+        $vod = tvCreateChannel($this->user, $this->playlist, [
+            'url' => $providerUrl,
+            'is_vod' => true,
+            'container_extension' => 'mkv',
+        ]);
+        $catchup = tvCreateChannel($this->user, $this->playlist, [
+            'url' => $providerUrl,
+            'catchup' => 'default',
+        ]);
+        $series = tvCreateSeries($this->user, $this->playlist, 'Credential Series');
+        $season = tvCreateSeason($this->user, $this->playlist, $series);
+        $episode = tvCreateEpisode($this->user, $this->playlist, $series, $season, overrides: [
+            'url' => $providerUrl,
+        ]);
+        $requests = [
+            ['type' => 'live', 'stream_id' => $live->id],
+            ['type' => 'vod', 'stream_id' => $vod->id],
+            ['type' => 'series', 'stream_id' => $episode->id],
+            [
+                'type' => 'catchup',
+                'stream_id' => $catchup->id,
+                'catchup_start' => '2026-07-10T12:30:00+00:00',
+                'catchup_duration_minutes' => 30,
+            ],
+        ];
+
+        config(['proxy.m3u_proxy_host' => '']);
+
+        foreach ($requests as $payload) {
+            $url = $this->withBasicAuth('chain_user', 'chain_pass')
+                ->postJson(route('tv.stream.resolve.basic'), $payload)
+                ->assertOk()
+                ->json('url');
+            $playbackResponse = $this->withBasicAuth('chain_user', 'chain_pass')->get($url);
+
+            $playbackResponse->assertServiceUnavailable();
+            expect($playbackResponse->headers->get('Location'))->toBeNull()
+                ->and($playbackResponse->getContent())->not->toContain('provider.example')
+                ->not->toContain('provider_user')
+                ->not->toContain('provider_pass')
+                ->not->toContain('provider_secret');
+        }
+    });
+
+    it('rejects unsigned, expired, and cross-playlist playback requests', function () {
+        $otherPlaylist = tvCreatePlaylist($this->user, 'Other Playlist');
+        $channel = tvCreateChannel($this->user, $this->playlist, ['name' => 'Signed Route Channel']);
+        $unsignedUrl = route('tv.stream.play', [
+            'playlistType' => 'playlist',
+            'playlistId' => $this->playlist->id,
+            'type' => 'live',
+            'streamId' => $channel->id,
+            'format' => 'ts',
+        ]);
+        $crossPlaylistUrl = URL::temporarySignedRoute('tv.stream.play', now()->addMinute(), [
+            'playlistType' => 'playlist',
+            'playlistId' => $otherPlaylist->id,
+            'type' => 'live',
+            'streamId' => $channel->id,
+            'format' => 'ts',
+        ]);
+        $expiredUrl = URL::temporarySignedRoute('tv.stream.play', now()->subMinute(), [
+            'playlistType' => 'playlist',
+            'playlistId' => $this->playlist->id,
+            'type' => 'live',
+            'streamId' => $channel->id,
+            'format' => 'ts',
+        ]);
+
+        $this->get($unsignedUrl)->assertForbidden();
+        $this->get($expiredUrl)->assertForbidden();
+        $this->get($crossPlaylistUrl)->assertNotFound();
+    });
+
+    it('rejects playback after the authorizing PlaylistAuth is disabled', function () {
+        $auth = tvCreateAuth($this->user, $this->playlist, 'revoked_user', 'revoked_pass');
+        $channel = tvCreateChannel($this->user, $this->playlist, ['name' => 'Revoked Auth Channel']);
+        $url = $this->withBasicAuth('revoked_user', 'revoked_pass')->postJson(route('tv.stream.resolve.basic'), [
+            'type' => 'live',
+            'stream_id' => $channel->id,
+        ])->json('url');
+
+        $auth->update(['enabled' => false]);
+
+        $this->get($url)->assertForbidden();
+    });
+
+    it('rejects disabled and wrong-type streams on signed playback', function () {
+        $disabledChannel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Disabled Playback Channel',
+            'enabled' => false,
+        ]);
+        $vodChannel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Wrong Type Playback Channel',
+            'is_vod' => true,
+        ]);
+
+        foreach ([$disabledChannel, $vodChannel] as $channel) {
+            $url = URL::temporarySignedRoute('tv.stream.play', now()->addMinute(), [
+                'playlistType' => 'playlist',
+                'playlistId' => $this->playlist->id,
+                'type' => 'live',
+                'streamId' => $channel->id,
+                'format' => 'ts',
+            ]);
+
+            $this->get($url)->assertNotFound();
+        }
+    });
+
+    it('rejects an episode whose parent series is disabled on signed playback', function () {
+        $series = tvCreateSeries($this->user, $this->playlist, 'Disabled Playback Series');
+        $season = tvCreateSeason($this->user, $this->playlist, $series);
+        $episode = tvCreateEpisode($this->user, $this->playlist, $series, $season);
+        $series->update(['enabled' => false]);
+        $url = URL::temporarySignedRoute('tv.stream.play', now()->addMinute(), [
+            'playlistType' => 'playlist',
+            'playlistId' => $this->playlist->id,
+            'type' => 'series',
+            'streamId' => $episode->id,
+            'format' => 'mkv',
+        ]);
+
+        $this->get($url)->assertNotFound();
+    });
+
+    it('rejects signed alias playback after the alias expires', function () {
+        $alias = tvCreateAlias($this->user, $this->playlist);
+        $channel = tvCreateChannel($this->user, $this->playlist, ['name' => 'Alias Playback Channel']);
+        $url = $this->withBasicAuth('alias_user', 'alias_pass')->postJson(route('tv.stream.resolve.basic'), [
+            'type' => 'live',
+            'stream_id' => $channel->id,
+        ])->json('url');
+
+        $alias->update(['expires_at' => now()->subMinute()]);
+
+        $this->get($url)->assertForbidden();
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| catchup stream resolve
+|--------------------------------------------------------------------------
+*/
+
+describe('catchup stream resolve', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+        $this->user = tvCreateUser('catchupuser');
+        $this->playlist = tvCreatePlaylist($this->user, 'Catchup Playlist');
+        tvCreateAuth($this->user, $this->playlist, 'catchup_user', 'catchup_pass');
+        $this->channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Catchup Channel',
+            'catchup' => 'default',
+        ]);
+        $this->resolveUrl = route('tv.stream.resolve.basic');
+        $this->withBasicAuth('catchup_user', 'catchup_pass');
+    });
+
+    it('validates catchup start, duration, and format', function () {
+        $this->postJson($this->resolveUrl, [
+            'type' => 'catchup',
+            'stream_id' => $this->channel->id,
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['catchup_start', 'catchup_duration_minutes']);
+
+        $this->postJson($this->resolveUrl, [
+            'type' => 'catchup',
+            'stream_id' => $this->channel->id,
+            'catchup_start' => 'tomorrow',
+            'catchup_duration_minutes' => 0,
+            'catchup_format' => 'mp4',
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors([
+                'catchup_start',
+                'catchup_duration_minutes',
+                'catchup_format',
+            ]);
+
+        $this->postJson($this->resolveUrl, [
+            'type' => 'catchup',
+            'stream_id' => $this->channel->id,
+            'catchup_start' => '2026-07-10T12:30:00+00:00',
+            'catchup_duration_minutes' => 30,
+            'extension' => 'm3u8',
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['extension']);
+    });
+
+    it('returns a signed credential-free URL and dispatches timeshift arguments', function () {
+        $controller = $this->mock(XtreamStreamController::class);
+        $controller->shouldReceive('handleTimeshift')
+            ->once()
+            ->withArgs(fn (
+                Request $request,
+                string $username,
+                string $password,
+                int $duration,
+                string $date,
+                int $streamId,
+                string $format,
+            ): bool => $username === 'catchup_user'
+                && $password === 'catchup_pass'
+                && $duration === 90
+                && $date === '2026-07-10:12-30-00'
+                && $streamId === $this->channel->id
+                && $format === 'm3u8')
+            ->andReturn(response('timeshift'));
+
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'catchup',
+            'stream_id' => $this->channel->id,
+            'catchup_start' => '2026-07-10T14:30:00+02:00',
+            'catchup_duration_minutes' => 90,
+            'catchup_format' => 'm3u8',
+        ]);
+
+        $response->assertOk()->assertJsonPath('mode', 'direct_play');
+        $url = $response->json('url');
+        expect(parse_url($url, PHP_URL_PATH))
+            ->toBe("/api/tv/stream/playlist/{$this->playlist->id}/catchup/{$this->channel->id}")
+            ->and(URL::hasValidSignature(Request::create($url)))->toBeTrue()
+            ->and($url)->not->toContain('catchup_user')
+            ->not->toContain('catchup_pass')
+            ->not->toContain('example.com');
+
+        $this->get($url)->assertOk()->assertSee('timeshift');
+    });
+
+    it('rejects cross-playlist and VOD catchup streams', function () {
+        $otherPlaylist = tvCreatePlaylist($this->user, 'Other Catchup Playlist');
+        $otherChannel = tvCreateChannel($this->user, $otherPlaylist, ['catchup' => 'default']);
+        $vodChannel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Catchup VOD',
+            'is_vod' => true,
+            'catchup' => 'default',
+        ]);
+
+        foreach ([$otherChannel, $vodChannel] as $channel) {
+            $this->postJson($this->resolveUrl, [
+                'type' => 'catchup',
+                'stream_id' => $channel->id,
+                'catchup_start' => '2026-07-10T12:30:00+00:00',
+                'catchup_duration_minutes' => 30,
+            ])->assertNotFound();
+        }
+    });
+
+    it('rejects catchup disabled by the source playlist or unavailable on the channel', function () {
+        $this->playlist->update(['disable_catchup' => true]);
+
+        $this->postJson($this->resolveUrl, [
+            'type' => 'catchup',
+            'stream_id' => $this->channel->id,
+            'catchup_start' => '2026-07-10T12:30:00+00:00',
+            'catchup_duration_minutes' => 30,
+        ])->assertNotFound();
+
+        $this->playlist->update(['disable_catchup' => false]);
+        $this->channel->update(['catchup' => null]);
+
+        $this->postJson($this->resolveUrl, [
+            'type' => 'catchup',
+            'stream_id' => $this->channel->id,
+            'catchup_start' => '2026-07-10T12:30:00+00:00',
+            'catchup_duration_minutes' => 30,
+        ])->assertNotFound();
+    });
+
+    it('protects catchup query parameters with the signature', function () {
+        $url = $this->postJson($this->resolveUrl, [
+            'type' => 'catchup',
+            'stream_id' => $this->channel->id,
+            'catchup_start' => '2026-07-10T12:30:00+00:00',
+            'catchup_duration_minutes' => 30,
+            'catchup_format' => 'm3u8',
+        ])->json('url');
+
+        foreach (['duration=31', 'start=2026-07-11%3A12-30-00', 'format=ts'] as $replacement) {
+            $tamperedUrl = match (true) {
+                str_starts_with($replacement, 'duration') => str_replace('duration=30', $replacement, $url),
+                str_starts_with($replacement, 'start') => preg_replace('/start=[^&]+/', $replacement, $url),
+                default => str_replace('format=m3u8', $replacement, $url),
+            };
+
+            $this->get($tamperedUrl)->assertForbidden();
+        }
+    });
+
+    it('skips catchup failovers whose source playlist disables catchup', function () {
+        $this->playlist->update(['server_timezone' => 'Etc/UTC']);
+        $blockedPlaylist = tvCreatePlaylist($this->user, 'Blocked Catchup Source');
+        $blockedPlaylist->update(['disable_catchup' => true]);
+        $blockedFailover = tvCreateChannel($this->user, $blockedPlaylist, [
+            'name' => 'Blocked Catchup Failover',
+            'url' => 'https://provider.example/live/user/pass/blocked.ts',
+            'catchup' => 'default',
+        ]);
+        $eligibleFailover = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Eligible Catchup Failover',
+            'url' => 'https://provider.example/live/user/pass/eligible.ts',
+            'catchup' => 'default',
+        ]);
+        $this->channel->update(['catchup' => null]);
+        foreach ([$blockedFailover, $eligibleFailover] as $sort => $failover) {
+            ChannelFailover::create([
+                'user_id' => $this->user->id,
+                'channel_id' => $this->channel->id,
+                'channel_failover_id' => $failover->id,
+                'sort' => $sort,
+                'metadata' => [],
+            ]);
+        }
+        $url = $this->postJson($this->resolveUrl, [
+            'type' => 'catchup',
+            'stream_id' => $this->channel->id,
+            'catchup_start' => '2026-07-10T12:30:00+00:00',
+            'catchup_duration_minutes' => 30,
+        ])->json('url');
+
+        $this->get($url)
+            ->assertRedirect()
+            ->assertRedirectContains('eligible.ts');
+    });
+
+    it('keeps a shift-only primary instead of replacing it with a failover', function () {
+        $this->channel->update([
+            'url' => 'https://provider.example/live/user/pass/primary.ts',
+            'catchup' => null,
+            'shift' => 1,
+        ]);
+        $failover = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Catchup Failover',
+            'url' => 'https://provider.example/live/user/pass/failover.ts',
+            'catchup' => 'default',
+        ]);
+        ChannelFailover::create([
+            'user_id' => $this->user->id,
+            'channel_id' => $this->channel->id,
+            'channel_failover_id' => $failover->id,
+            'sort' => 0,
+            'metadata' => [],
+        ]);
+
+        $response = app(XtreamStreamController::class)->handleTimeshift(
+            Request::create('/timeshift', 'GET'),
+            'catchup_user',
+            'catchup_pass',
+            30,
+            '2026-07-10:12-30-00',
+            $this->channel->id,
+            'ts',
+        );
+
+        expect($response->getTargetUrl())->toContain('primary.ts');
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| playback URL and log secrecy
+|--------------------------------------------------------------------------
+*/
+
+describe('playback URL and log secrecy', function () {
+    it('does not log client capability request fields', function () {
+        $user = tvCreateUser('safe_log_user');
+        $playlist = tvCreatePlaylist($user, 'Safe Log Playlist');
+        tvCreateAuth($user, $playlist, 'safe_log_auth', 'safe_log_password');
+        $channel = tvCreateChannel($user, $playlist);
+        Log::spy();
+
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class)
+            ->withBasicAuth('safe_log_auth', 'safe_log_password')
+            ->postJson(route('tv.stream.resolve.basic'), [
+                'type' => 'live',
+                'stream_id' => $channel->id,
+                'client_capabilities' => [
+                    'profile' => 'secret_profile_marker',
+                    'platform' => 'secret_platform_marker',
+                    'backend' => 'secret_backend_marker',
+                    'video_codecs' => ['h264'],
+                    'audio_codecs' => ['aac'],
+                    'containers' => ['mpegts'],
+                ],
+            ])
+            ->assertOk();
+
+        Log::shouldHaveReceived('info')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'TV stream resolve'
+                && ! array_key_exists('profile', $context)
+                && ! array_key_exists('platform', $context)
+                && ! array_key_exists('backend', $context));
+    });
+
+    it('does not append usernames to proxy playback URLs', function () {
+        config(['proxy.m3u_proxy_public_url' => 'https://proxy.example.test']);
+        $service = new class extends M3uProxyService
+        {
+            public function proxyUrl(string $username): string
+            {
+                return $this->buildProxyUrl('stream-id', 'ts', $username);
+            }
+        };
+
+        expect($service->proxyUrl('basic_user'))
+            ->toBe('https://proxy.example.test/m3u-proxy/stream/stream-id')
+            ->not->toContain('basic_user');
+    });
+
+    it('rejects proxy public URLs containing URI credentials', function () {
+        config(['proxy.m3u_proxy_public_url' => 'https://proxy_user:proxy_pass@proxy.example.test']);
+        $service = new class extends M3uProxyService
+        {
+            public function proxyUrl(): string
+            {
+                return $this->buildProxyUrl('stream-id', 'ts');
+            }
+        };
+
+        expect(fn () => $service->proxyUrl())
+            ->toThrow(Exception::class, 'Proxy public URL must not contain credentials');
+    });
+
+    it('does not log provider URLs or proxy response bodies', function () {
+        config([
+            'proxy.m3u_proxy_host' => 'https://proxy.example.test',
+            'proxy.m3u_proxy_port' => null,
+        ]);
+        Http::fake(['*' => Http::response('secret proxy response body', 500)]);
+        Log::spy();
+        $service = new class extends M3uProxyService
+        {
+            public function create(string $url): void
+            {
+                $this->createStream($url);
+            }
+        };
+
+        expect(fn () => $service->create('https://provider_user:provider_pass@provider.example/live/1.ts'))
+            ->toThrow(Exception::class, 'Failed to create stream');
+        Log::shouldHaveReceived('error')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'Error creating/updating stream on m3u-proxy'
+                && $context === ['error_type' => Exception::class]);
+    });
+
+    it('does not log transcode profile arguments', function () {
+        config([
+            'proxy.m3u_proxy_host' => 'https://proxy.example.test',
+            'proxy.m3u_proxy_port' => null,
+        ]);
+        Http::fake(['*' => Http::response('secret proxy response body', 500)]);
+        Log::spy();
+        $profile = new StreamProfile([
+            'backend' => 'ffmpeg',
+            'format' => 'ts',
+            'args' => '-headers secret_profile_token -c:v libx264 -c:a aac -f mpegts',
+        ]);
+        $service = new class extends M3uProxyService
+        {
+            public function transcode(string $url, StreamProfile $profile): void
+            {
+                $this->createTranscodedStream($url, $profile);
+            }
+        };
+
+        expect(fn () => $service->transcode('https://provider.example/live/user/pass/1.ts', $profile))
+            ->toThrow(Exception::class, 'Failed to create transcoded stream');
+        Log::shouldHaveReceived('error')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'Error creating transcoded stream on m3u-proxy'
+                && $context === ['error_type' => Exception::class]);
+    });
+
+    it('does not log generated provider timeshift URLs', function () {
+        $request = Request::create('/timeshift', 'GET', [
+            'timeshift_duration' => 30,
+            'timeshift_date' => '2026-07-10:12-30-00',
+        ]);
+        Log::spy();
+
+        PlaylistService::generateTimeshiftUrl(
+            $request,
+            'https://provider.example/live/provider_user/provider_pass/1.ts',
+            (object) ['server_timezone' => 'Etc/UTC'],
+        );
+
+        Log::shouldHaveReceived('debug')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'Generated Xtream timeshift URL'
+                && array_keys($context) === ['duration_minutes']);
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| loadStream content type enforcement
+|--------------------------------------------------------------------------
+*/
+
+describe('loadStream content type enforcement', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+        $this->user = tvCreateUser('ctypeuser');
+        $this->playlist = tvCreatePlaylist($this->user, 'CType Playlist');
+        tvCreateAuth($this->user, $this->playlist, 'ctype_user', 'ctype_pass');
+        $this->resolveUrl = route('tv.stream.resolve.basic');
+        $this->withBasicAuth('ctype_user', 'ctype_pass');
+    });
+
+    it('returns 404 when requesting live type for a VOD channel', function () {
+        $channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'VOD Mismatch',
+            'is_vod' => true,
+            'url' => 'https://example.com/vod.ts',
+        ]);
+
+        $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $channel->id,
+        ])->assertNotFound();
+    });
+
+    it('returns 404 when requesting vod type for a live channel', function () {
+        $channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Live Mismatch',
+            'is_vod' => false,
+            'url' => 'https://example.com/live.ts',
+        ]);
+
+        $this->postJson($this->resolveUrl, [
+            'type' => 'vod',
+            'stream_id' => $channel->id,
+        ])->assertNotFound();
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| series stream resolve
+|--------------------------------------------------------------------------
+*/
+
+describe('series stream resolve', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+        $this->user = tvCreateUser('seriesuser');
+        $this->playlist = tvCreatePlaylist($this->user, 'Series Playlist');
+        tvCreateAuth($this->user, $this->playlist, 'series_user', 'series_pass');
+        $this->series = tvCreateSeries($this->user, $this->playlist);
+        $this->season = tvCreateSeason($this->user, $this->playlist, $this->series);
+        $this->episode = tvCreateEpisode($this->user, $this->playlist, $this->series, $this->season);
+        $this->seriesUrl = route('tv.stream.resolve.basic');
+        $this->withBasicAuth('series_user', 'series_pass');
+    });
+
+    it('resolves a series episode with direct_play', function () {
+        $response = $this->postJson($this->seriesUrl, [
+            'type' => 'series',
+            'stream_id' => $this->episode->id,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'direct_play')
+            ->assertJsonStructure(['mode', 'url', 'reason', 'source']);
+    });
+
+    it('returns 404 for a disabled episode', function () {
+        $this->episode->update(['enabled' => false]);
+
+        $this->postJson($this->seriesUrl, [
+            'type' => 'series',
+            'stream_id' => $this->episode->id,
+        ])->assertNotFound();
+    });
+
+    it('returns 404 for an episode belonging to a different playlist', function () {
+        $otherPlaylist = tvCreatePlaylist($this->user, 'Other Playlist');
+        $otherSeries = tvCreateSeries($this->user, $otherPlaylist, 'Other Series');
+        $otherSeason = tvCreateSeason($this->user, $otherPlaylist, $otherSeries, 'Season Other');
+        $otherEpisode = tvCreateEpisode($this->user, $otherPlaylist, $otherSeries, $otherSeason, 'Other Episode');
+
+        $this->postJson($this->seriesUrl, [
+            'type' => 'series',
+            'stream_id' => $otherEpisode->id,
+        ])->assertNotFound();
+    });
+
+    it('returns 404 when the owning series is disabled', function () {
+        $this->series->update(['enabled' => false]);
+
+        $this->postJson($this->seriesUrl, [
+            'type' => 'series',
+            'stream_id' => $this->episode->id,
+        ])->assertNotFound();
+    });
+
+    it('returns 404 for non-existent episode', function () {
+        $this->postJson($this->seriesUrl, [
+            'type' => 'series',
+            'stream_id' => 99999,
+        ])->assertNotFound();
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| profile precedence
+|--------------------------------------------------------------------------
+*/
+
+describe('profile precedence', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+        $this->user = tvCreateUser('precuser', ['permissions' => ['use_proxy']]);
+        $this->playlist = tvCreatePlaylist($this->user, 'Prec Playlist');
+        tvCreateAuth($this->user, $this->playlist, 'prec_user', 'prec_pass');
+        $this->resolveUrl = route('tv.stream.resolve.basic');
+        $this->withBasicAuth('prec_user', 'prec_pass');
+    });
+
+    it('uses channel-level profile over playlist profile for incompatible codec', function () {
+        $channelProfile = tvCreateTranscodeProfile($this->user, ['name' => 'chan-profile']);
+        $playlistProfile = tvCreateTranscodeProfile($this->user, ['name' => 'pl-profile']);
+        $this->playlist->update(['stream_profile_id' => $playlistProfile->id]);
+        $this->playlist->load('streamProfile');
+
+        $channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Prec Channel',
+            'stream_profile_id' => $channelProfile->id,
+        ]);
+
+        $mockUrl = 'https://proxy.test/hls/chan/playlist.m3u8';
+        $this->mock(M3uProxyService::class, function ($mock) use ($mockUrl, $channelProfile) {
+            $mock->shouldReceive('getChannelUrl')
+                ->once()
+                ->withArgs(fn ($playlist, $channel, $request, $profile) => $profile?->id === $channelProfile->id)
+                ->andReturn($mockUrl);
+        });
+
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $channel->id,
+            'client_capabilities' => tvIncompatibleCaps(),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'transcode')
+            ->assertJsonPath('url', $mockUrl);
+    });
+
+    it('falls back to playlist profile when channel has no profile', function () {
+        $playlistProfile = tvCreateTranscodeProfile($this->user, ['name' => 'pl-profile']);
+        $this->playlist->update(['stream_profile_id' => $playlistProfile->id]);
+        $this->playlist->load('streamProfile');
+
+        $channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Prec Channel 2',
+            'stream_profile_id' => null,
+        ]);
+
+        $mockUrl = 'https://proxy.test/hls/pl/playlist.m3u8';
+        $this->mock(M3uProxyService::class, function ($mock) use ($mockUrl, $playlistProfile) {
+            $mock->shouldReceive('getChannelUrl')
+                ->once()
+                ->withArgs(fn ($playlist, $channel, $request, $profile) => $profile?->id === $playlistProfile->id)
+                ->andReturn($mockUrl);
+        });
+
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $channel->id,
+            'client_capabilities' => tvIncompatibleCaps(),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'transcode')
+            ->assertJsonPath('url', $mockUrl);
+    });
+
+    it('falls back to GeneralSettings default when neither channel nor playlist has a profile', function () {
+        $defaultProfile = tvCreateTranscodeProfile($this->user, ['name' => 'default-profile']);
+
+        $mockSettings = Mockery::mock(GeneralSettings::class);
+        $mockSettings->default_stream_profile_id = $defaultProfile->id;
+        $mockSettings->default_vod_stream_profile_id = null;
+        app()->instance(GeneralSettings::class, $mockSettings);
+
+        $channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'Prec Channel 3',
+            'stream_profile_id' => null,
+        ]);
+
+        $mockUrl = 'https://proxy.test/hls/default/playlist.m3u8';
+        $this->mock(M3uProxyService::class, function ($mock) use ($mockUrl, $defaultProfile) {
+            $mock->shouldReceive('getChannelUrl')
+                ->once()
+                ->withArgs(fn ($playlist, $channel, $request, $profile) => $profile?->id === $defaultProfile->id)
+                ->andReturn($mockUrl);
+        });
+
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $channel->id,
+            'client_capabilities' => tvIncompatibleCaps(),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'transcode')
+            ->assertJsonPath('url', $mockUrl);
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| proxy disabled/unconfigured
+|--------------------------------------------------------------------------
+*/
+
+describe('proxy disabled/unconfigured', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+        $this->user = tvCreateUser('proxoffuser', ['permissions' => ['use_proxy']]);
+        $this->playlist = tvCreatePlaylist($this->user, 'ProxOff Playlist');
+        tvCreateAuth($this->user, $this->playlist, 'proxoff_user', 'proxoff_pass');
+        $this->resolveUrl = route('tv.stream.resolve.basic');
+        $this->withBasicAuth('proxoff_user', 'proxoff_pass');
+    });
+
+    it('returns unsupported when proxy host is empty', function () {
+        config(['proxy.m3u_proxy_host' => '']);
+        $profile = tvCreateTranscodeProfile($this->user);
+        $channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'ProxOff Channel',
+            'stream_profile_id' => $profile->id,
+        ]);
+
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $channel->id,
+            'client_capabilities' => tvIncompatibleCaps(),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'unsupported')
+            ->assertJsonPath('url', null);
+    });
+
+    it('returns unsupported when proxy integration is disabled', function () {
+        $profile = tvCreateTranscodeProfile($this->user);
+        $this->user->update(['permissions' => []]);
+
+        $channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'ProxOff Channel 2',
+            'stream_profile_id' => $profile->id,
+        ]);
+
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $channel->id,
+            'client_capabilities' => tvIncompatibleCaps(),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'unsupported')
+            ->assertJsonPath('url', null);
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| transcode service exception
+|--------------------------------------------------------------------------
+*/
+
+describe('transcode service exception', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+        $this->user = tvCreateUser('txfailuser', ['permissions' => ['use_proxy']]);
+        $this->playlist = tvCreatePlaylist($this->user, 'TxFail Playlist');
+        tvCreateAuth($this->user, $this->playlist, 'txfail_user', 'txfail_pass');
+        $this->resolveUrl = route('tv.stream.resolve.basic');
+        $this->withBasicAuth('txfail_user', 'txfail_pass');
+    });
+
+    it('returns unsupported with null url when getChannelUrl throws', function () {
+        $profile = tvCreateTranscodeProfile($this->user);
+        $channel = tvCreateChannel($this->user, $this->playlist, [
+            'name' => 'TxFail Channel',
+            'stream_profile_id' => $profile->id,
+        ]);
+
+        $this->mock(M3uProxyService::class, function ($mock) {
+            $mock->shouldReceive('getChannelUrl')
+                ->once()
+                ->andThrow(new Exception('Proxy connection refused'));
+        });
+
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'live',
+            'stream_id' => $channel->id,
+            'client_capabilities' => tvIncompatibleCaps(),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'unsupported')
+            ->assertJsonPath('url', null)
+            ->assertJsonPath('reason', 'Transcoding unavailable')
+            ->assertJsonStructure(['mode', 'url', 'reason', 'source']);
+    });
+
+    it('returns unsupported with null url when getEpisodeUrl throws', function () {
+        $profile = tvCreateTranscodeProfile($this->user);
+        $this->playlist->update(['vod_stream_profile_id' => $profile->id]);
+
+        $series = tvCreateSeries($this->user, $this->playlist, 'TxFail Series');
+        $season = tvCreateSeason($this->user, $this->playlist, $series, 'Season Tx');
+        $episode = tvCreateEpisode($this->user, $this->playlist, $series, $season, 'TxFail Episode', [
+            'stream_stats' => json_encode(tvMakeStats(format: 'matroska')),
+        ]);
+
+        $this->mock(M3uProxyService::class, function ($mock) {
+            $mock->shouldReceive('getEpisodeUrl')
+                ->once()
+                ->andThrow(new Exception('API timeout'));
+        });
+
+        $response = $this->postJson($this->resolveUrl, [
+            'type' => 'series',
+            'stream_id' => $episode->id,
+            'client_capabilities' => tvIncompatibleCaps(),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'unsupported')
+            ->assertJsonPath('url', null)
+            ->assertJsonPath('reason', 'Transcoding unavailable')
+            ->assertJsonStructure(['mode', 'url', 'reason', 'source']);
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| adaptive profile resolution for episodes
+|--------------------------------------------------------------------------
+*/
+
+describe('adaptive profile resolution for episodes', function () {
+    beforeEach(function () {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+        $this->user = tvCreateUser('adaptepuser', ['permissions' => ['use_proxy']]);
+        $this->playlist = tvCreatePlaylist($this->user, 'AdaptEp Playlist');
+        tvCreateAuth($this->user, $this->playlist, 'adaptep_user', 'adaptep_pass');
+        $this->seriesUrl = route('tv.stream.resolve.basic');
+        $this->withBasicAuth('adaptep_user', 'adaptep_pass');
+    });
+
+    it('resolves adaptive profile on episode using stream stats', function () {
+        $concrete = tvCreateTranscodeProfile($this->user, [
+            'name' => 'concrete-720p',
+            'format' => 'mkv',
+            'args' => '-vf scale=-2:720 -c:v libx265 -c:a aac -f matroska',
+        ]);
+        $adaptive = StreamProfile::factory()->for($this->user)->create([
+            'backend' => 'adaptive',
+            'name' => 'adaptive-720p',
+            'rules' => [
+                ['conditions' => [['field' => 'video.height', 'op' => '<=', 'value' => 720]], 'stream_profile_id' => $concrete->id],
+            ],
+            'else_stream_profile_id' => null,
+        ]);
+
+        $this->playlist->update(['vod_stream_profile_id' => $adaptive->id]);
+        $this->playlist->load('vodStreamProfile');
+
+        $series = tvCreateSeries($this->user, $this->playlist, 'AdaptEp Series');
+        $season = tvCreateSeason($this->user, $this->playlist, $series, 'Season AE');
+        $episode = tvCreateEpisode($this->user, $this->playlist, $series, $season, 'AdaptEp Episode', [
+            'stream_stats' => json_encode(tvMakeStats(['height' => 480], format: 'matroska')),
+        ]);
+
+        $mockUrl = 'https://proxy.test/hls/episode/adaptive.m3u8';
+        $this->mock(M3uProxyService::class, function ($mock) use ($mockUrl, $concrete) {
+            $mock->shouldReceive('getEpisodeUrl')
+                ->once()
+                ->withArgs(fn ($playlist, $episode, $profile) => $profile?->id === $concrete->id)
+                ->andReturn($mockUrl);
+        });
+
+        $response = $this->postJson($this->seriesUrl, [
+            'type' => 'series',
+            'stream_id' => $episode->id,
+            'client_capabilities' => tvIncompatibleCaps(['containers' => ['mkv']]),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'transcode')
+            ->assertJsonPath('url', $mockUrl);
+    });
+
+    it('returns unsupported when adaptive profile resolves to null on episode', function () {
+        $adaptive = StreamProfile::factory()->for($this->user)->create([
+            'backend' => 'adaptive',
+            'name' => 'adaptive-no-match',
+            'rules' => [
+                ['conditions' => [['field' => 'video.height', 'op' => '>', 'value' => 1080]], 'stream_profile_id' => 99999],
+            ],
+            'else_stream_profile_id' => null,
+        ]);
+
+        $this->playlist->update(['vod_stream_profile_id' => $adaptive->id]);
+        $this->playlist->load('vodStreamProfile');
+
+        $series = tvCreateSeries($this->user, $this->playlist, 'AdaptEp Series 2');
+        $season = tvCreateSeason($this->user, $this->playlist, $series, 'Season AE2');
+        $episode = tvCreateEpisode($this->user, $this->playlist, $series, $season, 'AdaptEp Episode 2', [
+            'stream_stats' => json_encode(tvMakeStats(['height' => 720], format: 'matroska')),
+        ]);
+
+        $response = $this->postJson($this->seriesUrl, [
+            'type' => 'series',
+            'stream_id' => $episode->id,
+            'client_capabilities' => tvIncompatibleCaps(['containers' => ['mkv']]),
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('mode', 'unsupported')
+            ->assertJsonPath('url', null);
+    });
+});


### PR DESCRIPTION
## Summary

- Add optional HTTP Basic authenticated `POST /api/tv/stream/resolve` support for live, VOD, series, and catchup playback.
- Compare persisted stream metadata with per-client codec, container, resolution, bitrate, and HDR capabilities.
- Return `direct_play`, `transcode`, or `unsupported` with source metadata and concrete output metadata when transcoding is proven compatible.
- Preserve backward-compatible direct resolution when `client_capabilities` is omitted.

## Contract

Requests include `type`, `stream_id`, and optional `client_capabilities` with `video_codecs`, `audio_codecs`, `containers`, `max_height`, `max_bitrate_kbps`, and `hdr`. Catchup additionally requires `catchup_start` and `catchup_duration_minutes`, and accepts only `catchup_format` values `ts` or `m3u8`. The legacy `extension` key is rejected.

Responses contain `mode`, a credential-free `url` when playable, `reason`, original `source` metadata, and optional effective `output` metadata for transcoding.

## Security

- Direct playback uses a short-lived signed editor URL and remains backend mediated for every stream type.
- Signed playback revalidates playlist ownership, auth state and expiry, stream membership, enabled state, content type, and parent series state.
- Provider URLs, provider credentials, HTTP Basic credentials, proxy credentials, request bodies, proxy response bodies, and transcode arguments are excluded from client-visible URLs, responses, logs, and exceptions.
- Credential-bearing provider response chains fail closed without exposing a redirect location, including forced catchup mediation when playlist proxy is disabled.
- Catchup uses one shift-aware eligibility predicate for primary and failover channels.
- Declared capabilities fail closed when persisted source facts or compatible transcode output facts are unknown.

## TDD Evidence

- RED: resolver route regression failed with 1 failed assertion because `tv.stream.resolve.basic` was absent.
- RED: unknown height, bitrate, HDR, and unbounded output regressions failed with 4 failed assertions because they returned `direct_play`.
- RED remediation: signed catchup with configured proxy and playlist proxy disabled returned a provider-facing `302` instead of the required credential-free `503`.
- GREEN: focused resolver suite passes 90 tests with 369 assertions.
- GREEN: legacy timeshift, proxy, and stream-profile suite passes 119 tests with 246 assertions.

## Checks

- `vendor/bin/pint --dirty --format agent`
- `vendor/bin/pint --test`
- PHP syntax checks for all 10 changed PHP files
- `npm run build`
- `php artisan route:list --name=tv.stream --except-vendor`
- `git diff --check` and `git diff --cached --check`
- Added-line U+2013 and U+2014 scan: zero matches
- `composer audit --format=summary`: no advisories
- `npm audit --audit-level=high`: zero vulnerabilities
- Redis integration checks used Predis with isolated Redis 7.4.9 on port 36790

Closes #1241
