### PR TITLE
Fix lossless XMLTV programme export

### DIFF
--- a/app/Http/Controllers/EpgGenerateController.php
+++ b/app/Http/Controllers/EpgGenerateController.php
@@ -43,6 +43,73 @@ class EpgGenerateController extends Controller
     }
 
     /**
+     * @param  array<int, mixed>  $images
+     */
+    private function formatProgrammeImages(array $images, ?string $primaryIconUrl, bool $proxyEnabled): string
+    {
+        $xml = '';
+        $seenUrls = [];
+        $primaryIconUrl = trim((string) $primaryIconUrl);
+
+        if ($primaryIconUrl !== '') {
+            $seenUrls[$primaryIconUrl] = true;
+        }
+
+        foreach ($images as $image) {
+            if (! is_array($image)) {
+                continue;
+            }
+
+            $rawUrl = is_string($image['url'] ?? null) ? trim($image['url']) : '';
+            if ($rawUrl === '' || isset($seenUrls[$rawUrl]) || ! filter_var($rawUrl, FILTER_VALIDATE_URL)) {
+                continue;
+            }
+            $seenUrls[$rawUrl] = true;
+
+            $sourceType = is_string($image['type'] ?? null) ? mb_strtolower(trim($image['type'])) : '';
+            $type = in_array($sourceType, ['poster', 'backdrop', 'still', 'person', 'character'], true)
+                ? $sourceType
+                : null;
+
+            $width = is_numeric($image['width'] ?? null) ? max(0, (int) $image['width']) : 0;
+            $height = is_numeric($image['height'] ?? null) ? max(0, (int) $image['height']) : 0;
+
+            $orient = is_string($image['orient'] ?? null) ? mb_strtoupper(trim($image['orient'])) : '';
+            if (! in_array($orient, ['P', 'L'], true)) {
+                $orient = $width > 0 && $height > 0
+                    ? ($width > $height ? 'L' : 'P')
+                    : '';
+            }
+
+            $size = is_int($image['size'] ?? null) || is_string($image['size'] ?? null)
+                ? trim((string) $image['size'])
+                : '';
+            if (! in_array($size, ['1', '2', '3'], true)) {
+                $largestDimension = max($width, $height);
+                $size = match (true) {
+                    $largestDimension === 0 => '',
+                    $largestDimension < 200 => '1',
+                    $largestDimension <= 400 => '2',
+                    default => '3',
+                };
+            }
+
+            $system = is_string($image['system'] ?? null) ? trim($image['system']) : '';
+            $attributes = '';
+            foreach (['type' => $type, 'size' => $size, 'orient' => $orient, 'system' => $system] as $name => $value) {
+                if ($value !== null && $value !== '') {
+                    $attributes .= ' '.$name.'="'.$this->escapeXml($value).'"';
+                }
+            }
+
+            $url = $proxyEnabled ? LogoProxyController::generateProxyUrl($rawUrl) : $rawUrl;
+            $xml .= '    <image'.$attributes.'>'.$this->escapeXml($url).'</image>'.PHP_EOL;
+        }
+
+        return $xml;
+    }
+
+    /**
      * Generate the EPG XML file
      *
      * @return Response
@@ -381,14 +448,11 @@ class EpgGenerateController extends Controller
                                 if ($programme['desc']) {
                                     $progXml .= '    <desc>'.$this->escapeXml($programme['desc']).'</desc>'.PHP_EOL;
                                 }
+                                if (! empty($programme['production_year'])) {
+                                    $progXml .= '    <date>'.$this->escapeXml($programme['production_year']).'</date>'.PHP_EOL;
+                                }
                                 if ($programme['category']) {
                                     $progXml .= '    <category>'.$this->escapeXml($programme['category']).'</category>'.PHP_EOL;
-                                }
-                                foreach (EpisodeNumberNormalizer::forProgramme($programme) as $episodeNumber) {
-                                    $systemAttribute = ($episodeNumber['system'] !== null && $episodeNumber['system'] !== '')
-                                        ? ' system="'.$this->escapeXml($episodeNumber['system']).'"'
-                                        : '';
-                                    $progXml .= '    <episode-num'.$systemAttribute.'>'.$this->escapeXml($episodeNumber['value']).'</episode-num>'.PHP_EOL;
                                 }
                                 if ($programme['icon']) {
                                     $icon = $logoProxyEnabled
@@ -396,29 +460,42 @@ class EpgGenerateController extends Controller
                                         : $programme['icon'];
                                     $progXml .= '    <icon src="'.$this->escapeXml($icon).'"/>'.PHP_EOL;
                                 }
-                                // Program artwork images (NEW)
-                                if (! empty($programme['images'] ?? null) && is_array($programme['images'])) {
-                                    foreach ($programme['images'] as $image) {
-                                        $rawUrl = $image['url'] ?? '';
-                                        $proxiedUrl = $logoProxyEnabled && $rawUrl
-                                            ? LogoProxyController::generateProxyUrl($rawUrl)
-                                            : $rawUrl;
-
-                                        $url = $this->escapeXml($proxiedUrl);
-                                        $type = $this->escapeXml($image['type']);
-                                        $width = $this->escapeXml($image['width']);
-                                        $height = $this->escapeXml($image['height']);
-                                        $orient = $this->escapeXml($image['orient']);
-                                        $size = $this->escapeXml($image['size']);
-
-                                        $progXml .= "    <icon src=\"{$url}\" type=\"{$type}\" width=\"{$width}\" height=\"{$height}\" orient=\"{$orient}\" size=\"{$size}\" />\n";
+                                foreach ($programme['urls'] ?? [] as $url) {
+                                    $urlValue = is_string($url['value'] ?? null) ? trim($url['value']) : '';
+                                    if ($urlValue === '' || ! filter_var($urlValue, FILTER_VALIDATE_URL)) {
+                                        continue;
                                     }
+
+                                    $urlSystem = is_string($url['system'] ?? null) ? trim($url['system']) : '';
+                                    $systemAttribute = $urlSystem !== ''
+                                        ? ' system="'.$this->escapeXml($urlSystem).'"'
+                                        : '';
+                                    $progXml .= '    <url'.$systemAttribute.'>'.$this->escapeXml($urlValue).'</url>'.PHP_EOL;
+                                }
+                                foreach (EpisodeNumberNormalizer::forProgramme($programme) as $episodeNumber) {
+                                    $systemAttribute = ($episodeNumber['system'] !== null && $episodeNumber['system'] !== '')
+                                        ? ' system="'.$this->escapeXml($episodeNumber['system']).'"'
+                                        : '';
+                                    $progXml .= '    <episode-num'.$systemAttribute.'>'.$this->escapeXml($episodeNumber['value']).'</episode-num>'.PHP_EOL;
+                                }
+                                if (! empty($programme['previously_shown'])) {
+                                    $progXml .= '    <previously-shown />'.PHP_EOL;
+                                }
+                                if (! empty($programme['premiere'])) {
+                                    $progXml .= '    <premiere />'.PHP_EOL;
+                                }
+                                if (! empty($programme['new']) && $programme['new']) {
+                                    $progXml .= '    <new />'.PHP_EOL;
                                 }
                                 if ($programme['rating']) {
                                     $progXml .= '    <rating><value>'.$this->escapeXml($programme['rating']).'</value></rating>'.PHP_EOL;
                                 }
-                                if (! empty($programme['new']) && $programme['new']) {
-                                    $progXml .= '    <new />'.PHP_EOL;
+                                if (! empty($programme['images']) && is_array($programme['images'])) {
+                                    $progXml .= $this->formatProgrammeImages(
+                                        $programme['images'],
+                                        $programme['icon'] ?? null,
+                                        $logoProxyEnabled,
+                                    );
                                 }
 
                                 $progXml .= '  </programme>'.PHP_EOL;

--- a/tests/Feature/EpgGenerateControllerTest.php
+++ b/tests/Feature/EpgGenerateControllerTest.php
@@ -33,6 +33,67 @@ beforeEach(function () {
     Storage::disk('local')->deleteDirectory('playlist-epg-files');
 });
 
+/**
+ * @param  array<string, mixed>  $programme
+ */
+function createCachedProgrammeExportFixture(array $programme): Playlist
+{
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create([
+        'dummy_epg' => false,
+    ]);
+    $epg = Epg::factory()->for($user)->create([
+        'url' => 'https://example.com/export.xml',
+        'is_cached' => true,
+    ]);
+    $epgChannel = EpgChannel::factory()->for($user)->for($epg)->create([
+        'channel_id' => 'source.export',
+        'display_name' => 'Export Channel',
+        'lang' => 'en',
+    ]);
+
+    Channel::factory()->for($user)->for($playlist)->create([
+        'enabled' => true,
+        'is_vod' => false,
+        'epg_channel_id' => $epgChannel->id,
+        'stream_id' => 'export-channel',
+        'title' => 'Export Channel',
+        'channel' => 1,
+    ]);
+
+    $cacheDirectory = "epg-cache/{$epg->uuid}/v2";
+    Storage::disk('local')->put("{$cacheDirectory}/metadata.json", json_encode([
+        'cache_created' => time(),
+        'cache_version' => 'v2',
+    ], JSON_THROW_ON_ERROR));
+    Storage::disk('local')->put(
+        "{$cacheDirectory}/programmes-".now()->format('Y-m-d').'.jsonl',
+        json_encode([
+            'channel' => 'source.export',
+            'programme' => array_merge([
+                'start' => now()->startOfDay()->addHour()->toISOString(),
+                'stop' => now()->startOfDay()->addHours(2)->toISOString(),
+                'title' => 'Export Programme',
+                'subtitle' => '',
+                'desc' => '',
+                'category' => '',
+                'episode_num' => '',
+                'episode_nums' => [],
+                'rating' => '',
+                'icon' => '',
+                'images' => [],
+                'new' => false,
+                'previously_shown' => false,
+                'premiere' => false,
+                'urls' => [],
+                'production_year' => null,
+            ], $programme),
+        ], JSON_THROW_ON_ERROR)."\n",
+    );
+
+    return $playlist;
+}
+
 test('epg download does not crash when epg source file is missing', function () {
     $user = User::factory()->create();
 
@@ -384,6 +445,190 @@ test('legacy scalar episode numbers emit only valid xmltv namespace identities',
 
     expect($episodeNumbers)->toBe([
         ['system' => 'xmltv_ns', 'value' => '0.4.'],
+    ]);
+});
+
+test('cached epg generation exports programme urls and structural signals', function () {
+    $playlist = createCachedProgrammeExportFixture([
+        'urls' => [
+            ['system' => 'imdb', 'value' => 'https://www.imdb.com/title/tt0090390/'],
+            ['system' => '', 'value' => 'https://example.com/programmes/export'],
+            ['system' => 'unsafe', 'value' => 'javascript:alert(1)'],
+        ],
+        'production_year' => 2024,
+        'previously_shown' => true,
+        'premiere' => true,
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertOk()->assertHeader('Content-Type', 'application/gzip');
+
+    $document = new DOMDocument;
+    expect($document->loadXML(gzdecode($response->getContent())))->toBeTrue();
+
+    $xpath = new DOMXPath($document);
+    $urls = [];
+    foreach ($xpath->query('//programme[@channel="export-channel"]/url') as $url) {
+        $urls[] = [
+            'system' => $url->hasAttribute('system') ? $url->getAttribute('system') : null,
+            'value' => $url->textContent,
+        ];
+    }
+
+    expect($urls)->toBe([
+        ['system' => 'imdb', 'value' => 'https://www.imdb.com/title/tt0090390/'],
+        ['system' => null, 'value' => 'https://example.com/programmes/export'],
+    ])->and($xpath->query('//programme[@channel="export-channel"]/date[text()="2024"]'))->toHaveCount(1)
+        ->and($xpath->query('//programme[@channel="export-channel"]/previously-shown'))->toHaveCount(1)
+        ->and($xpath->query('//programme[@channel="export-channel"]/premiere'))->toHaveCount(1);
+});
+
+test('cached epg generation exports deterministic dtd valid programme artwork', function () {
+    $primaryIconUrl = 'https://example.com/artwork/primary.jpg';
+    $playlist = createCachedProgrammeExportFixture([
+        'desc' => 'Artwork description',
+        'production_year' => 2024,
+        'category' => 'Drama',
+        'urls' => [
+            ['system' => 'imdb', 'value' => 'https://www.imdb.com/title/tt0090390/'],
+        ],
+        'episode_nums' => [
+            ['system' => 'onscreen', 'value' => 'S01E02'],
+        ],
+        'previously_shown' => true,
+        'premiere' => true,
+        'rating' => 'TV-14',
+        'icon' => $primaryIconUrl,
+        'new' => true,
+        'images' => [
+            [
+                'url' => 'https://example.com/artwork/backdrop.jpg',
+                'type' => 'backdrop',
+                'width' => 1280,
+                'height' => 720,
+                'orient' => 'L',
+                'size' => 3,
+                'system' => 'tmdb',
+            ],
+            [
+                'url' => 'https://example.com/artwork/poster.jpg',
+                'type' => 'poster',
+                'width' => 300,
+                'height' => 450,
+                'orient' => '',
+                'size' => 2,
+            ],
+            [
+                'url' => 'https://example.com/artwork/still.jpg',
+                'type' => 'still',
+                'width' => -1,
+                'height' => -2,
+                'orient' => 'square',
+                'size' => 4,
+            ],
+            [
+                'url' => 'https://example.com/artwork/logo.png',
+                'type' => 'logo',
+                'width' => 600,
+                'height' => 200,
+                'orient' => 'L',
+                'size' => 3,
+            ],
+            [
+                'url' => 'https://example.com/artwork/backdrop.jpg',
+                'type' => 'poster',
+                'orient' => 'P',
+                'size' => 1,
+            ],
+            [
+                'url' => $primaryIconUrl,
+                'type' => 'poster',
+                'orient' => 'P',
+                'size' => 3,
+            ],
+            [
+                'url' => 'not-a-url',
+                'type' => 'poster',
+                'orient' => 'P',
+                'size' => 1,
+            ],
+        ],
+    ]);
+
+    $response = $this->get("/{$playlist->uuid}/epg.xml.gz");
+
+    $response->assertOk()->assertHeader('Content-Type', 'application/gzip');
+
+    $xml = gzdecode($response->getContent());
+    $dtdPath = realpath(base_path('tests/Fixtures/xmltv-programme-export.dtd'));
+    expect($dtdPath)->not->toBeFalse();
+
+    $xmlWithLocalDtd = str_replace(
+        '<!DOCTYPE tv SYSTEM "xmltv.dtd">',
+        '<!DOCTYPE tv SYSTEM "file://'.$dtdPath.'">',
+        $xml,
+    );
+
+    $previousInternalErrors = libxml_use_internal_errors(true);
+    libxml_clear_errors();
+
+    try {
+        $document = new DOMDocument;
+        expect($document->loadXML($xmlWithLocalDtd, LIBXML_DTDLOAD))->toBeTrue()
+            ->and($document->validate())->toBeTrue();
+    } finally {
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousInternalErrors);
+    }
+
+    $xpath = new DOMXPath($document);
+    $programmePath = '//programme[@channel="export-channel"]';
+    expect($xpath->query($programmePath.'/icon'))->toHaveCount(1)
+        ->and($xpath->query($programmePath.'/icon[@src="'.$primaryIconUrl.'"]'))->toHaveCount(1)
+        ->and($xpath->query($programmePath.'/icon[@type or @orient or @size]'))->toHaveCount(0)
+        ->and($xpath->query($programmePath.'/image[@width or @height]'))->toHaveCount(0);
+
+    $images = [];
+    foreach ($xpath->query($programmePath.'/image') as $image) {
+        $images[] = [
+            'url' => $image->textContent,
+            'type' => $image->hasAttribute('type') ? $image->getAttribute('type') : null,
+            'size' => $image->hasAttribute('size') ? $image->getAttribute('size') : null,
+            'orient' => $image->hasAttribute('orient') ? $image->getAttribute('orient') : null,
+            'system' => $image->hasAttribute('system') ? $image->getAttribute('system') : null,
+        ];
+    }
+
+    expect($images)->toBe([
+        [
+            'url' => 'https://example.com/artwork/backdrop.jpg',
+            'type' => 'backdrop',
+            'size' => '3',
+            'orient' => 'L',
+            'system' => 'tmdb',
+        ],
+        [
+            'url' => 'https://example.com/artwork/poster.jpg',
+            'type' => 'poster',
+            'size' => '2',
+            'orient' => 'P',
+            'system' => null,
+        ],
+        [
+            'url' => 'https://example.com/artwork/still.jpg',
+            'type' => 'still',
+            'size' => null,
+            'orient' => null,
+            'system' => null,
+        ],
+        [
+            'url' => 'https://example.com/artwork/logo.png',
+            'type' => null,
+            'size' => '3',
+            'orient' => 'L',
+            'system' => null,
+        ],
     ]);
 });
 

--- a/tests/Fixtures/xmltv-programme-export.dtd
+++ b/tests/Fixtures/xmltv-programme-export.dtd
@@ -1,0 +1,45 @@
+<!ELEMENT tv (channel*, programme*)>
+<!ATTLIST tv generator-info-name CDATA #IMPLIED
+             generator-info-url CDATA #IMPLIED>
+
+<!ELEMENT channel (display-name+, icon*)>
+<!ATTLIST channel id CDATA #REQUIRED>
+
+<!ELEMENT display-name (#PCDATA)>
+<!ATTLIST display-name lang CDATA #IMPLIED>
+
+<!ELEMENT programme (title+, sub-title*, desc*, date?, category*, icon*, url*, episode-num*, previously-shown?, premiere?, new?, rating*, image*)>
+<!ATTLIST programme start CDATA #REQUIRED
+                    stop CDATA #IMPLIED
+                    channel CDATA #REQUIRED>
+
+<!ELEMENT title (#PCDATA)>
+<!ELEMENT sub-title (#PCDATA)>
+<!ELEMENT desc (#PCDATA)>
+<!ELEMENT date (#PCDATA)>
+<!ELEMENT category (#PCDATA)>
+
+<!ELEMENT icon EMPTY>
+<!ATTLIST icon src CDATA #REQUIRED
+               width CDATA #IMPLIED
+               height CDATA #IMPLIED>
+
+<!ELEMENT url (#PCDATA)>
+<!ATTLIST url system CDATA #IMPLIED>
+
+<!ELEMENT episode-num (#PCDATA)>
+<!ATTLIST episode-num system CDATA "onscreen">
+
+<!ELEMENT previously-shown EMPTY>
+<!ELEMENT premiere (#PCDATA)>
+<!ELEMENT new EMPTY>
+
+<!ELEMENT rating (value, icon*)>
+<!ATTLIST rating system CDATA #IMPLIED>
+<!ELEMENT value (#PCDATA)>
+
+<!ELEMENT image (#PCDATA)>
+<!ATTLIST image type (poster | backdrop | still | person | character) #IMPLIED
+                size (1 | 2 | 3) #IMPLIED
+                orient (P | L) #IMPLIED
+                system CDATA #IMPLIED>


### PR DESCRIPTION
## Summary

- export cached programme URLs, production dates, repeat markers, and premiere markers in XMLTV DTD order
- keep the primary artwork as the single programme icon and serialize secondary artwork as deterministic, duplicate-free XMLTV image elements
- preserve valid image type, orientation, size, and system metadata while deriving missing orientation or size from valid dimensions
- keep logo artwork without a type attribute because the XMLTV DTD has no logo enum instead of relabeling it as another role
- retain the existing episode number compatibility fallback: structured episode_nums preserve their systems and no-system entries, while legacy scalar episode_num values emit as xmltv_ns only when valid

## TDD evidence

- RED: cached URL and structural signal test expected two URLs but received an empty array
- RED: artwork test expected one primary icon but received none after legacy secondary icon serialization forced fallback
- RED: invalid negative image dimensions incorrectly emitted size 1 instead of omitting size
- GREEN: focused controller and cache signal suite passes with 15 tests and 90 assertions
- GREEN: generated cached XML is well formed and validates against the focused local XMLTV DTD fixture

## Verification

- `REVERB_APP_SECRET=123 php artisan test --compact tests/Feature/EpgGenerateControllerTest.php tests/Unit/EpgCacheServiceXmltvSignalsTest.php`
- `vendor/bin/pint --dirty --format agent`
- `git diff --check`
- `grep -rP "[\x{2013}\x{2014}]" app/Http/Controllers/EpgGenerateController.php tests/Feature/EpgGenerateControllerTest.php` returned no matches
