### PR TITLE
feat(arr-search): add availability filter (All/Available/In Library/Missing)

### DIFF
--- a/app/Livewire/ArrSearch.php
+++ b/app/Livewire/ArrSearch.php
@@ -66,6 +66,13 @@ class ArrSearch extends Component implements HasActions, HasSchemas
      */
     public array $selectedGenres = [];
 
+    /**
+     * Active availability filter. Null means "show all".
+     * One of 'available' (has files), 'in_library' (in library, no files), 'missing' (not in library).
+     * Mutually exclusive with the genre filter — combined with AND logic.
+     */
+    public ?string $availability = null;
+
     public bool $isSearching = false;
 
     public bool $guestMode = false;
@@ -247,21 +254,82 @@ class ArrSearch extends Component implements HasActions, HasSchemas
     }
 
     /**
-     * Results filtered by the active genres (OR logic).
+     * Results filtered by the active genres (OR logic) AND the active availability bucket.
      * Preserves original array keys so openDetail($index)/request($index) remain valid.
      *
      * @return array<int, array<string, mixed>>
      */
     public function getFilteredResultsProperty(): array
     {
-        if (empty($this->selectedGenres)) {
+        $hasGenreFilter = ! empty($this->selectedGenres);
+        $hasAvailabilityFilter = $this->availability !== null;
+
+        if (! $hasGenreFilter && ! $hasAvailabilityFilter) {
             return $this->results;
         }
 
         return array_filter(
             $this->results,
-            fn ($r) => ! empty(array_intersect($r['genres'] ?? [], $this->selectedGenres))
+            function ($r) use ($hasGenreFilter, $hasAvailabilityFilter) {
+                if ($hasGenreFilter && empty(array_intersect($r['genres'] ?? [], $this->selectedGenres))) {
+                    return false;
+                }
+
+                if ($hasAvailabilityFilter && $this->bucketResult($r) !== $this->availability) {
+                    return false;
+                }
+
+                return true;
+            }
         );
+    }
+
+    // ── Availability filter ────────────────────────────────────────────────────
+
+    /**
+     * Set the active availability filter. Empty string resets to "all".
+     */
+    public function setAvailability(?string $value): void
+    {
+        $this->availability = ($value === null || $value === '') ? null : $value;
+    }
+
+    /**
+     * Per-bucket counts across the current result set.
+     * Used to render count badges on the availability tab strip.
+     *
+     * @return array{all: int, available: int, in_library: int, missing: int}
+     */
+    public function getAvailabilityCountsProperty(): array
+    {
+        $counts = ['all' => count($this->results), 'available' => 0, 'in_library' => 0, 'missing' => 0];
+
+        foreach ($this->results as $result) {
+            $bucket = $this->bucketResult($result);
+            $counts[$bucket]++;
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Classify a single result into an availability bucket.
+     * Mirrors the card-overlay logic in arr-search.blade.php.
+     *
+     * @param  array<string, mixed>  $result
+     */
+    private function bucketResult(array $result): string
+    {
+        if (empty($result['existsInLibrary'])) {
+            return 'missing';
+        }
+
+        $isSonarr = ($result['integrationType'] ?? '') === 'sonarr';
+        $hasFiles = $isSonarr
+            ? ($result['episodeFileCount'] ?? 0) > 0
+            : ($result['hasFile'] ?? false);
+
+        return $hasFiles ? 'available' : 'in_library';
     }
 
     // ── Guest request queuing ─────────────────────────────────────────────────
@@ -301,6 +369,7 @@ class ArrSearch extends Component implements HasActions, HasSchemas
         $this->searchTerm = '';
         $this->results = [];
         $this->selectedGenres = [];
+        $this->availability = null;
         $this->isSearching = false;
     }
 
@@ -309,6 +378,7 @@ class ArrSearch extends Component implements HasActions, HasSchemas
         if (strlen(trim($this->searchTerm)) < 2) {
             $this->results = [];
             $this->selectedGenres = [];
+            $this->availability = null;
 
             return;
         }
@@ -316,6 +386,7 @@ class ArrSearch extends Component implements HasActions, HasSchemas
         $this->isSearching = true;
         $this->results = [];
         $this->selectedGenres = [];
+        $this->availability = null;
 
         $integrations = $this->integrationsForSearch;
 

--- a/resources/views/livewire/arr-search.blade.php
+++ b/resources/views/livewire/arr-search.blade.php
@@ -46,6 +46,33 @@
                                         class="ml-3 text-sm text-gray-500 dark:text-gray-400">{{ __('Searching...') }}</span>
                                 </div>
                             @elseif(count($results) > 0)
+                                {{-- Availability filter tabs (mirrors release-logs.blade.php tab strip) --}}
+                                @php
+                                    $availTabs = [
+                                        null         => ['label' => __('All'),        'color' => 'gray'],
+                                        'available'  => ['label' => __('Available'),  'color' => 'success'],
+                                        'in_library' => ['label' => __('In Library'), 'color' => 'warning'],
+                                        'missing'    => ['label' => __('Missing'),    'color' => 'gray'],
+                                    ];
+                                    $availCounts = $this->availabilityCounts;
+                                @endphp
+                                <div class="flex flex-wrap gap-2 mb-3">
+                                    @foreach ($availTabs as $value => $tab)
+                                        @php $current = ($availability ?? '') === ($value ?? ''); @endphp
+                                        <x-filament::button
+                                            wire:click="setAvailability('{{ $value ?? '' }}')"
+                                            color="{{ $tab['color'] }}"
+                                            icon="{{ $current ? 'heroicon-s-check-circle' : '' }}"
+                                            size="sm"
+                                            class="flex items-center gap-1">
+                                            {{ $tab['label'] }}
+                                            <x-filament::badge size="sm" color="{{ $tab['color'] }}">
+                                                {{ $availCounts[$value ?? 'all'] ?? 0 }}
+                                            </x-filament::badge>
+                                        </x-filament::button>
+                                    @endforeach
+                                </div>
+
                                 {{-- Genre filter chips --}}
                                 @if (count($this->availableGenres) > 0)
                                     <div class="flex flex-wrap gap-1.5 mb-4">

--- a/tests/Feature/ArrSearchAvailabilityFilterTest.php
+++ b/tests/Feature/ArrSearchAvailabilityFilterTest.php
@@ -1,0 +1,195 @@
+<?php
+
+use App\Livewire\ArrSearch;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+it('returns all results when availability is null (default)', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    $component->set('results', [
+        0 => ['title' => 'Movie A', 'existsInLibrary' => true, 'hasFile' => true, 'integrationType' => 'radarr'],
+        1 => ['title' => 'Movie B', 'existsInLibrary' => true, 'hasFile' => false, 'integrationType' => 'radarr'],
+        2 => ['title' => 'Show C', 'existsInLibrary' => false, 'hasFile' => false, 'integrationType' => 'sonarr'],
+    ]);
+
+    expect($component->get('filteredResults'))->toHaveCount(3);
+});
+
+it('filters results to only available items (hasFile for Radarr)', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    $component->set('results', [
+        0 => ['title' => 'Movie A', 'existsInLibrary' => true, 'hasFile' => true, 'integrationType' => 'radarr'],
+        1 => ['title' => 'Movie B', 'existsInLibrary' => true, 'hasFile' => false, 'integrationType' => 'radarr'],
+        2 => ['title' => 'Movie C', 'existsInLibrary' => false, 'integrationType' => 'radarr'],
+    ]);
+
+    $component->call('setAvailability', 'available');
+
+    $filtered = $component->get('filteredResults');
+    expect($filtered)->toHaveCount(1);
+    expect(array_values($filtered)[0]['title'])->toBe('Movie A');
+});
+
+it('filters results to only available items (episodeFileCount > 0 for Sonarr)', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    $component->set('results', [
+        0 => ['title' => 'Show A', 'existsInLibrary' => true, 'episodeFileCount' => 5, 'totalEpisodeCount' => 10, 'integrationType' => 'sonarr'],
+        1 => ['title' => 'Show B', 'existsInLibrary' => true, 'episodeFileCount' => 0, 'totalEpisodeCount' => 10, 'integrationType' => 'sonarr'],
+        2 => ['title' => 'Show C', 'existsInLibrary' => false, 'integrationType' => 'sonarr'],
+    ]);
+
+    $component->call('setAvailability', 'available');
+
+    $filtered = $component->get('filteredResults');
+    expect($filtered)->toHaveCount(1);
+    expect(array_values($filtered)[0]['title'])->toBe('Show A');
+});
+
+it('filters results to in-library items that have no files', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    $component->set('results', [
+        0 => ['title' => 'Movie A', 'existsInLibrary' => true, 'hasFile' => true, 'integrationType' => 'radarr'],
+        1 => ['title' => 'Movie B', 'existsInLibrary' => true, 'hasFile' => false, 'integrationType' => 'radarr'],
+        2 => ['title' => 'Movie C', 'existsInLibrary' => false, 'integrationType' => 'radarr'],
+        3 => ['title' => 'Show D', 'existsInLibrary' => true, 'episodeFileCount' => 0, 'integrationType' => 'sonarr'],
+    ]);
+
+    $component->call('setAvailability', 'in_library');
+
+    $filtered = $component->get('filteredResults');
+    expect($filtered)->toHaveCount(2);
+    $titles = array_column(array_values($filtered), 'title');
+    expect($titles)->toContain('Movie B');
+    expect($titles)->toContain('Show D');
+});
+
+it('filters results to items not yet in the library', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    $component->set('results', [
+        0 => ['title' => 'Movie A', 'existsInLibrary' => true, 'hasFile' => true, 'integrationType' => 'radarr'],
+        1 => ['title' => 'Movie B', 'existsInLibrary' => false, 'integrationType' => 'radarr'],
+        2 => ['title' => 'Show C', 'existsInLibrary' => false, 'integrationType' => 'sonarr'],
+        3 => ['title' => 'Show D', 'existsInLibrary' => true, 'episodeFileCount' => 0, 'integrationType' => 'sonarr'],
+    ]);
+
+    $component->call('setAvailability', 'missing');
+
+    $filtered = $component->get('filteredResults');
+    expect($filtered)->toHaveCount(2);
+    $titles = array_column(array_values($filtered), 'title');
+    expect($titles)->toContain('Movie B');
+    expect($titles)->toContain('Show C');
+});
+
+it('treats empty string as "all" when setAvailability is called', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    $component->set('availability', 'available');
+    expect($component->get('availability'))->toBe('available');
+
+    $component->call('setAvailability', '');
+    expect($component->get('availability'))->toBeNull();
+});
+
+it('treats null as "all" when setAvailability is called', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    $component->set('availability', 'missing');
+    $component->call('setAvailability', null);
+
+    expect($component->get('availability'))->toBeNull();
+});
+
+it('combines availability filter with genre filter using AND logic', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    $component->set('results', [
+        0 => ['title' => 'Drama A', 'genres' => ['Drama'], 'existsInLibrary' => true, 'hasFile' => true, 'integrationType' => 'radarr'],
+        1 => ['title' => 'Drama B', 'genres' => ['Drama'], 'existsInLibrary' => false, 'integrationType' => 'radarr'],
+        2 => ['title' => 'Drama C', 'genres' => ['Drama'], 'existsInLibrary' => true, 'hasFile' => false, 'integrationType' => 'radarr'],
+        3 => ['title' => 'Action D', 'genres' => ['Action'], 'existsInLibrary' => true, 'hasFile' => true, 'integrationType' => 'radarr'],
+    ]);
+
+    $component->call('toggleGenre', 'Drama');
+    $component->call('setAvailability', 'available');
+
+    $filtered = $component->get('filteredResults');
+    expect($filtered)->toHaveCount(1);
+    expect(array_values($filtered)[0]['title'])->toBe('Drama A');
+});
+
+it('preserves original result indices so openDetail still resolves correctly', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    // Index 0 = available, index 1 = missing, index 2 = in-library
+    $component->set('results', [
+        0 => ['title' => 'Available Item', 'existsInLibrary' => true, 'hasFile' => true, 'integrationType' => 'radarr'],
+        1 => ['title' => 'Missing Item', 'existsInLibrary' => false, 'integrationType' => 'radarr'],
+        2 => ['title' => 'In Library Item', 'existsInLibrary' => true, 'hasFile' => false, 'integrationType' => 'radarr'],
+    ]);
+
+    $component->call('setAvailability', 'missing');
+
+    $filtered = $component->get('filteredResults');
+
+    expect(array_key_exists(1, $filtered))->toBeTrue();
+    expect(array_key_exists(0, $filtered))->toBeFalse();
+    expect(array_key_exists(2, $filtered))->toBeFalse();
+});
+
+it('counts results correctly across all availability buckets', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    $component->set('results', [
+        0 => ['title' => 'Avail 1', 'existsInLibrary' => true, 'hasFile' => true, 'integrationType' => 'radarr'],
+        1 => ['title' => 'Avail 2', 'existsInLibrary' => true, 'episodeFileCount' => 3, 'integrationType' => 'sonarr'],
+        2 => ['title' => 'InLib 1', 'existsInLibrary' => true, 'hasFile' => false, 'integrationType' => 'radarr'],
+        3 => ['title' => 'InLib 2', 'existsInLibrary' => true, 'episodeFileCount' => 0, 'integrationType' => 'sonarr'],
+        4 => ['title' => 'Miss 1', 'existsInLibrary' => false, 'integrationType' => 'radarr'],
+    ]);
+
+    $counts = $component->get('availabilityCounts');
+
+    expect($counts['all'])->toBe(5);
+    expect($counts['available'])->toBe(2);
+    expect($counts['in_library'])->toBe(2);
+    expect($counts['missing'])->toBe(1);
+});
+
+it('clears availability when clearSearch is called', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    $component->set('availability', 'available');
+    $component->call('clearSearch');
+
+    expect($component->get('availability'))->toBeNull();
+});
+
+it('handles results with missing fields gracefully (defaults to missing bucket)', function () {
+    $component = Livewire::test(ArrSearch::class);
+
+    // Minimal result with no availability fields at all (should not crash)
+    $component->set('results', [
+        0 => ['title' => 'Bare Item', 'integrationType' => 'radarr'],
+        1 => ['title' => 'With Library', 'existsInLibrary' => true, 'hasFile' => true, 'integrationType' => 'radarr'],
+    ]);
+
+    $component->call('setAvailability', 'missing');
+
+    $filtered = $component->get('filteredResults');
+    expect($filtered)->toHaveCount(1);
+    expect(array_values($filtered)[0]['title'])->toBe('Bare Item');
+});


