### PR TITLE
fix: honor EPG map exclude prefixes in the similarity search stage

### DIFF
--- a/app/Jobs/MapPlaylistChannelsToEpgChunk.php
+++ b/app/Jobs/MapPlaylistChannelsToEpgChunk.php
@@ -254,6 +254,10 @@ class MapPlaylistChannelsToEpgChunk implements ShouldQueue
                         $fuzzyMaxDistance,
                         $exactMatchDistance,
                         $customQualityIndicators ?: null,
+                        // Pass the prefix/pattern-cleaned values so the similarity
+                        // search honors the map's exclude settings (issue #1265)
+                        cleanedTitle: $title,
+                        cleanedName: $name,
                     );
                 }
             }

--- a/app/Services/SimilaritySearchService.php
+++ b/app/Services/SimilaritySearchService.php
@@ -134,6 +134,8 @@ class SimilaritySearchService
         int $fuzzyMaxDistance = 25,
         int $exactMatchDistance = 8,
         ?array $customQualityIndicators = null,
+        ?string $cleanedTitle = null,
+        ?string $cleanedName = null,
     ): ?EpgChannel {
         $this->removeQualityIndicators = $removeQualityIndicators;
         $this->upperFuzzyThreshold = $fuzzyMaxDistance;
@@ -146,9 +148,12 @@ class SimilaritySearchService
         $debug = false; // config('app.debug');
         $regionCode = $epg->preferred_local ? mb_strtolower($epg->preferred_local, 'UTF-8') : null;
 
-        // Sanitize UTF-8 encoding immediately to prevent PostgreSQL errors
-        $title = $this->sanitizeUtf8($channel->title_custom ?? $channel->title);
-        $name = $this->sanitizeUtf8($channel->name_custom ?? $channel->name);
+        // Sanitize UTF-8 encoding immediately to prevent PostgreSQL errors.
+        // Callers that already stripped configured prefixes/patterns from the
+        // channel attributes pass the cleaned values so the similarity search
+        // works on the same names as the exact-match steps.
+        $title = $this->sanitizeUtf8($cleanedTitle ?? $channel->title_custom ?? $channel->title);
+        $name = $this->sanitizeUtf8($cleanedName ?? $channel->name_custom ?? $channel->name);
         $fallbackName = trim($title ?: $name);
         $normalizedChan = $this->normalizeChannelName($fallbackName);
 

--- a/database/factories/EpgMapFactory.php
+++ b/database/factories/EpgMapFactory.php
@@ -28,7 +28,7 @@ class EpgMapFactory extends Factory
             'status' => fake()->randomElement(['pending', 'processing', 'completed', 'failed']),
             'processing' => fake()->boolean(),
             'progress' => fake()->randomFloat(0, 0, 9999999999.),
-            'sync_time' => fake()->dateTime(),
+            'sync_time' => fake()->randomFloat(2, 0, 600),
             'user_id' => User::factory(),
             'epg_id' => Epg::factory(),
         ];

