### PR TITLE
feat: add release date playlist sort rules

### DIFF
--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -2563,7 +2563,7 @@ class PlaylistResource extends Resource implements CopilotResource
                                 ->live()
                                 ->default('title')
                                 ->required()
-                                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('sort', $state === 'release_date' ? 'DESC' : 'ASC'))
+                                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('sort', ($state ?? '') === 'release_date' ? 'DESC' : 'ASC'))
                                 ->columnSpan(2),
                             Select::make('sort')
                                 ->label(__('Sort Order'))

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -795,7 +795,7 @@ class PlaylistResource extends Resource implements CopilotResource
                                 Rule::unique('playlist_aliases', 'uuid'), // Ensure UUID is unique in playlist_aliases table as well
                             ];
                         })
-                        ->helperText(__('3-36 characters. Only letters, numbers, hyphens, and underscores are allowed.'))
+                        ->helperText(__('3–36 characters. Only letters, numbers, hyphens, and underscores are allowed.'))
                         ->hintIcon(
                             'heroicon-m-exclamation-triangle',
                             tooltip: 'Be careful changing this value as this will change the URLs for the Playlist, its EPG, and HDHR.'
@@ -2594,7 +2594,7 @@ class PlaylistResource extends Resource implements CopilotResource
                             $groupLabel = \in_array('all', $groups) ? 'All' : implode(', ', $groups);
                             $disabled = ($state['enabled'] ?? true) ? '' : ' (disabled)';
 
-                            return "{$targetLabel} - {$groupLabel}{$disabled}";
+                            return "{$targetLabel} — {$groupLabel}{$disabled}";
                         }),
                 ]),
 
@@ -2772,7 +2772,7 @@ class PlaylistResource extends Resource implements CopilotResource
                                 : 'No playlist';
                             $disabled = ($state['enabled'] ?? true) ? '' : ' (disabled)';
 
-                            return "{$typeLabel} - {$groupLabel} → {$customPlaylistName}{$disabled}";
+                            return "{$typeLabel} — {$groupLabel} → {$customPlaylistName}{$disabled}";
                         }),
                 ]),
         ];
@@ -2943,7 +2943,7 @@ class PlaylistResource extends Resource implements CopilotResource
                             TextInput::make('available_streams')
                                 ->label(__('Available Streams'))
                                 ->hint(__('Set to 0 for unlimited streams.'))
-                                ->helperText(__('Maximum proxy streams allowed. Applies regardless of Provider Profiles - set to 0 for unlimited. When Provider Profiles are enabled, this is the authoritative proxy-level limit while provider limits control routing.'))
+                                ->helperText(__('Maximum proxy streams allowed. Applies regardless of Provider Profiles — set to 0 for unlimited. When Provider Profiles are enabled, this is the authoritative proxy-level limit while provider limits control routing.'))
                                 ->columnSpan(1)
                                 ->rules(['min:0'])
                                 ->type('number')
@@ -3075,7 +3075,7 @@ class PlaylistResource extends Resource implements CopilotResource
                         ->hidden(fn (Get $get): bool => ! $get('dummy_epg')),
                     Repeater::make('dummy_epg_fallback_order')
                         ->label(__('Dummy EPG Title Source'))
-                        ->helperText(__('Which field to use as the programme title for dummy EPG entries. Tried in order - first non-empty value wins. Leave empty to use the channel title.'))
+                        ->helperText(__('Which field to use as the programme title for dummy EPG entries. Tried in order — first non-empty value wins. Leave empty to use the channel title.'))
                         ->schema([
                             Select::make('method')
                                 ->label(__('Field'))

--- a/app/Filament/Resources/Playlists/PlaylistResource.php
+++ b/app/Filament/Resources/Playlists/PlaylistResource.php
@@ -795,7 +795,7 @@ class PlaylistResource extends Resource implements CopilotResource
                                 Rule::unique('playlist_aliases', 'uuid'), // Ensure UUID is unique in playlist_aliases table as well
                             ];
                         })