### PR DESCRIPTION
## Summary

Adds a 4-tab availability filter to the Sonarr/Radarr search results UI so users can quickly narrow down to content they care about.

## Tabs

- **All** (gray) — default, shows everything
- **Available** (success/green) — in library AND has files (Radarr `hasFile`, Sonarr `episodeFileCount > 0`)
- **In Library** (warning/amber) — in library, no files yet
- **Missing** (gray) — not in library

Each tab shows a live count badge so users see the bucket distribution at a glance without clicking.

## Implementation

- **No service-layer or interface changes** — all required fields already returned by `SonarrService::parseSearchResponse()` and `RadarrService::parseSearchResponse()`
- UI mirrors the existing tab strip pattern from `release-logs.blade.php` (Filament button + badge)
- Color tokens (gray/success/warning) match the existing result-card badge language — no new visual vocabulary
- Combines with genre filter using AND logic; resets in `clearSearch()` and on new `search()`

## Files

- `app/Livewire/ArrSearch.php` — added `$availability` state, `setAvailability()` action, `getAvailabilityCountsProperty()`, `bucketResult()` helper, extended `getFilteredResultsProperty()`
- `resources/views/livewire/arr-search.blade.php` — added tab strip above genre chips
- `tests/Feature/ArrSearchAvailabilityFilterTest.php` — 12 tests covering all 4 states, AND-with-genre, index preservation, counts, null/empty reset, Radarr vs Sonarr bucketing, malformed-result safety

## Tests

```
Tests:    12 passed (26 assertions)
Duration: 2.09s
```

All 108 existing `ArrSearch`-related tests still pass.
Pint clean on changed files.

## Screenshots

N/A — UI follows existing app patterns verbatim (see `release-logs.blade.php:1-21` and `arr-discover.blade.php:22-41`).