### PR TITLE
feat(content): pin fields and chain_id for network content relations

### DIFF
--- a/app/Filament/CopilotTools/NetworkContentPinTool.php
+++ b/app/Filament/CopilotTools/NetworkContentPinTool.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\CopilotTools;
+
+use App\Models\Network;
+use App\Models\NetworkContent;
+use EslamRedaDiv\FilamentCopilot\Tools\BaseTool;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Tools\Request;
+use Stringable;
+
+/**
+ * Copilot tool for pinning network content to a specific day and time.
+ *
+ * Allows the AI to set or clear weekly time pins on content items
+ * in a network playlist (e.g. "play The Wild Robot every Friday at 8pm").
+ */
+class NetworkContentPinTool extends BaseTool
+{
+    public function description(): Stringable|string
+    {
+        return 'Pin or unpin a content item in a network playlist to a specific day of the week and time. Use this to schedule "play X every Friday at 8pm" — the schedule generator will always place the content at that time. To clear a pin, omit pin_day_of_week and pin_time_of_day (or pass null). You must provide the network_content_id, which you can get by listing the network\'s content items.';
+    }
+
+    /** @return array<string, mixed> */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'network_content_id' => $schema->integer()
+                ->description('The ID of the NetworkContent record to pin. List the network\'s content to find this.'),
+            'pin_day_of_week' => $schema->string()
+                ->description('Day of the week: monday, tuesday, wednesday, thursday, friday, saturday, sunday. Omit or null to clear the pin.'),
+            'pin_time_of_day' => $schema->string()
+                ->description('Time in 24-hour HH:MM format, e.g. "20:00" for 8pm. Required when setting a pin.'),
+        ];
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        $ncId = (int) ($request['network_content_id'] ?? 0);
+        $day = isset($request['pin_day_of_week']) ? strtolower(trim((string) $request['pin_day_of_week'])) : null;
+        $time = isset($request['pin_time_of_day']) ? trim((string) $request['pin_time_of_day']) : null;
+
+        if ($ncId === 0) {
+            return 'Error: network_content_id is required.';
+        }
+
+        $validDays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+
+        if ($day !== null && ! in_array($day, $validDays, true)) {
+            return 'Error: pin_day_of_week must be one of: '.implode(', ', $validDays).'.';
+        }
+
+        if ($day !== null && (! $time || ! preg_match('/^\d{2}:\d{2}$/', $time))) {
+            return 'Error: pin_time_of_day is required when setting a pin. Use HH:MM format, e.g. "20:00".';
+        }
+
+        $nc = NetworkContent::find($ncId);
+
+        if (! $nc) {
+            return "Error: Network content item {$ncId} not found.";
+        }
+
+        // Verify the network belongs to the authenticated user
+        $network = Network::where('id', $nc->network_id)
+            ->where('user_id', auth()->id())
+            ->first();
+
+        if (! $network) {
+            return 'Error: Network not found or you do not have access to it.';
+        }
+
+        $clearing = $day === null || $time === null;
+
+        $nc->update([
+            'pin_day_of_week' => $clearing ? null : $day,
+            'pin_time_of_day' => $clearing ? null : $time,
+        ]);
+
+        $contentTitle = $nc->title;
+
+        if ($clearing) {
+            return "Cleared pin for \"{$contentTitle}\" in network \"{$network->name}\". It will now play in normal rotation.";
+        }
+
+        return "Pinned \"{$contentTitle}\" to ".ucfirst($day)."s at {$time} in network \"{$network->name}\". The schedule will be regenerated automatically.";
+    }
+}

--- a/app/Filament/Pages/Preferences.php
+++ b/app/Filament/Pages/Preferences.php
@@ -11,6 +11,7 @@ use App\Filament\CopilotTools\EpgMappingApplyTool;
 use App\Filament\CopilotTools\EpgMappingStateTool;
 use App\Filament\CopilotTools\ExecuteDatabaseQueryTool;
 use App\Filament\CopilotTools\GetDatabaseSchemaTool;
+use App\Filament\CopilotTools\NetworkContentPinTool;
 use App\Filament\CopilotTools\SearchDocsTool;
 use App\Filament\Resources\Assets\AssetResource;
 use App\Jobs\RestartQueue;
@@ -1834,6 +1835,7 @@ class Preferences extends SettingsPage
                                                 ExecuteDatabaseQueryTool::class => __('Database: Execute Query'),
                                                 DvrOverviewTool::class => __('DVR: Overview'),
                                                 DvrScheduleTool::class => __('DVR: Schedule'),
+                                                NetworkContentPinTool::class => __('Content: Pin to Timeslot'),
                                             ])
                                             ->afterStateHydrated(function ($component, $state) {
                                                 // Strip built-in tools that were saved by older versions.

--- a/app/Filament/Resources/Networks/NetworkResource.php
+++ b/app/Filament/Resources/Networks/NetworkResource.php
@@ -26,7 +26,9 @@ use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
+use Filament\Forms\Components\Component;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -145,10 +147,13 @@ class NetworkResource extends Resource implements CopilotResource
                                     Select::make('media_server_integration_id')
                                         ->label(__('Media Server'))
                                         ->relationship('mediaServerIntegration', 'name')
-                                        ->helperText(__('Networks pull VOD content from the linked media server.'))
                                         ->required()
                                         ->native(false)
-                                        ->disabled(),
+                                        ->preload()
+                                        ->disabled(fn (Network $record): bool => $record->networkContent()->count() > 0)
+                                        ->helperText(fn (Network $record): string => $record->networkContent()->count() > 0
+                                            ? __('Cannot change once content has been added to this network.')
+                                            : __('Networks pull VOD content from the linked media server.')),
                                 ]),
                         ]),
 
@@ -1029,19 +1034,26 @@ class NetworkResource extends Resource implements CopilotResource
                     Action::make('generateSchedule')
                         ->label(__('Generate Schedule'))
                         ->icon('heroicon-o-calendar')
-                        ->requiresConfirmation()
                         ->modalHeading(__('Generate Schedule'))
-                        ->modalDescription(fn (Network $record): string => 'This will generate a '.($record->schedule_window_days ?? 7).'-day programme schedule for this network. Existing future programmes will be replaced.')
+                        ->modalSubmitActionLabel(__('Generate'))
                         ->disabled(fn (Network $record): bool => $record->network_playlist_id === null)
                         ->tooltip(fn (Network $record): ?string => $record->network_playlist_id === null ? 'Assign to a playlist first' : null)
-                        ->action(function (Network $record) {
-                            $service = app(NetworkScheduleService::class);
-                            $service->generateSchedule($record);
+                        ->schema(fn (Network $record): array => static::generateScheduleModalSchema($record->schedule_window_days ?? 7, $record->schedule_type))
+                        ->action(function (Network $record, array $data) {
+                            $forceReset = ($data['mode'] ?? 'continue') === 'reset';
+
+                            app(NetworkScheduleService::class)->generateSchedule($record, forceReset: $forceReset);
+
+                            if ($forceReset && $record->isBroadcasting()) {
+                                app(NetworkBroadcastService::class)->restart($record);
+                            }
 
                             Notification::make()
                                 ->success()
                                 ->title(__('Schedule Generated'))
-                                ->body("Generated programme schedule for {$record->name}")
+                                ->body($forceReset
+                                    ? "Fresh schedule generated for {$record->name}."
+                                    : "Schedule continued for {$record->name}.")
                                 ->send();
                         }),
 
@@ -1276,5 +1288,32 @@ class NetworkResource extends Resource implements CopilotResource
     {
         return parent::getEloquentQuery()
             ->where('user_id', Auth::id());
+    }
+
+    /**
+     * Build the Radio schema for the generate-schedule modal.
+     *
+     * @return array<int, Component>
+     */
+    public static function generateScheduleModalSchema(int $windowDays, string $scheduleType): array
+    {
+        $shuffleNote = $scheduleType === 'shuffle'
+            ? ' The shuffle order will be randomised afresh.'
+            : ' The content sequence restarts from the beginning.';
+
+        return [
+            Radio::make('mode')
+                ->label(__('How should the schedule be generated?'))
+                ->options([
+                    'continue' => __('Continue from current position'),
+                    'reset' => __('Fresh start'),
+                ])
+                ->descriptions([
+                    'continue' => __("Keeps the currently-airing programme. Regenerates the next {$windowDays} days from where the schedule left off. The content order stays the same — good for topping up an expiring schedule without disrupting viewers."),
+                    'reset' => __("Deletes all existing programmes and builds a completely new {$windowDays}-day schedule from scratch.{$shuffleNote} Use this after reordering content, setting pins, or when you want a fresh lineup."),
+                ])
+                ->default('continue')
+                ->required(),
+        ];
     }
 }

--- a/app/Filament/Resources/Networks/RelationManagers/NetworkContentRelationManager.php
+++ b/app/Filament/Resources/Networks/RelationManagers/NetworkContentRelationManager.php
@@ -9,18 +9,24 @@ use App\Models\Episode;
 use App\Models\Network;
 use App\Models\NetworkContent;
 use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
 use Filament\Forms\Components\ModalTableSelect;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\Column;
+use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\TextInputColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Collection;
 
 class NetworkContentRelationManager extends RelationManager
 {
@@ -126,9 +132,30 @@ class NetworkContentRelationManager extends RelationManager
                         : sprintf('%dm', $minutes);
                 }),
 
-            TextColumn::make('weight')
+            TextInputColumn::make('weight')
                 ->label(__('Weight'))
+                ->type('number')
+                ->rules(['required', 'integer', 'min:1'])
                 ->sortable()
+                ->toggleable(isToggledHiddenByDefault: true),
+
+            IconColumn::make('chain_id')
+                ->label(__('Chained'))
+                ->icon(fn (NetworkContent $record): string => $record->isChained() ? 'heroicon-o-link' : 'heroicon-o-minus')
+                ->color(fn (NetworkContent $record): string => $record->isChained() ? 'warning' : 'gray')
+                ->tooltip(fn (NetworkContent $record): ?string => $record->isChained()
+                    ? 'Chained with '.($record->chainMembers()->count() - 1).' other item(s)'
+                    : null)
+                ->toggleable(isToggledHiddenByDefault: true),
+
+            TextColumn::make('pin_day_of_week')
+                ->label(__('Pin Day'))
+                ->formatStateUsing(fn (?string $state): string => $state ? ucfirst($state) : '—')
+                ->toggleable(isToggledHiddenByDefault: true),
+
+            TextColumn::make('pin_time_of_day')
+                ->label(__('Pin Time'))
+                ->formatStateUsing(fn (?string $state): string => $state ?? '—')
                 ->toggleable(isToggledHiddenByDefault: true),
         ];
     }