--- a/tests/Feature/EpgMapExcludePrefixSimilarityTest.php
+++ b/tests/Feature/EpgMapExcludePrefixSimilarityTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Regression tests for "Channel prefixes to remove before matching is broken"
+ * (issue #1265).
+ *
+ * MapPlaylistChannelsToEpgChunk stripped the configured prefixes/patterns for
+ * its exact-match steps, but passed the raw Channel model to
+ * SimilaritySearchService — so the fuzzy stage searched on the original
+ * prefixed name. Any channel that needed fuzzy matching behaved as if the
+ * exclude setting was never configured. The cleaned title/name are now passed
+ * through to the similarity search.
+ */
+
+use App\Models\Channel;
+use App\Models\Epg;
+use App\Models\EpgChannel;
+use App\Models\EpgMap;
+use App\Models\Group;
+use App\Models\Job;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\SimilaritySearchService;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function () {
+    $this->tempJobsDb = sys_get_temp_dir().'/jobs_test_'.uniqid().'.sqlite';
+    touch($this->tempJobsDb);
+    config(['database.connections.jobs.database' => $this->tempJobsDb]);
+    DB::purge('jobs');
+
+    $migration = require database_path('migrations/2025_02_13_215803_create_jobs_table.php');
+    $migration->up();
+
+    $this->user = User::factory()->create();
+    $this->epg = Epg::factory()->for($this->user)->create();
+    $this->playlist = Playlist::withoutEvents(fn () => Playlist::factory()->for($this->user)->create());
+    $this->group = Group::factory()->for($this->playlist)->for($this->user)->create();
+});
+
+afterEach(function () {
+    DB::purge('jobs');
+    config(['database.connections.jobs.database' => database_path('jobs.sqlite')]);
+
+    if (isset($this->tempJobsDb) && file_exists($this->tempJobsDb)) {
+        @unlink($this->tempJobsDb);
+    }
+});
+
+describe('SimilaritySearchService cleaned name overrides', function () {
+    it('matches via cleaned title and name when the raw channel name carries a provider prefix', function () {
+        $epgChannel = EpgChannel::factory()->for($this->epg)->for($this->user)->create([
+            'name' => 'CBS Sports Network',
+            'display_name' => 'CBS Sports Network',
+            'channel_id' => 'cbssn.us',
+        ]);
+
+        $channel = Channel::factory()->for($this->playlist)->for($this->user)->for($this->group)->create([
+            'title' => 'SPRT| CBS Sports Network',
+            'name' => 'SPRT| CBS Sports Network',
+        ]);
+
+        $match = (new SimilaritySearchService)->findMatchingEpgChannel(
+            $channel,
+            $this->epg,
+            cleanedTitle: 'CBS Sports Network',
+            cleanedName: 'CBS Sports Network',
+        );
+
+        expect($match?->id)->toBe($epgChannel->id);
+    });
+
+    it('does not match on the raw prefixed name without cleaned overrides', function () {
+        EpgChannel::factory()->for($this->epg)->for($this->user)->create([
+            'name' => 'CBS Sports Network',
+            'display_name' => 'CBS Sports Network',
+            'channel_id' => 'cbssn.us',
+        ]);
+
+        $channel = Channel::factory()->for($this->playlist)->for($this->user)->for($this->group)->create([
+            'title' => 'SPRT| CBS Sports Network',
+            'name' => 'SPRT| CBS Sports Network',
+        ]);
+
+        $match = (new SimilaritySearchService)->findMatchingEpgChannel($channel, $this->epg);
+
+        expect($match)->toBeNull();
+    });
+});
+
+describe('MapPlaylistChannelsToEpgChunk exclude prefixes', function () {
+    function runEpgMapChunk(Epg $epg, Playlist $playlist, Channel $channel, array $settings): string
+    {
+        $map = EpgMap::factory()->create([
+            'epg_id' => $epg->id,
+            'playlist_id' => $playlist->id,
+            'user_id' => $epg->user_id,
+            'settings' => $settings,
+        ]);
+
+        $batchNo = 'epg-map-batch-'.uniqid();
+        (new \App\Jobs\MapPlaylistChannelsToEpgChunk(
+            channelIds: [$channel->id],
+            epgId: $epg->id,
+            epgMapId: $map->id,
+            settings: $settings,
+            batchNo: $batchNo,
+            totalChannels: 1,
+        ))->handle();
+
+        return $batchNo;
+    }
+
+    it('maps a prefixed channel through the similarity stage when exclude prefixes are configured', function () {
+        $epgChannel = EpgChannel::factory()->for($this->epg)->for($this->user)->create([
+            'name' => 'CBS Sports Network',
+            'display_name' => 'CBS Sports Network',
+            'channel_id' => 'cbssn.us',
+        ]);
+
+        // "HD" forces the chunk's exact-match steps to miss, so the mapping can
+        // only succeed through the similarity stage with the prefix stripped.
+        $channel = Channel::factory()->for($this->playlist)->for($this->user)->for($this->group)->create([
+            'title' => 'SPRT| CBS Sports Network HD',
+            'name' => 'SPRT| CBS Sports Network HD',
+            'stream_id' => 'sprt-cbs-sports',
+        ]);
+
+        $batchNo = runEpgMapChunk($this->epg, $this->playlist, $channel, [
+            'exclude_prefixes' => ['SPRT| '],
+            'use_regex' => false,
+            'remove_quality_indicators' => true,
+        ]);
+
+        $mapJob = Job::where('batch_no', $batchNo)->first();
+
+        expect($mapJob)->not->toBeNull()
+            ->and($mapJob->payload[0]['epg_channel_id'])->toBe($epgChannel->id);
+    });
+
+    it('does not map the same channel when no exclude prefixes are configured', function () {
+        EpgChannel::factory()->for($this->epg)->for($this->user)->create([
+            'name' => 'CBS Sports Network',
+            'display_name' => 'CBS Sports Network',
+            'channel_id' => 'cbssn.us',
+        ]);
+
+        $channel = Channel::factory()->for($this->playlist)->for($this->user)->for($this->group)->create([
+            'title' => 'SPRT| CBS Sports Network HD',
+            'name' => 'SPRT| CBS Sports Network HD',
+            'stream_id' => 'sprt-cbs-sports',
+        ]);
+
+        $batchNo = runEpgMapChunk($this->epg, $this->playlist, $channel, [
+            'use_regex' => false,
+            'remove_quality_indicators' => true,
+        ]);
+
+        expect(Job::where('batch_no', $batchNo)->exists())->toBeFalse();
+    });
+});