-                        ->helperText(__('3–36 characters. Only letters, numbers, hyphens, and underscores are allowed.'))
+                        ->helperText(__('3-36 characters. Only letters, numbers, hyphens, and underscores are allowed.'))
                         ->hintIcon(
                             'heroicon-m-exclamation-triangle',
                             tooltip: 'Be careful changing this value as this will change the URLs for the Playlist, its EPG, and HDHR.'
@@ -2500,41 +2500,70 @@ class PlaylistResource extends Resource implements CopilotResource
                                 ->options([
                                     'live_groups' => 'Live Groups',
                                     'vod_groups' => 'VOD Groups',
+                                    'series_categories' => 'Series Categories',
                                 ])
                                 ->live()
                                 ->default('live_groups')
                                 ->required()
-                                ->afterStateUpdated(fn (Set $set) => $set('group', ['all']))
+                                ->afterStateUpdated(function (Set $set, ?string $state): void {
+                                    $set('group', ['all']);
+                                    $set('column', $state === 'series_categories' ? 'release_date' : 'title');
+                                    $set('sort', $state === 'series_categories' ? 'DESC' : 'ASC');
+                                })
                                 ->columnSpan(1),
                             Select::make('group')
-                                ->label(__('Groups'))
-                                ->options(fn (Get $get, ?Playlist $record): array => [
-                                    'all' => 'All groups',
-                                    ...($record
-                                        ? SourceGroup::where('playlist_id', $record->id)
-                                            ->where('type', match ($get('target')) {
-                                                'vod_groups' => 'vod',
-                                                default => 'live',
-                                            })
-                                            ->orderBy('name')
-                                            ->pluck('name', 'name')
-                                            ->toArray()
-                                        : []),
-                                ])
+                                ->label(fn (Get $get): string => $get('target') === 'series_categories' ? __('Categories') : __('Groups'))
+                                ->options(function (Get $get, ?Playlist $record): array {
+                                    if ($get('target') === 'series_categories') {
+                                        return [
+                                            'all' => 'All categories',
+                                            ...($record
+                                                ? SourceCategory::where('playlist_id', $record->id)
+                                                    ->orderBy('name')
+                                                    ->pluck('name', 'name')
+                                                    ->toArray()
+                                                : []),
+                                        ];
+                                    }
+
+                                    return [
+                                        'all' => 'All groups',
+                                        ...($record
+                                            ? SourceGroup::where('playlist_id', $record->id)
+                                                ->where('type', match ($get('target')) {
+                                                    'vod_groups' => 'vod',
+                                                    default => 'live',
+                                                })
+                                                ->orderBy('name')
+                                                ->pluck('name', 'name')
+                                                ->toArray()
+                                            : []),
+                                    ];
+                                })
                                 ->default(['all'])
                                 ->multiple()
                                 ->searchable()
                                 ->columnSpan(3),
                             Select::make('column')
                                 ->label(__('Sort By'))
-                                ->options([
-                                    'title' => 'Title (or override if set)',
-                                    'name' => 'Name (or override if set)',
-                                    'stream_id' => 'ID (or override if set)',
-                                    'channel' => 'Channel No.',
-                                ])
+                                ->options(function (Get $get): array {
+                                    $alphaOptions = [
+                                        'title' => 'Title (or override if set)',
+                                        'name' => 'Name (or override if set)',
+                                        'stream_id' => 'ID (or override if set)',
+                                        'channel' => 'Channel No.',
+                                    ];
+
+                                    return match ($get('target')) {
+                                        'series_categories' => ['release_date' => 'Release Date'],
+                                        'vod_groups' => [...$alphaOptions, 'release_date' => 'Release Date'],
+                                        default => $alphaOptions,
+                                    };
+                                })
+                                ->live()
                                 ->default('title')
                                 ->required()
+                                ->afterStateUpdated(fn (Set $set, ?string $state) => $set('sort', $state === 'release_date' ? 'DESC' : 'ASC'))
                                 ->columnSpan(2),
                             Select::make('sort')
                                 ->label(__('Sort Order'))
@@ -2556,12 +2585,16 @@ class PlaylistResource extends Resource implements CopilotResource
                             if (empty($state['target'])) {
                                 return null;
                             }
-                            $targetLabel = $state['target'] === 'vod_groups' ? 'VOD Groups' : 'Live Groups';
+                            $targetLabel = match ($state['target']) {
+                                'vod_groups' => 'VOD Groups',
+                                'series_categories' => 'Series Categories',
+                                default => 'Live Groups',
+                            };
                             $groups = (array) ($state['group'] ?? ['all']);
                             $groupLabel = \in_array('all', $groups) ? 'All' : implode(', ', $groups);
                             $disabled = ($state['enabled'] ?? true) ? '' : ' (disabled)';
 
-                            return "{$targetLabel} — {$groupLabel}{$disabled}";
+                            return "{$targetLabel} - {$groupLabel}{$disabled}";
                         }),
                 ]),
 
