### PR TITLE
feat: auto enable/disable channels by title/name pattern on sync

### DIFF
--- a/app/Enums/SyncRunPhase.php
+++ b/app/Enums/SyncRunPhase.php
@@ -19,6 +19,7 @@ enum SyncRunPhase: string
     case SeriesStrmPostProbe = 'series_strm_post_probe';
 
     case FindReplace = 'find_replace';
+    case ChannelEnableRules = 'channel_enable_rules';
     case ChannelMerge = 'channel_merge';
     case LiveProbe = 'live_probe';
     case CustomPlaylistSync = 'custom_playlist_sync';
@@ -40,6 +41,7 @@ enum SyncRunPhase: string
             self::SeriesProbe => 'Series Stream Probe',
             self::SeriesStrmPostProbe => 'Series STRM Files (Post-Probe)',
             self::FindReplace => 'Find & Replace / Sort',
+            self::ChannelEnableRules => 'Channel Enable/Disable Rules',
             self::ChannelMerge => 'Channel Merge',
             self::LiveProbe => 'Live Stream Probe',
             self::CustomPlaylistSync => 'Custom Playlist Sync',
@@ -62,6 +64,7 @@ enum SyncRunPhase: string
             self::SeriesProbe,
             self::SeriesStrmPostProbe => 'warning',
             self::FindReplace,
+            self::ChannelEnableRules,
             self::ChannelMerge,
             self::LiveProbe,
             self::CustomPlaylistSync => 'gray',

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2481,6 +2481,76 @@ class PlaylistResource extends Resource implements CopilotResource
                             : null
                         ),
                 ]),
+            Section::make(__('Auto Enable/Disable Rules'))
+                ->description(__('Automatically enable or disable channels whose title or name matches a regex pattern, re-evaluated after each playlist sync. Rules run in order and the last matching rule wins; channels matching no rule keep their current state. Useful for event channels that providers rename between syncs (e.g. disable "NO EVENT" placeholders).'))
+                ->columnSpanFull()
+                ->collapsible()
+                ->collapsed($creating)
+                ->schema([
+                    Repeater::make('channel_enable_rules')
+                        ->label('')
+                        ->schema([
+                            Toggle::make('enabled')
+                                ->label(__('Enabled'))
+                                ->default(true)
+                                ->inline(false)
+                                ->columnSpan(1),
+                            TextInput::make('name')
+                                ->label(__('Rule Name'))
+                                ->required()
+                                ->placeholder(__('e.g. Disable idle event channels'))
+                                ->columnSpan(2),
+                            Select::make('target')
+                                ->label(__('Target'))
+                                ->options([
+                                    'channels' => 'Live Channels',
+                                    'vod_channels' => 'VOD Channels',
+                                ])
+                                ->default('channels')
+                                ->required()
+                                ->columnSpan(2),
+                            Select::make('column')
+                                ->label(__('Column to match'))
+                                ->options([
+                                    'title' => 'Channel Title',
+                                    'name' => 'Channel Name (tvg-name)',
+                                ])
+                                ->default('title')
+                                ->required()
+                                ->columnSpan(2),
+                            Select::make('action')
+                                ->label(__('Action'))
+                                ->options([
+                                    'enable' => 'Enable matching channels',
+                                    'disable' => 'Disable matching channels',
+                                ])
+                                ->default('disable')
+                                ->required()
+                                ->columnSpan(2),
+                            TextInput::make('pattern')
+                                ->label(__('Pattern to match'))
+                                ->required()
+                                ->placeholder(__('e.g. NO EVENT'))
+                                ->suffixAction(
+                                    RegexTesterAction::make(
+                                        name: 'test-enable-rules',
+                                        samplesContext: fn (Get $get): string => $get('target') ?? 'channels',
+                                        patternField: 'pattern',
+                                    )
+                                )
+                                ->columnSpan(5),
+                        ])
+                        ->columns(7)
+                        ->reorderable()
+                        ->reorderableWithButtons()
+                        ->collapsible()
+                        ->defaultItems(0)
+                        ->addActionLabel('Add enable/disable rule')
+                        ->itemLabel(fn (array $state): ?string => ($state['name'] ?? null)
+                            ? ($state['name'].($state['enabled'] ?? true ? '' : ' (disabled)'))
+                            : null
+                        ),
+                ]),
             Section::make(__('Sort Alpha Configs'))
                 ->description(__('Define sort configurations that automatically run after each playlist sync. Configurations execute in order.'))
                 ->columnSpanFull()

