### PR TITLE
fix: restrict Copilot EPG mapping to live TV

### DIFF
--- a/app/Filament/CopilotTools/EpgChannelMatcherTool.php
+++ b/app/Filament/CopilotTools/EpgChannelMatcherTool.php
@@ -87,7 +87,17 @@ class EpgChannelMatcherTool extends BaseTool
             ->count();
 
         if ($totalUnmapped === 0) {
-            return "No eligible unmapped live TV channels in group \"{$group}\" for playlist #{$playlistId}.";
+            $totalEligible = Channel::where('playlist_id', $playlistId)
+                ->where('user_id', auth()->id())
+                ->where('group', $group)
+                ->eligibleForEpgMapping()
+                ->count();
+
+            if ($totalEligible === 0) {
+                return "No eligible live TV channels in group \"{$group}\" for playlist #{$playlistId}. The group may contain only VOD content or have EPG mapping disabled.";
+            }
+
+            return "All {$totalEligible} eligible live TV channel(s) in group \"{$group}\" for playlist #{$playlistId} are already mapped.";
         }
 
         $channels = Channel::where('playlist_id', $playlistId)

--- a/app/Filament/CopilotTools/EpgChannelMatcherTool.php
+++ b/app/Filament/CopilotTools/EpgChannelMatcherTool.php
@@ -82,16 +82,18 @@ class EpgChannelMatcherTool extends BaseTool
         $totalUnmapped = Channel::where('playlist_id', $playlistId)
             ->where('user_id', auth()->id())
             ->where('group', $group)
+            ->eligibleForEpgMapping()
             ->whereNull('epg_channel_id')
             ->count();
 
         if ($totalUnmapped === 0) {
-            return "No unmapped channels in group \"{$group}\" for playlist #{$playlistId}. All channels in this group are already mapped.";
+            return "No eligible unmapped live TV channels in group \"{$group}\" for playlist #{$playlistId}.";
         }
 
         $channels = Channel::where('playlist_id', $playlistId)
             ->where('user_id', auth()->id())
             ->where('group', $group)
+            ->eligibleForEpgMapping()
             ->whereNull('epg_channel_id')
             ->orderBy('name')
             ->offset($offset)
@@ -108,7 +110,7 @@ class EpgChannelMatcherTool extends BaseTool
         $matcher = app(SimilaritySearchService::class);
 
         // Preload matching EPG channels once for the whole batch instead of