--- a/tests/Feature/EpgMapExcludePrefixSimilarityTest.php
+++ b/tests/Feature/EpgMapExcludePrefixSimilarityTest.php
@@ -12,6 +12,7 @@
  * through to the similarity search.
  */
 
+use App\Jobs\MapPlaylistChannelsToEpgChunk;
 use App\Models\Channel;
 use App\Models\Epg;
 use App\Models\EpgChannel;
@@ -99,7 +100,7 @@ describe('MapPlaylistChannelsToEpgChunk exclude prefixes', function () {
         ]);
 
         $batchNo = 'epg-map-batch-'.uniqid();
-        (new \App\Jobs\MapPlaylistChannelsToEpgChunk(
+        (new MapPlaylistChannelsToEpgChunk(
             channelIds: [$channel->id],
             epgId: $epg->id,
             epgMapId: $map->id,


### PR DESCRIPTION
## Summary

Fixes #1265 — "Channel prefixes to remove before matching" appears to do nothing for channels that need fuzzy matching.

**Root cause:** `MapPlaylistChannelsToEpgChunk` strips the configured prefixes/regex patterns from `streamId`/`name`/`title` for its exact-match steps, but the Step-4 fallback passes the **raw `Channel` model** to `SimilaritySearchService`, which re-reads `title_custom ?? title` / `name_custom ?? name` — so the fuzzy stage searches on the original prefixed name. Since the service's LIKE-based candidate discovery anchors on the leading characters of the search term (first 5 normalized chars + first 10 original chars), a provider prefix reliably prevents any candidates from being found. Every channel whose match depends on the fuzzy stage therefore behaves exactly as if the exclude setting was never configured — matching the report.

**Fix:** `findMatchingEpgChannel()` accepts optional `cleanedTitle`/`cleanedName` overrides (backwards-compatible — existing callers unaffected), and the chunk job passes its already-cleaned values through, so the similarity stage operates on the same names as the exact-match steps.

## Tests

New `EpgMapExcludePrefixSimilarityTest` (4 cases):
- service matches via cleaned overrides when the raw name carries a provider prefix
- service finds no match on the raw prefixed name (documents the failure mode)
- chunk job maps a prefixed channel through the similarity stage when `exclude_prefixes` is configured (exact steps forced to miss via a quality suffix)
- control: the same channel does not map when no prefixes are configured

Full EPG-related suite (`--filter=Epg`, 81 tests) passes, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)