@@ -2739,7 +2772,7 @@ class PlaylistResource extends Resource implements CopilotResource
                                 : 'No playlist';
                             $disabled = ($state['enabled'] ?? true) ? '' : ' (disabled)';
 
-                            return "{$typeLabel} — {$groupLabel} → {$customPlaylistName}{$disabled}";
+                            return "{$typeLabel} - {$groupLabel} → {$customPlaylistName}{$disabled}";
                         }),
                 ]),
         ];
@@ -2910,7 +2943,7 @@ class PlaylistResource extends Resource implements CopilotResource
                             TextInput::make('available_streams')
                                 ->label(__('Available Streams'))
                                 ->hint(__('Set to 0 for unlimited streams.'))
-                                ->helperText(__('Maximum proxy streams allowed. Applies regardless of Provider Profiles — set to 0 for unlimited. When Provider Profiles are enabled, this is the authoritative proxy-level limit while provider limits control routing.'))
+                                ->helperText(__('Maximum proxy streams allowed. Applies regardless of Provider Profiles - set to 0 for unlimited. When Provider Profiles are enabled, this is the authoritative proxy-level limit while provider limits control routing.'))
                                 ->columnSpan(1)
                                 ->rules(['min:0'])
                                 ->type('number')
@@ -3042,7 +3075,7 @@ class PlaylistResource extends Resource implements CopilotResource
                         ->hidden(fn (Get $get): bool => ! $get('dummy_epg')),
                     Repeater::make('dummy_epg_fallback_order')
                         ->label(__('Dummy EPG Title Source'))
-                        ->helperText(__('Which field to use as the programme title for dummy EPG entries. Tried in order — first non-empty value wins. Leave empty to use the channel title.'))
+                        ->helperText(__('Which field to use as the programme title for dummy EPG entries. Tried in order - first non-empty value wins. Leave empty to use the channel title.'))
                         ->schema([
                             Select::make('method')
                                 ->label(__('Field'))

--- a/app/Jobs/RunPlaylistSortAlpha.php
+++ b/app/Jobs/RunPlaylistSortAlpha.php
@@ -115,7 +115,7 @@ class RunPlaylistSortAlpha implements ShouldQueue
 
         Notification::make()
             ->success()
-            ->title('Playlist sorting completed')
+            ->title('Sort Alpha completed')
             ->body("Ran {$summary} for \"{$this->playlist->name}\" in {$completedIn}s.")
             ->broadcast($user)
             ->sendToDatabase($user);

--- a/app/Jobs/RunPlaylistSortAlpha.php
+++ b/app/Jobs/RunPlaylistSortAlpha.php
@@ -80,15 +80,17 @@ class RunPlaylistSortAlpha implements ShouldQueue
                     }
                 });
                 $vodRulesRun++;