--- a/app/Jobs/RunPlaylistChannelEnableDisableRules.php
+++ b/app/Jobs/RunPlaylistChannelEnableDisableRules.php
@@ -4,13 +4,12 @@ namespace App\Jobs;
 
 use App\Models\Channel;
 use App\Models\Playlist;
-use App\Models\User;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 
-class RunPlaylistChannelEnableRules implements ShouldQueue
+class RunPlaylistChannelEnableDisableRules implements ShouldQueue
 {
     use Queueable;
 
@@ -49,8 +48,6 @@ class RunPlaylistChannelEnableRules implements ShouldQueue
 
         $start = now();
 
-        // Pre-compile the patterns, skipping any that fail to compile so one
-        // bad rule doesn't abort the rest.
         $compiled = [];
         $invalidRules = [];
         foreach ($rules as $rule) {
@@ -96,7 +93,6 @@ class RunPlaylistChannelEnableRules implements ShouldQueue
                                 ? ($channel->name_custom ?? $channel->name)
                                 : ($channel->title_custom ?? $channel->title);
                             if ($value !== null && preg_match($rule['pattern'], $value)) {
-                                // Last matching rule wins
                                 $targetState = $rule['enable'];
                             }
                         }
@@ -128,7 +124,7 @@ class RunPlaylistChannelEnableRules implements ShouldQueue
         }
 
         $completedIn = round($start->diffInSeconds(now()), 2);
