### PR TITLE
feat: Add proxy ability to user auth and expose as capabilities for t…

### DIFF
--- a/app/Filament/Resources/PlaylistAuths/PlaylistAuthResource.php
+++ b/app/Filament/Resources/PlaylistAuths/PlaylistAuthResource.php
@@ -11,6 +11,7 @@ use App\Models\MergedPlaylist;
 use App\Models\Playlist;
 use App\Models\PlaylistAlias;
 use App\Models\PlaylistAuth;
+use App\Models\StreamProfile;
 use App\Pivots\PlaylistAuthPivot;
 use App\Services\DateFormatService;
 use App\Traits\HasUserFiltering;
@@ -22,11 +23,13 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Forms;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Resources\Resource;
 use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Tables;
 use Filament\Tables\Columns\TextColumn;
@@ -151,6 +154,48 @@ class PlaylistAuthResource extends Resource implements CopilotResource
 
     public static function getForm(): array
     {
+        $proxySection = auth()->user()->canUseProxy()
+            ? Section::make(__('Proxy Access'))
+                ->description(__('Advertise the m3u proxy to compatible clients (e.g. the TV app) authenticating with this user, allowing them to enable proxied playback and select a transcoding profile.'))
+                ->compact()
+                ->hidden(fn () => ! (auth()->user()?->canUseProxy() ?? false))
+                ->schema([
+                    Toggle::make('proxy_enabled')
+                        ->label(__('Enable Proxy'))
+                        ->helperText(__('Allow this user\'s clients to see and use the proxy, including per-device transcoding profile selection.'))
+                        ->default(false)
+                        ->live()
+                        ->columnSpan(2),
+                    Radio::make('proxy_profile_access')
+                        ->label(__('Transcoding Profile Access'))
+                        ->options([
+                            'all' => __('All profiles'),
+                            'selected' => __('Selected profiles'),
+                            'none' => __('None (direct proxy only)'),
+                        ])
+                        ->default('all')
+                        ->live()
+                        ->required()
+                        ->helperText(__('Which transcoding profiles this user may apply when streaming through the proxy.'))
+                        ->visible(fn ($get) => $get('proxy_enabled'))
+                        ->columnSpan(2),
+                    Select::make('proxy_stream_profile_ids')
+                        ->label(__('Allowed Profiles'))
+                        ->multiple()
+                        ->required()
+                        ->options(fn () => StreamProfile::where('user_id', auth()->id())
+                            ->orderBy('name')
+                            ->pluck('name', 'id')
+                            ->toArray())
+                        ->helperText(__('Only these profiles will be offered to (and accepted from) this user.'))
+                        ->hidden(fn ($get) => ! $get('proxy_enabled') || $get('proxy_profile_access') !== 'selected')
+                        ->columnSpan(2),
+                ])
+                ->columns(2)
+                ->collapsible()
+                ->collapsed(fn ($record) => ! ($record?->proxy_enabled))
+            : null;
+
         return [
             Grid::make()
                 ->schema([
@@ -318,6 +363,7 @@ class PlaylistAuthResource extends Resource implements CopilotResource
                         ->columnSpan(2),
                 ])
                 ->columns(2),
+            $proxySection,
         ];
     }
 }

--- a/app/Http/Controllers/Api/M3uProxyApiController.php
+++ b/app/Http/Controllers/Api/M3uProxyApiController.php
@@ -63,8 +63,19 @@ class M3uProxyApiController extends Controller
         // If neither is set, the stream is proxied directly without transcoding.
         // An adaptive profile (backend === 'adaptive') is unwrapped to its
         // concrete target via the channel's cached probe data.
-        $profile = $channel->streamProfile
-            ?? ($channel->is_vod ? $playlist->vodStreamProfile : $playlist->streamProfile);
+        //
+        // A client-selected profile (validated upstream in XtreamStreamController and
+        // passed via request attributes) replaces the playlist-level default; the
+        // channel-level profile still wins since it is pinned to make that specific
+        // stream work (e.g. resolver profiles). 'none' means explicit direct proxy.
+        $playlistProfile = $channel->is_vod ? $playlist->vodStreamProfile : $playlist->streamProfile;
+        $clientProfile = $request->attributes->get('client_stream_profile');
+        if ($clientProfile === 'none') {
+            $playlistProfile = null;
+        } elseif ($clientProfile instanceof StreamProfile) {
+            $playlistProfile = $clientProfile;
+        }
+        $profile = $channel->streamProfile ?? $playlistProfile;
         $profile = app(StreamProfileRuleEvaluator::class)->unwrap($profile, $channel->stream_stats);
 
         $url = app(M3uProxyService::class)