-            } elseif ($target === 'series_categories' && $column === 'release_date') {
-                if ($isAll) {
-                    SortFacade::bulkSortPlaylistSeriesByReleaseDate($this->playlist, $order);
-                } else {
-                    $this->playlist->categories()
-                        ->whereIn('name_internal', $selectedGroups)
-                        ->each(function ($category) use ($order): void {
-                            SortFacade::bulkSortCategorySeriesByReleaseDate($category, $order);
-                        });
+            } elseif ($target === 'series_categories') {
+                if ($column === 'release_date') {
+                    if ($isAll) {
+                        SortFacade::bulkSortPlaylistSeriesByReleaseDate($this->playlist, $order);
+                    } else {
+                        $this->playlist->categories()
+                            ->whereIn('name_internal', $selectedGroups)
+                            ->each(function ($category) use ($order): void {
+                                SortFacade::bulkSortCategorySeriesByReleaseDate($category, $order);
+                            });
+                    }
                 }
                 $seriesRulesRun++;
             }

--- a/app/Jobs/RunPlaylistSortAlpha.php
+++ b/app/Jobs/RunPlaylistSortAlpha.php
@@ -42,6 +42,7 @@ class RunPlaylistSortAlpha implements ShouldQueue
         $start = now();
         $liveRulesRun = 0;
         $vodRulesRun = 0;
+        $seriesRulesRun = 0;
 
         foreach ($rules as $rule) {
             $target = $rule['target'] ?? 'live_groups';
@@ -60,15 +61,41 @@ class RunPlaylistSortAlpha implements ShouldQueue
                 });
                 $liveRulesRun++;
             } elseif ($target === 'vod_groups') {
+                if ($column === 'release_date' && $isAll) {
+                    SortFacade::bulkSortPlaylistVodByReleaseDate($this->playlist, $order);
+                    $vodRulesRun++;
+
+                    continue;
+                }
+
                 $query = $this->playlist->vodGroups();
                 if (! $isAll) {
                     $query = $query->whereIn('name_internal', $selectedGroups);
                 }
                 $query->each(function ($group) use ($column, $order): void {
-                    SortFacade::bulkSortGroupChannels($group, $order, $column);
+                    if ($column === 'release_date') {
+                        SortFacade::bulkSortGroupChannelsByReleaseDate($group, $order);
+                    } else {
+                        SortFacade::bulkSortGroupChannels($group, $order, $column);
+                    }
                 });
                 $vodRulesRun++;
+            } elseif ($target === 'series_categories' && $column === 'release_date') {
+                if ($isAll) {
+                    SortFacade::bulkSortPlaylistSeriesByReleaseDate($this->playlist, $order);
+                } else {
+                    $this->playlist->categories()
+                        ->whereIn('name_internal', $selectedGroups)
+                        ->each(function ($category) use ($order): void {
+                            SortFacade::bulkSortCategorySeriesByReleaseDate($category, $order);
+                        });
+                }
+                $seriesRulesRun++;
             }
+        }
+
+        if (($liveRulesRun + $vodRulesRun + $seriesRulesRun) === 0) {
+            return;
         }
 
         $completedIn = round($start->diffInSeconds(now()), 2);
@@ -81,11 +108,14 @@ class RunPlaylistSortAlpha implements ShouldQueue
         if ($vodRulesRun > 0) {
             $parts[] = "{$vodRulesRun} VOD ".($vodRulesRun === 1 ? 'rule' : 'rules');
         }
+        if ($seriesRulesRun > 0) {
+            $parts[] = "{$seriesRulesRun} Series ".($seriesRulesRun === 1 ? 'rule' : 'rules');
+        }
         $summary = implode(' and ', $parts);
 
         Notification::make()
             ->success()
-            ->title('Sort Alpha completed')
+            ->title('Playlist sorting completed')
             ->body("Ran {$summary} for \"{$this->playlist->name}\" in {$completedIn}s.")
             ->broadcast($user)
             ->sendToDatabase($user);

--- a/tests/Feature/PlaylistSortAlphaConfigTest.php
+++ b/tests/Feature/PlaylistSortAlphaConfigTest.php
@@ -114,5 +114,5 @@ it('persists a series release date sort rule', function () {
         ->call('save')
         ->assertHasNoFormErrors();
 
-    expect($this->playlist->fresh()->sort_alpha_config)->toBe([$rule]);
+    expect($this->playlist->fresh()->sort_alpha_config)->toEqual([$rule]);
 });