-        $user = User::find($this->playlist->user_id);
+        $user = $this->playlist->user;
 
         $body = "Enabled {$enabledCount} and disabled {$disabledCount} channels for \"{$this->playlist->name}\" in {$completedIn}s.";
         if (! empty($invalidRules)) {

--- a/app/Jobs/RunPlaylistChannelEnableRules.php
+++ b/app/Jobs/RunPlaylistChannelEnableRules.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+use Filament\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+
+class RunPlaylistChannelEnableRules implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     */
+    public int $timeout = 900;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Playlist $playlist,
+    ) {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * Re-evaluates every non-custom channel of the playlist against the saved
+     * enable/disable rules. Rules run in order and the last matching rule wins;
+     * channels that match no rule keep their current enabled state. This runs
+     * on every sync so channels whose provider renames them between syncs
+     * (e.g. "LIVE EVENT 01 | NO EVENT TODAY" placeholders) flip automatically.
+     */
+    public function handle(): void
+    {
+        $rules = collect($this->playlist->channel_enable_rules ?? [])
+            ->filter(fn (array $rule): bool => ($rule['enabled'] ?? false) && filled($rule['pattern'] ?? null))
+            ->values();
+
+        if ($rules->isEmpty()) {
+            return;
+        }
+
+        $start = now();
+
+        // Pre-compile the patterns, skipping any that fail to compile so one
+        // bad rule doesn't abort the rest.
+        $compiled = [];
+        $invalidRules = [];
+        foreach ($rules as $rule) {
+            $pattern = '/'.str_replace('/', '\\/', $rule['pattern']).'/ui';
+            if (@preg_match($pattern, '') === false) {
+                $invalidRules[] = $rule['name'] ?? $rule['pattern'];
+
+                continue;
+            }
+            $compiled[] = [
+                'pattern' => $pattern,
+                'column' => $rule['column'] ?? 'title',
+                'is_vod' => ($rule['target'] ?? 'channels') === 'vod_channels',
+                'enable' => ($rule['action'] ?? 'disable') === 'enable',
+            ];
+        }
+
+        if (! empty($invalidRules)) {
+            Log::warning('Skipping invalid channel enable/disable rules for playlist '.$this->playlist->id, [
+                'rules' => $invalidRules,
+            ]);
+        }
+
+        $enabledCount = 0;
+        $disabledCount = 0;
+
+        if (! empty($compiled)) {
+            Channel::query()
+                ->where('playlist_id', $this->playlist->id)
+                ->where('is_custom', false)
+                ->select(['id', 'title', 'title_custom', 'name', 'name_custom', 'enabled', 'is_vod'])
+                ->chunkById(1000, function ($channels) use ($compiled, &$enabledCount, &$disabledCount) {
+                    $toEnable = [];
+                    $toDisable = [];
+
+                    foreach ($channels as $channel) {
+                        $targetState = null;
+                        foreach ($compiled as $rule) {
+                            if ($rule['is_vod'] !== (bool) $channel->is_vod) {
+                                continue;
+                            }
+                            $value = $rule['column'] === 'name'
+                                ? ($channel->name_custom ?? $channel->name)
+                                : ($channel->title_custom ?? $channel->title);
+                            if ($value !== null && preg_match($rule['pattern'], $value)) {
+                                // Last matching rule wins
+                                $targetState = $rule['enable'];
+                            }
+                        }
+
+                        if ($targetState === null || $targetState === (bool) $channel->enabled) {
+                            continue;
+                        }
+
+                        if ($targetState) {
+                            $toEnable[] = $channel->id;
+                        } else {
+                            $toDisable[] = $channel->id;
+                        }
+                    }
+
+                    if (! empty($toEnable)) {
+                        Channel::whereIn('id', $toEnable)->update(['enabled' => true]);
+                        $enabledCount += count($toEnable);
+                    }
+                    if (! empty($toDisable)) {
+                        Channel::whereIn('id', $toDisable)->update(['enabled' => false]);
+                        $disabledCount += count($toDisable);
+                    }
+                });
+        }
+
+        if ($enabledCount > 0 || $disabledCount > 0) {
+            SyncPlexDvrJob::dispatchIfConfigured(trigger: 'channel_enable_rules');
+        }
+
+        $completedIn = round($start->diffInSeconds(now()), 2);
+        $user = User::find($this->playlist->user_id);
+
+        $body = "Enabled {$enabledCount} and disabled {$disabledCount} channels for \"{$this->playlist->name}\" in {$completedIn}s.";
+        if (! empty($invalidRules)) {
+            $body .= ' Skipped invalid rules: '.implode(', ', $invalidRules).'.';
+        }
+
+        Notification::make()
+            ->success()
+            ->title('Channel enable/disable rules completed')
+            ->body($body)
+            ->broadcast($user)
+            ->sendToDatabase($user);
+    }
+}

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -67,6 +67,7 @@ class Playlist extends Model
         'probe_timeout' => 'integer',
         'find_replace_rules' => 'array',
         'sort_alpha_config' => 'array',
+        'channel_enable_rules' => 'array',
         'auto_sync_to_custom_config' => 'array',
         'emby_config' => 'array',
         'custom_headers' => 'array',

--- a/app/Services/SyncPipelineService.php
+++ b/app/Services/SyncPipelineService.php
@@ -14,6 +14,7 @@ use App\Jobs\ProbeStreams;
 use App\Jobs\ProcessChannelScrubber;
 use App\Jobs\ProcessM3uImportSeries;
 use App\Jobs\ProcessVodChannels;
+use App\Jobs\RunPlaylistChannelEnableRules;
 use App\Jobs\RunPlaylistFindReplaceRules;
 use App\Jobs\RunPlaylistSortAlpha;
 use App\Jobs\SyncSeriesStrmFiles;
@@ -276,6 +277,7 @@ class SyncPipelineService
             SyncRunPhase::SeriesProbe => $this->dispatchProbe($run, $playlist, isSeriesProbe: true),
             SyncRunPhase::SeriesStrmPostProbe => $this->dispatchSeriesStrmPostProbe($run, $playlist),
             SyncRunPhase::FindReplace => $this->dispatchFindReplace($run, $playlist),