@@ -112,8 +123,17 @@ class M3uProxyApiController extends Controller
             $playlist->load('streamProfile', 'vodStreamProfile');
         }
 
-        // For Series, use the VOD stream profile if set
+        // For Series, use the VOD stream profile if set.
+        // A client-selected profile (validated upstream in XtreamStreamController and
+        // passed via request attributes) replaces the playlist-level default;
+        // 'none' means explicit direct proxy.
         $profile = $playlist->vodStreamProfile;
+        $clientProfile = $request->attributes->get('client_stream_profile');
+        if ($clientProfile === 'none') {
+            $profile = null;
+        } elseif ($clientProfile instanceof StreamProfile) {
+            $profile = $clientProfile;
+        }
 
         $url = app(M3uProxyService::class)
             ->getEpisodeUrl(

--- a/app/Http/Controllers/Api/M3uProxyApiController.php
+++ b/app/Http/Controllers/Api/M3uProxyApiController.php
@@ -72,8 +72,11 @@ class M3uProxyApiController extends Controller
         $clientProfile = $request->attributes->get('client_stream_profile');
         if ($clientProfile === 'none') {
             $playlistProfile = null;
-        } elseif ($clientProfile instanceof StreamProfile) {
-            $playlistProfile = $clientProfile;
+        } elseif ($clientProfile !== null) {
+            $profileId = (int) $clientProfile;
+            $playlistProfile = StreamProfile::where('id', $profileId)
+                ->where('user_id', $playlist->user_id)
+                ->first();
         }
         $profile = $channel->streamProfile ?? $playlistProfile;
         $profile = app(StreamProfileRuleEvaluator::class)->unwrap($profile, $channel->stream_stats);
@@ -131,8 +134,11 @@ class M3uProxyApiController extends Controller
         $clientProfile = $request->attributes->get('client_stream_profile');
         if ($clientProfile === 'none') {
             $profile = null;
-        } elseif ($clientProfile instanceof StreamProfile) {
-            $profile = $clientProfile;
+        } elseif ($clientProfile !== null) {
+            $profileId = (int) $clientProfile;
+            $profile = StreamProfile::where('id', $profileId)
+                ->where('user_id', $playlist->user_id)
+                ->first();
         }
 
         $url = app(M3uProxyService::class)

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -18,6 +18,7 @@ use App\Models\PlaylistAlias;
 use App\Models\PlaylistAuth;
 use App\Models\PlaylistViewer;
 use App\Models\Series;
+use App\Models\StreamProfile;
 use App\Models\ViewerWatchProgress;
 use App\Services\EpgCacheService;
 use App\Services\LogoCacheService;
@@ -442,15 +443,16 @@ class XtreamApiController extends Controller
                 $streams = $playlist->streams ?? 1;
                 $activeConnections = 0;
             }
+            // Resolve the PlaylistAuth once — used for the per-auth connection limit
+            // override and for feature advertisement (proxy access).
+            $playlistAuth = $authMethod === 'playlist_auth'
+                ? PlaylistAuth::where('username', $username)->where('password', $password)->first()
+                : null;
+
             // Override max_connections when the request is authenticated via a PlaylistAuth
             // that has a specific per-auth limit configured.
-            if ($authMethod === 'playlist_auth') {
-                $authMaxConnections = PlaylistAuth::where('username', $username)
-                    ->where('password', $password)
-                    ->value('max_connections');
-                if ($authMaxConnections) {
-                    $streams = $authMaxConnections;
-                }
+            if ($playlistAuth?->max_connections) {
+                $streams = $playlistAuth->max_connections;
             }
 
             $outputFormats = ['m3u8', 'ts'];
@@ -517,13 +519,22 @@ class XtreamApiController extends Controller
                 'process' => true, // Always true
             ];
 
