### PR TITLE
chore: align setting copy and tests with info notification suppression (follow-up to #1257)

### DIFF
--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -278,9 +278,9 @@ class Preferences extends SettingsPage
                                                     ->label(__('Suppress success notifications'))
                                                     ->hintIcon(
                                                         'heroicon-m-question-mark-circle',
-                                                        tooltip: 'When enabled, success notifications from background tasks (e.g. sync completed successfully) will be hidden. Errors and warnings will still be shown regardless of this setting.'
+                                                        tooltip: 'When enabled, success and informational notifications from background tasks (e.g. sync started or completed successfully) will be hidden. Errors and warnings will still be shown regardless of this setting.'
                                                     )
-                                                    ->helperText(__('Hide success notifications from background tasks (errors and warnings are always shown).')),
+                                                    ->helperText(__('Hide success and informational notifications from background tasks (errors and warnings are always shown).')),
                                             ]),
                                         Grid::make()
                                             ->columnSpanFull()

--- a/tests/Feature/SuppressSuccessNotificationsTest.php
+++ b/tests/Feature/SuppressSuccessNotificationsTest.php
@@ -58,10 +58,26 @@ it('does not suppress a warning notification when suppression is enabled', funct
     NotificationFacade::assertSentTo($this->user, DatabaseNotification::class);
 });
 
-it('does not suppress an info notification when suppression is enabled', function () {
+it('suppresses an info database notification when suppression is enabled', function () {
     mockNotificationSettings(suppress: true);
 
     Notification::make()->title('Info')->info()->sendToDatabase($this->user);
 
     NotificationFacade::assertNothingSent();
+});
+
+it('suppresses an info broadcast notification when suppression is enabled', function () {
+    mockNotificationSettings(suppress: true);
+
+    Notification::make()->title('Info')->info()->broadcast($this->user);
+
+    NotificationFacade::assertNothingSent();
+});
+
+it('sends an info database notification when suppression is disabled', function () {
+    mockNotificationSettings(suppress: false);
+
+    Notification::make()->title('Info')->info()->sendToDatabase($this->user);
+
+    NotificationFacade::assertSentTo($this->user, DatabaseNotification::class);
 });


### PR DESCRIPTION
## Summary

Small follow-up to e0bce5d, which extended the success-notification suppression to info notifications (resolves #1257).

- **Rename the flipped test** — after e0bce5d the test `does not suppress an info notification when suppression is enabled` asserts the opposite of its name (`assertNothingSent`). Renamed to `suppresses an info database notification when suppression is enabled`.
- **Add coverage** — info suppression on the `broadcast()` path, and info notifications still being sent when suppression is disabled.
- **Update setting copy** — the Preferences tooltip and helper text for "Suppress success notifications" now mention that informational notifications are also hidden, matching the new behavior.

No runtime behavior changes beyond the UI text.

## Test plan

- `vendor/bin/pint --dirty` passes
- `php artisan test --filter=SuppressSuccessNotifications` — 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)