+            SyncRunPhase::ChannelEnableRules => $this->dispatchChannelEnableRules($run, $playlist),
             SyncRunPhase::ChannelMerge => $this->dispatchChannelMerge($run, $playlist),
             SyncRunPhase::LiveProbe => $this->dispatchLiveProbe($run, $playlist),
             SyncRunPhase::CustomPlaylistSync => $this->dispatchCustomPlaylistSync($run, $playlist),
@@ -397,6 +399,14 @@ class SyncPipelineService
         $jobs[] = new CompleteSyncPhase($run->id, SyncRunPhase::FindReplace);
 
         $this->chainOrDispatch($jobs, $run);
+    }
+
+    private function dispatchChannelEnableRules(SyncRun $run, Playlist $playlist): void
+    {
+        $this->chainOrDispatch([
+            new RunPlaylistChannelEnableRules($playlist),
+            new CompleteSyncPhase($run->id, SyncRunPhase::ChannelEnableRules),
+        ], $run);
     }
 
     /**
@@ -626,6 +636,13 @@ class SyncPipelineService
 
         if ($hasFindReplaceWork) {
             $phases[] = SyncRunPhase::FindReplace;
+        }
+
+        // Enable/disable rules run after FindReplace so they match against the
+        // cleaned titles, and before ChannelMerge/LiveProbe so those phases see
+        // the final enabled set.
+        if ($this->hasEnabledRule($playlist->channel_enable_rules)) {
+            $phases[] = SyncRunPhase::ChannelEnableRules;
         }
 
         // ChannelMerge and LiveProbe operate on live channels and are independent

--- a/app/Services/SyncPipelineService.php
+++ b/app/Services/SyncPipelineService.php
@@ -14,7 +14,7 @@ use App\Jobs\ProbeStreams;
 use App\Jobs\ProcessChannelScrubber;
 use App\Jobs\ProcessM3uImportSeries;
 use App\Jobs\ProcessVodChannels;
-use App\Jobs\RunPlaylistChannelEnableRules;
+use App\Jobs\RunPlaylistChannelEnableDisableRules;
 use App\Jobs\RunPlaylistFindReplaceRules;
 use App\Jobs\RunPlaylistSortAlpha;
 use App\Jobs\SyncSeriesStrmFiles;
@@ -404,7 +404,7 @@ class SyncPipelineService
     private function dispatchChannelEnableRules(SyncRun $run, Playlist $playlist): void
     {
         $this->chainOrDispatch([
-            new RunPlaylistChannelEnableRules($playlist),
+            new RunPlaylistChannelEnableDisableRules($playlist),
             new CompleteSyncPhase($run->id, SyncRunPhase::ChannelEnableRules),
         ], $run);
     }
@@ -638,8 +638,8 @@ class SyncPipelineService
             $phases[] = SyncRunPhase::FindReplace;
         }
 
-        // Enable/disable rules run after FindReplace so they match against the
-        // cleaned titles, and before ChannelMerge/LiveProbe so those phases see
+        // Enable/disable rules run after FindReplace when present (so they match
+        // cleaned titles), and before ChannelMerge/LiveProbe so those phases see
         // the final enabled set.
         if ($this->hasEnabledRule($playlist->channel_enable_rules)) {
             $phases[] = SyncRunPhase::ChannelEnableRules;

--- a/database/migrations/2026_07_11_185834_add_channel_enable_rules_to_playlists_table.php
+++ b/database/migrations/2026_07_11_185834_add_channel_enable_rules_to_playlists_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->jsonb('channel_enable_rules')->nullable()->after('sort_alpha_config');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->dropColumn('channel_enable_rules');
+        });
+    }
+};

--- a/tests/Feature/ChannelEnableRulesTest.php
+++ b/tests/Feature/ChannelEnableRulesTest.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * Tests for the per-playlist auto enable/disable rules (issue #1199).
+ *
+ * Rules are re-evaluated against every non-custom channel on each sync:
+ * rules run in order, the last matching rule wins, and channels matching
+ * no rule keep their current enabled state.
+ */
+
+use App\Enums\SyncRunPhase;
+use App\Jobs\RunPlaylistChannelEnableRules;
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+use App\Services\SyncPipelineService;
+use App\Settings\GeneralSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Notification::fake();
+
+    $this->user = User::factory()->create();
+});
+
+function makeEnableRulesPlaylist(User $user, array $rules): Playlist
+{
+    return Playlist::factory()->for($user)->createQuietly([
+        'channel_enable_rules' => $rules,
+    ]);
+}
+
+function makeEnableRulesChannel(Playlist $playlist, string $title, bool $enabled, array $attrs = []): Channel
+{
+    return Channel::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $playlist->user_id,
+        'group_id' => null,
+        'title' => $title,
+        'enabled' => $enabled,
+        'is_vod' => false,
+        'is_custom' => false,
+        ...$attrs,
+    ]);
+}
+
+it('disables channels matching a disable rule and leaves others untouched', function () {
+    $playlist = makeEnableRulesPlaylist($this->user, [
+        ['enabled' => true, 'name' => 'No event', 'target' => 'channels', 'column' => 'title', 'action' => 'disable', 'pattern' => 'NO EVENT'],
+    ]);
+
+    $idle = makeEnableRulesChannel($playlist, 'LIVE EVENT 02 | NO EVENT TODAY', true);
+    $active = makeEnableRulesChannel($playlist, 'LIVE EVENT 01 | EVENT TITLE', true);
+
+    (new RunPlaylistChannelEnableRules($playlist))->handle();
+
+    expect($idle->refresh()->enabled)->toBeFalse()
+        ->and($active->refresh()->enabled)->toBeTrue();
+});
+
+it('re-enables a disabled channel when its title matches an enable rule', function () {
+    $playlist = makeEnableRulesPlaylist($this->user, [
+        ['enabled' => true, 'name' => 'Event live', 'target' => 'channels', 'column' => 'title', 'action' => 'enable', 'pattern' => 'EVENT \\d+ \\| (?!NO EVENT)'],
+    ]);
+
+    // Previously disabled placeholder that the provider renamed to a real event
+    $channel = makeEnableRulesChannel($playlist, 'EVENT 01 | Big Game Tonight', false);
+
+    (new RunPlaylistChannelEnableRules($playlist))->handle();
+
+    expect($channel->refresh()->enabled)->toBeTrue();
+});
+
+it('applies rules in order with the last matching rule winning', function () {
+    $playlist = makeEnableRulesPlaylist($this->user, [
+        ['enabled' => true, 'name' => 'Disable all events', 'target' => 'channels', 'column' => 'title', 'action' => 'disable', 'pattern' => '^LIVE EVENT'],
+        ['enabled' => true, 'name' => 'Enable active events', 'target' => 'channels', 'column' => 'title', 'action' => 'enable', 'pattern' => '^LIVE EVENT (?!.*NO EVENT)'],
+    ]);
+
+    $idle = makeEnableRulesChannel($playlist, 'LIVE EVENT 02 | NO EVENT TODAY', true);
+    $active = makeEnableRulesChannel($playlist, 'LIVE EVENT 01 | EVENT TITLE', false);
+
+    (new RunPlaylistChannelEnableRules($playlist))->handle();
+
+    expect($idle->refresh()->enabled)->toBeFalse()
+        ->and($active->refresh()->enabled)->toBeTrue();
+});
+
+it('matches against the custom title override when set', function () {
+    $playlist = makeEnableRulesPlaylist($this->user, [
+        ['enabled' => true, 'name' => 'No event', 'target' => 'channels', 'column' => 'title', 'action' => 'disable', 'pattern' => 'NO EVENT'],
+    ]);
+
+    $channel = makeEnableRulesChannel($playlist, 'LIVE EVENT 01', true, ['title_custom' => 'NO EVENT TODAY']);
+
+    (new RunPlaylistChannelEnableRules($playlist))->handle();
+
+    expect($channel->refresh()->enabled)->toBeFalse();
+});
+
+it('matches against the channel name when the rule targets the name column', function () {
+    $playlist = makeEnableRulesPlaylist($this->user, [
+        ['enabled' => true, 'name' => 'No event', 'target' => 'channels', 'column' => 'name', 'action' => 'disable', 'pattern' => 'NO EVENT'],
+    ]);
+
+    $channel = makeEnableRulesChannel($playlist, 'Some title', true, ['name' => 'EVENT 05 | NO EVENT']);
+
+    (new RunPlaylistChannelEnableRules($playlist))->handle();
+
+    expect($channel->refresh()->enabled)->toBeFalse();
+});
+
+it('skips disabled rules and rules with invalid regex without aborting the rest', function () {
+    $playlist = makeEnableRulesPlaylist($this->user, [
+        ['enabled' => false, 'name' => 'Disabled rule', 'target' => 'channels', 'column' => 'title', 'action' => 'disable', 'pattern' => 'EVENT TITLE'],
+        ['enabled' => true, 'name' => 'Broken rule', 'target' => 'channels', 'column' => 'title', 'action' => 'disable', 'pattern' => '([unclosed'],
+        ['enabled' => true, 'name' => 'No event', 'target' => 'channels', 'column' => 'title', 'action' => 'disable', 'pattern' => 'NO EVENT'],
+    ]);
+
+    $active = makeEnableRulesChannel($playlist, 'LIVE EVENT 01 | EVENT TITLE', true);
+    $idle = makeEnableRulesChannel($playlist, 'LIVE EVENT 02 | NO EVENT TODAY', true);
+
+    (new RunPlaylistChannelEnableRules($playlist))->handle();
+
+    expect($active->refresh()->enabled)->toBeTrue()
+        ->and($idle->refresh()->enabled)->toBeFalse();
+});
+
+it('only applies rules to channels of the matching target type', function () {
+    $playlist = makeEnableRulesPlaylist($this->user, [
+        ['enabled' => true, 'name' => 'VOD only', 'target' => 'vod_channels', 'column' => 'title', 'action' => 'disable', 'pattern' => 'NO EVENT'],
+    ]);
+
+    $live = makeEnableRulesChannel($playlist, 'NO EVENT TODAY', true);
+    $vod = makeEnableRulesChannel($playlist, 'NO EVENT TODAY', true, ['is_vod' => true]);
+
+    (new RunPlaylistChannelEnableRules($playlist))->handle();
+
+    expect($live->refresh()->enabled)->toBeTrue()
+        ->and($vod->refresh()->enabled)->toBeFalse();
+});
+
+it('never touches custom channels', function () {
+    $playlist = makeEnableRulesPlaylist($this->user, [
+        ['enabled' => true, 'name' => 'No event', 'target' => 'channels', 'column' => 'title', 'action' => 'disable', 'pattern' => 'NO EVENT'],
+    ]);
+
+    $custom = makeEnableRulesChannel($playlist, 'NO EVENT TODAY', true, ['is_custom' => true]);
+
+    (new RunPlaylistChannelEnableRules($playlist))->handle();
+
+    expect($custom->refresh()->enabled)->toBeTrue();
+});
+
+// ── Pipeline integration ─────────────────────────────────────────────────────
+
+it('includes the ChannelEnableRules phase after FindReplace when rules are enabled', function () {
+    Bus::fake();
+    Event::fake();
+
+    $mock = Mockery::mock(GeneralSettings::class);
+    $mock->tmdb_auto_lookup_on_import = false;
+    $mock->tmdb_auto_lookup_all_new = 'enabled';
+    app()->instance(GeneralSettings::class, $mock);
+
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'find_replace_rules' => [['enabled' => true, 'find_replace' => 'HD', 'replace_with' => '']],
+        'channel_enable_rules' => [
+            ['enabled' => true, 'name' => 'No event', 'target' => 'channels', 'column' => 'title', 'action' => 'disable', 'pattern' => 'NO EVENT'],
+        ],
+    ]);
+
+    $run = app(SyncPipelineService::class)->buildPipeline($playlist, app(GeneralSettings::class));
+
+    $findReplacePos = array_search(SyncRunPhase::FindReplace->value, $run->phases);
+    $enableRulesPos = array_search(SyncRunPhase::ChannelEnableRules->value, $run->phases);
+
+    expect($findReplacePos)->not->toBeFalse()
+        ->and($enableRulesPos)->not->toBeFalse()
+        ->and($findReplacePos)->toBeLessThan($enableRulesPos);
+});
+
+it('omits the ChannelEnableRules phase when no rules are enabled', function () {
+    Bus::fake();
+    Event::fake();
+
+    $mock = Mockery::mock(GeneralSettings::class);
+    $mock->tmdb_auto_lookup_on_import = false;
+    $mock->tmdb_auto_lookup_all_new = 'enabled';
+    app()->instance(GeneralSettings::class, $mock);
+
+    $playlist = Playlist::factory()->for($this->user)->createQuietly([
+        'channel_enable_rules' => [
+            ['enabled' => false, 'name' => 'Off', 'target' => 'channels', 'column' => 'title', 'action' => 'disable', 'pattern' => 'NO EVENT'],
+        ],
+    ]);
+
+    $run = app(SyncPipelineService::class)->buildPipeline($playlist, app(GeneralSettings::class));
+
+    expect($run->phases)->not->toContain(SyncRunPhase::ChannelEnableRules->value);
+});