@@ -272,6 +299,10 @@ class NetworkContentRelationManager extends RelationManager
     protected function getRecordActions(): array
     {
         return [
+            EditAction::make()
+                ->icon('heroicon-o-pencil-square')
+                ->button()
+                ->hiddenLabel(),
             DeleteAction::make()
                 ->icon('heroicon-o-x-circle')
                 ->button()
@@ -286,8 +317,110 @@ class NetworkContentRelationManager extends RelationManager
      */
     protected function getToolbarActions(): array
     {
+        /** @var Network $network */
+        $network = $this->getOwnerRecord();
+
         return [
             BulkActionGroup::make([
+                BulkAction::make('linkAsChain')
+                    ->label(__('Link as Chain'))
+                    ->icon('heroicon-o-link')
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalDescription(__('Selected items will always play consecutively, in their current sort order, as one unit — most impactful in Shuffle mode.'))
+                    ->action(function (Collection $records) use ($network): void {
+                        if ($records->count() < 2) {
+                            Notification::make()
+                                ->warning()
+                                ->title(__('Select at least 2 items to chain'))
+                                ->send();
+
+                            return;
+                        }
+
+                        $pinned = $records->filter(fn (NetworkContent $record): bool => $record->isPinned());
+
+                        if ($pinned->isNotEmpty()) {
+                            Notification::make()
+                                ->danger()
+                                ->title(__('Cannot chain pinned items'))
+                                ->body(__('Unpin the selected item(s) first: ').$pinned->map(fn (NetworkContent $r) => $r->title)->implode(', '))
+                                ->send();
+
+                            return;
+                        }
+
+                        $sorted = $records->sortBy('sort_order')->values();
+                        $chainId = $sorted->first()->id;
+
+                        // Chains being vacated by items joining this new chain —
+                        // clean up any left with a single member afterward.
+                        $vacatedChainIds = $records->pluck('chain_id')->filter()->unique()
+                            ->reject(fn ($id) => $id === $chainId);
+
+                        foreach ($sorted as $record) {
+                            $record->update(['chain_id' => $chainId]);
+                        }
+
+                        foreach ($vacatedChainIds as $oldChainId) {
+                            $remaining = NetworkContent::where('network_id', $network->id)
+                                ->where('chain_id', $oldChainId)
+                                ->get();
+
+                            if ($remaining->count() === 1) {
+                                $remaining->first()->update(['chain_id' => null]);
+                            }
+                        }
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Items chained'))
+                            ->body($sorted->count().' item(s) will now play consecutively.')
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion(),
+
+                BulkAction::make('unlinkChain')
+                    ->label(__('Unlink Chain'))
+                    ->icon('heroicon-o-link-slash')
+                    ->color('gray')
+                    ->requiresConfirmation()
+                    ->action(function (Collection $records) use ($network): void {
+                        $chained = $records->filter(fn (NetworkContent $record): bool => $record->isChained());
+
+                        if ($chained->isEmpty()) {
+                            Notification::make()
+                                ->warning()
+                                ->title(__('No chained items selected'))
+                                ->send();
+
+                            return;
+                        }
+
+                        $affectedChainIds = $chained->pluck('chain_id')->unique();
+
+                        foreach ($chained as $record) {
+                            $record->update(['chain_id' => null]);
+                        }
+
+                        // A chain of one left behind after unlinking is meaningless.
+                        foreach ($affectedChainIds as $chainId) {
+                            $remaining = NetworkContent::where('network_id', $network->id)
+                                ->where('chain_id', $chainId)
+                                ->get();
+
+                            if ($remaining->count() === 1) {
+                                $remaining->first()->update(['chain_id' => null]);
+                            }
+                        }
+
+                        Notification::make()
+                            ->success()
+                            ->title(__('Chain(s) unlinked'))
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion(),
+
                 DeleteBulkAction::make(),
             ]),
         ];
@@ -308,6 +441,28 @@ class NetworkContentRelationManager extends RelationManager
                 ->default(1)
                 ->minValue(1)
                 ->helperText(__('Higher weight = more likely to appear when shuffling')),
+
+            Select::make('pin_day_of_week')
+                ->label(__('Pin Day of Week'))
+                ->options([
+                    'monday' => __('Monday'),
+                    'tuesday' => __('Tuesday'),
+                    'wednesday' => __('Wednesday'),
+                    'thursday' => __('Thursday'),
+                    'friday' => __('Friday'),
+                    'saturday' => __('Saturday'),
+                    'sunday' => __('Sunday'),
+                ])
+                ->nullable()
+                ->placeholder(__('No pin'))
+                ->helperText(__('Pin this content to a specific day each week')),
+
+            TextInput::make('pin_time_of_day')
+                ->label(__('Pin Time (HH:MM)'))
+                ->placeholder('20:00')
+                ->regex('/^\d{2}:\d{2}$/')
+                ->nullable()
+                ->helperText(__('Time in 24-hour format, e.g. 20:00 for 8pm')),
         ]);
     }
 }

--- a/app/Filament/Resources/Networks/RelationManagers/NetworkContentRelationManager.php
+++ b/app/Filament/Resources/Networks/RelationManagers/NetworkContentRelationManager.php
@@ -27,6 +27,7 @@ use Filament\Tables\Columns\TextInputColumn;
 use Filament\Tables\Enums\RecordActionsPosition;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
 
 class NetworkContentRelationManager extends RelationManager
 {
@@ -350,32 +351,35 @@ class NetworkContentRelationManager extends RelationManager
                             return;
                         }
 
-                        $sorted = $records->sortBy('sort_order')->values();
-                        $chainId = $sorted->first()->id;
+                        // Wrap the writes so a mid-loop failure can't leave chains half-reassigned.
+                        DB::transaction(function () use ($records, $network): void {
+                            $sorted = $records->sortBy('sort_order')->values();
+                            $chainId = $sorted->first()->id;
 
-                        // Chains being vacated by items joining this new chain —
-                        // clean up any left with a single member afterward.
-                        $vacatedChainIds = $records->pluck('chain_id')->filter()->unique()
-                            ->reject(fn ($id) => $id === $chainId);
+                            // Chains being vacated by items joining this new chain —
+                            // clean up any left with a single member afterward.
+                            $vacatedChainIds = $records->pluck('chain_id')->filter()->unique()
+                                ->reject(fn ($id) => $id === $chainId);
 
-                        foreach ($sorted as $record) {
-                            $record->update(['chain_id' => $chainId]);
-                        }
-
-                        foreach ($vacatedChainIds as $oldChainId) {
-                            $remaining = NetworkContent::where('network_id', $network->id)
-                                ->where('chain_id', $oldChainId)
-                                ->get();
-
-                            if ($remaining->count() === 1) {
-                                $remaining->first()->update(['chain_id' => null]);
+                            foreach ($sorted as $record) {
+                                $record->update(['chain_id' => $chainId]);
                             }
-                        }
+
+                            foreach ($vacatedChainIds as $oldChainId) {
+                                $remaining = NetworkContent::where('network_id', $network->id)
+                                    ->where('chain_id', $oldChainId)
+                                    ->get();
+
+                                if ($remaining->count() === 1) {
+                                    $remaining->first()->update(['chain_id' => null]);
+                                }
+                            }
+                        });
 
                         Notification::make()
                             ->success()
                             ->title(__('Items chained'))
-                            ->body($sorted->count().' item(s) will now play consecutively.')
+                            ->body($records->count().' item(s) will now play consecutively.')
                             ->send();
                     })
                     ->deselectRecordsAfterCompletion(),
@@ -397,22 +401,25 @@ class NetworkContentRelationManager extends RelationManager
                             return;
                         }
 
-                        $affectedChainIds = $chained->pluck('chain_id')->unique();
+                        // Wrap the writes so a mid-loop failure can't leave a chain half-broken.
+                        DB::transaction(function () use ($chained, $network): void {
+                            $affectedChainIds = $chained->pluck('chain_id')->unique();
 
-                        foreach ($chained as $record) {
-                            $record->update(['chain_id' => null]);
-                        }
-
-                        // A chain of one left behind after unlinking is meaningless.
-                        foreach ($affectedChainIds as $chainId) {
-                            $remaining = NetworkContent::where('network_id', $network->id)
-                                ->where('chain_id', $chainId)
-                                ->get();
-
-                            if ($remaining->count() === 1) {
-                                $remaining->first()->update(['chain_id' => null]);
+                            foreach ($chained as $record) {
+                                $record->update(['chain_id' => null]);
                             }
-                        }
+
+                            // A chain of one left behind after unlinking is meaningless.
+                            foreach ($affectedChainIds as $chainId) {
+                                $remaining = NetworkContent::where('network_id', $network->id)
+                                    ->where('chain_id', $chainId)
+                                    ->get();
+
+                                if ($remaining->count() === 1) {
+                                    $remaining->first()->update(['chain_id' => null]);
+                                }
+                            }
+                        });
 
                         Notification::make()
                             ->success()
@@ -455,14 +462,16 @@ class NetworkContentRelationManager extends RelationManager
                 ])
                 ->nullable()
                 ->placeholder(__('No pin'))
-                ->helperText(__('Pin this content to a specific day each week')),
+                ->helperText(__('Pin this content to a specific day each week'))
+                ->rule('required_with:pin_time_of_day'),
 
             TextInput::make('pin_time_of_day')
                 ->label(__('Pin Time (HH:MM)'))
                 ->placeholder('20:00')
                 ->regex('/^\d{2}:\d{2}$/')
                 ->nullable()
-                ->helperText(__('Time in 24-hour format, e.g. 20:00 for 8pm')),
+                ->helperText(__('Time in 24-hour format, e.g. 20:00 for 8pm'))
+                ->rule('required_with:pin_day_of_week'),
         ]);
     }
 }

--- a/app/Models/NetworkContent.php
+++ b/app/Models/NetworkContent.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 
 class NetworkContent extends Model
@@ -32,6 +33,9 @@ class NetworkContent extends Model
         'network_id' => 'integer',
         'sort_order' => 'integer',
         'weight' => 'integer',
