### PR TITLE
fix(xtream): support unix timestamp for timeshift date parameter

### DIFF
--- a/app/Http/Controllers/XtreamStreamController.php
+++ b/app/Http/Controllers/XtreamStreamController.php
@@ -391,8 +391,13 @@ class XtreamStreamController extends Controller
             }
         }
 
+        // Convert Unix timestamp to Xtream format if the player sends a numeric date string
+        if (is_numeric($date)) {
+            $date = \Carbon\Carbon::createFromTimestamp((int)$date)->format('Y-m-d:H-i-s');
+        }
+
         // Parse the date parameter and add timeshift parameters to the request
-        // Date format from Xtream API: YYYY-MM-DD:HH-MM-SS
+        // Expected downstream format: YYYY-MM-DD:HH-MM-SS
         // Also add username for proxy traceability
         $mergeData = [
             'timeshift_duration' => $duration,


### PR DESCRIPTION
### 🐛 Problem Description
Some IPTV players, most notably **TiviMate**, send the timeshift/catchup `date` parameter as a raw Unix timestamp (e.g., `1783662300`) instead of the standard Xtream API string format (`YYYY-MM-DD:HH-MM-SS`). 

Because `XtreamStreamController::handleTimeshift` strictly expected the string format, passing a numeric timestamp caused an unhandled parsing exception inside Carbon, leading to a **500 Internal Server Error** and breaking the rewind/timeshift functionality entirely.

### 🛠️ Solution
This PR introduces a safe check using `is_numeric($date)` right before request data parsing and merging. If a player sends a numeric timestamp, Carbon seamlessly converts it into the required text format (`Y-m-d:H-i-s`). 

* **No breaking changes:** Standard `YYYY-MM-DD:HH-MM-SS` text formats sent by other players remain completely untouched.
* **Code style compliance:** The code has been fully formatted and cleaned up using Laravel Pint.

### 🧪 Testing Done
* Tested internally with **TiviMate** app — timeshift requests now parse correctly, and catchup/rewind streams play seamlessly without throwing 500 errors.