--- a/tests/Feature/ChannelEnableRulesTest.php
+++ b/tests/Feature/ChannelEnableRulesTest.php
@@ -9,7 +9,7 @@
  */
 
 use App\Enums\SyncRunPhase;
-use App\Jobs\RunPlaylistChannelEnableRules;
+use App\Jobs\RunPlaylistChannelEnableDisableRules;
 use App\Models\Channel;
 use App\Models\Playlist;
 use App\Models\User;
@@ -57,7 +57,7 @@ it('disables channels matching a disable rule and leaves others untouched', func
     $idle = makeEnableRulesChannel($playlist, 'LIVE EVENT 02 | NO EVENT TODAY', true);
     $active = makeEnableRulesChannel($playlist, 'LIVE EVENT 01 | EVENT TITLE', true);
 
-    (new RunPlaylistChannelEnableRules($playlist))->handle();
+    (new RunPlaylistChannelEnableDisableRules($playlist))->handle();
 
     expect($idle->refresh()->enabled)->toBeFalse()
         ->and($active->refresh()->enabled)->toBeTrue();
@@ -71,7 +71,7 @@ it('re-enables a disabled channel when its title matches an enable rule', functi
     // Previously disabled placeholder that the provider renamed to a real event
     $channel = makeEnableRulesChannel($playlist, 'EVENT 01 | Big Game Tonight', false);
 
-    (new RunPlaylistChannelEnableRules($playlist))->handle();
+    (new RunPlaylistChannelEnableDisableRules($playlist))->handle();
 
     expect($channel->refresh()->enabled)->toBeTrue();
 });