+            $features = $this->resolveM3uEditorFeatures($playlist, $authMethod, $playlistAuth);
+
+            $m3uEditorPayload = [
+                'version' => config('dev.version'),
+                'features' => $features,
+            ];
+
+            $proxyData = $this->resolveProxyData($playlist, $features, $authMethod, $playlistAuth);
+            if (! empty($proxyData)) {
+                $m3uEditorPayload['proxy'] = $proxyData;
+            }
+
             return response()->json([
                 'user_info' => $userInfo,
                 'server_info' => $serverInfo,
-                'm3u_editor' => [
-                    'version' => config('dev.version'),
-                    'features' => ['viewers', 'progress'],
-                ],
+                'm3u_editor' => $m3uEditorPayload,
             ]);
         } elseif ($action === 'get_live_streams') {
             // Handle network playlists - return networks as live streams
@@ -2561,5 +2572,88 @@ class XtreamApiController extends Controller
         $password = $request->input('password');
 
         return PlaylistFacade::authenticate($username, $password);
+    }
+
+    /**
+     * Resolve optional m3u-editor capabilities advertised to compatible clients.
+     *
+     * The proxy feature is advertised when the playlist owner may use the proxy
+     * and, for PlaylistAuth credentials, the individual auth has proxy access
+     * enabled. Owner/alias credentials act with the owner's own permission.
+     *
+     * @return array<int, string>
+     */
+    private function resolveM3uEditorFeatures($playlist, string $authMethod, ?PlaylistAuth $playlistAuth): array
+    {
+        $features = ['viewers', 'progress'];
+
+        if ($this->canAdvertiseProxyFeature($playlist, $authMethod, $playlistAuth)) {
+            $features[] = 'proxy';
+        }
+
+        return $features;
+    }
+
+    private function canAdvertiseProxyFeature($playlist, string $authMethod, ?PlaylistAuth $playlistAuth): bool
+    {
+        if (! $playlist->user?->canUseProxy()) {
+            return false;
+        }
+
+        if ($authMethod === 'playlist_auth') {
+            return (bool) $playlistAuth?->proxy_enabled;
+        }
+
+        return true;
+    }
+
+    /**
+     * Build the proxy payload for the auth response: whether the proxy is forced
+     * at the playlist level, and the transcoding profiles the authenticated user
+     * may apply to proxied streams. Profile ffmpeg args are intentionally never
+     * exposed to clients.
+     *
+     * When 'forced' is true the playlist already routes every stream through the
+     * proxy, so clients should present the proxy as locked on — profile selection
+     * still applies.
+     *
+     * @return array{forced: bool, profiles: array<int, array{id: int, name: string, description: string|null, format: string|null}>}|array{}
+     */
+    private function resolveProxyData($playlist, array $features, string $authMethod, ?PlaylistAuth $playlistAuth): array
+    {
+        if (! in_array('proxy', $features)) {
+            return [];
+        }
+
+        $forced = (bool) ($playlist->enable_proxy ?? false);
+
+        $query = StreamProfile::where('user_id', $playlist->user_id)->orderBy('name');
+
+        if ($authMethod === 'playlist_auth') {
+            $access = $playlistAuth->proxy_profile_access ?? 'all';
+            if ($access === 'none') {
+                return ['forced' => $forced, 'profiles' => []];
+            }
+            if ($access === 'selected') {
+                $allowedIds = array_map('intval', $playlistAuth->proxy_stream_profile_ids ?? []);
+                if (empty($allowedIds)) {
+                    return ['forced' => $forced, 'profiles' => []];
+                }
+                $query->whereIn('id', $allowedIds);
+            }
+        }
+
+        return [
+            'forced' => $forced,
+            'profiles' => $query->get(['id', 'name', 'description', 'format'])
+                ->map(fn (StreamProfile $profile) => [
+                    'id' => $profile->id,
+                    'name' => $profile->name,
+                    'description' => $profile->description,
+                    'format' => $profile->format,
+                ])
+                ->values()
+                ->all(),
+        ];
     }
 }

--- a/app/Http/Controllers/XtreamStreamController.php
+++ b/app/Http/Controllers/XtreamStreamController.php
@@ -11,7 +11,6 @@ use App\Models\Network;
 use App\Models\Playlist;
 use App\Models\PlaylistAlias;
 use App\Models\PlaylistAuth;
-use App\Models\StreamProfile;
 use App\Services\PlaylistService;
 use App\Services\PlaylistUrlService;
 use Carbon\Carbon;
@@ -57,13 +56,7 @@ class XtreamStreamController extends Controller
             return;
         }
 