-        // issuing a LIKE scan per channel — most EPG sources are large enough
+        // issuing a LIKE scan per channel. Most EPG sources are large enough
         // that N round-trips dominate the request time.
         $unionTerms = $channels->flatMap(
             fn (Channel $channel): array => $matcher->searchTermsFor(
@@ -200,9 +202,9 @@ class EpgChannelMatcherTool extends BaseTool
         $currentPage = (int) floor($offset / $limit) + 1;
 
         $lines = [
-            "EPG Match Preview — {$group} (playlist: {$playlistName})",
+            "EPG Match Preview - {$group} (playlist: {$playlistName})",
             "EPG Source: {$epgName} (id: {$epgId})",
-            "Channels {$rangeStart}–{$rangeEnd} of {$totalUnmapped} unmapped (page {$currentPage}/{$totalPages})",
+            "Channels {$rangeStart}-{$rangeEnd} of {$totalUnmapped} unmapped (page {$currentPage}/{$totalPages})",
             '',
         ];
 
@@ -224,7 +226,7 @@ class EpgChannelMatcherTool extends BaseTool
                 $lines[] = "  Channel #{$m['channel_id']} \"{$m['original_name']}\" → normalized: \"{$m['cleaned_name']}\"";
 
                 foreach ($m['candidates'] as $i => $c) {
-                    $lines[] = '    '.($i + 1).". {$c['display_name']} (epg_channel_id: {$c['epg_channel_id']}) — {$c['score']}% — {$c['reason']}; compared \"{$c['matched_value']}\" as \"{$c['normalized_value']}\"";
+                    $lines[] = '    '.($i + 1).". {$c['display_name']} (epg_channel_id: {$c['epg_channel_id']}) - {$c['score']}% - {$c['reason']}; compared \"{$c['matched_value']}\" as \"{$c['normalized_value']}\"";
                 }
             }
 
@@ -232,7 +234,7 @@ class EpgChannelMatcherTool extends BaseTool
         }
 
         if (! empty($unresolved)) {
-            $lines[] = 'UNRESOLVED (no match found — will remain unmapped):';
+            $lines[] = 'UNRESOLVED (no match found, will remain unmapped):';
 
             foreach ($unresolved as $u) {
                 $lines[] = "  Channel #{$u['channel_id']} \"{$u['original_name']}\" → normalized: \"{$u['cleaned_name']}\"";
@@ -250,7 +252,7 @@ class EpgChannelMatcherTool extends BaseTool
 
         if ($totalUnmapped > $offset + $limit) {
             $nextOffset = $offset + $limit;
-            $lines[] = "More channels available — call this tool again with offset={$nextOffset} to continue.";
+            $lines[] = "More channels available. Call this tool again with offset={$nextOffset} to continue.";
         }
 
         $lines[] = '';

--- a/app/Filament/CopilotTools/EpgMappingApplyTool.php
+++ b/app/Filament/CopilotTools/EpgMappingApplyTool.php
@@ -75,6 +75,7 @@ class EpgMappingApplyTool extends BaseTool
         // Fetch valid IDs in two queries rather than validating one-by-one.
         // Channel IDs are scoped to the current user to prevent cross-user manipulation.
         $validChannelIds = Channel::where('user_id', auth()->id())
+            ->eligibleForEpgMapping()
             ->whereNull('epg_channel_id')
             ->whereIn('id', $channelIds)
             ->pluck('id')
@@ -96,7 +97,7 @@ class EpgMappingApplyTool extends BaseTool
             $epgChannelId = (int) $mapping['epg_channel_id'];
 
             if (! isset($validChannelIds[$channelId])) {
-                $skipped[] = "Channel #{$channelId} not found or already mapped - skipped.";
+                $skipped[] = "Channel #{$channelId} not found, already mapped, or not an eligible live TV channel - skipped.";
 
                 continue;
             }
@@ -131,6 +132,7 @@ class EpgMappingApplyTool extends BaseTool
             foreach ($groupedToApply as $epgChannelId => $channelIds) {
                 $applied += Channel::whereIn('id', $channelIds)
                     ->where('user_id', auth()->id())
+                    ->eligibleForEpgMapping()
                     ->whereNull('epg_channel_id')
                     ->update(['epg_channel_id' => $epgChannelId]);
             }

--- a/app/Filament/CopilotTools/EpgMappingStateTool.php
+++ b/app/Filament/CopilotTools/EpgMappingStateTool.php
@@ -24,7 +24,7 @@ class EpgMappingStateTool extends BaseTool
 {
     public function description(): Stringable|string
     {
-        return 'Show EPG mapping state. FIRST CALL: always omit playlist_id — this lists every playlist with mapped/unmapped counts so the user can choose one. SECOND CALL: pass the playlist_id the user chose to get a per-group breakdown. Never guess or infer a playlist_id; always list playlists first and let the user pick.';
+        return 'Show EPG mapping state. FIRST CALL: always omit playlist_id. This lists every playlist with mapped/unmapped counts so the user can choose one. SECOND CALL: pass the playlist_id the user chose to get a per-group breakdown. Never guess or infer a playlist_id; always list playlists first and let the user pick.';
     }
 
     /** @return array<string, mixed> */
@@ -32,7 +32,7 @@ class EpgMappingStateTool extends BaseTool
     {
         return [
             'playlist_id' => $schema->integer()
-                ->description(__('The playlist ID chosen by the user. Omit on the first call — you must list playlists first so the user can select one.')),
+                ->description(__('The playlist ID chosen by the user. Omit on the first call. You must list playlists first so the user can select one.')),
             'group' => $schema->string()
                 ->description(__('Filter to a specific group within the playlist. Omit to show all groups.')),
         ];
@@ -79,6 +79,7 @@ class EpgMappingStateTool extends BaseTool
         $playlistIds = $playlists->pluck('id');
         $channelStats = Channel::whereIn('playlist_id', $playlistIds)
             ->where('user_id', auth()->id())
+            ->eligibleForEpgMapping()
             ->select('playlist_id')
             ->selectRaw('COUNT(*) as total, COUNT(epg_channel_id) as mapped')
             ->groupBy('playlist_id')
@@ -91,7 +92,7 @@ class EpgMappingStateTool extends BaseTool
             $mapped = $stats ? (int) $stats->mapped : 0;
             $unmapped = $total - $mapped;
 
-            $lines[] = "  #{$playlist->id} {$playlist->name} — {$mapped}/{$total} mapped, {$unmapped} unmapped";
+            $lines[] = "  #{$playlist->id} {$playlist->name} - {$mapped}/{$total} mapped, {$unmapped} unmapped";
         }
 
         $lines[] = '';
@@ -112,6 +113,7 @@ class EpgMappingStateTool extends BaseTool
 
         $query = Channel::where('playlist_id', $playlistId)
             ->where('user_id', auth()->id())
+            ->eligibleForEpgMapping()
             ->select('group')
             ->selectRaw('COUNT(*) as total, COUNT(epg_channel_id) as mapped')
             ->groupBy('group');
@@ -133,11 +135,11 @@ class EpgMappingStateTool extends BaseTool
         if ($rows->isEmpty()) {
             $suffix = $group ? " group \"{$group}\"" : '';
 
-            return "No channels found in playlist #{$playlistId}{$suffix}.";
+            return "No eligible live TV channels found in playlist #{$playlistId}{$suffix}.";
         }
 
         $lines = [
-            "EPG Mapping State — {$playlist->name} (id: {$playlistId})",
+            "EPG Mapping State - {$playlist->name} (id: {$playlistId})",
             '',
             str_pad('Group', 42).str_pad('Mapped', 10).str_pad('Unmapped', 10).'Total',
             str_repeat('-', 72),

--- a/app/Filament/Resources/EpgMaps/RelationManagers/CandidatesRelationManager.php
+++ b/app/Filament/Resources/EpgMaps/RelationManagers/CandidatesRelationManager.php
@@ -421,8 +421,7 @@ class CandidatesRelationManager extends RelationManager
                 ->whereKey((int) $channelId)
                 ->where('user_id', $map->user_id)
                 ->where('playlist_id', $map->playlist_id)
-                ->where('is_vod', false)
-                ->where('epg_map_enabled', true)
+                ->eligibleForEpgMapping()
                 ->whereNull('epg_channel_id')
                 ->update(['epg_channel_id' => (int) $epgChannelId]);
         }

--- a/app/Jobs/BuildEpgMapCandidatesJob.php
+++ b/app/Jobs/BuildEpgMapCandidatesJob.php
@@ -78,8 +78,7 @@ class BuildEpgMapCandidatesJob implements ShouldQueue
         $channels = Channel::query()
             ->where('user_id', $map->user_id)
             ->where('playlist_id', $map->playlist_id)
-            ->where('is_vod', false)
-            ->where('epg_map_enabled', true)
+            ->eligibleForEpgMapping()
             ->whereNull('epg_channel_id')
             ->orderBy('name')
             ->get(['id', 'name', 'name_custom', 'title', 'title_custom']);

--- a/app/Jobs/MapPlaylistChannelsToEpg.php
+++ b/app/Jobs/MapPlaylistChannelsToEpg.php
@@ -103,30 +103,24 @@ class MapPlaylistChannelsToEpg implements ShouldQueue
             $channels = [];
             if ($this->channels) {
                 $channels = Channel::whereIn('id', $this->channels);
-                $totalChannelCount = $channels->where('is_vod', false)->count();
+                $totalChannelCount = $channels->eligibleForEpgMapping()->count();
                 $mappedCount = $channels
-                    ->where('is_vod', false)
+                    ->eligibleForEpgMapping()
                     ->whereNotNull('epg_channel_id')
                     ->count();
                 $channels = Channel::whereIn('id', $this->channels)
-                    ->where([
-                        ['is_vod', false],
-                        ['epg_map_enabled', true],
-                    ])
+                    ->eligibleForEpgMapping()
                     ->when(! $this->force, function ($query) {
                         $query->where('epg_channel_id', null);
                     });
             } elseif ($playlist) {
-                $totalChannelCount = $playlist->channels()->where('is_vod', false)->count();
+                $totalChannelCount = $playlist->channels()->eligibleForEpgMapping()->count();
                 $mappedCount = $playlist->channels()
-                    ->where('is_vod', false)
+                    ->eligibleForEpgMapping()
                     ->whereNotNull('epg_channel_id')
                     ->count();
                 $channels = $playlist->channels()
-                    ->where([
-                        ['is_vod', false],
-                        ['epg_map_enabled', true],
-                    ])
+                    ->eligibleForEpgMapping()
                     ->when(! $this->force, function ($query) {
                         $query->where('epg_channel_id', null);
                     });

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -792,6 +792,13 @@ class Channel extends Model
         return $this->getTmdbId() !== null || $this->getImdbId() !== null;
     }
 
+    public function scopeEligibleForEpgMapping(Builder $query): Builder
+    {
+        return $query
+            ->where('is_vod', false)
+            ->where('epg_map_enabled', true);
+    }
+
     public function scopeHasMovieId(Builder $query): Builder
     {
         $isPgsql = config('database.connections.'.config('database.default').'.driver') === 'pgsql';

--- a/tests/Feature/CopilotEpgLiveTvScopeTest.php
+++ b/tests/Feature/CopilotEpgLiveTvScopeTest.php
@@ -1,0 +1,181 @@
+<?php
+
+use App\Filament\CopilotTools\EpgChannelMatcherTool;
+use App\Filament\CopilotTools\EpgMappingApplyTool;
+use App\Filament\CopilotTools\EpgMappingStateTool;
+use App\Models\Channel;
+use App\Models\Epg;
+use App\Models\EpgChannel;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\User;
+use Laravel\Ai\Tools\Request;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+    $this->playlist = Playlist::withoutEvents(fn () => Playlist::factory()
+        ->for($this->user)
+        ->create(['name' => 'Live TV Playlist']));
+    $this->epg = Epg::withoutEvents(fn () => Epg::factory()
+        ->for($this->user)
+        ->create(['name' => 'Guide Source']));
+    $this->epgChannel = EpgChannel::factory()
+        ->for($this->epg)
+        ->for($this->user)
+        ->create([
+            'name' => 'Guide Station',
+            'display_name' => 'Guide Station',
+            'channel_id' => 'guide-station',
+        ]);
+});
+
+function copilotEpgGroup(string $name): Group
+{
+    return Group::factory()
+        ->for(test()->playlist)
+        ->for(test()->user)
+        ->create(['name' => $name]);
+}
+
+function copilotEpgChannel(Group $group, string $name, array $attributes = []): Channel
+{
+    return Channel::factory()
+        ->for(test()->playlist)
+        ->for(test()->user)
+        ->for($group)
+        ->create(array_merge([
+            'name' => $name,
+            'title' => $name,
+            'stream_id' => str($name)->slug(),
+            'group' => $group->name,
+            'is_vod' => false,
+            'epg_map_enabled' => true,
+            'epg_channel_id' => null,
+        ], $attributes));
+}
+
+it('lists only eligible live TV channels in playlist mapping totals', function () {
+    $group = copilotEpgGroup('Mixed Group');
+
+    copilotEpgChannel($group, 'Mapped Live', ['epg_channel_id' => $this->epgChannel->id]);
+    copilotEpgChannel($group, 'Unmapped Live');
+    copilotEpgChannel($group, 'Mapped VOD', ['is_vod' => true, 'epg_channel_id' => $this->epgChannel->id]);
+    copilotEpgChannel($group, 'Unmapped VOD', ['is_vod' => true]);
+    copilotEpgChannel($group, 'Disabled Live', ['epg_map_enabled' => false]);
+
+    $output = (string) (new EpgMappingStateTool)->handle(new Request([]));
+
+    expect($output)->toContain("#{$this->playlist->id} Live TV Playlist")
+        ->toContain('1/2 mapped, 1 unmapped')
+        ->not->toContain('2/5 mapped, 3 unmapped');
+});
+
+it('uses only eligible live TV channels in group and total rows', function () {
+    $liveGroup = copilotEpgGroup('Live Group');
+    $secondLiveGroup = copilotEpgGroup('Second Live');
+    $vodGroup = copilotEpgGroup('VOD Only');
+    $disabledGroup = copilotEpgGroup('Disabled Only');
+
+    copilotEpgChannel($liveGroup, 'Mapped Live', ['epg_channel_id' => $this->epgChannel->id]);
+    copilotEpgChannel($liveGroup, 'Unmapped Live');
+    copilotEpgChannel($secondLiveGroup, 'Another Live');
+    copilotEpgChannel($vodGroup, 'Movie One', ['is_vod' => true]);
+    copilotEpgChannel($disabledGroup, 'Opted Out', ['epg_map_enabled' => false]);
+
+    $output = (string) (new EpgMappingStateTool)->handle(new Request([
+        'playlist_id' => $this->playlist->id,
+    ]));
+
+    expect($output)->toMatch('/Live Group\s+1\s+1\s+2/')
+        ->toMatch('/Second Live\s+0\s+1\s+1/')
+        ->toMatch('/TOTAL\s+1\s+2\s+3/')
+        ->not->toContain('VOD Only')
+        ->not->toContain('Disabled Only');
+});
+
+it('reports when a playlist or requested group has no eligible live TV channels', function () {
+    $vodGroup = copilotEpgGroup('VOD Only');
+    $disabledGroup = copilotEpgGroup('Disabled Only');
+
+    copilotEpgChannel($vodGroup, 'Movie One', ['is_vod' => true]);
+    copilotEpgChannel($disabledGroup, 'Opted Out', ['epg_map_enabled' => false]);
+
+    $stateTool = new EpgMappingStateTool;
+    $playlistOutput = (string) $stateTool->handle(new Request([
+        'playlist_id' => $this->playlist->id,
+    ]));
+    $vodOutput = (string) $stateTool->handle(new Request([
+        'playlist_id' => $this->playlist->id,
+        'group' => $vodGroup->name,
+    ]));
+    $disabledOutput = (string) $stateTool->handle(new Request([
+        'playlist_id' => $this->playlist->id,
+        'group' => $disabledGroup->name,
+    ]));
+
+    expect($playlistOutput)->toContain('No eligible live TV channels found')
+        ->and($vodOutput)->toContain('No eligible live TV channels found')
+        ->and($disabledOutput)->toContain('No eligible live TV channels found');
+});
+
+it('uses the same live TV eligibility predicate for matcher totals and pagination', function () {
+    $group = copilotEpgGroup('Mixed Group');
+    $eligibleFirst = copilotEpgChannel($group, 'Eligible 01');
+    $eligibleSecond = copilotEpgChannel($group, 'Eligible 02');
+    $eligibleThird = copilotEpgChannel($group, 'Eligible 03');
+    $vod = copilotEpgChannel($group, 'Eligible 00 VOD', ['is_vod' => true]);
+    $disabled = copilotEpgChannel($group, 'Eligible 015 Disabled', ['epg_map_enabled' => false]);
+
+    $output = (string) (new EpgChannelMatcherTool)->handle(new Request([
+        'playlist_id' => $this->playlist->id,
+        'group' => $group->name,
+        'epg_id' => $this->epg->id,
+        'limit' => 2,
+        'offset' => 1,
+    ]));
+
+    expect($output)->toMatch('/Channels 2\D+3 of 3 unmapped/')
+        ->toContain('page 1/2')
+        ->toContain("Channel #{$eligibleSecond->id} \"")
+        ->toContain("Channel #{$eligibleThird->id} \"")
+        ->not->toContain("Channel #{$eligibleFirst->id} \"")
+        ->not->toContain("Channel #{$vod->id} \"")
+        ->not->toContain("Channel #{$disabled->id} \"");
+});
+
+it('reports when a group has no eligible unmapped live TV channels', function () {
+    $group = copilotEpgGroup('Ineligible Group');
+
+    copilotEpgChannel($group, 'Movie One', ['is_vod' => true]);
+    copilotEpgChannel($group, 'Opted Out', ['epg_map_enabled' => false]);
+
+    $output = (string) (new EpgChannelMatcherTool)->handle(new Request([
+        'playlist_id' => $this->playlist->id,
+        'group' => $group->name,
+        'epg_id' => $this->epg->id,
+    ]));
+
+    expect($output)->toContain('No eligible unmapped live TV channels');
+});
+
+it('applies mappings only to eligible live TV channels', function () {
+    $group = copilotEpgGroup('Mixed Group');
+    $eligible = copilotEpgChannel($group, 'Eligible Live');
+    $vod = copilotEpgChannel($group, 'Movie One', ['is_vod' => true]);
+    $disabled = copilotEpgChannel($group, 'Opted Out', ['epg_map_enabled' => false]);
+
+    $output = (string) (new EpgMappingApplyTool)->handle(new Request([
+        'epg_id' => $this->epg->id,
+        'mappings' => json_encode([
+            ['channel_id' => $eligible->id, 'epg_channel_id' => $this->epgChannel->id],
+            ['channel_id' => $vod->id, 'epg_channel_id' => $this->epgChannel->id],
+            ['channel_id' => $disabled->id, 'epg_channel_id' => $this->epgChannel->id],
+        ], JSON_THROW_ON_ERROR),
+    ]));
+
+    expect($output)->toContain('Applied 1 mapping(s) successfully.')
+        ->and($eligible->refresh()->epg_channel_id)->toBe($this->epgChannel->id)
+        ->and($vod->refresh()->epg_channel_id)->toBeNull()
+        ->and($disabled->refresh()->epg_channel_id)->toBeNull();
+});

--- a/tests/Feature/CopilotEpgLiveTvScopeTest.php
+++ b/tests/Feature/CopilotEpgLiveTvScopeTest.php
@@ -144,7 +144,7 @@ it('uses the same live TV eligibility predicate for matcher totals and paginatio
         ->not->toContain("Channel #{$disabled->id} \"");
 });
 
-it('reports when a group has no eligible unmapped live TV channels', function () {
+it('reports when a group has no eligible live TV channels at all', function () {
     $group = copilotEpgGroup('Ineligible Group');
 
     copilotEpgChannel($group, 'Movie One', ['is_vod' => true]);
@@ -156,7 +156,21 @@ it('reports when a group has no eligible unmapped live TV channels', function ()
         'epg_id' => $this->epg->id,
     ]));
 
-    expect($output)->toContain('No eligible unmapped live TV channels');
+    expect($output)->toContain('No eligible live TV channels in group');
+});
+
+it('reports when all eligible live TV channels in a group are already mapped', function () {
+    $group = copilotEpgGroup('Fully Mapped Group');
+
+    copilotEpgChannel($group, 'Already Mapped', ['epg_channel_id' => $this->epgChannel->id]);
+
+    $output = (string) (new EpgChannelMatcherTool)->handle(new Request([
+        'playlist_id' => $this->playlist->id,
+        'group' => $group->name,
+        'epg_id' => $this->epg->id,
+    ]));
+
+    expect($output)->toContain('already mapped');
 });
 
 it('applies mappings only to eligible live TV channels', function () {


### PR DESCRIPTION
## Summary

- add a shared Channel eligibility scope for live, EPG-enabled channels
- restrict Copilot EPG state totals, group rows, matcher pagination, and apply operations to that scope
- return live-TV-specific empty results and recheck eligibility inside transactional updates
- add focused regression coverage for counts, groups, pagination, and direct apply calls

## Context

The task screenshot regression showed playlist #10 as 833/5,814 mapped with 4,981 unmapped and playlist #11 as 1,040/18,340 mapped with 17,300 unmapped because Copilot totals included VOD. This is a separate focused bugfix adjacent to #1276 and does not change the broader candidate review feature.

## Testing

- RED: `php artisan test --compact tests/Feature/CopilotEpgLiveTvScopeTest.php` produced 6 expected failures and 9 assertions before the fix
- GREEN: focused suite completed with 23 assertions and no failures
- relevant Copilot EPG suites completed with 71 assertions and no failures
- full parallel Pest suite completed with 1,669 passed, 29 skipped, and 4,491 assertions
- `vendor/bin/pint --dirty --format agent`
- `vendor/bin/pint --test`: 1,333 files passed
- `composer audit --format=summary`: no advisories
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm run build`
- `php artisan checkpoint:scan`: 25 passed, 1 local environment warning, 0 failed
- `php artisan plugins:discover` and `php artisan plugins:validate`
- `git diff --check`
- no repository Rector configuration or CI static-analysis command applies