+        'pin_day_of_week' => 'string',
+        'pin_time_of_day' => 'string',
+        'chain_id' => 'integer',
     ];
 
     /**
@@ -52,6 +56,25 @@ class NetworkContent extends Model
             }
 
             if (! in_array($network->schedule_type, ['sequential', 'shuffle'])) {
+                return;
+            }
+
+            if ($network->auto_regenerate_schedule === false) {
+                return;
+            }
+
+            RegenerateNetworkSchedule::dispatch($network->id)->delay(3);
+        });
+
+        // When pin or chain fields change, queue a schedule regeneration.
+        static::updated(function (NetworkContent $networkContent) {
+            if (! $networkContent->wasChanged(['pin_day_of_week', 'pin_time_of_day', 'chain_id'])) {
+                return;
+            }
+
+            $network = $networkContent->network;
+
+            if (! $network || ! in_array($network->schedule_type, ['sequential', 'shuffle'])) {
                 return;
             }
 
@@ -103,6 +126,18 @@ class NetworkContent extends Model
                         'network_id' => $network->id,
                         'error' => $e->getMessage(),
                     ]);
+                }
+            }
+
+            // A chain of one is meaningless — if this deletion left exactly one
+            // member behind, clear its chain_id too.
+            if ($networkContent->chain_id !== null) {
+                $remaining = static::where('network_id', $network->id)
+                    ->where('chain_id', $networkContent->chain_id)
+                    ->get();
+
+                if ($remaining->count() === 1) {
+                    $remaining->first()->update(['chain_id' => null]);
                 }
             }
         });
@@ -217,6 +252,47 @@ class NetworkContent extends Model
         }
 
         return $content->name ?? $content->title ?? 'Unknown';
+    }
+
+    /**
+     * Whether this content item is pinned to a specific day and time.
+     */
+    public function isPinned(): bool
+    {
+        return $this->pin_day_of_week !== null && $this->pin_time_of_day !== null;
+    }
+
+    /**
+     * Whether this content item is chained with other items to always play consecutively.
+     */
+    public function isChained(): bool
+    {
+        return $this->chain_id !== null;
+    }
+
+    /**
+     * All members of this item's chain (including itself), ordered by sort_order.
+     * Returns just itself when not chained.
+     */
+    public function chainMembers(): Collection
+    {
+        if (! $this->isChained()) {
+            return collect([$this]);
+        }
+
+        return static::where('network_id', $this->network_id)
+            ->where('chain_id', $this->chain_id)
+            ->orderBy('sort_order')
+            ->get();
+    }
+
+    /**
+     * The lead (first-playing) member of this item's chain, resolved dynamically
+     * by lowest sort_order — not by matching chain_id to an id.
+     */
+    public function chainLead(): self
+    {
+        return $this->isChained() ? $this->chainMembers()->first() : $this;
     }
 
     /**

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -446,10 +446,12 @@ class AdminPanelProvider extends PanelProvider
                 config(["ai.providers.{$provider}.url" => $s['copilot_url']]);
             }
 
+            $defaultPrompt = $this->defaultCopilotSystemPrompt();
+
             return FilamentCopilotPlugin::make()
                 ->provider($provider)
                 ->model($model)
-                ->systemPrompt($s['copilot_system_prompt'] ?: 'You are a helpful AI assistant integrated into m3u editor. You help users manage playlists, EPG data, streams, channels, and other media features. You can look up the live TV guide for the user’s mapped channels: what is on right now, what is on later today/tomorrow/this week, what is airing around a specific show, and full channel schedules. Be concise and accurate. If the user asks for something you cannot do, call Get Available Tools to see which tools are currently enabled, identify the missing capability, and tell the user the exact tool to enable in Preferences → AI Copilot → Global Tools (for example: "I do not have the TV schedule tool enabled. Enable DVR: Schedule in Preferences → AI Copilot → Global Tools and try again.").')
+                ->systemPrompt($s['copilot_system_prompt'] ?: $defaultPrompt)
                 ->globalTools($this->filterBuiltInTools($s['copilot_global_tools'] ?? []))
                 ->quickActions($this->buildQuickActions($s))
                 ->managementEnabled($s['copilot_mgmt_enabled'] ?? false)
@@ -460,6 +462,29 @@ class AdminPanelProvider extends PanelProvider
 
             return null;
         }
+    }
+
+    private function defaultCopilotSystemPrompt(): string
+    {
+        return <<<'PROMPT'
+You are a helpful AI assistant integrated into m3u editor. You help users manage playlists, EPG data, streams, channels, and other media features. Be concise and accurate.
+
+## Live TV Guide
+You can look up the live TV guide for the user's mapped channels: what is on right now, what is on later today/tomorrow/this week, what is airing around a specific show, and full channel schedules.
+
+## Resource Tools (ListRecordsTool, CreateRecordTool, EditRecordTool, etc.)
+These are never called by name directly. Call GetToolsTool with the resource's `source_class` first, then call RunToolTool with `source_class`, the exact `tool_class` string GetToolsTool returned (a fully-qualified class name, e.g. `App\Filament\CopilotTools\CreateRecordTool` — not the short name), and `arguments`. Do not guess a short tool_class name; it will be rejected as "not registered" and wastes a round trip.
+
+## Network Content Scheduling (Time Pins)
+You can pin specific content in a network playlist to a recurring weekly timeslot — for example, "play The Wild Robot every Friday at 8pm":
+1. List the network's content items to find the network_content_id for the title the user wants to pin.
+2. Call NetworkContentPinTool with the network_content_id, pin_day_of_week (e.g. "friday"), and pin_time_of_day (e.g. "20:00").
+3. The schedule regenerates automatically — pinned content will always air at that day/time each week.
+4. To remove a pin, call NetworkContentPinTool with only the network_content_id (omit day and time).
+
+## Tools Guidance
+If the user asks for something you cannot do, call Get Available Tools to see which tools are currently enabled, identify the missing capability, and tell the user the exact tool to enable in Preferences → AI Copilot → Global Tools (for example: "I do not have the TV schedule tool enabled. Enable DVR: Schedule in Preferences → AI Copilot → Global Tools and try again.").
+PROMPT;
     }
 
     /**

--- a/app/Services/NetworkScheduleService.php
+++ b/app/Services/NetworkScheduleService.php
@@ -96,6 +96,15 @@ class NetworkScheduleService
             // Pre-place pinned content at their anchored day+time slots across the window
             $this->prePlacePinnedOccurrences($network, $pinnedNetworkContent, $startFrom, $endAt);
 
+            // Pre-load pinned programmes once — the rotation loop below reads them
+            // on every iteration to avoid overrunning a pin slot, so a per-iteration
+            // query would mean ~336 DB hits on a 7-day/30-min schedule.
+            $pinnedProgrammes = $network->programmes()
+                ->whereNotNull('pinned_start_time')
+                ->where('start_time', '>', $startFrom)
+                ->orderBy('start_time')
+                ->get();
+
             // If there's a currently airing programme, start from its end time
             // This prevents creating overlapping programmes
             if ($currentlyAiring) {
@@ -169,12 +178,9 @@ class NetworkScheduleService
                 $content = $contentItems[$contentIndex];
                 $duration = $this->getContentDuration($content);
 
-                // If placing this item would overrun a pinned programme, skip to the pin start instead
-                $nextPinned = $network->programmes()
-                    ->whereNotNull('pinned_start_time')
-                    ->where('start_time', '>', $currentTime)
-                    ->orderBy('start_time')
-                    ->first();
+                // If placing this item would overrun a pinned programme, skip to the pin start instead.
+                // $pinnedProgrammes is pre-loaded once above — search it in-memory here.
+                $nextPinned = $pinnedProgrammes->first(fn (NetworkProgramme $p) => $p->start_time->gt($currentTime));
 
                 if ($nextPinned && $currentTime->copy()->addSeconds($duration)->gt($nextPinned->start_time)) {
                     $currentTime = $nextPinned->start_time->copy();

--- a/app/Services/NetworkScheduleService.php
+++ b/app/Services/NetworkScheduleService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Channel;
 use App\Models\Episode;
 use App\Models\Network;
+use App\Models\NetworkContent;
 use App\Models\NetworkProgramme;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
@@ -28,8 +29,11 @@ class NetworkScheduleService
 
     /**
      * Generate the programme schedule for a network.
+     *
+     * @param  bool  $forceReset  When true, clears all existing programmes and starts fresh from content index 0.
+     *                            When false (default), continues from the current position in the content sequence.
      */
-    public function generateSchedule(Network $network, ?Carbon $startFrom = null): int
+    public function generateSchedule(Network $network, ?Carbon $startFrom = null, bool $forceReset = false): int
     {
         // Manual schedules are managed by the Schedule Builder UI, not auto-generated
         if ($network->schedule_type === 'manual') {
@@ -46,32 +50,51 @@ class NetworkScheduleService
             'network_id' => $network->id,
             'start_from' => $startFrom->toDateTimeString(),
             'end_at' => $endAt->toDateTimeString(),
+            'force_reset' => $forceReset,
         ]);
 
         // Get all content for this network
-        $contentItems = $this->getOrderedContent($network);
+        $allNetworkContent = $network->networkContent()->with('contentable')->get();
+        $contentItems = $this->getOrderedContent($network, $forceReset);
 