-        $profile = StreamProfile::where('id', $profileId)
-            ->where('user_id', $playlist->user_id)
-            ->first();
-
-        if ($profile) {
-            $request->attributes->set('client_stream_profile', $profile);
-        }
+        $request->attributes->set('client_stream_profile', $profileId);
     }
 
     /**

--- a/app/Http/Controllers/XtreamStreamController.php
+++ b/app/Http/Controllers/XtreamStreamController.php
@@ -11,6 +11,7 @@ use App\Models\Network;
 use App\Models\Playlist;
 use App\Models\PlaylistAlias;
 use App\Models\PlaylistAuth;
+use App\Models\StreamProfile;
 use App\Services\PlaylistService;
 use App\Services\PlaylistUrlService;
 use Carbon\Carbon;
@@ -21,6 +22,50 @@ use Illuminate\Support\Facades\Redirect;
 
 class XtreamStreamController extends Controller
 {
+    /**
+     * Validate a client-requested transcoding profile (?profile=<id>|none) and stash
+     * the result in request attributes for the proxy controller. Request attributes
+     * are server-side only, so downstream code can trust the resolved value.
+     *
+     * Invalid or unauthorized selections are ignored (playback continues with the
+     * default proxy behavior) rather than failing the stream — a client may hold a
+     * profile the admin has since revoked.
+     */
+    private function applyClientStreamProfile(Request $request, $playlist, ?PlaylistAuth $playlistAuth): void
+    {
+        $requested = $request->input('profile');
+        if ($requested === null || $requested === '') {
+            return;
+        }
+
+        // Explicit direct proxy — suppress the playlist-level default profile.
+        if ($requested === 'none' || $requested === '0') {
+            $request->attributes->set('client_stream_profile', 'none');
+
+            return;
+        }
+
+        if (! is_numeric($requested)) {
+            return;
+        }
+
+        $profileId = (int) $requested;
+
+        // PlaylistAuth users may only use profiles the auth allows; owner/alias
+        // credentials may use any of the playlist owner's profiles.
+        if ($playlistAuth instanceof PlaylistAuth && ! $playlistAuth->allowsProxyStreamProfile($profileId)) {
+            return;
+        }
+
+        $profile = StreamProfile::where('id', $profileId)
+            ->where('user_id', $playlist->user_id)
+            ->first();
+
+        if ($profile) {
+            $request->attributes->set('client_stream_profile', $profile);
+        }
+    }
+
     /**
      * Authenticates a playlist using either PlaylistAuth credentials or the original method
      * (username = playlist owner's name, password = playlist UUID).
@@ -232,6 +277,7 @@ class XtreamStreamController extends Controller
                 if ($playlistAuth instanceof PlaylistAuth) {
                     $request->merge(['playlist_auth_id' => $playlistAuth->id]);
                 }
+                $this->applyClientStreamProfile($request, $playlist, $playlistAuth);
 
                 // player=true signals an in-app player request — route to channelPlayer
                 // so the in-app transcoding profile is applied instead of the playlist profile
@@ -283,6 +329,7 @@ class XtreamStreamController extends Controller
                 if ($playlistAuth instanceof PlaylistAuth) {
                     $request->merge(['playlist_auth_id' => $playlistAuth->id]);
                 }
+                $this->applyClientStreamProfile($request, $playlist, $playlistAuth);
 
                 // player=true signals an in-app player request — apply in-app transcoding profile
                 $method = $request->input('player') === 'true' ? 'channelPlayer' : 'channel';
@@ -318,6 +365,7 @@ class XtreamStreamController extends Controller
                 if ($playlistAuth instanceof PlaylistAuth) {
                     $request->merge(['playlist_auth_id' => $playlistAuth->id]);
                 }
+                $this->applyClientStreamProfile($request, $playlist, $playlistAuth);
 
                 // player=true signals an in-app player request — apply in-app transcoding profile
                 $method = $request->input('player') === 'true' ? 'episodePlayer' : 'episode';
@@ -410,7 +458,9 @@ class XtreamStreamController extends Controller
         }
         $request->merge($mergeData);
 
-        if ($playlist->enable_proxy && $playlist->user->canUseProxy()) {
+        if (($playlist->enable_proxy || $request->input('proxy') === 'true') && $playlist->user->canUseProxy()) {
+            $this->applyClientStreamProfile($request, $playlist, $playlistAuth);
+
             return app()->call([app(M3uProxyApiController::class), 'channel'], [
                 'id' => $timeshiftChannel->id,
                 'uuid' => $playlist->uuid,

--- a/app/Models/PlaylistAuth.php
+++ b/app/Models/PlaylistAuth.php
@@ -27,6 +27,8 @@ class PlaylistAuth extends Model
         'expires_at' => 'datetime',
         'max_connections' => 'integer',
         'stop_oldest_on_limit' => 'boolean',
+        'proxy_enabled' => 'boolean',
+        'proxy_stream_profile_ids' => 'array',
     ];
 
     public function user(): BelongsTo
@@ -37,6 +39,25 @@ class PlaylistAuth extends Model
     public function viewer(): HasOne
     {
         return $this->hasOne(PlaylistViewer::class);
+    }
+
+    /**
+     * Whether this auth may apply the given stream profile when proxying.
+     *
+     * Profile access modes: 'all' (any owner profile), 'selected' (only the
+     * IDs in proxy_stream_profile_ids), 'none' (direct proxy only).
+     */
+    public function allowsProxyStreamProfile(int $profileId): bool
+    {
+        if (! $this->proxy_enabled) {
+            return false;
+        }
+
+        return match ($this->proxy_profile_access) {
+            'none' => false,
+            'selected' => in_array($profileId, array_map('intval', $this->proxy_stream_profile_ids ?? []), true),
+            default => true, // 'all'
+        };
     }
 
     /**

--- a/database/migrations/2026_07_13_000001_add_proxy_access_to_playlist_auths_table.php
+++ b/database/migrations/2026_07_13_000001_add_proxy_access_to_playlist_auths_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('playlist_auths', function (Blueprint $table) {
+            $table->boolean('proxy_enabled')->default(false)->after('stop_oldest_on_limit');
+            // 'all' = every owner profile, 'selected' = only proxy_stream_profile_ids, 'none' = direct proxy only (no transcoding)
+            $table->string('proxy_profile_access')->default('all')->after('proxy_enabled');
+            $table->json('proxy_stream_profile_ids')->nullable()->after('proxy_profile_access');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('playlist_auths', function (Blueprint $table) {
+            $table->dropColumn(['proxy_enabled', 'proxy_profile_access', 'proxy_stream_profile_ids']);
+        });
+    }
+};

--- a/tests/Feature/PlaylistAuthProxyAccessTest.php
+++ b/tests/Feature/PlaylistAuthProxyAccessTest.php
@@ -1,0 +1,421 @@
+<?php
+
+/**
+ * Tests for capability-aware proxy access:
+ *
+ * - player_api advertises the 'proxy' feature and the transcoding profiles the
+ *   authenticated user may apply (owner/alias = all owner profiles, PlaylistAuth =
+ *   gated by proxy_enabled + proxy_profile_access), plus whether the proxy is
+ *   forced at the playlist level.
+ * - A client-requested ?profile=<id>|none on Xtream stream URLs is validated
+ *   server-side and applied as the stream profile (replacing the playlist-level
+ *   default; channel-level profiles still win).
+ */
+
+use App\Models\Channel;
+use App\Models\Episode;
+use App\Models\Playlist;
+use App\Models\PlaylistAuth;
+use App\Models\Season;
+use App\Models\Series;
+use App\Models\StreamProfile;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+    $this->user = User::factory()->create([
+        'name' => 'owner',
+        'permissions' => ['use_proxy'],
+    ]);
+    $this->playlist = Playlist::factory()->for($this->user)->create([
+        'enable_proxy' => false,
+        'xtream' => false,
+    ]);
+
+    $this->makeAuth = function (array $attributes = []): PlaylistAuth {
+        $auth = PlaylistAuth::create(array_merge([
+            'name' => 'TV Auth',
+            'username' => 'tvuser',
+            'password' => 'tvpass',
+            'enabled' => true,
+            'user_id' => $this->user->id,
+        ], $attributes));
+        $auth->assignTo($this->playlist);
+
+        return $auth->fresh();
+    };
+
+    $this->playerApi = function (string $username, string $password) {
+        return $this->get('/player_api.php?'.http_build_query([
+            'username' => $username,
+            'password' => $password,
+        ]));
+    };
+
+    $this->makeEpisode = function (): Episode {
+        $series = Series::factory()->for($this->user)->for($this->playlist)->create(['enabled' => true]);
+        $season = Season::factory()->for($this->user)->for($this->playlist)->for($series)->create();
+
+        return Episode::factory()->for($this->user)->for($this->playlist)->for($series)->for($season)->create([
+            'container_extension' => 'mp4',
+        ]);
+    };
+
+    $this->mockChannelUrl = function (&$capturedProfile) {
+        $mock = Mockery::mock(M3uProxyService::class);
+        $mock->shouldReceive('getChannelUrl')
+            ->once()
+            ->withArgs(function ($playlist, $ch, $request, $profile) use (&$capturedProfile) {
+                $capturedProfile = $profile;
+
+                return true;
+            })
+            ->andReturn('http://proxy.test/redirected');
+        app()->instance(M3uProxyService::class, $mock);
+    };
+});
+
+// ── player_api feature advertisement ─────────────────────────────────────────
+
+test('owner auth advertises proxy feature with all owner profiles', function () {
+    $profileA = StreamProfile::factory()->for($this->user)->create(['name' => 'A 1080p']);
+    $profileB = StreamProfile::factory()->for($this->user)->create(['name' => 'B 720p']);
+
+    $response = ($this->playerApi)($this->user->name, $this->playlist->uuid);
+
+    $response->assertOk();
+    $payload = $response->json('m3u_editor');
+
+    expect($payload['features'])->toContain('proxy')
+        ->and($payload['proxy']['forced'])->toBeFalse()
+        ->and(collect($payload['proxy']['profiles'])->pluck('id')->all())
+        ->toBe([$profileA->id, $profileB->id]);
+});
+
+test('proxy profile payload never exposes ffmpeg args or cookies path', function () {
+    StreamProfile::factory()->for($this->user)->create();
+
+    $response = ($this->playerApi)($this->user->name, $this->playlist->uuid);
+
+    $profile = $response->json('m3u_editor.proxy.profiles.0');
+
+    expect(array_keys($profile))->toBe(['id', 'name', 'description', 'format'])
+        ->and($response->getContent())->not->toContain('libx264');
+});
+
+test('owner without use_proxy permission does not advertise proxy', function () {
+    $this->user->update(['permissions' => []]);
+
+    $response = ($this->playerApi)($this->user->name, $this->playlist->uuid);
+
+    $payload = $response->json('m3u_editor');
+
+    expect($payload['features'])->not->toContain('proxy')
+        ->and($payload)->not->toHaveKey('proxy');
+});
+
+test('proxy is not advertised when the integration is globally disabled', function () {
+    config(['proxy.proxy_integration_enabled' => false]);
+
+    $response = ($this->playerApi)($this->user->name, $this->playlist->uuid);
+
+    expect($response->json('m3u_editor.features'))->not->toContain('proxy');
+});
+
+test('playlist auth without proxy_enabled does not advertise proxy', function () {
+    ($this->makeAuth)(['proxy_enabled' => false]);
+
+    $response = ($this->playerApi)('tvuser', 'tvpass');
+
+    $payload = $response->json('m3u_editor');
+
+    expect($payload['features'])->not->toContain('proxy')
+        ->and($payload)->not->toHaveKey('proxy');
+});
+
+test('playlist auth with proxy_enabled and all-profile access advertises every owner profile', function () {
+    $profileA = StreamProfile::factory()->for($this->user)->create(['name' => 'A']);
+    $profileB = StreamProfile::factory()->for($this->user)->create(['name' => 'B']);
+    ($this->makeAuth)(['proxy_enabled' => true, 'proxy_profile_access' => 'all']);
+
+    $response = ($this->playerApi)('tvuser', 'tvpass');
+
+    $payload = $response->json('m3u_editor');
+
+    expect($payload['features'])->toContain('proxy')
+        ->and(collect($payload['proxy']['profiles'])->pluck('id')->all())
+        ->toBe([$profileA->id, $profileB->id]);
+});
+
+test('playlist auth with selected profile access advertises only the allowed profiles', function () {
+    StreamProfile::factory()->for($this->user)->create(['name' => 'A']);
+    $allowed = StreamProfile::factory()->for($this->user)->create(['name' => 'B']);
+    ($this->makeAuth)([
+        'proxy_enabled' => true,
+        'proxy_profile_access' => 'selected',
+        'proxy_stream_profile_ids' => [$allowed->id],
+    ]);
+
+    $response = ($this->playerApi)('tvuser', 'tvpass');
+
+    expect(collect($response->json('m3u_editor.proxy.profiles'))->pluck('id')->all())
+        ->toBe([$allowed->id]);
+});
+
+test('playlist auth with no profile access advertises proxy with an empty profile list', function () {
+    StreamProfile::factory()->for($this->user)->create();
+    ($this->makeAuth)(['proxy_enabled' => true, 'proxy_profile_access' => 'none']);
+
+    $response = ($this->playerApi)('tvuser', 'tvpass');
+
+    $payload = $response->json('m3u_editor');
+
+    expect($payload['features'])->toContain('proxy')
+        ->and($payload['proxy']['profiles'])->toBe([]);
+});
+
+test('proxy is advertised as forced when the playlist has enable_proxy set', function () {
+    $this->playlist->update(['enable_proxy' => true]);
+    ($this->makeAuth)(['proxy_enabled' => true]);
+
+    $response = ($this->playerApi)('tvuser', 'tvpass');
+
+    expect($response->json('m3u_editor.proxy.forced'))->toBeTrue();
+});
+
+// ── Client-requested profile on Xtream stream URLs ───────────────────────────
+
+test('owner request with ?proxy=true&profile applies the requested profile', function () {
+    $profile = StreamProfile::factory()->for($this->user)->create();
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'url' => 'http://provider.test/stream/live.ts',
+        'is_vod' => false,
+        'enabled' => true,
+    ]);
+
+    $capturedProfile = null;
+    ($this->mockChannelUrl)($capturedProfile);
+
+    $this->get("/live/{$this->user->name}/{$this->playlist->uuid}/{$channel->id}.ts?proxy=true&profile={$profile->id}")
+        ->assertRedirect();
+
+    expect($capturedProfile?->id)->toBe($profile->id);
+});
+
+test('profile=none suppresses the playlist-level default profile', function () {
+    $playlistProfile = StreamProfile::factory()->for($this->user)->create();
+    $this->playlist->update(['enable_proxy' => true, 'stream_profile_id' => $playlistProfile->id]);
+
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'url' => 'http://provider.test/stream/live.ts',
+        'is_vod' => false,
+        'enabled' => true,
+    ]);
+
+    $capturedProfile = 'unset';
+    ($this->mockChannelUrl)($capturedProfile);
+
+    $this->get("/live/{$this->user->name}/{$this->playlist->uuid}/{$channel->id}.ts?profile=none")
+        ->assertRedirect();
+
+    expect($capturedProfile)->toBeNull();
+});
+
+test('a channel-level profile still wins over the client-requested profile', function () {
+    $channelProfile = StreamProfile::factory()->for($this->user)->create();
+    $clientProfile = StreamProfile::factory()->for($this->user)->create();
+    $this->playlist->update(['enable_proxy' => true]);
+
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'stream_profile_id' => $channelProfile->id,
+        'url' => 'http://provider.test/stream/live.ts',
+        'is_vod' => false,
+        'enabled' => true,
+    ]);
+
+    $capturedProfile = null;
+    ($this->mockChannelUrl)($capturedProfile);
+
+    $this->get("/live/{$this->user->name}/{$this->playlist->uuid}/{$channel->id}.ts?profile={$clientProfile->id}")
+        ->assertRedirect();
+
+    expect($capturedProfile?->id)->toBe($channelProfile->id);
+});
+
+test('playlist auth may apply a profile its access list allows', function () {
+    $profile = StreamProfile::factory()->for($this->user)->create();
+    ($this->makeAuth)([
+        'proxy_enabled' => true,
+        'proxy_profile_access' => 'selected',
+        'proxy_stream_profile_ids' => [$profile->id],
+    ]);
+
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'url' => 'http://provider.test/stream/live.ts',
+        'is_vod' => false,
+        'enabled' => true,
+    ]);
+
+    $capturedProfile = null;
+    ($this->mockChannelUrl)($capturedProfile);
+
+    $this->get("/live/tvuser/tvpass/{$channel->id}.ts?proxy=true&profile={$profile->id}")
+        ->assertRedirect();
+
+    expect($capturedProfile?->id)->toBe($profile->id);
+});
+
+test('playlist auth cannot apply a profile outside its access list', function () {
+    $allowed = StreamProfile::factory()->for($this->user)->create();
+    $denied = StreamProfile::factory()->for($this->user)->create();
+    ($this->makeAuth)([
+        'proxy_enabled' => true,
+        'proxy_profile_access' => 'selected',
+        'proxy_stream_profile_ids' => [$allowed->id],
+    ]);
+
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'url' => 'http://provider.test/stream/live.ts',
+        'is_vod' => false,
+        'enabled' => true,
+    ]);
+
+    $capturedProfile = 'unset';
+    ($this->mockChannelUrl)($capturedProfile);
+
+    // The unauthorized selection is ignored; the stream still plays with defaults.
+    $this->get("/live/tvuser/tvpass/{$channel->id}.ts?proxy=true&profile={$denied->id}")
+        ->assertRedirect();
+
+    expect($capturedProfile)->toBeNull();
+});
+
+test('playlist auth without proxy_enabled cannot apply any profile', function () {
+    $profile = StreamProfile::factory()->for($this->user)->create();
+    ($this->makeAuth)(['proxy_enabled' => false]);
+
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'url' => 'http://provider.test/stream/live.ts',
+        'is_vod' => false,
+        'enabled' => true,
+    ]);
+
+    $capturedProfile = 'unset';
+    ($this->mockChannelUrl)($capturedProfile);
+
+    // ?proxy=true itself keeps working (back-compat); only the profile is ignored.
+    $this->get("/live/tvuser/tvpass/{$channel->id}.ts?proxy=true&profile={$profile->id}")
+        ->assertRedirect();
+
+    expect($capturedProfile)->toBeNull();
+});
+
+test('a profile belonging to another user is ignored', function () {
+    $otherUser = User::factory()->create(['permissions' => ['use_proxy']]);
+    $foreignProfile = StreamProfile::factory()->for($otherUser)->create();
+
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'url' => 'http://provider.test/stream/live.ts',
+        'is_vod' => false,
+        'enabled' => true,
+    ]);
+
+    $capturedProfile = 'unset';
+    ($this->mockChannelUrl)($capturedProfile);
+
+    $this->get("/live/{$this->user->name}/{$this->playlist->uuid}/{$channel->id}.ts?proxy=true&profile={$foreignProfile->id}")
+        ->assertRedirect();
+
+    expect($capturedProfile)->toBeNull();
+});
+
+test('timeshift request with ?proxy=true&profile applies the requested profile', function () {
+    $profile = StreamProfile::factory()->for($this->user)->create();
+    $channel = Channel::factory()->for($this->user)->for($this->playlist)->create([
+        'url' => 'http://provider.test/stream/live.ts',
+        'is_vod' => false,
+        'enabled' => true,
+        'catchup' => 'default',
+    ]);
+
+    $capturedProfile = null;
+    ($this->mockChannelUrl)($capturedProfile);
+
+    $this->get("/timeshift/{$this->user->name}/{$this->playlist->uuid}/60/2026-01-01:00-00-00/{$channel->id}.ts?proxy=true&profile={$profile->id}")
+        ->assertRedirect();
+
+    expect($capturedProfile?->id)->toBe($profile->id);
+});
+
+test('episode request with ?proxy=true&profile applies the requested profile', function () {
+    $profile = StreamProfile::factory()->for($this->user)->create();
+    $episode = ($this->makeEpisode)();
+
+    $capturedProfile = null;
+    $mock = Mockery::mock(M3uProxyService::class);
+    $mock->shouldReceive('getEpisodeUrl')
+        ->once()
+        ->withArgs(function ($playlist, $ep, $episodeProfile) use (&$capturedProfile) {
+            $capturedProfile = $episodeProfile;
+
+            return true;
+        })
+        ->andReturn('http://proxy.test/redirected');
+    app()->instance(M3uProxyService::class, $mock);
+
+    $this->get("/series/{$this->user->name}/{$this->playlist->uuid}/{$episode->id}.mp4?proxy=true&profile={$profile->id}")
+        ->assertRedirect();
+
+    expect($capturedProfile?->id)->toBe($profile->id);
+});
+
+test('episode request with profile=none suppresses the playlist vod profile', function () {
+    $vodProfile = StreamProfile::factory()->for($this->user)->create();
+    $this->playlist->update(['enable_proxy' => true, 'vod_stream_profile_id' => $vodProfile->id]);
+
+    $episode = ($this->makeEpisode)();
+
+    $capturedProfile = 'unset';
+    $mock = Mockery::mock(M3uProxyService::class);
+    $mock->shouldReceive('getEpisodeUrl')
+        ->once()
+        ->withArgs(function ($playlist, $ep, $episodeProfile) use (&$capturedProfile) {
+            $capturedProfile = $episodeProfile;
+
+            return true;
+        })
+        ->andReturn('http://proxy.test/redirected');
+    app()->instance(M3uProxyService::class, $mock);
+
+    $this->get("/series/{$this->user->name}/{$this->playlist->uuid}/{$episode->id}.mp4?profile=none")
+        ->assertRedirect();
+
+    expect($capturedProfile)->toBeNull();
+});
+
+// ── PlaylistAuth::allowsProxyStreamProfile ───────────────────────────────────
+
+test('allowsProxyStreamProfile honors access modes', function () {
+    $auth = ($this->makeAuth)([
+        'proxy_enabled' => true,
+        'proxy_profile_access' => 'selected',
+        'proxy_stream_profile_ids' => [7, 9],
+    ]);
+
+    expect($auth->allowsProxyStreamProfile(7))->toBeTrue()
+        ->and($auth->allowsProxyStreamProfile(8))->toBeFalse();
+
+    $auth->update(['proxy_profile_access' => 'all']);
+    expect($auth->fresh()->allowsProxyStreamProfile(8))->toBeTrue();
+
+    $auth->update(['proxy_profile_access' => 'none']);
+    expect($auth->fresh()->allowsProxyStreamProfile(7))->toBeFalse();
+
+    $auth->update(['proxy_profile_access' => 'all', 'proxy_enabled' => false]);
+    expect($auth->fresh()->allowsProxyStreamProfile(7))->toBeFalse();
+});


### PR DESCRIPTION
Adds API contract for Proxy access by Playlist/Auth for dynamic request-time routing and proxy profile selection.

Closes #1241

Companion PR: https://github.com/m3ue/m3u-tv/pull/97