--- a/tests/Feature/PlaylistSortAlphaConfigTest.php
+++ b/tests/Feature/PlaylistSortAlphaConfigTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Filament\Resources\Playlists\Pages\EditPlaylist;
+use App\Models\Playlist;
+use App\Models\SourceCategory;
+use App\Models\User;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Livewire\Livewire;
+use PHPUnit\Framework\Assert;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create([
+        'sort_alpha_config' => null,
+    ]);
+
+    $this->actingAs($this->user);
+});
+
+it('offers only valid sort columns for each target', function (string $target, array $expectedOptions) {
+    Livewire::test(EditPlaylist::class, ['record' => $this->playlist->id])
+        ->fillForm([
+            'sort_alpha_config' => [[
+                'enabled' => true,
+                'target' => $target,
+                'group' => ['all'],
+                'column' => array_key_first($expectedOptions),
+                'sort' => 'ASC',
+            ]],
+        ])
+        ->assertFormFieldExists('sort_alpha_config', function (Repeater $field) use ($expectedOptions): bool {
+            $item = collect($field->getItems())->first();
+            $column = $item?->getFlatFields(withHidden: true)['column'] ?? null;
+
+            Assert::assertInstanceOf(Select::class, $column);
+            Assert::assertSame($expectedOptions, $column->getOptions());
+
+            return true;
+        });
+})->with([
+    'live groups' => [
+        'live_groups',
+        [
+            'title' => 'Title (or override if set)',
+            'name' => 'Name (or override if set)',
+            'stream_id' => 'ID (or override if set)',
+            'channel' => 'Channel No.',
+        ],
+    ],
+    'vod groups' => [
+        'vod_groups',
+        [
+            'title' => 'Title (or override if set)',
+            'name' => 'Name (or override if set)',
+            'stream_id' => 'ID (or override if set)',
+            'channel' => 'Channel No.',
+            'release_date' => 'Release Date',
+        ],
+    ],
+    'series categories' => [
+        'series_categories',
+        [
+            'release_date' => 'Release Date',
+        ],
+    ],
+]);
+
+it('offers playlist categories for series release date rules', function () {
+    $category = SourceCategory::create([
+        'playlist_id' => $this->playlist->id,
+        'name' => 'Provider Drama',
+        'source_category_id' => 123,
+    ]);
+
+    Livewire::test(EditPlaylist::class, ['record' => $this->playlist->id])
+        ->fillForm([
+            'sort_alpha_config' => [[
+                'enabled' => true,
+                'target' => 'series_categories',
+                'group' => ['all'],
+                'column' => 'release_date',
+                'sort' => 'DESC',
+            ]],
+        ])
+        ->assertFormFieldExists('sort_alpha_config', function (Repeater $field) use ($category): bool {
+            $item = collect($field->getItems())->first();
+            $group = $item?->getFlatFields(withHidden: true)['group'] ?? null;
+
+            Assert::assertInstanceOf(Select::class, $group);
+            Assert::assertSame([
+                'all' => 'All categories',
+                $category->name => $category->name,
+            ], $group->getOptions());
+
+            return true;
+        });
+});
+
+it('persists a series release date sort rule', function () {
+    $rule = [
+        'enabled' => true,
+        'target' => 'series_categories',
+        'group' => ['all'],
+        'column' => 'release_date',
+        'sort' => 'DESC',
+    ];
+
+    Livewire::test(EditPlaylist::class, ['record' => $this->playlist->id])
+        ->fillForm([
+            'user_agent' => 'Test Agent',
+            'sort_alpha_config' => [$rule],
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($this->playlist->fresh()->sort_alpha_config)->toBe([$rule]);
+});

--- a/tests/Feature/RunPlaylistSortAlphaTest.php
+++ b/tests/Feature/RunPlaylistSortAlphaTest.php
@@ -1,10 +1,14 @@
 <?php
 
 use App\Jobs\RunPlaylistSortAlpha;
+use App\Models\Category;
 use App\Models\Channel;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Models\Series;
 use App\Models\User;
+use Filament\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
 
 beforeEach(function () {
     $this->user = User::factory()->create();
@@ -127,4 +131,185 @@ it('only sorts vod groups when target is vod_groups', function () {
     // VOD group sorted
     expect($vodGroup->channels()->orderBy('sort')->pluck('title')->toArray())
         ->toBe(['Alpha VOD', 'Zebra VOD']);
+});
+
+it('sorts all vod groups by release date across the playlist', function () {
+    $this->playlist->update([
+        'sort_alpha_config' => [
+            ['enabled' => true, 'target' => 'vod_groups', 'group' => ['all'], 'column' => 'release_date', 'sort' => 'DESC'],
+        ],
+    ]);
+
+    $firstGroup = Group::factory()->for($this->playlist)->for($this->user)->create(['type' => 'vod']);
+    $oldest = Channel::factory()->for($this->user)->for($this->playlist)->for($firstGroup)->create([
+        'title' => 'Oldest',
+        'is_vod' => true,
+        'info' => ['release_date' => '2020-01-01'],
+        'sort' => 1,
+    ]);
+    $newest = Channel::factory()->for($this->user)->for($this->playlist)->for($firstGroup)->create([
+        'title' => 'Newest',
+        'is_vod' => true,
+        'info' => ['release_date' => '2024-01-01'],
+        'sort' => 2,
+    ]);
+
+    $secondGroup = Group::factory()->for($this->playlist)->for($this->user)->create(['type' => 'vod']);
+    $middle = Channel::factory()->for($this->user)->for($this->playlist)->for($secondGroup)->create([
+        'title' => 'Middle',
+        'is_vod' => true,
+        'info' => ['release_date' => '2022-01-01'],
+        'sort' => 1,
+    ]);
+
+    (new RunPlaylistSortAlpha($this->playlist))->handle();
+
+    expect($this->playlist->vod_channels()->orderBy('sort')->pluck('id')->all())
+        ->toBe([$newest->id, $middle->id, $oldest->id]);
+});
+
+it('sorts only selected vod groups by release date', function () {
+    $this->playlist->update([
+        'sort_alpha_config' => [
+            ['enabled' => true, 'target' => 'vod_groups', 'group' => ['Selected VOD'], 'column' => 'release_date', 'sort' => 'ASC'],
+        ],
+    ]);
+
+    $selectedGroup = Group::factory()->for($this->playlist)->for($this->user)->create([
+        'type' => 'vod',
+        'name_internal' => 'Selected VOD',
+    ]);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($selectedGroup)->create([
+        'title' => 'Newer selected',
+        'is_vod' => true,
+        'info' => ['release_date' => '2024-01-01'],
+        'sort' => 1,
+    ]);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($selectedGroup)->create([
+        'title' => 'Older selected',
+        'is_vod' => true,
+        'info' => ['release_date' => '2020-01-01'],
+        'sort' => 2,
+    ]);
+
+    $unselectedGroup = Group::factory()->for($this->playlist)->for($this->user)->create([
+        'type' => 'vod',
+        'name_internal' => 'Unselected VOD',
+    ]);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($unselectedGroup)->create([
+        'title' => 'Newer unselected',
+        'is_vod' => true,
+        'info' => ['release_date' => '2024-01-01'],
+        'sort' => 1,
+    ]);
+    Channel::factory()->for($this->user)->for($this->playlist)->for($unselectedGroup)->create([
+        'title' => 'Older unselected',
+        'is_vod' => true,
+        'info' => ['release_date' => '2020-01-01'],
+        'sort' => 2,
+    ]);
+
+    (new RunPlaylistSortAlpha($this->playlist))->handle();
+
+    expect($selectedGroup->channels()->orderBy('sort')->pluck('title')->all())
+        ->toBe(['Older selected', 'Newer selected'])
+        ->and($unselectedGroup->channels()->orderBy('sort')->pluck('title')->all())
+        ->toBe(['Newer unselected', 'Older unselected']);
+});
+
+it('sorts all series categories by release date across the playlist', function () {
+    $this->playlist->update([
+        'sort_alpha_config' => [
+            ['enabled' => true, 'target' => 'series_categories', 'group' => ['all'], 'column' => 'release_date', 'sort' => 'DESC'],
+        ],
+    ]);
+
+    $firstCategory = Category::factory()->for($this->playlist)->for($this->user)->create();
+    $oldest = Series::factory()->for($this->user)->for($this->playlist)->for($firstCategory)->create([
+        'name' => 'Oldest',
+        'release_date' => '2020-01-01',
+        'sort' => 1,
+    ]);
+    $newest = Series::factory()->for($this->user)->for($this->playlist)->for($firstCategory)->create([
+        'name' => 'Newest',
+        'release_date' => '2024-01-01',
+        'sort' => 2,
+    ]);
+
+    $secondCategory = Category::factory()->for($this->playlist)->for($this->user)->create();
+    $middle = Series::factory()->for($this->user)->for($this->playlist)->for($secondCategory)->create([
+        'name' => 'Middle',
+        'release_date' => '2022-01-01',
+        'sort' => 1,
+    ]);
+
+    (new RunPlaylistSortAlpha($this->playlist))->handle();
+
+    expect($this->playlist->series()->orderBy('sort')->pluck('id')->all())
+        ->toBe([$newest->id, $middle->id, $oldest->id]);
+});
+
+it('sorts only selected series categories by release date', function () {
+    $this->playlist->update([
+        'sort_alpha_config' => [
+            ['enabled' => true, 'target' => 'series_categories', 'group' => ['Selected Series'], 'column' => 'release_date', 'sort' => 'ASC'],
+        ],
+    ]);
+
+    $selectedCategory = Category::factory()->for($this->playlist)->for($this->user)->create([
+        'name_internal' => 'Selected Series',
+    ]);
+    Series::factory()->for($this->user)->for($this->playlist)->for($selectedCategory)->create([
+        'name' => 'Newer selected',
+        'release_date' => '2024-01-01',
+        'sort' => 1,
+    ]);
+    Series::factory()->for($this->user)->for($this->playlist)->for($selectedCategory)->create([
+        'name' => 'Older selected',
+        'release_date' => '2020-01-01',
+        'sort' => 2,
+    ]);
+
+    $unselectedCategory = Category::factory()->for($this->playlist)->for($this->user)->create([
+        'name_internal' => 'Unselected Series',
+    ]);
+    Series::factory()->for($this->user)->for($this->playlist)->for($unselectedCategory)->create([
+        'name' => 'Newer unselected',
+        'release_date' => '2024-01-01',
+        'sort' => 1,
+    ]);
+    Series::factory()->for($this->user)->for($this->playlist)->for($unselectedCategory)->create([
+        'name' => 'Older unselected',
+        'release_date' => '2020-01-01',
+        'sort' => 2,
+    ]);
+
+    (new RunPlaylistSortAlpha($this->playlist))->handle();
+
+    expect($selectedCategory->series()->orderBy('sort')->pluck('name')->all())
+        ->toBe(['Older selected', 'Newer selected'])
+        ->and($unselectedCategory->series()->orderBy('sort')->pluck('name')->all())
+        ->toBe(['Newer unselected', 'Older unselected']);
+});
+
+it('summarizes executed live vod and series rules in the notification', function () {
+    $this->playlist->update([
+        'sort_alpha_config' => [
+            ['enabled' => true, 'target' => 'live_groups', 'group' => ['all'], 'column' => 'title', 'sort' => 'ASC'],
+            ['enabled' => true, 'target' => 'vod_groups', 'group' => ['all'], 'column' => 'release_date', 'sort' => 'DESC'],
+            ['enabled' => true, 'target' => 'series_categories', 'group' => ['all'], 'column' => 'release_date', 'sort' => 'DESC'],
+        ],
+    ]);
+    NotificationFacade::fake();
+
+    (new RunPlaylistSortAlpha($this->playlist))->handle();
+
+    NotificationFacade::assertSentTo(
+        $this->user,
+        DatabaseNotification::class,
+        fn (DatabaseNotification $notification): bool => $notification->data['title'] === 'Playlist sorting completed'
+            && str_contains($notification->data['body'], '1 live rule')
+            && str_contains($notification->data['body'], '1 VOD rule')
+            && str_contains($notification->data['body'], '1 Series rule'),
+    );
 });

--- a/tests/Feature/RunPlaylistSortAlphaTest.php
+++ b/tests/Feature/RunPlaylistSortAlphaTest.php
@@ -307,7 +307,7 @@ it('summarizes executed live vod and series rules in the notification', function
     NotificationFacade::assertSentTo(
         $this->user,
         DatabaseNotification::class,
-        fn (DatabaseNotification $notification): bool => $notification->data['title'] === 'Playlist sorting completed'
+        fn (DatabaseNotification $notification): bool => $notification->data['title'] === 'Sort Alpha completed'
             && str_contains($notification->data['body'], '1 live rule')
             && str_contains($notification->data['body'], '1 VOD rule')
             && str_contains($notification->data['body'], '1 Series rule'),


### PR DESCRIPTION
## Summary

- add release-date sorting to automatic playlist sort configs for VOD groups and Series categories
- reuse the existing playlist-wide and selected group/category release-date sort services
- keep live and VOD alphabetical rules unchanged and report live, VOD, and Series rules in completion notifications
- restrict Filament sort options to valid target and column combinations

Closes #1277

## Tests

- RED: `php artisan test --compact tests/Feature/RunPlaylistSortAlphaTest.php` failed with invalid VOD release-date columns, unsorted Series records, and missing Series notification handling
- `php artisan test --compact tests/Feature/RunPlaylistSortAlphaTest.php tests/Feature/PlaylistSortAlphaConfigTest.php tests/Feature/SortServiceTest.php tests/Feature/GuestPanelReleaseDateSortingTest.php tests/Feature/SyncListenerTest.php` (64 passed, 126 assertions)
- `php artisan test --compact` (1640 passed, 4398 assertions, 29 skipped)
- `vendor/bin/pint --test`
- `composer audit --format=summary`
- `npm ci`
- `npm audit --audit-level=high`
- `npm run build`
- `php artisan checkpoint:scan` (25 passed, 1 local APP_URL warning, 0 failed)
- `git diff --check upstream/dev...HEAD`