-        if ($contentItems->isEmpty()) {
+        if ($contentItems->isEmpty() && $allNetworkContent->filter(fn ($nc) => $nc->isPinned())->isEmpty()) {
             Log::warning("No content found for network {$network->name}");
 
             return 0;
         }
 
-        // Determine the starting content index BEFORE deleting anything.
-        // Look for the most recent programme to determine where we should continue from.
-        $startingContentIndex = $this->determineStartingContentIndex($network, $contentItems, $startFrom);
+        // Force reset: wipe everything and start from index 0, ignoring continuity
+        if ($forceReset) {
+            $startingContentIndex = 0;
+            $currentlyAiring = null;
+        } else {
+            // Determine the starting content index BEFORE deleting anything.
+            // Look for the most recent programme to determine where we should continue from.
+            $startingContentIndex = $this->determineStartingContentIndex($network, $contentItems, $startFrom);
 
-        // Check if there's a currently airing programme - if so, we should skip to its end
-        $currentlyAiring = $network->programmes()
-            ->where('start_time', '<=', $startFrom)
-            ->where('end_time', '>', $startFrom)
-            ->first();
+            // Check if there's a currently airing programme - if so, we should skip to its end
+            $currentlyAiring = $network->programmes()
+                ->where('start_time', '<=', $startFrom)
+                ->where('end_time', '>', $startFrom)
+                ->first();
+        }
 
-        DB::transaction(function () use ($network, $startFrom, $endAt, $contentItems, $startingContentIndex, $currentlyAiring) {
-            // Clear future programmes (keep past for history) — exclude programmes that start exactly at the regeneration boundary
-            $network->programmes()
-                ->where('start_time', '>', $startFrom)
-                ->delete();
+        // Gather pinned items for pre-placement
+        $pinnedNetworkContent = $allNetworkContent->filter(fn ($nc) => $nc->isPinned());
+
+        DB::transaction(function () use ($network, $startFrom, $endAt, $contentItems, $startingContentIndex, $currentlyAiring, $pinnedNetworkContent, $forceReset) {
+            if ($forceReset) {
+                // Wipe all programmes — past and future — and start completely fresh
+                $network->programmes()->delete();
+            } else {
+                // Clear future programmes (keep past for history)
+                $network->programmes()
+                    ->where('start_time', '>', $startFrom)
+                    ->delete();
+            }
+
+            // Pre-place pinned content at their anchored day+time slots across the window
+            $this->prePlacePinnedOccurrences($network, $pinnedNetworkContent, $startFrom, $endAt);
 
             // If there's a currently airing programme, start from its end time
             // This prevents creating overlapping programmes
@@ -136,6 +159,19 @@ class NetworkScheduleService
 
                 $content = $contentItems[$contentIndex];
                 $duration = $this->getContentDuration($content);
+
+                // If placing this item would overrun a pinned programme, skip to the pin start instead
+                $nextPinned = $network->programmes()
+                    ->whereNotNull('pinned_start_time')
+                    ->where('start_time', '>', $currentTime)
+                    ->orderBy('start_time')
+                    ->first();
+
+                if ($nextPinned && $currentTime->copy()->addSeconds($duration)->gt($nextPinned->start_time)) {
+                    $currentTime = $nextPinned->start_time->copy();
+
+                    continue;
+                }
 
                 // Create programme entry
                 NetworkProgramme::create([
@@ -273,17 +309,19 @@ class NetworkScheduleService
 
     /**
      * Get ordered content based on network schedule type.
+     * Pinned items are excluded from the rotation — they're pre-placed at their anchored times.
      */
-    protected function getOrderedContent(Network $network): Collection
+    protected function getOrderedContent(Network $network, bool $forceReset = false): Collection
     {
-        $networkContent = $network->networkContent()->with('contentable')->get();
+        $networkContent = $network->networkContent()->with('contentable')->get()
+            ->filter(fn ($nc) => ! $nc->isPinned());
 
         if ($networkContent->isEmpty()) {
             return collect();
         }
 
         return match ($network->schedule_type) {
-            'shuffle' => $this->shuffleContent($networkContent, $network),
+            'shuffle' => $this->shuffleContent($networkContent, $network, $forceReset),
             'sequential' => $networkContent->sortBy('sort_order')->pluck('contentable')->filter(),
             'manual' => collect(), // Manual schedules are managed via Schedule Builder
             default => $networkContent->sortBy('sort_order')->pluck('contentable')->filter(),
@@ -291,33 +329,172 @@ class NetworkScheduleService
     }
 
     /**
+     * Pre-place pinned content at their anchored day-of-week + time slots across the schedule window.
+     *
+     * Pinned items always land at their target time. If two pins collide at the same time,
+     * the one with the lower sort_order wins; subsequent conflicting pins are skipped.
+     *
+     * @param  Collection<int, NetworkContent>  $pinnedItems
+     */
+    protected function prePlacePinnedOccurrences(
+        Network $network,
+        Collection $pinnedItems,
+        Carbon $startFrom,
+        Carbon $endAt
+    ): void {
+        if ($pinnedItems->isEmpty()) {
+            return;
+        }
+
+        $dayMap = [
+            'monday' => 1, 'tuesday' => 2, 'wednesday' => 3, 'thursday' => 4,
+            'friday' => 5, 'saturday' => 6, 'sunday' => 0,
+        ];
+
+        // Sort pinned items by sort_order so earlier ones win on collision
+        $sorted = $pinnedItems->sortBy('sort_order');
+
+        // Collect occupied intervals to detect collisions: [start => end]
+        $occupied = [];
+
+        $day = $startFrom->copy()->startOfDay();
+
+        while ($day->lt($endAt)) {
+            foreach ($sorted as $nc) {
+                $targetDow = $dayMap[strtolower($nc->pin_day_of_week)] ?? null;
+
+                if ($targetDow === null || (int) $day->format('w') !== $targetDow) {
+                    continue;
+                }
+
+                [$hour, $minute] = array_map('intval', explode(':', $nc->pin_time_of_day));
+                $occurrenceStart = $day->copy()->setTime($hour, $minute, 0);
+
+                // Skip occurrences before the schedule window start
+                if ($occurrenceStart->lte($startFrom)) {
+                    continue;
+                }
+
+                // Skip occurrences after the window end
+                if ($occurrenceStart->gte($endAt)) {
+                    continue;
+                }
+
+                $content = $nc->contentable;
+                if (! $content) {
+                    continue;
+                }
+
+                $duration = $this->getContentDuration($content);
+                $occurrenceEnd = $occurrenceStart->copy()->addSeconds($duration);
+
+                // Collision check: skip if this slot overlaps an already-placed pin
+                $collision = false;
+                foreach ($occupied as [$oStart, $oEnd]) {
+                    if ($occurrenceStart->lt($oEnd) && $occurrenceEnd->gt($oStart)) {
+                        $collision = true;
+                        Log::warning('Pinned content collision skipped', [
+                            'network_id' => $network->id,
+                            'content_id' => $content->id,
+                            'pin_start' => $occurrenceStart->toDateTimeString(),
+                        ]);
+                        break;
+                    }
+                }
+
+                if ($collision) {
+                    continue;
+                }
+
+                $occupied[] = [$occurrenceStart, $occurrenceEnd];
+
+                NetworkProgramme::create([
+                    'network_id' => $network->id,
+                    'title' => $this->getContentTitle($content),
+                    'description' => $this->getContentDescription($content),
+                    'image' => $this->getContentImage($content),
+                    'start_time' => $occurrenceStart->copy(),
+                    'end_time' => $occurrenceEnd,
+                    'duration_seconds' => $duration,
+                    'contentable_type' => get_class($content),
+                    'contentable_id' => $content->id,
+                    'pinned_start_time' => $occurrenceStart->copy(),
+                ]);
+            }
+
+            $day->addDay();
+        }
+    }
+
+    /**
      * Shuffle content with weighting support and week-based seeding.
      *
-     * Uses network ID + week number as seed to ensure:
-     * - Same week regeneration produces consistent schedule
-     * - Different weeks produce different shuffles (offset)
-     * - Different networks have unique shuffle patterns
+     * Normal mode: seeds by network ID + week number so the same week always
+     * produces the same shuffle order (stable programme guide, no mid-week jumps).
+     *
+     * Force-reset mode: seeds by network ID + current Unix timestamp so each
+     * hard reset produces a genuinely different order.
      */
-    protected function shuffleContent(Collection $networkContent, Network $network): Collection
+    protected function shuffleContent(Collection $networkContent, Network $network, bool $forceReset = false): Collection
     {
-        // Build weighted list
-        $weighted = collect();
-        foreach ($networkContent as $item) {
-            if (! $item->contentable) {
-                continue;
-            }
-            for ($i = 0; $i < $item->weight; $i++) {
-                $weighted->push($item->contentable);
+        // Deterministic base order before grouping, so both chain grouping and
+        // the seeded shuffle below stay stable/reproducible.
+        $ordered = $networkContent
+            ->filter(fn (NetworkContent $item) => $item->contentable)
+            ->sortBy([['sort_order', 'asc'], ['id', 'asc']])
+            ->values();
+
+        // Build shuffle "units" — a chain collapses into one unit carrying its
+        // ordered sub-list of contentables; an unchained item is a unit of one.
+        // Units are what gets shuffled, so a chain always stays consecutive.
+        $seenChains = [];
+        $units = collect();
+
+        foreach ($ordered as $item) {
+            if ($item->chain_id !== null) {
+                if (isset($seenChains[$item->chain_id])) {
+                    continue; // already folded into a unit
+                }
+                $seenChains[$item->chain_id] = true;
+
+                $members = $ordered->where('chain_id', $item->chain_id)->values();
+                $lead = $members->first(); // lowest sort_order = dynamically-resolved lead
+
+                $units->push([
+                    'weight' => max(1, (int) $lead->weight),
+                    'items' => $members->pluck('contentable')->all(),
+                ]);
+            } else {
+                $units->push([
+                    'weight' => max(1, (int) $item->weight),
+                    'items' => [$item->contentable],
+                ]);
             }
         }
 
-        // Create a seed based on network ID and current week number
-        // This ensures different weeks get different shuffles while
-        // regenerating the same week produces consistent results
-        $weekNumber = (int) now()->format('oW'); // Year + week number (e.g., 202603)
-        $seed = crc32($network->id.'-'.$weekNumber);
+        // Weight-expand at unit granularity — preserves today's per-item
+        // weighting for unchained items; a chain now scatters as one block.
+        $weighted = collect();
+        foreach ($units as $unit) {
+            for ($i = 0; $i < $unit['weight']; $i++) {
+                $weighted->push($unit['items']);
+            }
+        }
 
-        return $this->seededShuffle($weighted, $seed);
+        if ($forceReset) {
+            // Use current time as seed so every hard reset produces a unique shuffle
+            $seed = crc32($network->id.'-reset-'.now()->timestamp);
+        } else {
+            // Week-based seed: stable within the same week, changes each week
+            $weekNumber = (int) now()->format('oW'); // Year + week number (e.g., 202603)
+            $seed = crc32($network->id.'-'.$weekNumber);
+        }
+
+        $shuffledUnits = $this->seededShuffle($weighted, $seed);
+
+        // Flatten chosen units back into the flat Collection<Channel|Episode>
+        // that getOrderedContent() expects — chain members land consecutively.
+        return $shuffledUnits->flatMap(fn (array $items) => $items)->values();
     }
 
     /**
@@ -426,6 +603,20 @@ class NetworkScheduleService
                 : $content->title;
         }
 
+        // For VOD channels, prefer the metadata title (o_name/name from info) over
+        // the channel's display name, which may be a playlist group/category name.
+        if ($content instanceof Channel && $content->is_vod) {
+            $metaTitle = $content->info['o_name']
+                ?? $content->info['name']
+                ?? $content->movie_data['info']['o_name']
+                ?? $content->movie_data['info']['name']
+                ?? null;
+
+            if ($metaTitle) {
+                return $metaTitle;
+            }
+        }
+
         return $content->name ?? $content->title ?? 'Unknown';
     }
 
@@ -439,7 +630,13 @@ class NetworkScheduleService
         }
 
         if ($content instanceof Channel) {
-            return $content->movie_data['info']['plot'] ?? null;
+            // info['plot'] is where Emby/Jellyfin VOD metadata lands;
+            // movie_data is the older/alternative structure — check both.
+            return $content->info['plot']
+                ?? $content->info['description']
+                ?? $content->movie_data['info']['plot']
+                ?? $content->movie_data['info']['description']
+                ?? null;
         }
 
         return null;
@@ -447,7 +644,7 @@ class NetworkScheduleService
 
     /**
      * Get the image URL for a content item.
-     * Uses LogoService where applicable to ensure proper proxying.
+     * For VOD channels, prefers the media-server poster over the generic channel logo.
      */
     protected function getContentImage(Episode|Channel $content): ?string
     {
@@ -467,13 +664,25 @@ class NetworkScheduleService
         }
 
         if ($content instanceof Channel) {
-            // Try multiple sources for channel/VOD images
+            if ($content->is_vod) {
+                // For VOD, prefer the movie poster from metadata over the generic channel logo.
+                return $content->info['cover_big']
+                    ?? $content->info['movie_image']
+                    ?? $content->movie_data['info']['cover_big']
+                    ?? $content->movie_data['info']['movie_image']
+                    ?? $content->logo
+                    ?? $content->logo_internal
+                    ?? null;
+            }
+
+            // For live channels, logo is the correct channel icon.
             return $content->logo
                 ?? $content->logo_internal
-                ?? $content->movie_data['info']['cover_big'] ?? null
-                ?? $content->movie_data['info']['movie_image'] ?? null
-                ?? $content->info['cover_big'] ?? null
-                ?? $content->info['movie_image'] ?? null;
+                ?? $content->movie_data['info']['cover_big']
+                ?? $content->movie_data['info']['movie_image']
+                ?? $content->info['cover_big']
+                ?? $content->info['movie_image']
+                ?? null;
         }
 
         return null;

--- a/app/Services/NetworkScheduleService.php
+++ b/app/Services/NetworkScheduleService.php
@@ -127,6 +127,15 @@ class NetworkScheduleService
 
             $contentCount = $contentItems->count();
 
+            // Network has pinned content only — no rotation items. Pinned
+            // occurrences have already been pre-placed above; skip the
+            // rotation loop to avoid an undefined-array-key on $contentItems[0].
+            if ($contentCount === 0) {
+                $network->update(['schedule_generated_at' => Carbon::now()]);
+
+                return;
+            }
+
             while ($currentTime->lt($endAt)) {
                 // If a programme already exists that starts exactly at this time, skip creating it
                 $existingProgramme = $network->programmes()->where('start_time', $currentTime)->first();

--- a/database/migrations/2026_06_30_104923_add_pin_fields_to_network_content_table.php
+++ b/database/migrations/2026_06_30_104923_add_pin_fields_to_network_content_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('network_content', function (Blueprint $table) {
+            $table->string('pin_day_of_week')->nullable()->after('weight');
+            $table->string('pin_time_of_day')->nullable()->after('pin_day_of_week');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('network_content', function (Blueprint $table) {
+            $table->dropColumn(['pin_day_of_week', 'pin_time_of_day']);
+        });
+    }
+};

--- a/database/migrations/2026_07_02_103505_add_chain_id_to_network_content_table.php
+++ b/database/migrations/2026_07_02_103505_add_chain_id_to_network_content_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('network_content', function (Blueprint $table) {
+            $table->unsignedBigInteger('chain_id')->nullable()->after('pin_time_of_day');
+            $table->index('chain_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('network_content', function (Blueprint $table) {
+            $table->dropIndex(['chain_id']);
+            $table->dropColumn('chain_id');
+        });
+    }
+};

--- a/tests/Feature/NetworkContentChainRelationManagerTest.php
+++ b/tests/Feature/NetworkContentChainRelationManagerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use App\Filament\Resources\Networks\Pages\EditNetwork;
+use App\Filament\Resources\Networks\RelationManagers\NetworkContentRelationManager;
+use App\Models\Channel;
+use App\Models\Network;
+use App\Models\NetworkContent;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Queue::fake();
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+/**
+ * @param  array<string, mixed>  $attrs
+ */
+function makeChainRmContent(Network $network, array $attrs = []): NetworkContent
+{
+    $channel = Channel::factory()->create();
+
+    return NetworkContent::withoutEvents(fn () => NetworkContent::create(array_merge([
+        'network_id' => $network->id,
+        'contentable_type' => Channel::class,
+        'contentable_id' => $channel->id,
+        'sort_order' => 1,
+        'weight' => 1,
+    ], $attrs)));
+}
+
+it('shows link and unlink chain bulk actions on the content table', function () {
+    $network = Network::factory()->create(['user_id' => $this->user->id]);
+
+    Livewire::test(NetworkContentRelationManager::class, [
+        'ownerRecord' => $network,
+        'pageClass' => EditNetwork::class,
+    ])
+        ->assertTableBulkActionExists('linkAsChain')
+        ->assertTableBulkActionExists('unlinkChain');
+});
+
+it('sets a shared chain_id on selected records via linkAsChain', function () {
+    $network = Network::factory()->create(['user_id' => $this->user->id]);
+
+    $a = makeChainRmContent($network, ['sort_order' => 2]);
+    $b = makeChainRmContent($network, ['sort_order' => 1]);
+    $c = makeChainRmContent($network, ['sort_order' => 3]);
+
+    Livewire::test(NetworkContentRelationManager::class, [
+        'ownerRecord' => $network,
+        'pageClass' => EditNetwork::class,
+    ])->callTableBulkAction('linkAsChain', [$a, $b, $c]);
+
+    $a->refresh();
+    $b->refresh();
+    $c->refresh();
+
+    expect($a->chain_id)->not->toBeNull()
+        ->and($a->chain_id)->toBe($b->chain_id)
+        ->and($a->chain_id)->toBe($c->chain_id)
+        // b has the lowest sort_order among the selection, so it becomes the token.
+        ->and($a->chain_id)->toBe($b->id);
+});
+
+it('does not chain a selection of fewer than 2 records', function () {
+    $network = Network::factory()->create(['user_id' => $this->user->id]);
+    $a = makeChainRmContent($network);
+
+    Livewire::test(NetworkContentRelationManager::class, [
+        'ownerRecord' => $network,
+        'pageClass' => EditNetwork::class,
+    ])->callTableBulkAction('linkAsChain', [$a]);
+
+    expect($a->fresh()->chain_id)->toBeNull();
+});
+
+it('rejects linking a selection containing a pinned item', function () {
+    $network = Network::factory()->create(['user_id' => $this->user->id]);
+
+    $a = makeChainRmContent($network);
+    $pinned = makeChainRmContent($network, [
+        'pin_day_of_week' => 'friday',
+        'pin_time_of_day' => '20:00',
+    ]);
+
+    Livewire::test(NetworkContentRelationManager::class, [
+        'ownerRecord' => $network,
+        'pageClass' => EditNetwork::class,
+    ])->callTableBulkAction('linkAsChain', [$a, $pinned]);
+
+    expect($a->fresh()->chain_id)->toBeNull()
+        ->and($pinned->fresh()->chain_id)->toBeNull();
+});
+
+it('vacates and singleton-cleans the old chain when re-chaining a member elsewhere', function () {
+    $network = Network::factory()->create(['user_id' => $this->user->id]);
+
+    // Chain A: three members.
+    $a1 = makeChainRmContent($network, ['sort_order' => 1]);
+    $a2 = makeChainRmContent($network, ['sort_order' => 2]);
+    $a3 = makeChainRmContent($network, ['sort_order' => 3]);
+    $a1->update(['chain_id' => $a1->id]);
+    $a2->update(['chain_id' => $a1->id]);
+    $a3->update(['chain_id' => $a1->id]);
+
+    // Pull a3 into a brand-new chain with an unrelated item.
+    $other = makeChainRmContent($network, ['sort_order' => 4]);
+
+    Livewire::test(NetworkContentRelationManager::class, [
+        'ownerRecord' => $network,
+        'pageClass' => EditNetwork::class,
+    ])->callTableBulkAction('linkAsChain', [$a3, $other]);
+
+    // Old chain A had 2 members left (a1, a2) — singleton rule doesn't apply
+    // since 2 remain, so they should still be chained together.
+    expect($a1->fresh()->chain_id)->toBe($a2->fresh()->chain_id)
+        ->and($a3->fresh()->chain_id)->toBe($other->fresh()->chain_id)
+        ->and($a1->fresh()->chain_id)->not->toBe($a3->fresh()->chain_id);
+});
+
+it('clears chain_id on selected records via unlinkChain', function () {
+    $network = Network::factory()->create(['user_id' => $this->user->id]);
+
+    $a = makeChainRmContent($network, ['sort_order' => 1]);
+    $b = makeChainRmContent($network, ['sort_order' => 2]);
+    $c = makeChainRmContent($network, ['sort_order' => 3]);
+    $a->update(['chain_id' => $a->id]);
+    $b->update(['chain_id' => $a->id]);
+    $c->update(['chain_id' => $a->id]);
+
+    Livewire::test(NetworkContentRelationManager::class, [
+        'ownerRecord' => $network,
+        'pageClass' => EditNetwork::class,
+    ])->callTableBulkAction('unlinkChain', [$a, $b, $c]);
+
+    expect($a->fresh()->chain_id)->toBeNull()
+        ->and($b->fresh()->chain_id)->toBeNull()
+        ->and($c->fresh()->chain_id)->toBeNull();
+});
+
+it('leaves unchained records untouched when unlinkChain is called on a mixed selection', function () {
+    $network = Network::factory()->create(['user_id' => $this->user->id]);
+
+    $a = makeChainRmContent($network, ['sort_order' => 1]);
+    $b = makeChainRmContent($network, ['sort_order' => 2]);
+    $a->update(['chain_id' => $a->id]);
+    $b->update(['chain_id' => $a->id]);
+
+    $unchained = makeChainRmContent($network, ['sort_order' => 3]);
+
+    Livewire::test(NetworkContentRelationManager::class, [
+        'ownerRecord' => $network,
+        'pageClass' => EditNetwork::class,
+    ])->callTableBulkAction('unlinkChain', [$a, $b, $unchained]);
+
+    expect($a->fresh()->chain_id)->toBeNull()
+        ->and($b->fresh()->chain_id)->toBeNull()
+        ->and($unchained->fresh()->chain_id)->toBeNull();
+});

--- a/tests/Feature/NetworkContentChainTest.php
+++ b/tests/Feature/NetworkContentChainTest.php
@@ -1,0 +1,258 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Network;
+use App\Models\NetworkContent;
+use App\Models\NetworkProgramme;
+use App\Services\NetworkScheduleService;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    Queue::fake();
+});
+
+/**
+ * Helper: create a Channel with a known duration.
+ */
+function makeChainChannel(int $durationSeconds = 1800): Channel
+{
+    return Channel::factory()->create([
+        'is_vod' => true,
+        'info' => ['duration_secs' => $durationSeconds],
+    ]);
+}
+
+/**
+ * Helper: add a channel to a network as NetworkContent.
+ *
+ * @param  array<string, mixed>  $attrs
+ */
+function addChainContent(Network $network, Channel $channel, array $attrs = []): NetworkContent
+{
+    return NetworkContent::withoutEvents(function () use ($network, $channel, $attrs) {
+        return NetworkContent::create(array_merge([
+            'network_id' => $network->id,
+            'contentable_type' => Channel::class,
+            'contentable_id' => $channel->id,
+            'sort_order' => 1,
+            'weight' => 1,
+        ], $attrs));
+    });
+}
+
+/**
+ * Helper: the ordered sequence of contentable_id from a network's generated programmes.
+ *
+ * @return array<int, int>
+ */
+function programmeContentableIds(Network $network): array
+{
+    return NetworkProgramme::where('network_id', $network->id)
+        ->orderBy('start_time')
+        ->pluck('contentable_id')
+        ->all();
+}
+
+it('isChained returns false when chain_id is null, true when set', function () {
+    $nc = new NetworkContent(['chain_id' => null]);
+    expect($nc->isChained())->toBeFalse();
+
+    $nc->chain_id = 5;
+    expect($nc->isChained())->toBeTrue();
+});
+
+it('chainMembers returns all rows sharing chain_id ordered by sort_order', function () {
+    $network = Network::factory()->create(['schedule_type' => 'shuffle', 'auto_regenerate_schedule' => false]);
+
+    $a = addChainContent($network, makeChainChannel(), ['sort_order' => 3]);
+    $b = addChainContent($network, makeChainChannel(), ['sort_order' => 1, 'chain_id' => $a->id]);
+    $c = addChainContent($network, makeChainChannel(), ['sort_order' => 2, 'chain_id' => $a->id]);
+    $a->update(['chain_id' => $a->id]);
+
+    $members = $a->chainMembers();
+
+    expect($members->pluck('id')->all())->toBe([$b->id, $c->id, $a->id]);
+});
+
+it('chainLead resolves the lowest-sort_order member, not the row whose id equals chain_id', function () {
+    $network = Network::factory()->create(['schedule_type' => 'shuffle', 'auto_regenerate_schedule' => false]);
+
+    $a = addChainContent($network, makeChainChannel(), ['sort_order' => 5]);
+    $b = addChainContent($network, makeChainChannel(), ['sort_order' => 1, 'chain_id' => $a->id]);
+    $a->update(['chain_id' => $a->id]);
+
+    // chain_id equals $a->id, but $b has the lower sort_order — $b is the lead.
+    expect($a->chainLead()->id)->toBe($b->id)
+        ->and($b->chainLead()->id)->toBe($b->id);
+});
+
+it('chainMembers and chainLead on an unchained item return itself', function () {
+    $network = Network::factory()->create(['schedule_type' => 'shuffle', 'auto_regenerate_schedule' => false]);
+    $nc = addChainContent($network, makeChainChannel());
+
+    expect($nc->chainMembers()->pluck('id')->all())->toBe([$nc->id])
+        ->and($nc->chainLead()->id)->toBe($nc->id);
+});
+
+it('keeps chained items consecutive in shuffle mode across several distinct weeks', function () {
+    $weeks = ['2026-01-05', '2026-01-12', '2026-01-19', '2026-01-26'];
+
+    foreach ($weeks as $week) {
+        Carbon::setTestNow(Carbon::parse($week.' 08:00:00'));
+
+        $network = Network::factory()->create([
+            'schedule_type' => 'shuffle',
+            'loop_content' => true,
+            'schedule_window_days' => 1,
+            'auto_regenerate_schedule' => false,
+        ]);
+
+        $a = addChainContent($network, makeChainChannel(60), ['sort_order' => 1]);
+        $b = addChainContent($network, makeChainChannel(60), ['sort_order' => 2]);
+        $c = addChainContent($network, makeChainChannel(60), ['sort_order' => 3]);
+        $a->update(['chain_id' => $a->id]);
+        $b->update(['chain_id' => $a->id]);
+        $c->update(['chain_id' => $a->id]);
+
+        // Filler so the chain isn't the only content in the pool.
+        addChainContent($network, makeChainChannel(60), ['sort_order' => 4]);
+        addChainContent($network, makeChainChannel(60), ['sort_order' => 5]);
+
+        app(NetworkScheduleService::class)->generateSchedule($network);
+
+        $sequence = programmeContentableIds($network);
+        $chainIds = [$a->contentable_id, $b->contentable_id, $c->contentable_id];
+
+        // Every occurrence of the chain's lead must be immediately followed by
+        // b then c, in that order, with nothing else interleaved.
+        foreach ($sequence as $index => $contentableId) {
+            if ($contentableId === $a->contentable_id) {
+                expect(array_slice($sequence, $index, 3))->toBe($chainIds);
+            }
+        }
+
+        expect($sequence)->not->toBeEmpty();
+    }
+
+    Carbon::setTestNow();
+});
+
+it('applies the chain leads weight to the whole chain as one shuffle unit', function () {
+    Carbon::setTestNow(Carbon::parse('2026-01-05 08:00:00'));
+
+    $network = Network::factory()->create([
+        'schedule_type' => 'shuffle',
+        'loop_content' => true,
+        'schedule_window_days' => 1,
+        'auto_regenerate_schedule' => false,
+    ]);
+
+    // Chain: lead weight 3, second member's own weight is irrelevant once chained.
+    $lead = addChainContent($network, makeChainChannel(60), ['sort_order' => 1, 'weight' => 3]);
+    $second = addChainContent($network, makeChainChannel(60), ['sort_order' => 2, 'weight' => 1]);
+    $second->update(['chain_id' => $lead->id]);
+    $lead->update(['chain_id' => $lead->id]);
+
+    // Unchained item, weight 1 — baseline frequency.
+    $lone = addChainContent($network, makeChainChannel(60), ['sort_order' => 3, 'weight' => 1]);
+
+    app(NetworkScheduleService::class)->generateSchedule($network);
+
+    $chainOccurrences = NetworkProgramme::where('network_id', $network->id)
+        ->where('contentable_id', $lead->contentable_id)
+        ->count();
+
+    $loneOccurrences = NetworkProgramme::where('network_id', $network->id)
+        ->where('contentable_id', $lone->contentable_id)
+        ->count();
+
+    expect($loneOccurrences)->toBeGreaterThan(0);
+
+    $ratio = $chainOccurrences / $loneOccurrences;
+    expect($ratio)->toBeGreaterThan(2.5)->toBeLessThan(3.5);
+
+    Carbon::setTestNow();
+});
+
+it('unchained items do not always land adjacent to each other across different weeks', function () {
+    $weeks = ['2026-02-02', '2026-02-09', '2026-02-16', '2026-02-23', '2026-03-02', '2026-03-09'];
+    $adjacentCount = 0;
+
+    foreach ($weeks as $week) {
+        Carbon::setTestNow(Carbon::parse($week.' 08:00:00'));
+
+        $network = Network::factory()->create([
+            'schedule_type' => 'shuffle',
+            'loop_content' => true,
+            'schedule_window_days' => 1,
+            'auto_regenerate_schedule' => false,
+        ]);
+
+        $x = addChainContent($network, makeChainChannel(60), ['sort_order' => 1]);
+        $y = addChainContent($network, makeChainChannel(60), ['sort_order' => 2]);
+        foreach (range(3, 6) as $i) {
+            addChainContent($network, makeChainChannel(60), ['sort_order' => $i]);
+        }
+
+        app(NetworkScheduleService::class)->generateSchedule($network);
+
+        $sequence = programmeContentableIds($network);
+        $xPos = array_search($x->contentable_id, $sequence, true);
+        $yPos = array_search($y->contentable_id, $sequence, true);
+
+        if (abs($xPos - $yPos) === 1) {
+            $adjacentCount++;
+        }
+    }
+
+    // Unchained same-weight items should not be glued together every single week.
+    expect($adjacentCount)->toBeLessThan(count($weeks));
+
+    Carbon::setTestNow();
+});
+
+it('deleting the lead member of a chain does not orphan or crash scheduling', function () {
+    Carbon::setTestNow(Carbon::parse('2026-01-05 08:00:00'));
+
+    $network = Network::factory()->create([
+        'schedule_type' => 'shuffle',
+        'loop_content' => true,
+        'schedule_window_days' => 1,
+        'auto_regenerate_schedule' => false,
+    ]);
+
+    $a = addChainContent($network, makeChainChannel(60), ['sort_order' => 1]);
+    $b = addChainContent($network, makeChainChannel(60), ['sort_order' => 2]);
+    $c = addChainContent($network, makeChainChannel(60), ['sort_order' => 3]);
+    $a->update(['chain_id' => $a->id]);
+    $b->update(['chain_id' => $a->id]);
+    $c->update(['chain_id' => $a->id]);
+    addChainContent($network, makeChainChannel(60), ['sort_order' => 4]);
+
+    $a->delete();
+
+    app(NetworkScheduleService::class)->generateSchedule($network, forceReset: true);
+
+    $sequence = programmeContentableIds($network);
+    $bPos = array_search($b->contentable_id, $sequence, true);
+    $cPos = array_search($c->contentable_id, $sequence, true);
+
+    expect($bPos)->not->toBeFalse()
+        ->and($cPos)->toBe($bPos + 1);
+
+    Carbon::setTestNow();
+});
+
+it('deleting a chain member down to one survivor auto-clears its chain_id', function () {
+    $network = Network::factory()->create(['schedule_type' => 'shuffle', 'auto_regenerate_schedule' => false]);
+
+    $a = addChainContent($network, makeChainChannel(), ['sort_order' => 1]);
+    $b = addChainContent($network, makeChainChannel(), ['sort_order' => 2]);
+    $a->update(['chain_id' => $a->id]);
+    $b->update(['chain_id' => $a->id]);
+
+    $a->delete();
+
+    expect($b->fresh()->chain_id)->toBeNull();
+});

--- a/tests/Feature/NetworkContentPinSchedulingTest.php
+++ b/tests/Feature/NetworkContentPinSchedulingTest.php
@@ -1,0 +1,285 @@
+<?php
+
+use App\Jobs\RegenerateNetworkSchedule;
+use App\Models\Channel;
+use App\Models\Network;
+use App\Models\NetworkContent;
+use App\Models\NetworkProgramme;
+use App\Services\NetworkScheduleService;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    Queue::fake();
+});
+
+/**
+ * Helper: create a Channel with a known duration.
+ */
+function makePinChannel(int $durationSeconds = 3600): Channel
+{
+    return Channel::factory()->create([
+        'is_vod' => true,
+        'info' => ['duration_secs' => $durationSeconds],
+    ]);
+}
+
+/**
+ * Helper: add a channel to a network as NetworkContent.
+ *
+ * @param  array<string, mixed>  $attrs
+ */
+function addPinContent(Network $network, Channel $channel, array $attrs = []): NetworkContent
+{
+    return NetworkContent::withoutEvents(function () use ($network, $channel, $attrs) {
+        return NetworkContent::create(array_merge([
+            'network_id' => $network->id,
+            'contentable_type' => Channel::class,
+            'contentable_id' => $channel->id,
+            'sort_order' => 1,
+            'weight' => 1,
+        ], $attrs));
+    });
+}
+
+it('places a pinned item at the correct day and time', function () {
+    // Monday 2026-01-05 08:00 UTC
+    Carbon::setTestNow(Carbon::parse('2026-01-05 08:00:00'));
+
+    $network = Network::factory()->create([
+        'schedule_type' => 'sequential',
+        'loop_content' => true,
+        'schedule_window_days' => 7,
+        'auto_regenerate_schedule' => false,
+    ]);
+
+    // Filler content (unpinned)
+    $filler = makePinChannel(1800); // 30 min
+    addPinContent($network, $filler, ['sort_order' => 1]);
+
+    // Movie pinned to Friday at 20:00
+    $movie = makePinChannel(7200); // 2 hours
+    addPinContent($network, $movie, [
+        'sort_order' => 2,
+        'pin_day_of_week' => 'friday',
+        'pin_time_of_day' => '20:00',
+    ]);
+
+    app(NetworkScheduleService::class)->generateSchedule($network);
+
+    // Friday 2026-01-09 20:00
+    $friday8pm = Carbon::parse('2026-01-09 20:00:00');
+
+    $pinnedProgramme = NetworkProgramme::where('network_id', $network->id)
+        ->where('contentable_id', $movie->id)
+        ->first();
+
+    expect($pinnedProgramme)->not->toBeNull()
+        ->and($pinnedProgramme->start_time->toDateTimeString())->toBe($friday8pm->toDateTimeString())
+        ->and($pinnedProgramme->pinned_start_time)->not->toBeNull()
+        ->and($pinnedProgramme->end_time->toDateTimeString())->toBe($friday8pm->copy()->addSeconds(7200)->toDateTimeString());
+});
+
+it('excludes pinned items from normal rotation', function () {
+    Carbon::setTestNow(Carbon::parse('2026-01-05 08:00:00'));
+
+    $network = Network::factory()->create([
+        'schedule_type' => 'sequential',
+        'loop_content' => true,
+        'schedule_window_days' => 7,
+        'auto_regenerate_schedule' => false,
+    ]);
+
+    $filler = makePinChannel(1800);
+    addPinContent($network, $filler, ['sort_order' => 1]);
+
+    $pinned = makePinChannel(3600);
+    addPinContent($network, $pinned, [
+        'sort_order' => 2,
+        'pin_day_of_week' => 'friday',
+        'pin_time_of_day' => '20:00',
+    ]);
+
+    app(NetworkScheduleService::class)->generateSchedule($network);
+
+    // The pinned movie should appear exactly once (its pinned slot)
+    $pinnedOccurrences = NetworkProgramme::where('network_id', $network->id)
+        ->where('contentable_id', $pinned->id)
+        ->count();
+
+    expect($pinnedOccurrences)->toBe(1);
+
+    // The filler should fill the rest (not pinned to a fixed time)
+    $fillerOccurrences = NetworkProgramme::where('network_id', $network->id)
+        ->where('contentable_id', $filler->id)
+        ->count();
+
+    expect($fillerOccurrences)->toBeGreaterThan(0);
+});
+
+it('leaves a gap when filler does not fit before a pinned slot', function () {
+    // Wednesday 2026-01-07 20:00 — pin is Friday 20:00 (2 days away)
+    Carbon::setTestNow(Carbon::parse('2026-01-07 20:00:00'));
+
+    $network = Network::factory()->create([
+        'schedule_type' => 'sequential',
+        'loop_content' => true,
+        'schedule_window_days' => 7,
+        'auto_regenerate_schedule' => false,
+    ]);
+
+    // Filler is a 90-minute item
+    $filler = makePinChannel(5400); // 90 min
+    addPinContent($network, $filler, ['sort_order' => 1]);
+
+    // Movie pinned to Friday at 20:00
+    $movie = makePinChannel(7200);
+    addPinContent($network, $movie, [
+        'sort_order' => 2,
+        'pin_day_of_week' => 'friday',
+        'pin_time_of_day' => '20:00',
+    ]);
+
+    app(NetworkScheduleService::class)->generateSchedule($network);
+
+    // Confirm no filler programme overlaps the pinned start (2026-01-09 20:00)
+    $friday8pm = Carbon::parse('2026-01-09 20:00:00');
+
+    $overlap = NetworkProgramme::where('network_id', $network->id)
+        ->where('contentable_id', $filler->id)
+        ->where('start_time', '<', $friday8pm)
+        ->where('end_time', '>', $friday8pm)
+        ->count();
+
+    expect($overlap)->toBe(0);
+
+    // Pinned programme is still in place
+    $pinnedProgramme = NetworkProgramme::where('network_id', $network->id)
+        ->whereNotNull('pinned_start_time')
+        ->first();
+
+    expect($pinnedProgramme)->not->toBeNull()
+        ->and($pinnedProgramme->start_time->toDateTimeString())->toBe($friday8pm->toDateTimeString());
+});
+
+it('skips a colliding pinned item when two share the same slot', function () {
+    Carbon::setTestNow(Carbon::parse('2026-01-05 08:00:00'));
+
+    $network = Network::factory()->create([
+        'schedule_type' => 'sequential',
+        'loop_content' => true,
+        'schedule_window_days' => 7,
+        'auto_regenerate_schedule' => false,
+    ]);
+
+    $filler = makePinChannel(1800);
+    addPinContent($network, $filler, ['sort_order' => 1]);
+
+    // Two items both pinned to Friday 20:00 — sort_order 2 wins, sort_order 3 is skipped
+    $winner = makePinChannel(7200);
+    addPinContent($network, $winner, [
+        'sort_order' => 2,
+        'pin_day_of_week' => 'friday',
+        'pin_time_of_day' => '20:00',
+    ]);
+
+    $loser = makePinChannel(3600);
+    addPinContent($network, $loser, [
+        'sort_order' => 3,
+        'pin_day_of_week' => 'friday',
+        'pin_time_of_day' => '20:00',
+    ]);
+
+    app(NetworkScheduleService::class)->generateSchedule($network);
+
+    $friday8pm = Carbon::parse('2026-01-09 20:00:00');
+
+    // Winner placed at pin time
+    $winnerProgramme = NetworkProgramme::where('network_id', $network->id)
+        ->where('contentable_id', $winner->id)
+        ->whereNotNull('pinned_start_time')
+        ->first();
+    expect($winnerProgramme)->not->toBeNull()
+        ->and($winnerProgramme->start_time->toDateTimeString())->toBe($friday8pm->toDateTimeString());
+
+    // Loser not placed at Friday 20:00
+    $loserAtPin = NetworkProgramme::where('network_id', $network->id)
+        ->where('contentable_id', $loser->id)
+        ->where('start_time', $friday8pm)
+        ->first();
+    expect($loserAtPin)->toBeNull();
+});
+
+it('sets pinned_start_time on the programme record', function () {
+    Carbon::setTestNow(Carbon::parse('2026-01-05 08:00:00'));
+
+    $network = Network::factory()->create([
+        'schedule_type' => 'sequential',
+        'loop_content' => true,
+        'schedule_window_days' => 7,
+        'auto_regenerate_schedule' => false,
+    ]);
+
+    $filler = makePinChannel(1800);
+    addPinContent($network, $filler, ['sort_order' => 1]);
+
+    $movie = makePinChannel(3600);
+    addPinContent($network, $movie, [
+        'sort_order' => 2,
+        'pin_day_of_week' => 'saturday',
+        'pin_time_of_day' => '15:30',
+    ]);
+
+    app(NetworkScheduleService::class)->generateSchedule($network);
+
+    $programme = NetworkProgramme::where('network_id', $network->id)
+        ->where('contentable_id', $movie->id)
+        ->first();
+
+    expect($programme)->not->toBeNull()
+        ->and($programme->pinned_start_time)->not->toBeNull();
+});
+
+it('regenerates schedule when pin fields are updated', function () {
+    Queue::fake();
+
+    $network = Network::factory()->create([
+        'schedule_type' => 'sequential',
+        'loop_content' => true,
+        'auto_regenerate_schedule' => true,
+    ]);
+
+    $channel = makePinChannel(3600);
+    $nc = NetworkContent::create([
+        'network_id' => $network->id,
+        'contentable_type' => Channel::class,
+        'contentable_id' => $channel->id,
+        'sort_order' => 1,
+        'weight' => 1,
+    ]);
+
+    Queue::assertPushed(RegenerateNetworkSchedule::class);
+    Queue::fake(); // Reset
+
+    // Updating sort_order should NOT trigger regen (pin fields not changed)
+    $nc->update(['sort_order' => 2]);
+    Queue::assertNotPushed(RegenerateNetworkSchedule::class);
+
+    // Updating a pin field SHOULD trigger regen
+    $nc->update(['pin_day_of_week' => 'friday', 'pin_time_of_day' => '20:00']);
+    Queue::assertPushed(RegenerateNetworkSchedule::class);
+});
+
+it('isPinned returns true only when both fields are set', function () {
+    $nc = new NetworkContent([
+        'pin_day_of_week' => null,
+        'pin_time_of_day' => null,
+    ]);
+    expect($nc->isPinned())->toBeFalse();
+
+    $nc->pin_day_of_week = 'friday';
+    expect($nc->isPinned())->toBeFalse();
+
+    $nc->pin_time_of_day = '20:00';
+    expect($nc->isPinned())->toBeTrue();
+});

--- a/tests/Feature/NetworkContentPinSchedulingTest.php
+++ b/tests/Feature/NetworkContentPinSchedulingTest.php
@@ -283,3 +283,65 @@ it('isPinned returns true only when both fields are set', function () {
     $nc->pin_time_of_day = '20:00';
     expect($nc->isPinned())->toBeTrue();
 });
+
+it('generates a schedule when the network contains only pinned content', function () {
+    // Regression: previously crashed with an undefined-array-key error on
+    // $contentItems[$contentIndex] because the rotation loop ran against an
+    // empty $contentItems when every NetworkContent row was pinned.
+    Carbon::setTestNow(Carbon::parse('2026-01-05 08:00:00'));
+
+    $network = Network::factory()->create([
+        'schedule_type' => 'sequential',
+        'loop_content' => true,
+        'schedule_window_days' => 7,
+        'auto_regenerate_schedule' => false,
+    ]);
+
+    // Only pinned content — no rotation items at all.
+    $movie = makePinChannel(7200); // 2 hours
+    addPinContent($network, $movie, [
+        'sort_order' => 1,
+        'pin_day_of_week' => 'friday',
+        'pin_time_of_day' => '20:00',
+    ]);
+
+    $generated = app(NetworkScheduleService::class)->generateSchedule($network);
+
+    $friday8pm = Carbon::parse('2026-01-09 20:00:00');
+
+    $pinnedProgramme = NetworkProgramme::where('network_id', $network->id)
+        ->where('contentable_id', $movie->id)
+        ->first();
+
+    expect($generated)->toBe(1)
+        ->and($pinnedProgramme)->not->toBeNull()
+        ->and($pinnedProgramme->start_time->toDateTimeString())->toBe($friday8pm->toDateTimeString())
+        ->and($pinnedProgramme->end_time->toDateTimeString())->toBe($friday8pm->copy()->addSeconds(7200)->toDateTimeString())
+        ->and($pinnedProgramme->pinned_start_time)->not->toBeNull()
+        ->and($network->refresh()->schedule_generated_at)->not->toBeNull();
+});
+
+it('generates a schedule when the network contains only pinned content in shuffle mode', function () {
+    // Same regression but in shuffle mode — getOrderedContent() still
+    // returns an empty Collection, the guard must short-circuit there too.
+    Carbon::setTestNow(Carbon::parse('2026-01-05 08:00:00'));
+
+    $network = Network::factory()->create([
+        'schedule_type' => 'shuffle',
+        'loop_content' => true,
+        'schedule_window_days' => 7,
+        'auto_regenerate_schedule' => false,
+    ]);
+
+    $movie = makePinChannel(3600); // 1 hour
+    addPinContent($network, $movie, [
+        'sort_order' => 1,
+        'pin_day_of_week' => 'saturday',
+        'pin_time_of_day' => '15:30',
+    ]);
+
+    $generated = app(NetworkScheduleService::class)->generateSchedule($network);
+
+    expect($generated)->toBe(1)
+        ->and(NetworkProgramme::where('network_id', $network->id)->count())->toBe(1);
+});

--- a/tests/Feature/NetworkContentScheduleRegenerationTest.php
+++ b/tests/Feature/NetworkContentScheduleRegenerationTest.php
@@ -162,6 +162,65 @@ it('dispatches regeneration job when episodes are added', function () {
     });
 });
 
+it('dispatches regeneration job when chain_id is updated', function () {
+    $network = Network::factory()->create([
+        'schedule_type' => 'shuffle',
+        'loop_content' => true,
+        'auto_regenerate_schedule' => true,
+    ]);
+
+    $channelA = Channel::factory()->create();
+    $channelB = Channel::factory()->create();
+
+    $ncA = NetworkContent::withoutEvents(fn () => NetworkContent::create([
+        'network_id' => $network->id,
+        'contentable_type' => Channel::class,
+        'contentable_id' => $channelA->id,
+        'sort_order' => 1,
+        'weight' => 1,
+    ]));
+
+    $ncB = NetworkContent::withoutEvents(fn () => NetworkContent::create([
+        'network_id' => $network->id,
+        'contentable_type' => Channel::class,
+        'contentable_id' => $channelB->id,
+        'sort_order' => 2,
+        'weight' => 1,
+    ]));
+
+    Bus::fake();
+
+    $ncB->update(['chain_id' => $ncA->id]);
+
+    Bus::assertDispatched(RegenerateNetworkSchedule::class, function ($job) use ($network) {
+        return $job->networkId === $network->id;
+    });
+});
+
+it('does not dispatch regeneration job when sort_order alone is updated', function () {
+    $network = Network::factory()->create([
+        'schedule_type' => 'sequential',
+        'loop_content' => true,
+        'auto_regenerate_schedule' => true,
+    ]);
+
+    $channel = Channel::factory()->create();
+
+    $nc = NetworkContent::withoutEvents(fn () => NetworkContent::create([
+        'network_id' => $network->id,
+        'contentable_type' => Channel::class,
+        'contentable_id' => $channel->id,
+        'sort_order' => 1,
+        'weight' => 1,
+    ]));
+
+    Bus::fake();
+
+    $nc->update(['sort_order' => 5]);
+
+    Bus::assertNotDispatched(RegenerateNetworkSchedule::class);
+});
+
 it('dispatches regeneration job for mixed content types', function () {
     $network = Network::factory()->create([
         'schedule_type' => 'sequential',

--- a/tests/Feature/NetworkContentWeightInlineEditTest.php
+++ b/tests/Feature/NetworkContentWeightInlineEditTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Filament\Resources\Networks\Pages\EditNetwork;
+use App\Filament\Resources\Networks\RelationManagers\NetworkContentRelationManager;
+use App\Models\Channel;
+use App\Models\Network;
+use App\Models\NetworkContent;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Queue::fake();
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('updates weight inline from the network content table', function () {
+    $network = Network::factory()->create(['user_id' => $this->user->id]);
+    $channel = Channel::factory()->create();
+
+    $content = NetworkContent::withoutEvents(fn () => NetworkContent::create([
+        'network_id' => $network->id,
+        'contentable_type' => Channel::class,
+        'contentable_id' => $channel->id,
+        'sort_order' => 1,
+        'weight' => 1,
+    ]));
+
+    Livewire::test(NetworkContentRelationManager::class, [
+        'ownerRecord' => $network,
+        'pageClass' => EditNetwork::class,
+    ])
+        ->assertTableColumnExists('weight')
+        ->call('updateTableColumnState', 'weight', (string) $content->getKey(), '5');
+
+    expect($content->refresh()->weight)->toBe(5);
+});
+
+it('rejects a weight below the minimum via inline edit', function () {
+    $network = Network::factory()->create(['user_id' => $this->user->id]);
+    $channel = Channel::factory()->create();
+
+    $content = NetworkContent::withoutEvents(fn () => NetworkContent::create([
+        'network_id' => $network->id,
+        'contentable_type' => Channel::class,
+        'contentable_id' => $channel->id,
+        'sort_order' => 1,
+        'weight' => 3,
+    ]));
+
+    Livewire::test(NetworkContentRelationManager::class, [
+        'ownerRecord' => $network,
+        'pageClass' => EditNetwork::class,
+    ])->call('updateTableColumnState', 'weight', (string) $content->getKey(), '0');
+
+    expect($content->refresh()->weight)->toBe(3);
+});


### PR DESCRIPTION
## Summary
Split out of #1253 per review feedback (item 4 in the requested split).

- Add `pin_day_of_week`/`pin_time_of_day` and `chain_id` columns to `network_content`, for weekly time-slot pinning and consecutive playback chaining.
- `NetworkScheduleService` pre-places pinned content at anchored day+time slots and groups chained items so they always play as one shuffle unit; also picks up VOD title/description/poster from the richer metadata fields where available.
- `NetworkContentRelationManager`: inline weight editing, chain_id indicator column, pin day/time columns, and Link/Unlink Chain bulk actions.
- `NetworkResource`: "Generate Schedule" now offers continue-from-current-position vs. fresh-start modes; `media_server_integration_id` locks once content has been added to a network.
- `NetworkContentPinTool`: Copilot tool to pin/unpin content to a weekly timeslot by `network_content_id`, registered in Preferences and documented in the Copilot system prompt.

**Deviation from the suggested split:** `NetworkContentPinTool` was moved here from the housekeeping/CopilotTools PR (#1267), since it hard-depends on the `pin_day_of_week`/`pin_time_of_day` columns added in this PR and can't be tested independently of them.

## Test plan
- [x] Built independently off `experimental`
- [x] `vendor/bin/pint` clean
- [x] Own test suite passes: `NetworkContentChainRelationManagerTest`, `NetworkContentChainTest`, `NetworkContentPinSchedulingTest`, `NetworkContentScheduleRegenerationTest`, `NetworkContentWeightInlineEditTest` (34 passed)
- [x] Existing `NetworkResourceBulkBroadcastActionsTest` still passes (no regression from the Generate Schedule action changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)