### PR TITLE
fix: apply auto-sort channel numbers to existing channels on sync

### DIFF
--- a/app/Jobs/ProcessM3uImport.php
+++ b/app/Jobs/ProcessM3uImport.php
@@ -1183,6 +1183,7 @@ class ProcessM3uImport implements ShouldQueue
         if ($playlist->auto_sort_groups) {
             $groupOrder = 1;
         }
+        $autoSort = $playlist->auto_sort;
 
         // Determine if we should create the channels and groups in the database
         $preProcessingLive = $this->preprocess
@@ -1191,8 +1192,8 @@ class ProcessM3uImport implements ShouldQueue
 
         // Process live streams collection
         if ($liveStreamsEnabled && $liveCollection) {
-            $liveCollection->groupBy('group')->chunk(10)->each(function (LazyCollection $grouped) use ($userId, $playlistId, $batchNo, $preProcessingLive, &$groupOrder, $liveGroupsByName) {
-                $grouped->each(function ($channels, $groupName) use ($userId, $playlistId, $batchNo, $preProcessingLive, &$groupOrder, $liveGroupsByName) {
+            $liveCollection->groupBy('group')->chunk(10)->each(function (LazyCollection $grouped) use ($userId, $playlistId, $batchNo, $preProcessingLive, &$groupOrder, $liveGroupsByName, $autoSort) {
+                $grouped->each(function ($channels, $groupName) use ($userId, $playlistId, $batchNo, $preProcessingLive, &$groupOrder, $liveGroupsByName, $autoSort) {
                     // Add group and associated channels
                     if (! $preProcessingLive) {
                         // For Xtream, try matching by stable source_group_id first so groups
@@ -1255,7 +1256,7 @@ class ProcessM3uImport implements ShouldQueue
                             }
                             $group->update($data);
                         }
-                        $channels->chunk(50)->each(function ($chunk) use ($playlistId, $batchNo, $group) {
+                        $channels->chunk(50)->each(function ($chunk) use ($playlistId, $batchNo, $group, $autoSort) {
                             Job::create([
                                 'title' => "Processing live channel import for group: {$group->name}",
                                 'batch_no' => $batchNo,
@@ -1265,6 +1266,7 @@ class ProcessM3uImport implements ShouldQueue
                                     'groupName' => $group->name,
                                     'playlistId' => $playlistId,
                                     'type' => 'live', // Mark as live job
+                                    'autoSort' => $autoSort,
                                 ],
                             ]);
                         });
@@ -1280,8 +1282,8 @@ class ProcessM3uImport implements ShouldQueue
 
         // Process VOD streams collection
         if ($vodStreamsEnabled && $vodCollection) {
-            $vodCollection->groupBy('group')->chunk(10)->each(function (LazyCollection $grouped) use ($userId, $playlistId, $batchNo, $preProcessingVod, &$groupOrder, $vodGroupsByName) {
-                $grouped->each(function ($channels, $groupName) use ($userId, $playlistId, $batchNo, $preProcessingVod, &$groupOrder, $vodGroupsByName) {
+            $vodCollection->groupBy('group')->chunk(10)->each(function (LazyCollection $grouped) use ($userId, $playlistId, $batchNo, $preProcessingVod, &$groupOrder, $vodGroupsByName, $autoSort) {
+                $grouped->each(function ($channels, $groupName) use ($userId, $playlistId, $batchNo, $preProcessingVod, &$groupOrder, $vodGroupsByName, $autoSort) {
                     // Add group and associated channels
                     if (! $preProcessingVod) {
                         // For Xtream, try matching by stable source_group_id first so groups
@@ -1344,7 +1346,7 @@ class ProcessM3uImport implements ShouldQueue
                             }
                             $group->update($data);
                         }
-                        $channels->chunk(50)->each(function ($chunk) use ($playlistId, $batchNo, $group) {
+                        $channels->chunk(50)->each(function ($chunk) use ($playlistId, $batchNo, $group, $autoSort) {
                             Job::create([
                                 'title' => "Processing VOD channel import for group: {$group->name}",
                                 'batch_no' => $batchNo,
@@ -1354,6 +1356,7 @@ class ProcessM3uImport implements ShouldQueue
                                     'groupName' => $group->name,
                                     'playlistId' => $playlistId,
                                     'type' => 'vod', // Mark as VOD job
+                                    'autoSort' => $autoSort,
                                 ],
                             ]);
                         });
@@ -1724,6 +1727,7 @@ class ProcessM3uImport implements ShouldQueue
         if ($playlist->auto_sort) {
             $groupOrder = 1;
         }
+        $autoSort = $playlist->auto_sort;
 
         // Determine if we should create the channels and groups in the database
         $preProcessing = $this->preprocess
@@ -1731,8 +1735,8 @@ class ProcessM3uImport implements ShouldQueue
             && count($this->includedGroupPrefixes) === 0;
 
         // Process the collection
-        $collection->groupBy('group')->chunk(10)->each(function (LazyCollection $grouped) use ($userId, $playlistId, $batchNo, $preProcessing, &$groupOrder) {
-            $grouped->each(function ($channels, $groupName) use ($userId, $playlistId, $batchNo, $preProcessing, &$groupOrder) {
+        $collection->groupBy('group')->chunk(10)->each(function (LazyCollection $grouped) use ($userId, $playlistId, $batchNo, $preProcessing, &$groupOrder, $autoSort) {
+            $grouped->each(function ($channels, $groupName) use ($userId, $playlistId, $batchNo, $preProcessing, &$groupOrder, $autoSort) {
                 // Add group and associated channels
                 if (! $preProcessing) {
                     $group = Group::withTrashed()->where([
@@ -1770,7 +1774,7 @@ class ProcessM3uImport implements ShouldQueue
                         }
                         $group->update($data);
                     }
-                    $channels->chunk(50)->each(function ($chunk) use ($playlistId, $batchNo, $group) {
+                    $channels->chunk(50)->each(function ($chunk) use ($playlistId, $batchNo, $group, $autoSort) {
                         Job::create([
                             'title' => "Processing channel import for group: {$group->name}",
                             'batch_no' => $batchNo,
@@ -1779,6 +1783,7 @@ class ProcessM3uImport implements ShouldQueue
                                 'groupId' => $group->id,
                                 'groupName' => $group->name,
                                 'playlistId' => $playlistId,
+                                'autoSort' => $autoSort,
                             ],
                         ]);
                     });

--- a/app/Jobs/ProcessM3uImportChunk.php
+++ b/app/Jobs/ProcessM3uImportChunk.php
@@ -100,8 +100,7 @@ class ProcessM3uImportChunk implements ShouldQueue
                 ->values()
                 ->toArray();
 
-            // Upsert the channels
-            Channel::upsert($bulk, uniqueBy: ['source_id', 'playlist_id'], update: [
+            $updateColumns = [
                 // Don't update the following fields...
                 // 'title_custom',
                 // 'name_custom',
@@ -114,7 +113,6 @@ class ProcessM3uImportChunk implements ShouldQueue
                 // 'enabled',
                 // 'epg_channel_id',
                 // 'new',
-                // 'sort',
                 // 'station_id', // Gracenote station ID
                 // 'source_id', // won't change - for Xtream API this will be the `stream_id`, for M3U it will be a hash of the title, name, group and playlist ID
                 // ...only update the following fields
@@ -138,7 +136,17 @@ class ProcessM3uImportChunk implements ShouldQueue
                 'year', // new field for year
                 'rating', // new field for rating
                 'rating_5based', // new field for 5-based rating
-            ]);
+            ];
+
+            // Rows carry a provider-order `sort` value only when the playlist has
+            // auto-sort enabled; propagate it so existing channels are re-sorted on
+            // sync (manual sort stays untouched when auto-sort is disabled).
+            if (! empty($bulk) && array_key_exists('sort', $bulk[0])) {
+                $updateColumns[] = 'sort';
+            }
+
+            // Upsert the channels
+            Channel::upsert($bulk, uniqueBy: ['source_id', 'playlist_id'], update: $updateColumns);
         }
     }
 }

--- a/app/Jobs/ProcessM3uImportChunk.php
+++ b/app/Jobs/ProcessM3uImportChunk.php
@@ -138,10 +138,7 @@ class ProcessM3uImportChunk implements ShouldQueue
                 'rating_5based', // new field for 5-based rating
             ];
 
-            // Rows carry a provider-order `sort` value only when the playlist has
-            // auto-sort enabled; propagate it so existing channels are re-sorted on
-            // sync (manual sort stays untouched when auto-sort is disabled).
-            if (! empty($bulk) && array_key_exists('sort', $bulk[0])) {
+            if ($job->variables['autoSort'] ?? false) {
                 $updateColumns[] = 'sort';
             }
 

--- a/app/Jobs/ProcessM3uVodImportChunk.php
+++ b/app/Jobs/ProcessM3uVodImportChunk.php
@@ -137,10 +137,7 @@ class ProcessM3uVodImportChunk implements ShouldQueue
                 'rating_5based', // new field for 5-based rating
             ];
 
-            // Rows carry a provider-order `sort` value only when the playlist has
-            // auto-sort enabled; propagate it so existing channels are re-sorted on
-            // sync (manual sort stays untouched when auto-sort is disabled).
-            if (! empty($bulk) && array_key_exists('sort', $bulk[0])) {
+            if ($job->variables['autoSort'] ?? false) {
                 $updateColumns[] = 'sort';
             }
 

--- a/app/Jobs/ProcessM3uVodImportChunk.php
+++ b/app/Jobs/ProcessM3uVodImportChunk.php
@@ -100,8 +100,7 @@ class ProcessM3uVodImportChunk implements ShouldQueue
                 ->values()
                 ->toArray();
 
-            // Upsert the channels
-            Channel::upsert($bulk, uniqueBy: ['source_id', 'playlist_id'], update: [
+            $updateColumns = [
                 // Don't update the following fields...
                 // 'title_custom',
                 // 'name_custom',
@@ -114,7 +113,6 @@ class ProcessM3uVodImportChunk implements ShouldQueue
                 // 'enabled',
                 // 'epg_channel_id',
                 // 'new',
-                // 'sort',
                 // 'station_id', // Gracenote station ID
                 // 'source_id', // won't change - for Xtream API this will be the `stream_id`, for M3U it will be a hash of the title, name, group and playlist ID
                 // ...only update the following fields
@@ -137,7 +135,17 @@ class ProcessM3uVodImportChunk implements ShouldQueue
                 'year', // new field for year
                 'rating', // new field for rating
                 'rating_5based', // new field for 5-based rating
-            ]);
+            ];
+
+            // Rows carry a provider-order `sort` value only when the playlist has
+            // auto-sort enabled; propagate it so existing channels are re-sorted on
+            // sync (manual sort stays untouched when auto-sort is disabled).
+            if (! empty($bulk) && array_key_exists('sort', $bulk[0])) {
+                $updateColumns[] = 'sort';
+            }
+
+            // Upsert the channels
+            Channel::upsert($bulk, uniqueBy: ['source_id', 'playlist_id'], update: $updateColumns);
         }
     }
 }

--- a/tests/Feature/ProcessM3uImportChunkSortTest.php
+++ b/tests/Feature/ProcessM3uImportChunkSortTest.php
@@ -6,8 +6,8 @@
  * `sort` was unconditionally excluded from the chunk jobs' upsert update list,
  * so enabling "Auto channel sort" on an already-imported playlist never wrote a
  * sort number to existing channels — only newly inserted ones received it. The
- * chunk jobs now include `sort` in the update list when the payload rows carry
- * it (which is exactly when the import ran with auto-sort enabled).
+ * chunk jobs now include `sort` in the update list when `Job::variables['autoSort']`
+ * is true, which `ProcessM3uImport` sets to the playlist's `auto_sort` value.
  */
 
 use App\Jobs\ProcessM3uImportChunk;
@@ -84,7 +84,7 @@ function chunkSortPayloadRow(Playlist $playlist, array $overrides = []): array
     ];
 }
 
-function createChunkSortJob(Playlist $playlist, Group $group, array $rows): Job
+function createChunkSortJob(Playlist $playlist, Group $group, array $rows, bool $autoSort = false): Job
 {
     return Job::create([
         'title' => 'test chunk',
@@ -94,6 +94,7 @@ function createChunkSortJob(Playlist $playlist, Group $group, array $rows): Job
             'playlistId' => $playlist->id,
             'groupId' => $group->id,
             'groupName' => $group->name,
+            'autoSort' => $autoSort,
         ],
     ]);
 }
@@ -106,7 +107,7 @@ it('updates sort on existing channels when payload rows carry a sort value', fun
 
     $job = createChunkSortJob($this->playlist, $this->group, [
         chunkSortPayloadRow($this->playlist, ['sort' => 7]),
-    ]);
+    ], autoSort: true);
 
     (new ProcessM3uImportChunk([$job->id], batchCount: 1))->handle();
 
@@ -122,7 +123,7 @@ it('does not touch sort on existing channels when payload rows carry no sort val
 
     $job = createChunkSortJob($this->playlist, $this->group, [
         chunkSortPayloadRow($this->playlist),
-    ]);
+    ], autoSort: false);
 
     (new ProcessM3uImportChunk([$job->id], batchCount: 1))->handle();
 
@@ -143,10 +144,30 @@ it('updates sort on existing VOD channels when payload rows carry a sort value',
             'container_extension' => 'mp4',
             'sort' => 3,
         ]),
-    ]);
+    ], autoSort: true);
 
     (new ProcessM3uVodImportChunk([$job->id], batchCount: 1))->handle();
 
     expect((int) $existing->refresh()->sort)->toBe(3)
+        ->and(Channel::count())->toBe(1);
+});
+
+it('does not touch sort on existing VOD channels when auto-sort is disabled', function () {
+    $existing = Channel::factory()->for($this->playlist)->for($this->user)->for($this->group)->create([
+        'source_id' => 'src-1',
+        'is_vod' => true,
+        'sort' => 99,
+    ]);
+
+    $job = createChunkSortJob($this->playlist, $this->group, [
+        chunkSortPayloadRow($this->playlist, [
+            'is_vod' => true,
+            'container_extension' => 'mp4',
+        ]),
+    ], autoSort: false);
+
+    (new ProcessM3uVodImportChunk([$job->id], batchCount: 1))->handle();
+
+    expect((int) $existing->refresh()->sort)->toBe(99)
         ->and(Channel::count())->toBe(1);
 });

--- a/tests/Feature/ProcessM3uImportChunkSortTest.php
+++ b/tests/Feature/ProcessM3uImportChunkSortTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Regression tests for auto-sort not applying to existing channels (issue #1264).
+ *
+ * `sort` was unconditionally excluded from the chunk jobs' upsert update list,
+ * so enabling "Auto channel sort" on an already-imported playlist never wrote a
+ * sort number to existing channels — only newly inserted ones received it. The
+ * chunk jobs now include `sort` in the update list when the payload rows carry
+ * it (which is exactly when the import ran with auto-sort enabled).
+ */
+
+use App\Jobs\ProcessM3uImportChunk;
+use App\Jobs\ProcessM3uVodImportChunk;
+use App\Models\Channel;
+use App\Models\Group;
+use App\Models\Job;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function () {
+    $this->tempJobsDb = sys_get_temp_dir().'/jobs_test_'.uniqid().'.sqlite';
+    touch($this->tempJobsDb);
+    config(['database.connections.jobs.database' => $this->tempJobsDb]);
+    DB::purge('jobs');
+
+    $migration = require database_path('migrations/2025_02_13_215803_create_jobs_table.php');
+    $migration->up();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::withoutEvents(fn () => Playlist::factory()->for($this->user)->create([
+        'auto_sort' => true,
+    ]));
+    $this->group = Group::factory()->for($this->playlist)->for($this->user)->create();
+});
+
+afterEach(function () {
+    DB::purge('jobs');
+    config(['database.connections.jobs.database' => database_path('jobs.sqlite')]);
+
+    if (isset($this->tempJobsDb) && file_exists($this->tempJobsDb)) {
+        @unlink($this->tempJobsDb);
+    }
+});
+
+/**
+ * Build a full channel payload row as produced by ProcessM3uImport (Xtream path),
+ * i.e. containing every column present in the chunk jobs' upsert update list.
+ *
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function chunkSortPayloadRow(Playlist $playlist, array $overrides = []): array
+{
+    return [
+        'playlist_id' => $playlist->id,
+        'user_id' => $playlist->user_id,
+        'enabled' => false,
+        'channel' => null,
+        'shift' => 0,
+        'catchup' => null,
+        'catchup_source' => null,
+        'title' => 'Channel One',
+        'name' => 'Channel One',
+        'url' => 'http://provider.test/live/1.ts',
+        'logo_internal' => '',
+        'group' => '',
+        'group_internal' => '',
+        'stream_id' => 'ch-1',
+        'source_id' => 'src-1',
+        'lang' => null,
+        'country' => null,
+        'import_batch_no' => 'batch-1',
+        'extvlcopt' => null,
+        'kodidrop' => null,
+        'is_vod' => false,
+        'container_extension' => null,
+        'year' => null,
+        'rating' => null,
+        'rating_5based' => null,
+        'new' => true,
+        ...$overrides,
+    ];
+}
+
+function createChunkSortJob(Playlist $playlist, Group $group, array $rows): Job
+{
+    return Job::create([
+        'title' => 'test chunk',
+        'batch_no' => 'batch-1',
+        'payload' => $rows,
+        'variables' => [
+            'playlistId' => $playlist->id,
+            'groupId' => $group->id,
+            'groupName' => $group->name,
+        ],
+    ]);
+}
+
+it('updates sort on existing channels when payload rows carry a sort value', function () {
+    $existing = Channel::factory()->for($this->playlist)->for($this->user)->for($this->group)->create([
+        'source_id' => 'src-1',
+        'sort' => null,
+    ]);
+
+    $job = createChunkSortJob($this->playlist, $this->group, [
+        chunkSortPayloadRow($this->playlist, ['sort' => 7]),
+    ]);
+
+    (new ProcessM3uImportChunk([$job->id], batchCount: 1))->handle();
+
+    expect((int) $existing->refresh()->sort)->toBe(7)
+        ->and(Channel::count())->toBe(1);
+});
+
+it('does not touch sort on existing channels when payload rows carry no sort value', function () {
+    $existing = Channel::factory()->for($this->playlist)->for($this->user)->for($this->group)->create([
+        'source_id' => 'src-1',
+        'sort' => 42,
+    ]);
+
+    $job = createChunkSortJob($this->playlist, $this->group, [
+        chunkSortPayloadRow($this->playlist),
+    ]);
+
+    (new ProcessM3uImportChunk([$job->id], batchCount: 1))->handle();
+
+    expect((int) $existing->refresh()->sort)->toBe(42)
+        ->and(Channel::count())->toBe(1);
+});
+
+it('updates sort on existing VOD channels when payload rows carry a sort value', function () {
+    $existing = Channel::factory()->for($this->playlist)->for($this->user)->for($this->group)->create([
+        'source_id' => 'src-1',
+        'is_vod' => true,
+        'sort' => null,
+    ]);
+
+    $job = createChunkSortJob($this->playlist, $this->group, [
+        chunkSortPayloadRow($this->playlist, [
+            'is_vod' => true,
+            'container_extension' => 'mp4',
+            'sort' => 3,
+        ]),
+    ]);
+
+    (new ProcessM3uVodImportChunk([$job->id], batchCount: 1))->handle();
+
+    expect((int) $existing->refresh()->sort)->toBe(3)
+        ->and(Channel::count())->toBe(1);
+});


### PR DESCRIPTION
## Summary

Fixes #1264 — enabling **Auto channel sort** on an already-imported playlist never attached a sort number.

**Root cause:** `ProcessM3uImportChunk` / `ProcessM3uVodImportChunk` unconditionally exclude `sort` from the upsert update column list. New channels get their sort on insert, but existing channels are never updated — so toggling auto-sort on an existing playlist is a no-op, and provider order changes are never propagated on re-sync (despite the sort-column tooltip saying *"Playlist auto-sort enabled; any changes will be overwritten on next sync"*).

**Fix:** payload rows carry a `sort` value exactly when the import ran with auto-sort enabled (`$channelFields['sort']` is only set then), so the chunk jobs now append `sort` to the update list when the rows have the key. When auto-sort is disabled the rows have no `sort` key and manual sort orders remain untouched, preserving the existing user-override behavior.

## Tests

New `ProcessM3uImportChunkSortTest` (3 cases):
- existing channel gets the payload's sort value when rows carry one (live chunk)
- existing channel's manual sort is untouched when rows carry none
- same propagation through the VOD chunk

`ProcessM3uImportReimportTest`, `XtreamAutoChannelIncrementTest`, `ProcessM3uImportEnableChannelsTest`, `ProcessM3uImportCompleteVodGuardTest` all pass (12 tests), Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)