@@ -85,7 +85,7 @@ it('applies rules in order with the last matching rule winning', function () {
     $idle = makeEnableRulesChannel($playlist, 'LIVE EVENT 02 | NO EVENT TODAY', true);
     $active = makeEnableRulesChannel($playlist, 'LIVE EVENT 01 | EVENT TITLE', false);
 
-    (new RunPlaylistChannelEnableRules($playlist))->handle();
+    (new RunPlaylistChannelEnableDisableRules($playlist))->handle();
 
     expect($idle->refresh()->enabled)->toBeFalse()
         ->and($active->refresh()->enabled)->toBeTrue();
@@ -98,7 +98,7 @@ it('matches against the custom title override when set', function () {
 
     $channel = makeEnableRulesChannel($playlist, 'LIVE EVENT 01', true, ['title_custom' => 'NO EVENT TODAY']);
 
-    (new RunPlaylistChannelEnableRules($playlist))->handle();
+    (new RunPlaylistChannelEnableDisableRules($playlist))->handle();
 
     expect($channel->refresh()->enabled)->toBeFalse();
 });
@@ -110,7 +110,7 @@ it('matches against the channel name when the rule targets the name column', fun
 
     $channel = makeEnableRulesChannel($playlist, 'Some title', true, ['name' => 'EVENT 05 | NO EVENT']);
 
-    (new RunPlaylistChannelEnableRules($playlist))->handle();
+    (new RunPlaylistChannelEnableDisableRules($playlist))->handle();
 
     expect($channel->refresh()->enabled)->toBeFalse();
 });
@@ -125,7 +125,7 @@ it('skips disabled rules and rules with invalid regex without aborting the rest'
     $active = makeEnableRulesChannel($playlist, 'LIVE EVENT 01 | EVENT TITLE', true);
     $idle = makeEnableRulesChannel($playlist, 'LIVE EVENT 02 | NO EVENT TODAY', true);
 
-    (new RunPlaylistChannelEnableRules($playlist))->handle();
+    (new RunPlaylistChannelEnableDisableRules($playlist))->handle();
 
     expect($active->refresh()->enabled)->toBeTrue()
         ->and($idle->refresh()->enabled)->toBeFalse();
@@ -139,7 +139,7 @@ it('only applies rules to channels of the matching target type', function () {
     $live = makeEnableRulesChannel($playlist, 'NO EVENT TODAY', true);
     $vod = makeEnableRulesChannel($playlist, 'NO EVENT TODAY', true, ['is_vod' => true]);
 
-    (new RunPlaylistChannelEnableRules($playlist))->handle();
+    (new RunPlaylistChannelEnableDisableRules($playlist))->handle();
 
     expect($live->refresh()->enabled)->toBeTrue()
         ->and($vod->refresh()->enabled)->toBeFalse();
@@ -152,7 +152,7 @@ it('never touches custom channels', function () {
 
     $custom = makeEnableRulesChannel($playlist, 'NO EVENT TODAY', true, ['is_custom' => true]);
 
-    (new RunPlaylistChannelEnableRules($playlist))->handle();
+    (new RunPlaylistChannelEnableDisableRules($playlist))->handle();
 
     expect($custom->refresh()->enabled)->toBeTrue();
 });


### PR DESCRIPTION
## Summary

Implements option 2 of #1199: per-playlist rules that automatically enable/disable channels based on a regex match against the channel title or name, re-evaluated after **every** sync — so event channels that providers rename between syncs (`LIVE EVENT 01 | EVENT TITLE` ⇄ `LIVE EVENT 01 | NO EVENT TODAY`) flip automatically without manual curation.

## Semantics

- Rules run in order; the **last matching rule wins** per channel.
- Channels matching **no rule keep their current state** (manual enables/disables are untouched).
- This composes naturally: a broad `disable` rule followed by a narrower `enable` rule gives "only enable channels currently carrying an event".
- Matches against the effective value (`title_custom ?? title` / `name_custom ?? name`), so it plays nicely with Find & Replace output.

## Implementation

- `channel_enable_rules` JSON column on `playlists` + repeater UI in the playlist form (new *Auto Enable/Disable Rules* section next to Find & Replace), with target (Live/VOD), column (title / tvg-name), action (enable/disable) and pattern with the existing `RegexTesterAction`.
- New `RunPlaylistChannelEnableRules` job: chunked over the playlist's non-custom channels, bulk-updates only changed rows, skips (and reports) invalid regex patterns without aborting the rest, and triggers `SyncPlexDvrJob::dispatchIfConfigured` when anything changed (mirroring the bulk enable/disable actions).
- New `ChannelEnableRules` sync phase, included only when an enabled rule exists — placed **after FindReplace** (rules match cleaned titles) and **before ChannelMerge/LiveProbe** (those phases see the final enabled set).

Option 1 from the issue (EPG/event-time-based enabling) is intentionally out of scope here, but this phase would be the natural place to extend if that's wanted later.

## Test plan

- New `tests/Feature/ChannelEnableRulesTest.php` (10 tests): disable/enable matching, last-match-wins ordering, custom-title and name-column matching, invalid-regex resilience, live/VOD target isolation, custom channels untouched, and pipeline inclusion/ordering + omission when no rules are enabled.
- `php artisan test --compact --filter='ChannelEnableRulesTest|SyncPipelineServiceTest|SyncListenerTest|ProcessM3uImportCompleteVodGuardTest'` → 99 passed.
- `vendor/bin/pint --dirty` clean.

Closes #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)