### PR TITLE
fix(media-server): single-authority seek + byte-range fast-seek for Emby broadcasts

### DIFF
--- a/app/Http/Controllers/NetworkHlsController.php
+++ b/app/Http/Controllers/NetworkHlsController.php
@@ -70,15 +70,22 @@ class NetworkHlsController extends Controller
 
             $playlist = $response->body();
 
-            // Rewrite segment URLs to go through our proxy route
-            // FFmpeg outputs segment names like "live000001.ts" in the playlist
-            // We need to rewrite them to full URLs: /m3u-proxy/broadcast/{uuid}/segment/live000001.ts
-            $baseUrl = url("/network/{$network->uuid}");
-            $playlist = preg_replace(
-                '/^(live\d+\.ts)$/m',
-                $baseUrl.'/$1',
-                $playlist
-            );
+            if ($this->isMasterPlaylist($playlist)) {
+                // Subtitles are enabled for this network: the proxy returns a master
+                // playlist referencing a video variant + subtitle variant playlist
+                // instead of a flat list of .ts segments.
+                $playlist = $this->rewriteMasterPlaylist($playlist, $network);
+            } else {
+                // Rewrite segment URLs to go through our proxy route
+                // FFmpeg outputs segment names like "live000001.ts" in the playlist
+                // We need to rewrite them to full URLs: /m3u-proxy/broadcast/{uuid}/segment/live000001.ts
+                $baseUrl = url("/network/{$network->uuid}");
+                $playlist = preg_replace(
+                    '/^(live\d+\.ts)$/m',
+                    $baseUrl.'/$1',
+                    $playlist
+                );
+            }
 
             return response($playlist, 200, [
                 'Content-Type' => 'application/vnd.apple.mpegurl',
@@ -118,6 +125,118 @@ class NetworkHlsController extends Controller
         $proxyUrl = $this->proxyService->getProxyBroadcastSegmentUrl($network, $segment);
 
         return redirect()->to($proxyUrl);
+    }
+
+    /**
+     * Serve an HLS sub-playlist or segment referenced from the master playlist
+     * when subtitles are enabled (video variant, subtitle variant, or their .ts/.vtt
+     * segments). Unlike segment(), .m3u8 files are fetched and rewritten here (they're
+     * playlists, not opaque binary segments) so their own references resolve back
+     * through our domain; .ts/.vtt segments are redirected straight to the proxy.
+     */
+    public function variant(Request $request, Network $network, string $filename): RedirectResponse|Response
+    {
+        if (! $network->broadcast_enabled) {
+            return response('Broadcast not enabled for this network', 404);
+        }
+
+        if (! str_ends_with($filename, '.m3u8')) {
+            if ($network->enabled && $network->broadcast_requested && $network->broadcast_on_demand) {
+                $this->broadcastService->markConnectionSeen($network);
+            }
+
+            return redirect()->to($this->proxyService->getProxyBroadcastFileUrl($network, $filename));
+        }
+
+        try {
+            $http = Http::timeout(10);
+
+            if ($token = $this->proxyService->getApiToken()) {
+                $http = $http->withHeaders(['X-API-Token' => $token]);
+            }
+
+            $url = $this->proxyService->getApiBaseUrl()."/broadcast/{$network->uuid}/segment/{$filename}";
+            $response = $http->get($url);
+
+            if (! $response->successful()) {
+                return response('Not available', $response->status());
+            }
+
+            $content = $this->rewriteVariantPlaylist($response->body(), $network);
+
+            return response($content, 200, [
+                'Content-Type' => 'application/vnd.apple.mpegurl',
+                'Cache-Control' => 'no-cache, no-store, must-revalidate',
+                'Pragma' => 'no-cache',
+                'Access-Control-Allow-Origin' => '*',
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Failed to fetch HLS sub-playlist', [
+                'network_id' => $network->id,
+                'filename' => $filename,
+                'error' => $e->getMessage(),
+            ]);
+
+            return response('Not available', 503);
+        }
+    }
+
+    /**
+     * Whether a playlist body is a master playlist (subtitles enabled) rather
+     * than a flat media playlist of .ts segments.
+     */
+    protected function isMasterPlaylist(string $playlist): bool
+    {
+        return str_contains($playlist, '#EXT-X-STREAM-INF');
+    }
+
+    /**
+     * Rewrite a master playlist's references to its video/subtitle variant
+     * sub-playlists so they resolve back through our domain.
+     */
+    protected function rewriteMasterPlaylist(string $playlist, Network $network): string
+    {
+        $variantBaseUrl = url("/network/{$network->uuid}/hls-variant");
+
+        // FFmpeg marks the subtitle rendition DEFAULT=YES, which forces it on for
+        // every viewer. The operator enabling detection means "make it available",
+        // not "force it on" — flip to available-but-off (AUTOSELECT=YES keeps it
+        // selectable in the player's menu; a bare DEFAULT=NO can make some players
+        // drop it from the menu entirely).
+        $playlist = preg_replace(
+            '/^(#EXT-X-MEDIA:TYPE=SUBTITLES.*?)DEFAULT=YES(.*)$/m',
+            '$1DEFAULT=NO,AUTOSELECT=YES$2',
+            $playlist
+        );
+
+        // The subtitle rendition's URI="live_0_vtt.m3u8" attribute.
+        $playlist = preg_replace_callback(
+            '/URI="([^"]+\.m3u8)"/',
+            fn (array $matches) => 'URI="'.$variantBaseUrl.'/'.$matches[1].'"',
+            $playlist
+        );
+
+        // The bare video-variant playlist reference line, e.g. "live_0.m3u8".
+        return preg_replace(
+            '/^(live[^\s]*\.m3u8)$/m',
+            $variantBaseUrl.'/$1',
+            $playlist
+        );
+    }
+
+    /**
+     * Rewrite a video/subtitle variant sub-playlist's bare .ts/.vtt segment
+     * references so they resolve back through our domain.
+     */
+    protected function rewriteVariantPlaylist(string $playlist, Network $network): string
+    {
+        $variantBaseUrl = url("/network/{$network->uuid}/hls-variant");
+
+        return preg_replace(
+            '/^(live[^\s]*\.(?:ts|vtt))$/m',
+            $variantBaseUrl.'/$1',
+            $playlist
+        );
     }
 
     protected function fetchPlaylistResponse(Network $network): ClientResponse
@@ -175,6 +294,14 @@ class NetworkHlsController extends Controller
     protected function hasMinimumPlaylistSegments(string $playlist, int $minSegments): bool
     {
         if ($minSegments <= 1) {
+            return true;
+        }
+
+        if ($this->isMasterPlaylist($playlist)) {
+            // Master playlists (subtitles enabled) don't list .ts segments directly —
+            // they're nested in the video variant sub-playlist. Checking that requires
+            // an extra fetch we don't want on this hot path, so treat the presence of
+            // a populated STREAM-INF line as sufficient evidence FFmpeg has started.
             return true;
         }
 

--- a/app/Interfaces/MediaServer.php
+++ b/app/Interfaces/MediaServer.php
@@ -34,9 +34,42 @@ interface MediaServer
 
     public function getDirectStreamUrl(Request $request, string $itemId, string $container = 'ts', array $transcodeOptions = []): string;
 
+    /**
+     * Return the audio stream index for the given ISO 639 language code, or null if not found.
+     * The returned value is service-specific: Emby/Jellyfin use the MediaStreams array index;
+     * Plex uses the stream's ID field. Both map to AudioStreamIndex on the outgoing request.
+     */
+    public function getAudioStreamIndexForLanguage(string $itemId, string $languageCode): ?int;
+
+    /**
+     * Return the first available text-based subtitle stream for the item, or null if none
+     * exists. Covers both embedded and external (sidecar file) subtitle streams — the media
+     * server's own metadata is authoritative for external subtitles, which a raw ffprobe of
+     * the video file itself can never see. Bitmap subtitle formats (PGS/VobSub) are skipped,
+     * since ffmpeg's webvtt encoder only supports text-to-text conversion.
+     *
+     * When $seekSeconds > 0 the returned URL must be seeked server-side so the subtitle cues
+     * are rebased to zero at that content-time — matching the video's own server-side seek so
+     * both streams share one timeline origin. The returned 'server_seeked' flag tells the proxy
+     * whether the subtitle input still needs a local -ss (false) or already arrives aligned
+     * (true), so it never double-seeks.
+     *
+     * @return array{url: string, language: ?string, server_seeked: bool}|null
+     */
+    public function getSubtitleUrl(string $itemId, int $seekSeconds = 0): ?array;
+
     public function getImageUrl(string $itemId, string $imageType = 'Primary'): string;
 
     public function getDirectImageUrl(string $itemId, string $imageType = 'Primary'): string;
+
+    /**
+     * Return the total byte size of the item's primary static stream alongside its runtime,
+     * or null if unavailable. Used to compute an HTTP Range offset that lets ffmpeg seek
+     * a server-side-seeked static stream without help from the media server.
+     *
+     * @return array{bytes: int, runtime_ticks: int|null, runtime_seconds: float|null}|null
+     */
+    public function getStreamByteSize(string $itemId): ?array;
 
     public function extractGenres(array $item): array;
 

--- a/app/Services/EmbyJellyfinService.php
+++ b/app/Services/EmbyJellyfinService.php
@@ -27,6 +27,16 @@ class EmbyJellyfinService implements MediaServer
     protected string $apiKey;
 
     /**
+     * Cache of stream byte-size lookups, keyed by itemId:baseUrl. Static because
+     * the same item may be looked up repeatedly across the lifetime of a long-running
+     * broadcast worker tick — a per-instance cache would re-fetch on every new
+     * MediaServerService::make() call.
+     *
+     * @var array<string, array{bytes: int, runtime_ticks: int|null, runtime_seconds: float|null}>
+     */
+    protected static array $streamByteSizeCache = [];
+
+    /**
      * Create a new EmbyJellyfinService instance.
      */
     public function __construct(MediaServerIntegration $integration)
@@ -480,7 +490,13 @@ class EmbyJellyfinService implements MediaServer
             'session_id' => true,
         ]);
 
-        if (empty($effectiveTranscodeOptions)) {
+        // When an AudioStreamIndex is requested we cannot use static=true — the server
+        // ignores AudioStreamIndex on a raw-file pass-through. Instead use VideoCodec=copy
+        // so the server remuxes with the selected audio track while leaving the video
+        // bitstream untouched (no video transcoding overhead).
+        $audioStreamIndexRequested = $request->has('AudioStreamIndex');
+
+        if (empty($effectiveTranscodeOptions) && ! $audioStreamIndexRequested) {
             $params['static'] = 'true';
         }
 
@@ -531,6 +547,13 @@ class EmbyJellyfinService implements MediaServer
             if ($request->has($param)) {
                 $params[$param] = $request->input($param);
             }
+        }
+
+        // Copy video stream when audio selection is active without a full Server transcode.
+        // This avoids re-encoding the video while still letting Emby/Jellyfin pick the
+        // right audio track.
+        if ($audioStreamIndexRequested && empty($effectiveTranscodeOptions)) {
+            $params['VideoCodec'] = 'copy';
         }
 
         // Include transcode options (VideoBitrate, AudioBitrate, MaxWidth, MaxHeight) if requested
@@ -691,6 +714,224 @@ class EmbyJellyfinService implements MediaServer
                 'success' => false,
                 'message' => 'Failed to trigger refresh: '.$e->getMessage(),
             ];
+        }
+    }
+
+    /**
+     * Fetch an item's MediaStreams, retrying briefly on an empty/incomplete result.
+     *
+     * Emby/Jellyfin's /Items endpoint has been observed to momentarily return a
+     * successful response with no MediaStreams for a perfectly valid item —
+     * apparently under concurrent API load (e.g. while the same server is also
+     * serving a live transcode). Http::retry() on the client only covers
+     * connection failures and 4xx/5xx responses; it does nothing for a "200 OK
+     * but empty" response, which is what this guards against. This matters
+     * most for the proxy auto-transition path, where subtitle/audio-language
+     * resolution for the next programme runs exactly once, far ahead of when
+     * it's used — a single silent miss here loses subtitles/audio-language for
+     * an entire programme with nothing to catch it.
+     *
+     * Returns null (and logs a warning) if no usable item could be fetched.
+     */
+    protected function fetchItemWithMediaStreams(string $itemId, int $attempts = 3): ?array
+    {
+        for ($attempt = 1; $attempt <= $attempts; $attempt++) {
+            // Emby/Jellyfin requires /Items?Ids={id} — the /Items/{id} form 404s on some versions.
+            $response = $this->client()->get('/Items', [
+                'Ids' => $itemId,
+                // RunTimeTicks lets getStreamByteSize() return runtime alongside the byte
+                // size in a single backend round-trip. Other callers (subtitles, audio
+                // stream lookup) ignore this field.
+                'fields' => 'MediaStreams,RunTimeTicks',
+            ]);
+
+            if ($response->successful()) {
+                $item = ($response->json('Items') ?? [])[0] ?? null;
+
+                if ($item && ! empty($item['MediaStreams'])) {
+                    return $item;
+                }
+            }
+
+            if ($attempt < $attempts) {
+                usleep(300_000);
+            }
+        }
+
+        Log::warning('EmbyJellyfinService: /Items returned no usable MediaStreams after retries', [
+            'item_id' => $itemId,
+            'attempts' => $attempts,
+        ]);
+
+        return null;
+    }
+
+    /**
+     * Return the MediaStreams array index of the first audio stream matching the given
+     * ISO 639 language code (2- or 3-letter). Returns null if not found or on error.
+     */
+    public function getAudioStreamIndexForLanguage(string $itemId, string $languageCode): ?int
+    {
+        try {
+            $item = $this->fetchItemWithMediaStreams($itemId);
+
+            if (! $item) {
+                return null;
+            }
+
+            $streams = $item['MediaStreams'] ?? [];
+            $lang = strtolower($languageCode);
+
+            foreach ($streams as $stream) {
+                if (($stream['Type'] ?? '') !== 'Audio') {
+                    continue;
+                }
+
+                $streamLang = strtolower($stream['Language'] ?? '');
+                if ($streamLang === $lang) {
+                    return (int) $stream['Index'];
+                }
+            }
+        } catch (Exception $e) {
+            Log::warning('EmbyJellyfinService: Failed to look up audio stream for language', [
+                'item_id' => $itemId,
+                'language' => $languageCode,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Return the first available text-based subtitle stream for the item, or null if none
+     * exists. Covers both embedded and external (sidecar file) subtitle streams — this is
+     * Emby/Jellyfin's own metadata, which knows about external subtitles that a raw ffprobe
+     * of the video file itself can never see.
+     *
+     * When $seekSeconds > 0 the URL is built with a startPositionTicks path segment
+     * (/Subtitles/{index}/{ticks}/Stream.{format}) so Emby/Jellyfin rebases the cue timestamps
+     * to zero at that content-time. This mirrors the video stream's own StartTimeTicks seek so
+     * both share a single timeline origin — the subtitle then needs no further seeking in the
+     * proxy (server_seeked = true), which is what keeps subtitles locked to the video on a
+     * resumed/mid-programme broadcast.
+     *
+     * @return array{url: string, language: ?string, server_seeked: bool}|null
+     */
+    public function getSubtitleUrl(string $itemId, int $seekSeconds = 0): ?array
+    {
+        try {
+            $item = $this->fetchItemWithMediaStreams($itemId);
+
+            if (! $item) {
+                return null;
+            }
+
+            $mediaSourceId = $item['MediaSources'][0]['Id'] ?? null;
+
+            if (! $mediaSourceId) {
+                Log::warning('EmbyJellyfinService: item has MediaStreams but no MediaSources, cannot build subtitle URL', [
+                    'item_id' => $itemId,
+                ]);
+
+                return null;
+            }
+
+            $streams = $item['MediaStreams'] ?? [];
+
+            foreach ($streams as $stream) {
+                if (($stream['Type'] ?? '') !== 'Subtitle') {
+                    continue;
+                }
+
+                // Bitmap subtitle formats (PGS, VobSub) can't be converted to WebVTT —
+                // ffmpeg's webvtt encoder only supports text-to-text conversion.
+                if (! ($stream['IsTextSubtitleStream'] ?? false)) {
+                    continue;
+                }
+
+                $index = $stream['Index'];
+                $format = $stream['Codec'] ?? 'srt';
+
+                // Insert the startPositionTicks path segment so Emby/Jellyfin rebases the
+                // subtitle cues to zero at the seek point, exactly like StartTimeTicks does
+                // for the video. Ticks are 100-nanosecond intervals.
+                $seekPath = $seekSeconds > 0 ? ($seekSeconds * 10_000_000).'/' : '';
+
+                return [
+                    'url' => "{$this->baseUrl}/Videos/{$itemId}/{$mediaSourceId}/Subtitles/{$index}/{$seekPath}Stream.{$format}?api_key={$this->apiKey}",
+                    'language' => $stream['Language'] ?? null,
+                    'server_seeked' => $seekSeconds > 0,
+                ];
+            }
+        } catch (Exception $e) {
+            Log::warning('EmbyJellyfinService: Failed to look up subtitle URL', [
+                'item_id' => $itemId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Return the byte size of the item's static stream and its runtime, or null if
+     * either is unavailable. Cached per item+server — the static stream URL is
+     * content-addressed by item ID, so the size is stable for the lifetime of the item.
+     *
+     * The byte size comes from a HEAD against /Videos/{id}/stream.ts with the same
+     * query string shape getDirectStreamUrl() uses for a static raw pass-through
+     * (static=true, no StartTimeTicks/VideoCodec=copy). The runtime comes from
+     * RunTimeTicks on the item. Together they let callers compute an HTTP Range
+     * offset that aligns ffmpeg's input -ss with the server-side-seeked static URL.
+     */
+    public function getStreamByteSize(string $itemId): ?array
+    {
+        $cacheKey = $itemId.':'.$this->baseUrl;
+        if (isset(self::$streamByteSizeCache[$cacheKey])) {
+            return self::$streamByteSizeCache[$cacheKey];
+        }
+
+        try {
+            $response = Http::baseUrl($this->baseUrl)
+                ->timeout(10)
+                ->withHeaders(['X-Emby-Token' => $this->apiKey])
+                ->head('/Videos/'.$itemId.'/stream.ts', [
+                    'static' => 'true',
+                    'api_key' => $this->apiKey,
+                ]);
+
+            if (! $response->successful()) {
+                return null;
+            }
+
+            $bytes = $response->header('Content-Length');
+            if ($bytes === null || $bytes === '' || ! is_numeric($bytes)) {
+                return null;
+            }
+
+            $bytes = (int) $bytes;
+
+            $item = $this->fetchItemWithMediaStreams($itemId);
+            $runtimeTicks = isset($item['RunTimeTicks']) ? (int) $item['RunTimeTicks'] : null;
+            $runtimeSeconds = $runtimeTicks !== null ? $runtimeTicks / 10_000_000.0 : null;
+
+            $meta = [
+                'bytes' => $bytes,
+                'runtime_ticks' => $runtimeTicks,
+                'runtime_seconds' => $runtimeSeconds,
+            ];
+
+            self::$streamByteSizeCache[$cacheKey] = $meta;
+
+            return $meta;
+        } catch (Exception $e) {
+            Log::warning('EmbyJellyfinService: Failed to read stream byte size', [
+                'item_id' => $itemId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
         }
     }
 }

--- a/app/Services/LocalMediaService.php
+++ b/app/Services/LocalMediaService.php
@@ -902,4 +902,19 @@ class LocalMediaService implements MediaServer
 
         return $seasons->sortBy('IndexNumber')->values();
     }
+
+    public function getAudioStreamIndexForLanguage(string $itemId, string $languageCode): ?int
+    {
+        return null;
+    }
+
+    public function getSubtitleUrl(string $itemId, int $seekSeconds = 0): ?array
+    {
+        return null;
+    }
+
+    public function getStreamByteSize(string $itemId): ?array
+    {
+        return null;
+    }
 }

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -2953,6 +2953,17 @@ class M3uProxyService
     }
 
     /**
+     * Get the proxy URL for an arbitrary broadcast HLS file (segment or sub-playlist)
+     * by its already-extensioned filename. Used for subtitle-enabled broadcasts, where
+     * the proxy serves .ts/.vtt segments and .m3u8 video/subtitle variant playlists
+     * under the same generic endpoint.
+     */
+    public function getProxyBroadcastFileUrl(Network $network, string $filename): string
+    {
+        return "{$this->getPublicUrl()}/broadcast/{$network->uuid}/segment/{$filename}";
+    }
+
+    /**
      * Get the failover resolver URL for smart failover handling.
      * This URL is passed to m3u-proxy so it can call back to validate failover channels
      * before attempting to stream from them.

--- a/app/Services/NetworkBroadcastService.php
+++ b/app/Services/NetworkBroadcastService.php
@@ -303,12 +303,98 @@ class NetworkBroadcastService
         // Get the callback URL
         $callbackUrl = $this->getProxyService()->getBroadcastCallbackUrl();
 
-        // Only trust URL-based seeking when using server-side transcoding (TranscodeMode::Server).
-        // For direct streams (static=true), media servers like Emby/Jellyfin ignore StartTimeTicks,
-        // so FFmpeg must always handle seeking via -ss. Double-seeking is only a risk when the
-        // server is actively transcoding and applying the seek itself.
+        // Seek-coordination rules (verified against a live Emby at 192.168.1.42:18096):
+        //  - Static URL (static=true, no VideoCodec=copy): Emby IGNORES StartTimeTicks/offset
+        //    server-side (returns identical bytes with or without the flag — verified by md5).
+        //    The static endpoint DOES support byte-range requests (Accept-Ranges: bytes,
+        //    206 Partial Content), so ffmpeg can seek it via input -ss (byte-range).
+        //    ffmpeg must always seek. seek_seconds = $seekPosition.
+        //  - Server transcode URL (TranscodeMode::Server): Emby honors StartTimeTicks
+        //    server-side (this is what the transcode session was built for). ffmpeg must NOT
+        //    also seek. seek_seconds = 0.
+        //  - Remux URL (VideoCodec=copy with StartTimeTicks): Emby SILENTLY IGNORES
+        //    StartTimeTicks on this endpoint (returns the full file from byte 0 with
+        //    Accept-Ranges: none and unknown duration — verified by direct probe). ffmpeg
+        //    also can't seek it because the remux has no Range support and no duration.
+        //    The naive contract (send seek_seconds = 0 and trust the server) silently plays
+        //    from content-time 0 instead of the requested seek offset.
+        //
+        //    Remediation: when a seek is required on a remux URL, rewrite the URL to the
+        //    seek-capable static endpoint by stripping VideoCodec=copy AND StartTimeTicks/offset
+        //    (Emby ignores both on static anyway). The static endpoint supports byte-range
+        //    requests so ffmpeg can seek it via input -ss. The static endpoint also preserves
+        //    all original streams, so the resolved absolute MediaStreams audio index maps
+        //    directly to ffmpeg's track position — ffmpeg can -map 0:a:{idx} to honour the
+        //    preferred-audio-language selection that originally required the remux.
+        //    After the rewrite, the URL is no longer a "remux" and behaves like static:
+        //    ffmpeg MUST seek. seek_seconds = $seekPosition.
         $isServerTranscode = ($network->transcode_mode ?? null) === TranscodeMode::Server;
         $urlHasSeeking = preg_match('/[?&](offset|StartTimeTicks)=/', $streamUrl);
+        $urlIsRemux = preg_match('/[?&]VideoCodec=copy\b/', $streamUrl);
+
+        // Rewrite a remux+seek URL to the seek-capable static endpoint. Strip
+        // VideoCodec=copy (the remux trigger) AND StartTimeTicks/offset (Emby ignores both
+        // on static — verified by md5 — so they're just noise after the rewrite).
+        // Keep AudioStreamIndex (no-op on static but harmless; ffmpeg does the selection).
+        $remuxRewrittenToStatic = false;
+        if ($urlIsRemux && $urlHasSeeking) {
+            $streamUrl = preg_replace('/[?&]VideoCodec=copy\b/', '', $streamUrl);
+            $streamUrl = preg_replace('/[?&](?:offset|StartTimeTicks)=[^&]*/', '', $streamUrl);
+            $streamUrl = str_replace('?&', '?', $streamUrl);
+            if (str_ends_with($streamUrl, '?')) {
+                $streamUrl = rtrim($streamUrl, '?');
+            }
+            // Add static=true if the URL doesn't already have it (EmbyJellyfinService adds
+            // static=true only when there's no audio selection; after the audio selection
+            // was the trigger for VideoCodec=copy, static was NOT added, so we add it now).
+            if (! str_contains($streamUrl, 'static=')) {
+                $separator = str_contains($streamUrl, '?') ? '&' : '?';
+                $streamUrl .= $separator.'static=true';
+            }
+            $urlIsRemux = false;
+            // After the rewrite the URL no longer carries server-side seeking; ffmpeg must
+            // do the seek itself against the now-seekable static endpoint.
+            $urlHasSeeking = false;
+            // Mark that the rewrite just fired — only the rewritten-static path is a
+            // candidate for the #range= byte-offset hint below.
+            $remuxRewrittenToStatic = true;
+        }
+
+        // Range hint for the rewritten-static path. Emby's static endpoint supports HTTP
+        // byte-range requests but ignores StartTimeTicks server-side. After the rewrite
+        // strips the server-side seek, the only way to land ffmpeg at the right byte is
+        // a Range header on the very first read. The proxy accepts a `#range=<n>-$`
+        // fragment on the stream URL as a one-shot byte offset; ffmpeg then issues the
+        // range request and from byte N+ reads normally. Only Emby's rewritten-static URL
+        // gets this — non-Emby servers don't honour the static endpoint the same way and
+        // the rest of the URL shapes don't need it.
+        if ($remuxRewrittenToStatic && $seekPosition > 0) {
+            try {
+                $integration = $network->mediaServerIntegration;
+
+                if ($integration && $integration->isEmby()) {
+                    $itemId = $this->getMediaServerItemId($programme->contentable);
+
+                    if ($itemId) {
+                        $sizeMeta = MediaServerService::make($integration)->getStreamByteSize($itemId);
+
+                        if ($sizeMeta && ! empty($sizeMeta['runtime_seconds']) && $sizeMeta['runtime_seconds'] > 0) {
+                            $offset = intval(($seekPosition / $sizeMeta['runtime_seconds']) * $sizeMeta['bytes']);
+                            $streamUrl .= '#range='.$offset.'-';
+                        }
+                    }
+                }
+            } catch (\Exception $e) {
+                Log::warning('Failed to compute #range= byte offset for rewritten-static URL', [
+                    'network_id' => $network->id,
+                    'exception' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        // Server transcode: Emby honors StartTimeTicks server-side, ffmpeg must NOT seek.
+        // Static (raw or post-rewrite): Emby ignores StartTimeTicks server-side; the
+        // static endpoint IS seekable (Range support), so ffmpeg MUST seek via input -ss.
         $ffmpegSeekSeconds = ($isServerTranscode && $urlHasSeeking) ? 0 : $seekPosition;
 
         // If using server-side transcoding, ensure we have a valid transcode start URL from the media server
@@ -324,6 +410,25 @@ class NetworkBroadcastService
 
             return false;
         }
+
+        $subtitleInfo = $this->resolveSubtitleInfo($network, $programme, $seekPosition);
+
+        // When the media server already seeked the subtitle URL server-side (rebasing its
+        // cues to zero at $seekPosition, mirroring the video's own StartTimeTicks seek), the
+        // subtitle input shares the video's timeline origin and must NOT be seeked again in
+        // the proxy — so the proxy seek is 0. Otherwise (full-file subtitle, e.g. a provider
+        // that can't seek server-side) the proxy still needs the true offset. This single
+        // source of truth replaces the old always-full-offset value that desynced whenever
+        // the subtitle was in fact already server-seeked.
+        $subtitleSeekSeconds = $subtitleInfo['server_seeked'] ? 0 : $seekPosition;
+
+        // Audio track mapping:
+        //   - Static (or post-rewrite) URL: preserves all original streams, so the resolved
+        //     absolute MediaStreams index IS the correct ffmpeg -map target.
+        //   - Remux URL (no seek, rewrite didn't fire): Emby already remuxed to ONE audio
+        //     track at position 0, so ffmpeg must -map 0:a:0 regardless of original index.
+        $resolvedAudioStreamIndex = $this->resolveAudioStreamIndex($network);
+        $ffmpegAudioStreamIndex = ($urlIsRemux && $resolvedAudioStreamIndex !== null) ? 0 : $resolvedAudioStreamIndex;
 
         $payload = [
             'stream_url' => $streamUrl,
@@ -344,6 +449,24 @@ class NetworkBroadcastService
             'audio_codec' => $network->audio_codec,
             'preset' => $network->transcode_preset,
             'hwaccel' => $network->hwaccel,
+            // Audio stream index resolved from preferred_audio_language (null = use default).
+            // For Local mode the proxy FFmpeg uses this to select the right audio track.
+            'audio_stream_index' => $ffmpegAudioStreamIndex,
+            // Whether the proxy should detect embedded subtitle tracks on the source and
+            // expose them as a toggleable WebVTT rendition in the HLS output. Only meaningful
+            // outside Server mode: Media Server transcoding strips subtitle tracks before the
+            // proxy ever receives the stream.
+            'subtitles_enabled' => $this->subtitlesEnabledForProxy($network),
+            // Explicit subtitle URL resolved from the media server's own metadata (covers
+            // embedded AND external/sidecar-file subtitles). When present, the proxy uses
+            // this directly as a second FFmpeg input instead of probing the raw video stream.
+            'subtitle_url' => $subtitleInfo['url'],
+            'subtitle_language' => $subtitleInfo['language'],
+            // Seek offset the proxy must apply to the subtitle input. It is 0 when the
+            // subtitle URL was already seeked server-side (cues rebased to zero at the seek
+            // point, matching the video) so the proxy leaves it untouched; otherwise it is
+            // the true offset for a full-file subtitle. Derived from $subtitleInfo above.
+            'subtitle_seek_seconds' => $subtitleSeekSeconds,
             'callback_url' => $callbackUrl,
             // Pre-compute next programme config for zero-round-trip auto-transition.
             // The proxy will start the next programme immediately when the current
@@ -829,6 +952,29 @@ class NetworkBroadcastService
         // when Plex can't keep up with real-time demands. FFmpeg will handle all
         // transcoding locally instead (much more reliable for live broadcasting).
         $transcodeOptions['skip_plex_transcode'] = true;
+
+        // Inject the preferred audio stream index when a language is configured.
+        // For Server transcode mode, the media server honors AudioStreamIndex in
+        // the URL and emits only the chosen track. For Local/Direct mode, the
+        // index is forwarded so the proxy FFmpeg layer can select the right stream.
+        if (! empty($network->preferred_audio_language)) {
+            $audioStreamIndex = $service->getAudioStreamIndexForLanguage($itemId, $network->preferred_audio_language);
+
+            if ($audioStreamIndex !== null) {
+                $request->merge(['AudioStreamIndex' => $audioStreamIndex]);
+
+                Log::debug('Audio stream index resolved for preferred language', [
+                    'network_id' => $network->id,
+                    'language' => $network->preferred_audio_language,
+                    'audio_stream_index' => $audioStreamIndex,
+                ]);
+            } else {
+                Log::debug('Preferred audio language not found in media streams, using default', [
+                    'network_id' => $network->id,
+                    'language' => $network->preferred_audio_language,
+                ]);
+            }
+        }
 
         $streamUrl = $service->getDirectStreamUrl($request, $itemId, 'ts', $transcodeOptions);
 
@@ -1364,6 +1510,15 @@ class NetworkBroadcastService
 
         $nextDuration = (int) $nextProgramme->start_time->diffInSeconds($nextProgramme->end_time);
         $callbackUrl = $this->getProxyService()->getBroadcastCallbackUrl();
+        $nextSubtitleInfo = $this->resolveSubtitleInfo($network, $nextProgramme, 0);
+
+        // See the matching comment in startViaProxy(): a VideoCodec=copy remux already
+        // selected a single audio track server-side, so ffmpeg must map 0:a:0, not the
+        // original resolved index — otherwise the next-programme auto-transition dies
+        // the same way the initial start would.
+        $nextUrlIsRemux = preg_match('/[?&]VideoCodec=copy\b/', $nextStreamUrl);
+        $nextResolvedAudioStreamIndex = $this->resolveAudioStreamIndex($network, $nextProgramme);
+        $nextFfmpegAudioStreamIndex = ($nextUrlIsRemux && $nextResolvedAudioStreamIndex !== null) ? 0 : $nextResolvedAudioStreamIndex;
 
         $config = [
             'stream_url' => $nextStreamUrl,
@@ -1379,6 +1534,14 @@ class NetworkBroadcastService
             'audio_codec' => $network->audio_codec,
             'preset' => $network->transcode_preset,
             'hwaccel' => $network->hwaccel,
+            'audio_stream_index' => $nextFfmpegAudioStreamIndex,
+            'subtitles_enabled' => $this->subtitlesEnabledForProxy($network),
+            'subtitle_url' => $nextSubtitleInfo['url'],
+            'subtitle_language' => $nextSubtitleInfo['language'],
+            // A next programme always starts from its own beginning, so neither the video
+            // nor the subtitle needs seeking — kept explicit so the proxy's auto-transition
+            // payload is symmetric with the initial start payload.
+            'subtitle_seek_seconds' => 0,
             'callback_url' => $callbackUrl,
         ];
 
@@ -1435,5 +1598,112 @@ class NetworkBroadcastService
         }
 
         return $config;
+    }
+
+    /**
+     * Resolve the network-level preferred audio stream index.
+     *
+     * Returns null when no language is configured so the proxy/media server
+     * uses its own default. This method is intentionally cheap: it only queries
+     * the media server when a language preference is set AND the programme
+     * has a resolvable item ID; otherwise it returns null immediately.
+     *
+     * Accepts an explicit programme so computeNextStreamConfig() can resolve the
+     * audio index for the upcoming programme's content, not whatever is currently
+     * airing — defaults to the current programme for the startViaProxy() call site.
+     */
+    protected function resolveAudioStreamIndex(Network $network, ?NetworkProgramme $programme = null): ?int
+    {
+        if (empty($network->preferred_audio_language)) {
+            return null;
+        }
+
+        $programme ??= $network->getCurrentProgramme();
+        if (! $programme) {
+            return null;
+        }
+
+        $content = $programme->contentable;
+        if (! $content) {
+            return null;
+        }
+
+        $integration = $network->mediaServerIntegration ?? $this->getIntegrationFromContent($content);
+        if (! $integration) {
+            return null;
+        }
+
+        $itemId = $this->getMediaServerItemId($content);
+        if (! $itemId) {
+            return null;
+        }
+
+        return MediaServerService::make($integration)
+            ->getAudioStreamIndexForLanguage($itemId, $network->preferred_audio_language);
+    }
+
+    /**
+     * Whether the proxy should attempt to detect and expose embedded subtitle
+     * tracks for this broadcast. Forced off in Server transcode mode, since the
+     * media server's own transcode strips subtitle streams before the proxy ever
+     * receives the file — the operator's toggle would otherwise silently do nothing.
+     */
+    protected function subtitlesEnabledForProxy(Network $network): bool
+    {
+        return (bool) $network->subtitles_enabled
+            && ($network->transcode_mode ?? null) !== TranscodeMode::Server;
+    }
+
+    /**
+     * Resolve a subtitle URL for the current programme from the media server's own
+     * metadata (covers embedded AND external/sidecar-file subtitles). Returns null
+     * values when subtitles are disabled, unsupported for this content, or the
+     * media server integration doesn't implement subtitle lookup (Local/WebDAV/Plex).
+     * When this returns a URL, the proxy uses it directly instead of probing the raw
+     * video stream — the media server's metadata already knows definitively whether
+     * a subtitle exists, which is more complete and cheaper than a fresh ffprobe.
+     *
+     * Accepts an explicit programme so computeNextStreamConfig() can resolve subtitle
+     * info for the upcoming programme's content, not whatever is currently airing —
+     * defaults to the current programme for the startViaProxy() call site.
+     *
+     * $seekSeconds is forwarded to the media server so the subtitle URL can be seeked
+     * server-side (rebasing cues to zero at the seek point) to match the video's own
+     * server-side seek — keeping both on one timeline origin. The returned 'server_seeked'
+     * flag propagates to subtitle_seek_seconds so the proxy never double-seeks the input.
+     *
+     * @return array{url: ?string, language: ?string, server_seeked: bool}
+     */
+    protected function resolveSubtitleInfo(Network $network, ?NetworkProgramme $programme = null, int $seekSeconds = 0): array
+    {
+        $empty = ['url' => null, 'language' => null, 'server_seeked' => false];
+
+        if (! $this->subtitlesEnabledForProxy($network)) {
+            return $empty;
+        }
+
+        $programme ??= $network->getCurrentProgramme();
+        if (! $programme) {
+            return $empty;
+        }
+
+        $content = $programme->contentable;
+        if (! $content) {
+            return $empty;
+        }
+
+        $integration = $network->mediaServerIntegration ?? $this->getIntegrationFromContent($content);
+        if (! $integration) {
+            return $empty;
+        }
+
+        $itemId = $this->getMediaServerItemId($content);
+        if (! $itemId) {
+            return $empty;
+        }
+
+        $subtitle = MediaServerService::make($integration)->getSubtitleUrl($itemId, $seekSeconds);
+
+        return $subtitle ?? $empty;
     }
 }

--- a/app/Services/NetworkBroadcastService.php
+++ b/app/Services/NetworkBroadcastService.php
@@ -464,7 +464,7 @@ class NetworkBroadcastService
             'audio_codec' => $network->audio_codec,
             'preset' => $network->transcode_preset,
             'hwaccel' => $network->hwaccel,
-            // Audio stream index resolved from preferred_audio_language (null = use default).
+            // Audio stream index resolved from preferred_audio_track (null = use default).
             // For Local mode the proxy FFmpeg uses this to select the right audio track.
             'audio_stream_index' => $ffmpegAudioStreamIndex,
             // Whether the proxy should detect embedded subtitle tracks on the source and
@@ -968,29 +968,19 @@ class NetworkBroadcastService
         // transcoding locally instead (much more reliable for live broadcasting).
         $transcodeOptions['skip_plex_transcode'] = true;
 
-        // Inject the preferred audio stream index when a language is configured.
-        // For Server transcode mode, the media server honors AudioStreamIndex in
-        // the URL and emits only the chosen track. For Local/Direct mode, the
-        // index is forwarded so the proxy FFmpeg layer can select the right stream.
-        if (! empty($network->preferred_audio_language)) {
-            $audioStreamIndex = $service->getAudioStreamIndexForLanguage($itemId, $network->preferred_audio_language);
-
-            if ($audioStreamIndex !== null) {
-                $request->merge(['AudioStreamIndex' => $audioStreamIndex]);
-
-                Log::debug('Audio stream index resolved for preferred language', [
-                    'network_id' => $network->id,
-                    'language' => $network->preferred_audio_language,
-                    'audio_stream_index' => $audioStreamIndex,
-                ]);
-            } else {
-                Log::debug('Preferred audio language not found in media streams, using default', [
-                    'network_id' => $network->id,
-                    'language' => $network->preferred_audio_language,
-                ]);
-            }
-        }
-
+        // Inject the preferred audio track preference into the request so the media
+        // server's own track-prefs logic (Plex resolvePreferredStreamId / Emby
+        // resolvePreferredStreamIndex) picks the right stream when it builds the
+        // direct URL. Doing this here is what makes the audio selection work in
+        // both direct and transcode modes for the current programme.
+        //
+        // Note: the proxy payload's audio_stream_index for the CURRENT programme
+        // is also resolved via the same preferred_audio_track by startViaProxy()
+        // (resolveAudioStreamIndex -> getAudioStreamIndexForLanguage) so the proxy
+        // FFmpeg -map target is known without a second media-server roundtrip.
+        // The audio_stream_index for the NEXT programme (auto-transition) is
+        // resolved separately by computeNextStreamConfig() so the next programme's
+        // selection survives the zero-round-trip boundary.
         $streamUrl = $service->getDirectStreamUrl($request, $itemId, 'ts', $transcodeOptions);
 
         return $streamUrl;
@@ -1629,7 +1619,7 @@ class NetworkBroadcastService
      */
     protected function resolveAudioStreamIndex(Network $network, ?NetworkProgramme $programme = null): ?int
     {
-        if (empty($network->preferred_audio_language)) {
+        if (empty($network->preferred_audio_track)) {
             return null;
         }
 
@@ -1654,18 +1644,20 @@ class NetworkBroadcastService
         }
 
         return MediaServerService::make($integration)
-            ->getAudioStreamIndexForLanguage($itemId, $network->preferred_audio_language);
+            ->getAudioStreamIndexForLanguage($itemId, $network->preferred_audio_track);
     }
 
     /**
      * Whether the proxy should attempt to detect and expose embedded subtitle
-     * tracks for this broadcast. Forced off in Server transcode mode, since the
-     * media server's own transcode strips subtitle streams before the proxy ever
-     * receives the file — the operator's toggle would otherwise silently do nothing.
+     * tracks for this broadcast. Derived from preferred_subtitle_track (any
+     * non-empty value means the operator wants subtitles). Forced off in Server
+     * transcode mode, since the media server's own transcode strips subtitle
+     * streams before the proxy ever receives the file — the operator's preference
+     * would otherwise silently do nothing.
      */
     protected function subtitlesEnabledForProxy(Network $network): bool
     {
-        return (bool) $network->subtitles_enabled
+        return ! empty($network->preferred_subtitle_track)
             && ($network->transcode_mode ?? null) !== TranscodeMode::Server;
     }
 

--- a/app/Services/NetworkBroadcastService.php
+++ b/app/Services/NetworkBroadcastService.php
@@ -380,7 +380,22 @@ class NetworkBroadcastService
 
                         if ($sizeMeta && ! empty($sizeMeta['runtime_seconds']) && $sizeMeta['runtime_seconds'] > 0) {
                             $offset = intval(($seekPosition / $sizeMeta['runtime_seconds']) * $sizeMeta['bytes']);
+                            Log::debug('📍 #range= byte offset computed for rewritten-static URL', [
+                                'network_id' => $network->id,
+                                'item_id' => $itemId,
+                                'seek_seconds' => $seekPosition,
+                                'runtime_seconds' => $sizeMeta['runtime_seconds'],
+                                'bytes' => $sizeMeta['bytes'],
+                                'offset' => $offset,
+                            ]);
                             $streamUrl .= '#range='.$offset.'-';
+                        } else {
+                            Log::warning('📍 #range= byte offset NOT computed — getStreamByteSize returned unusable data', [
+                                'network_id' => $network->id,
+                                'item_id' => $itemId,
+                                'seek_seconds' => $seekPosition,
+                                'size_meta' => $sizeMeta,
+                            ]);
                         }
                     }
                 }

--- a/app/Services/PlexService.php
+++ b/app/Services/PlexService.php
@@ -957,4 +957,54 @@ class PlexService implements MediaServer
             ];
         }
     }
+
+    /**
+     * Return the Plex stream ID for the first audio stream matching the given
+     * ISO 639 language code. Returns null if not found or on error.
+     * Plex identifies audio streams by their ID, not a 0-based array index.
+     */
+    public function getAudioStreamIndexForLanguage(string $itemId, string $languageCode): ?int
+    {
+        try {
+            $response = $this->client()->get("/library/metadata/{$itemId}");
+
+            if (! $response->successful()) {
+                return null;
+            }
+
+            $data = $response->json();
+            $streams = $data['MediaContainer']['Metadata'][0]['Media'][0]['Part'][0]['Stream'] ?? [];
+            $lang = strtolower($languageCode);
+
+            foreach ($streams as $stream) {
+                // streamType 2 = audio in the Plex API
+                if ((int) ($stream['streamType'] ?? 0) !== 2) {
+                    continue;
+                }
+
+                $streamLang = strtolower($stream['languageCode'] ?? $stream['language'] ?? '');
+                if ($streamLang === $lang) {
+                    return isset($stream['id']) ? (int) $stream['id'] : null;
+                }
+            }
+        } catch (Exception $e) {
+            Log::warning('PlexService: Failed to look up audio stream for language', [
+                'item_id' => $itemId,
+                'language' => $languageCode,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return null;
+    }
+
+    public function getSubtitleUrl(string $itemId, int $seekSeconds = 0): ?array
+    {
+        return null;
+    }
+
+    public function getStreamByteSize(string $itemId): ?array
+    {
+        return null;
+    }
 }

--- a/app/Services/WebDavMediaService.php
+++ b/app/Services/WebDavMediaService.php
@@ -1651,4 +1651,19 @@ class WebDavMediaService implements MediaServer
             'password' => $this->integration->webdav_password,
         ];
     }
+
+    public function getAudioStreamIndexForLanguage(string $itemId, string $languageCode): ?int
+    {
+        return null;
+    }
+
+    public function getSubtitleUrl(string $itemId, int $seekSeconds = 0): ?array
+    {
+        return null;
+    }
+
+    public function getStreamByteSize(string $itemId): ?array
+    {
+        return null;
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -209,6 +209,12 @@ Route::get('/network/{network}/live.m3u8', [NetworkHlsController::class, 'playli
 Route::get('/network/{network}/{segment}.ts', [NetworkHlsController::class, 'segment'])
     ->name('network.hls.segment')
     ->where('segment', 'live[0-9]+');
+// Video/subtitle variant sub-playlists and their .ts/.vtt segments, used only
+// when a network has subtitles enabled (proxy emits a master playlist instead
+// of a flat live.m3u8).
+Route::get('/network/{network}/hls-variant/{filename}', [NetworkHlsController::class, 'variant'])
+    ->name('network.hls.variant')
+    ->where('filename', 'live[^/]*\.(?:ts|vtt|m3u8)');
 
 /*
  * API routes

--- a/tests/Feature/EmbySubtitleUrlTest.php
+++ b/tests/Feature/EmbySubtitleUrlTest.php
@@ -1,0 +1,222 @@
+<?php
+
+use App\Models\MediaServerIntegration;
+use App\Services\EmbyJellyfinService;
+use Illuminate\Support\Facades\Http;
+
+it('resolves a subtitle url for a text-based subtitle stream, embedded or external', function () {
+    $integration = new MediaServerIntegration([
+        'type' => 'emby',
+        'host' => 'emby.local',
+        'port' => 8096,
+        'ssl' => false,
+        'api_key' => 'emby-token',
+    ]);
+
+    Http::fake([
+        'http://emby.local:8096/Items*' => Http::response([
+            'Items' => [
+                [
+                    'MediaSources' => [
+                        ['Id' => 'mediasource_20074'],
+                    ],
+                    'MediaStreams' => [
+                        ['Type' => 'Video', 'Index' => 0],
+                        ['Type' => 'Audio', 'Index' => 1, 'Language' => 'eng'],
+                        [
+                            'Type' => 'Subtitle',
+                            'Index' => 2,
+                            'Codec' => 'srt',
+                            'Language' => 'eng',
+                            'IsExternal' => true,
+                            'IsTextSubtitleStream' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $service = EmbyJellyfinService::make($integration);
+    $result = $service->getSubtitleUrl('20074');
+
+    expect($result)->not->toBeNull()
+        ->and($result['language'])->toBe('eng')
+        ->and($result['url'])->toContain('/Videos/20074/mediasource_20074/Subtitles/2/Stream.srt')
+        ->and($result['url'])->toContain('api_key=emby-token')
+        ->and($result['server_seeked'])->toBeFalse();
+});
+
+it('seeks the subtitle url server-side via startPositionTicks to match the video seek', function () {
+    $integration = new MediaServerIntegration([
+        'type' => 'emby',
+        'host' => 'emby.local',
+        'port' => 8096,
+        'ssl' => false,
+        'api_key' => 'emby-token',
+    ]);
+
+    Http::fake([
+        'http://emby.local:8096/Items*' => Http::response([
+            'Items' => [
+                [
+                    'MediaSources' => [
+                        ['Id' => 'mediasource_465'],
+                    ],
+                    'MediaStreams' => [
+                        [
+                            'Type' => 'Subtitle',
+                            'Index' => 3,
+                            'Codec' => 'srt',
+                            'Language' => 'en',
+                            'IsExternal' => true,
+                            'IsTextSubtitleStream' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $service = EmbyJellyfinService::make($integration);
+
+    // 845 seconds -> 8_450_000_000 ticks, injected as a path segment before Stream.srt so
+    // Emby rebases the cues to zero at that content-time (mirrors the video's StartTimeTicks).
+    $result = $service->getSubtitleUrl('465', 845);
+
+    expect($result)->not->toBeNull()
+        ->and($result['server_seeked'])->toBeTrue()
+        ->and($result['url'])->toContain('/Videos/465/mediasource_465/Subtitles/3/8450000000/Stream.srt')
+        ->and($result['url'])->not->toContain('/Subtitles/3/Stream.srt');
+});
+
+it('skips bitmap subtitle streams since ffmpeg cannot convert them to webvtt', function () {
+    $integration = new MediaServerIntegration([
+        'type' => 'emby',
+        'host' => 'emby.local',
+        'port' => 8096,
+        'ssl' => false,
+        'api_key' => 'emby-token',
+    ]);
+
+    Http::fake([
+        'http://emby.local:8096/Items*' => Http::response([
+            'Items' => [
+                [
+                    'MediaSources' => [
+                        ['Id' => 'mediasource_1'],
+                    ],
+                    'MediaStreams' => [
+                        [
+                            'Type' => 'Subtitle',
+                            'Index' => 2,
+                            'Codec' => 'pgssub',
+                            'Language' => 'eng',
+                            'IsExternal' => false,
+                            'IsTextSubtitleStream' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $service = EmbyJellyfinService::make($integration);
+
+    expect($service->getSubtitleUrl('1'))->toBeNull();
+});
+
+it('retries when Emby returns a successful but empty MediaStreams payload', function () {
+    $integration = new MediaServerIntegration([
+        'type' => 'emby',
+        'host' => 'emby.local',
+        'port' => 8096,
+        'ssl' => false,
+        'api_key' => 'emby-token',
+    ]);
+
+    Http::fake([
+        'http://emby.local:8096/Items*' => Http::sequence()
+            // Emby/Jellyfin has been observed to momentarily return 200 with no
+            // MediaStreams for a valid item under concurrent API load.
+            ->push(['Items' => [['MediaSources' => [], 'MediaStreams' => []]]], 200)
+            ->push([
+                'Items' => [
+                    [
+                        'MediaSources' => [['Id' => 'mediasource_465']],
+                        'MediaStreams' => [
+                            [
+                                'Type' => 'Subtitle',
+                                'Index' => 3,
+                                'Codec' => 'srt',
+                                'Language' => 'en',
+                                'IsExternal' => true,
+                                'IsTextSubtitleStream' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ], 200),
+    ]);
+
+    $service = EmbyJellyfinService::make($integration);
+    $result = $service->getSubtitleUrl('465');
+
+    expect($result)->not->toBeNull()
+        ->and($result['language'])->toBe('en');
+
+    Http::assertSentCount(2);
+});
+
+it('returns null after exhausting retries when MediaStreams stays empty', function () {
+    $integration = new MediaServerIntegration([
+        'type' => 'emby',
+        'host' => 'emby.local',
+        'port' => 8096,
+        'ssl' => false,
+        'api_key' => 'emby-token',
+    ]);
+
+    Http::fake([
+        'http://emby.local:8096/Items*' => Http::response(
+            ['Items' => [['MediaSources' => [], 'MediaStreams' => []]]],
+            200
+        ),
+    ]);
+
+    $service = EmbyJellyfinService::make($integration);
+
+    expect($service->getSubtitleUrl('465'))->toBeNull();
+
+    Http::assertSentCount(3);
+});
+
+it('returns null when the item has no subtitle stream at all', function () {
+    $integration = new MediaServerIntegration([
+        'type' => 'emby',
+        'host' => 'emby.local',
+        'port' => 8096,
+        'ssl' => false,
+        'api_key' => 'emby-token',
+    ]);
+
+    Http::fake([
+        'http://emby.local:8096/Items*' => Http::response([
+            'Items' => [
+                [
+                    'MediaSources' => [
+                        ['Id' => 'mediasource_1'],
+                    ],
+                    'MediaStreams' => [
+                        ['Type' => 'Video', 'Index' => 0],
+                        ['Type' => 'Audio', 'Index' => 1, 'Language' => 'eng'],
+                    ],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $service = EmbyJellyfinService::make($integration);
+
+    expect($service->getSubtitleUrl('1'))->toBeNull();
+});

--- a/tests/Feature/NetworkBroadcastPayloadTest.php
+++ b/tests/Feature/NetworkBroadcastPayloadTest.php
@@ -1,9 +1,11 @@
 <?php
 
 use App\Enums\TranscodeMode;
+use App\Models\MediaServerIntegration;
 use App\Models\Network;
 use App\Models\NetworkProgramme;
 use App\Services\NetworkBroadcastService;
+use Illuminate\Http\Client\Factory;
 use Illuminate\Support\Facades\Http;
 
 beforeEach(function () {
@@ -18,7 +20,7 @@ beforeEach(function () {
 /**
  * Helper: call startViaProxy and capture the full broadcast start request payload.
  */
-function invokeStartViaProxyAndCapturePayload(array $networkAttrs = []): array
+function invokeStartViaProxyAndCapturePayload(array $networkAttrs = [], string $streamUrl = 'http://example.com/stream.ts', int $seekPosition = 0): array
 {
     $network = Network::factory()->create(array_merge([
         'enabled' => true,
@@ -38,7 +40,7 @@ function invokeStartViaProxyAndCapturePayload(array $networkAttrs = []): array
 
     $service = app(NetworkBroadcastService::class);
     $method = new ReflectionMethod(NetworkBroadcastService::class, 'startViaProxy');
-    $method->invoke($service, $network, 'http://example.com/stream.ts', 0, 3600, $programme);
+    $method->invoke($service, $network, $streamUrl, $seekPosition, 3600, $programme);
 
     $captured = [];
     Http::assertSent(function ($request) use (&$captured) {
@@ -68,4 +70,551 @@ it('sends required broadcast fields in the payload', function () {
         ->toHaveKey('stream_url')
         ->toHaveKey('segment_start_number')
         ->toHaveKey('callback_url');
+});
+
+it('sends subtitles_enabled true for direct mode when the toggle is on', function () {
+    $payload = invokeStartViaProxyAndCapturePayload([
+        'transcode_mode' => TranscodeMode::Direct->value,
+        'subtitles_enabled' => true,
+    ]);
+
+    expect($payload['subtitles_enabled'])->toBeTrue();
+});
+
+it('forces subtitles_enabled false in Server transcode mode even when the toggle is on', function () {
+    $payload = invokeStartViaProxyAndCapturePayload([
+        'transcode_mode' => TranscodeMode::Server->value,
+        'subtitles_enabled' => true,
+    ]);
+
+    expect($payload['subtitles_enabled'])->toBeFalse();
+});
+
+/*
+|--------------------------------------------------------------------------
+| Seek handling (avoid double-seeking video while subtitles need the
+| full offset — see NetworkBroadcastService::startViaProxy)
+|--------------------------------------------------------------------------
+*/
+
+it('applies the full ffmpeg seek for a static Direct-mode URL that does not seek server-side', function () {
+    $payload = invokeStartViaProxyAndCapturePayload(
+        ['transcode_mode' => TranscodeMode::Direct->value],
+        'http://emby.local/Videos/1/stream.ts?api_key=abc&static=true',
+        2715,
+    );
+
+    expect($payload['seek_seconds'])->toBe(2715)
+        ->and($payload['subtitle_seek_seconds'])->toBe(2715);
+});
+
+it('rewrites a VideoCodec=copy remux URL to static when seek is required, so Emby server-seeks via StartTimeTicks', function () {
+    // Uses an explicit Mockery setup (not invokeStartViaProxyAndCapturePayload) because
+    // this test needs to control resolveAudioStreamIndex and resolveSubtitleInfo to
+    // assert the post-rewrite contracts on audio_stream_index and subtitle_seek_seconds.
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => null,
+        'broadcast_started_at' => null,
+        'transcode_mode' => TranscodeMode::Direct->value,
+        'subtitles_enabled' => true,
+    ]);
+
+    $programme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinutes(55),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    // Emby resolved the preferred-language track at absolute MediaStreams index 1.
+    $service->shouldReceive('resolveAudioStreamIndex')->with($network)->andReturn(1);
+    // Subtitle URL is also server-pre-seeked by Emby (Jul 6 single-authority fix).
+    $service->shouldReceive('resolveSubtitleInfo')->andReturn([
+        'url' => 'http://emby.local/Videos/1/ms_1/Subtitles/2/27150000000/Stream.srt?api_key=abc',
+        'language' => 'eng',
+        'server_seeked' => true,
+    ]);
+    $service->shouldReceive('computeNextStreamConfig')->andReturn(null);
+
+    $method = new ReflectionMethod(NetworkBroadcastService::class, 'startViaProxy');
+    $method->invoke(
+        $service,
+        $network,
+        // Remux URL with StartTimeTicks — would normally break seek (Emby ignores
+        // StartTimeTicks on the remux endpoint). The PHP side must rewrite it.
+        'http://emby.local/Videos/1/stream.ts?api_key=abc&StartTimeTicks=27150000000&AudioStreamIndex=1&VideoCodec=copy',
+        2715,
+        3600,
+        $programme,
+    );
+
+    $captured = [];
+    Http::assertSent(function ($request) use (&$captured) {
+        if (str_contains($request->url(), '/broadcast/') && str_contains($request->url(), '/start')) {
+            $captured = $request->data();
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // URL rewritten to seek-capable static endpoint:
+    //   - VideoCodec=copy removed (Emby ignores StartTimeTicks on remux and Range is unsupported)
+    //   - StartTimeTicks removed (Emby ALSO ignores it on static — verified by md5 on real Emby).
+    //     The static endpoint is seekable via Range requests, so ffmpeg input -ss does the seek.
+    //   - AudioStreamIndex kept (no-op on static but harmless)
+    //   - static=true added (the static endpoint key for Range support)
+    expect($captured['stream_url'])->not->toContain('VideoCodec=copy')
+        ->and($captured['stream_url'])->not->toContain('StartTimeTicks')
+        ->and($captured['stream_url'])->toContain('AudioStreamIndex=1')
+        ->and($captured['stream_url'])->toContain('static=true')
+        // Static doesn't server-seek (Emby ignores StartTimeTicks) -> ffmpeg MUST seek via input -ss.
+        ->and($captured['seek_seconds'])->toBe(2715)
+        // Static preserves all original streams; resolved absolute MediaStreams index is the
+        // correct ffmpeg -map target (replaces the old "remux -> audio at position 0" rule).
+        ->and($captured['audio_stream_index'])->toBe(1)
+        // Subtitle URL was already server-pre-seeked by Emby (Jul 6 single-authority fix).
+        ->and($captured['subtitle_seek_seconds'])->toBe(0);
+});
+
+it('keeps a VideoCodec=copy remux URL unchanged when no seek is required (programme start)', function () {
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => null,
+        'broadcast_started_at' => null,
+        'transcode_mode' => TranscodeMode::Direct->value,
+    ]);
+
+    $programme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinutes(55),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    // Emby resolved the preferred-language track at absolute MediaStreams index 1.
+    $service->shouldReceive('resolveAudioStreamIndex')->with($network)->andReturn(1);
+    $service->shouldReceive('resolveSubtitleInfo')->andReturn(['url' => null, 'language' => null, 'server_seeked' => false]);
+    $service->shouldReceive('computeNextStreamConfig')->andReturn(null);
+
+    $method = new ReflectionMethod(NetworkBroadcastService::class, 'startViaProxy');
+    $method->invoke(
+        $service,
+        $network,
+        // No seek at all — broadcast begins from the start of the programme. The remux URL
+        // is fine as-is; we shouldn't waste a rewrite.
+        'http://emby.local/Videos/1/stream.ts?api_key=abc&AudioStreamIndex=1&VideoCodec=copy',
+        0,
+        3600,
+        $programme,
+    );
+
+    $captured = [];
+    Http::assertSent(function ($request) use (&$captured) {
+        if (str_contains($request->url(), '/broadcast/') && str_contains($request->url(), '/start')) {
+            $captured = $request->data();
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // URL untouched (no StartTimeTicks to honor, no rewrite needed).
+    expect($captured['stream_url'])->toContain('VideoCodec=copy')
+        ->and($captured['seek_seconds'])->toBe(0)
+        // AudioStreamIndex on a remux means the server already remuxed to a single
+        // audio track at position 0 — ffmpeg must map 0:a:0.
+        ->and($captured['audio_stream_index'])->toBe(0);
+});
+
+it('keeps a VideoCodec=copy remux URL unchanged when no seek is required', function () {
+    // No seek at all — broadcast begins from the start of the programme. The remux URL
+    // is fine as-is; we shouldn't waste a rewrite or strip server-side audio selection.
+    //
+    // This test requires mocking resolveAudioStreamIndex because invokeStartViaProxyAndCapturePayload
+    // doesn't mock it (and the real resolver would need an Emby item with the right MediaStreams).
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => null,
+        'broadcast_started_at' => null,
+        'transcode_mode' => TranscodeMode::Direct->value,
+    ]);
+
+    $programme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinutes(55),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    // Without the rewrite, the remux pre-selects a single audio track at position 0.
+    $service->shouldReceive('resolveAudioStreamIndex')->with($network)->andReturn(1);
+    $service->shouldReceive('resolveSubtitleInfo')->andReturn(['url' => null, 'language' => null, 'server_seeked' => false]);
+    $service->shouldReceive('computeNextStreamConfig')->andReturn(null);
+
+    $method = new ReflectionMethod(NetworkBroadcastService::class, 'startViaProxy');
+    $method->invoke(
+        $service,
+        $network,
+        // No StartTimeTicks in URL, no seek passed -> no rewrite triggers.
+        'http://emby.local/Videos/1/stream.ts?api_key=abc&AudioStreamIndex=1&VideoCodec=copy',
+        0,
+        3600,
+        $programme,
+    );
+
+    $captured = [];
+    Http::assertSent(function ($request) use (&$captured) {
+        if (str_contains($request->url(), '/broadcast/') && str_contains($request->url(), '/start')) {
+            $captured = $request->data();
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // URL untouched (no StartTimeTicks to rewrite around, no seek required).
+    expect($captured['stream_url'])->toContain('VideoCodec=copy')
+        ->and($captured['stream_url'])->not->toContain('StartTimeTicks')
+        ->and($captured['seek_seconds'])->toBe(0)
+        // Remux pre-selected audio -> ffmpeg must map the single track at position 0.
+        ->and($captured['audio_stream_index'])->toBe(0);
+});
+
+it('skips the redundant ffmpeg seek for Server transcode mode URLs that already seeked server-side', function () {
+    $payload = invokeStartViaProxyAndCapturePayload(
+        ['transcode_mode' => TranscodeMode::Server->value],
+        'http://emby.local/Videos/1/master.m3u8?api_key=abc&StartTimeTicks=27150000000',
+        2715,
+    );
+
+    expect($payload['seek_seconds'])->toBe(0)
+        ->and($payload['subtitle_seek_seconds'])->toBe(2715);
+});
+
+it('zeroes subtitle_seek_seconds when the subtitle url was already seeked server-side', function () {
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => null,
+        'broadcast_started_at' => null,
+        'transcode_mode' => TranscodeMode::Direct->value,
+        'subtitles_enabled' => true,
+    ]);
+
+    $programme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinutes(55),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('resolveAudioStreamIndex')->andReturn(null);
+    $service->shouldReceive('computeNextStreamConfig')->andReturn(null);
+    // Emby served the subtitle already seeked server-side (startPositionTicks), so it
+    // shares the video's timeline origin and the proxy must not seek it again.
+    $service->shouldReceive('resolveSubtitleInfo')->andReturn([
+        'url' => 'http://emby.local/Videos/1/ms_1/Subtitles/2/27150000000/Stream.srt?api_key=abc',
+        'language' => 'eng',
+        'server_seeked' => true,
+    ]);
+
+    $method = new ReflectionMethod(NetworkBroadcastService::class, 'startViaProxy');
+    $method->invoke(
+        $service,
+        $network,
+        'http://emby.local/Videos/1/stream.ts?api_key=abc&StartTimeTicks=27150000000&VideoCodec=copy',
+        2715,
+        3600,
+        $programme,
+    );
+
+    $captured = [];
+    Http::assertSent(function ($request) use (&$captured) {
+        if (str_contains($request->url(), '/broadcast/') && str_contains($request->url(), '/start')) {
+            $captured = $request->data();
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // Video remux URL is rewritten to static (StartTimeTicks stripped) so ffmpeg can
+    // input-seek via Range. Subtitle URL is independently server-pre-seeked by Emby
+    // (Jul 6 single-authority fix), so its seek stays 0.
+    expect($captured['seek_seconds'])->toBe(2715)
+        ->and($captured['subtitle_seek_seconds'])->toBe(0)
+        ->and($captured['subtitle_url'])->toContain('/27150000000/Stream.srt');
+});
+
+/**
+ * Replace the HTTP factory's stub callbacks with a single dispatcher closure so a
+ * specific URL wins over the catch-all `*` pattern installed in beforeEach().
+ * Http::fake() only appends to the callback list — Laravel's stub pipeline calls
+ * every callback and uses ->first(), so a catch-all registered first wins against
+ * any specific pattern appended later. Reflection-based replacement is the only
+ * way to guarantee our specific patterns match for tests that exercise the real
+ * EmbyJellyfinService HTTP layer.
+ */
+function replaceHttpStubsWith(callable $dispatcher): void
+{
+    $factory = app(Factory::class);
+    $reflection = new ReflectionProperty($factory, 'stubCallbacks');
+    $reflection->setAccessible(true);
+    $reflection->setValue($factory, collect([
+        function ($request, $options) use ($dispatcher) {
+            return $dispatcher($request, $options);
+        },
+    ]));
+}
+
+it('appends a #range= byte offset to the rewritten-static URL when seek is required and size meta is available', function () {
+    // Sizes chosen so the math is easy to verify by hand: intval((2715/5102.306)*4083507852).
+    // Computed value: 2172884930 (PHP intval truncates the fractional part).
+    $runtimeSeconds = 5102.306;
+    $totalBytes = 4083507852;
+    $seekSeconds = 2715;
+    $expectedOffset = intval(($seekSeconds / $runtimeSeconds) * $totalBytes);
+
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => null,
+        'broadcast_started_at' => null,
+        'transcode_mode' => TranscodeMode::Direct->value,
+        'subtitles_enabled' => false,
+    ]);
+
+    $integration = MediaServerIntegration::factory()->create([
+        'type' => 'emby',
+        'enabled' => true,
+    ]);
+    $network->update(['media_server_integration_id' => $integration->id]);
+    $network->refresh();
+
+    $programme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinutes(55),
+        'duration_seconds' => 3600,
+    ]);
+
+    // Stub the HTTP layer so the real EmbyJellyfinService::getStreamByteSize() can run
+    // and get a deterministic Content-Length + RunTimeTicks. MediaStreams must be
+    // non-empty or fetchItemWithMediaStreams() will retry and warn. See replaceHttpStubsWith()
+    // for why we replace the stub callbacks rather than append via Http::fake().
+    replaceHttpStubsWith(function ($request) use ($totalBytes) {
+        $url = (string) $request->url();
+
+        if (str_contains($url, '/Videos/42/stream.ts')) {
+            return Http::response('', 200, ['Content-Length' => (string) $totalBytes]);
+        }
+
+        if (str_contains($url, '/Items')) {
+            return Http::response(['Items' => [['Id' => '42', 'RunTimeTicks' => 51023060000, 'MediaStreams' => [['Index' => 0]]]]], 200);
+        }
+
+        return Http::response([], 200);
+    });
+
+    $service = Mockery::mock(NetworkBroadcastService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('resolveAudioStreamIndex')->andReturn(null);
+    $service->shouldReceive('resolveSubtitleInfo')->andReturn(['url' => null, 'language' => null, 'server_seeked' => false]);
+    $service->shouldReceive('computeNextStreamConfig')->andReturn(null);
+    $service->shouldReceive('getMediaServerItemId')->andReturn('42');
+
+    $method = new ReflectionMethod(NetworkBroadcastService::class, 'startViaProxy');
+    $method->invoke(
+        $service,
+        $network,
+        // Remux URL with StartTimeTicks — fires the rewrite to the static endpoint.
+        'http://emby.local/Videos/42/stream.ts?api_key=abc&StartTimeTicks=27150000000&AudioStreamIndex=1&VideoCodec=copy',
+        $seekSeconds,
+        3600,
+        $programme,
+    );
+
+    $captured = [];
+    Http::assertSent(function ($request) use (&$captured) {
+        if (str_contains($request->url(), '/broadcast/') && str_contains($request->url(), '/start')) {
+            $captured = $request->data();
+
+            return true;
+        }
+
+        return false;
+    });
+
+    expect($captured['stream_url'])
+        ->toContain('static=true')
+        ->not->toContain('VideoCodec=copy')
+        ->not->toContain('StartTimeTicks')
+        ->toContain('#range='.$expectedOffset.'-');
+});
+
+it('omits the #range= byte offset on the rewritten-static URL when size meta is unavailable', function () {
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => null,
+        'broadcast_started_at' => null,
+        'transcode_mode' => TranscodeMode::Direct->value,
+        'subtitles_enabled' => false,
+    ]);
+
+    $integration = MediaServerIntegration::factory()->create([
+        'type' => 'emby',
+        'enabled' => true,
+    ]);
+    $network->update(['media_server_integration_id' => $integration->id]);
+    $network->refresh();
+
+    $programme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinutes(55),
+        'duration_seconds' => 3600,
+    ]);
+
+    // 404 on the HEAD forces getStreamByteSize() to return null. The /Items GET is
+    // not reached because the byte-size lookup short-circuits before the retry loop
+    // calls fetchItemWithMediaStreams(), but we fake it anyway to be safe.
+    replaceHttpStubsWith(function ($request) {
+        $url = (string) $request->url();
+
+        if (str_contains($url, '/Videos/42/stream.ts')) {
+            return Http::response('', 404);
+        }
+
+        return Http::response([], 200);
+    });
+
+    $service = Mockery::mock(NetworkBroadcastService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('resolveAudioStreamIndex')->andReturn(null);
+    $service->shouldReceive('resolveSubtitleInfo')->andReturn(['url' => null, 'language' => null, 'server_seeked' => false]);
+    $service->shouldReceive('computeNextStreamConfig')->andReturn(null);
+    $service->shouldReceive('getMediaServerItemId')->andReturn('42');
+
+    $method = new ReflectionMethod(NetworkBroadcastService::class, 'startViaProxy');
+    $method->invoke(
+        $service,
+        $network,
+        'http://emby.local/Videos/42/stream.ts?api_key=abc&StartTimeTicks=27150000000&AudioStreamIndex=1&VideoCodec=copy',
+        2715,
+        3600,
+        $programme,
+    );
+
+    $captured = [];
+    Http::assertSent(function ($request) use (&$captured) {
+        if (str_contains($request->url(), '/broadcast/') && str_contains($request->url(), '/start')) {
+            $captured = $request->data();
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // Rewrite still happened, but no #range= fragment because we couldn't learn the size.
+    expect($captured['stream_url'])
+        ->toContain('static=true')
+        ->not->toContain('VideoCodec=copy')
+        ->not->toContain('StartTimeTicks')
+        ->not->toContain('#range=');
+});
+
+/*
+|--------------------------------------------------------------------------
+| Audio stream index handling (avoid mapping the original absolute index
+| against an already-remuxed single-track stream)
+|--------------------------------------------------------------------------
+*/
+
+it('maps audio track 0 when a VideoCodec=copy remux already selected the preferred audio track server-side', function () {
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'broadcast_pid' => null,
+        'broadcast_started_at' => null,
+        'transcode_mode' => TranscodeMode::Direct->value,
+    ]);
+
+    $programme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinutes(55),
+        'duration_seconds' => 3600,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    // Emby resolved the preferred-language track at absolute MediaStreams index 2.
+    $service->shouldReceive('resolveAudioStreamIndex')->with($network)->andReturn(2);
+    $service->shouldReceive('resolveSubtitleInfo')->andReturn(['url' => null, 'language' => null, 'server_seeked' => false]);
+    $service->shouldReceive('computeNextStreamConfig')->andReturn(null);
+
+    $method = new ReflectionMethod(NetworkBroadcastService::class, 'startViaProxy');
+    $method->invoke(
+        $service,
+        $network,
+        'http://emby.local/Videos/1/stream.ts?api_key=abc&AudioStreamIndex=2&VideoCodec=copy',
+        0,
+        3600,
+        $programme,
+    );
+
+    $captured = [];
+    Http::assertSent(function ($request) use (&$captured) {
+        if (str_contains($request->url(), '/broadcast/') && str_contains($request->url(), '/start')) {
+            $captured = $request->data();
+
+            return true;
+        }
+
+        return false;
+    });
+
+    // Emby's remux already narrowed the stream to a single audio track (always at
+    // position 0) — ffmpeg must not re-select index 2, which no longer exists in the
+    // already-filtered stream (that mismatch is what crashes the whole broadcast with
+    // "Unable to map stream at a:0").
+    expect($captured['audio_stream_index'])->toBe(0);
+});
+
+it('keeps the original resolved audio index when the URL is a raw passthrough with no server-side selection', function () {
+    $payload = invokeStartViaProxyAndCapturePayload(
+        ['transcode_mode' => TranscodeMode::Direct->value],
+        'http://example.com/video.ts',
+        0,
+    );
+
+    // No preferred_audio_language configured -> resolveAudioStreamIndex returns null,
+    // and the URL has no VideoCodec=copy remux to begin with.
+    expect($payload['audio_stream_index'])->toBeNull();
 });

--- a/tests/Feature/NetworkBroadcastPayloadTest.php
+++ b/tests/Feature/NetworkBroadcastPayloadTest.php
@@ -72,19 +72,19 @@ it('sends required broadcast fields in the payload', function () {
         ->toHaveKey('callback_url');
 });
 
-it('sends subtitles_enabled true for direct mode when the toggle is on', function () {
+it('sends subtitles_enabled true for direct mode when a preferred subtitle track is set', function () {
     $payload = invokeStartViaProxyAndCapturePayload([
         'transcode_mode' => TranscodeMode::Direct->value,
-        'subtitles_enabled' => true,
+        'preferred_subtitle_track' => 'eng',
     ]);
 
     expect($payload['subtitles_enabled'])->toBeTrue();
 });
 
-it('forces subtitles_enabled false in Server transcode mode even when the toggle is on', function () {
+it('forces subtitles_enabled false in Server transcode mode even when a preferred subtitle track is set', function () {
     $payload = invokeStartViaProxyAndCapturePayload([
         'transcode_mode' => TranscodeMode::Server->value,
-        'subtitles_enabled' => true,
+        'preferred_subtitle_track' => 'eng',
     ]);
 
     expect($payload['subtitles_enabled'])->toBeFalse();
@@ -119,7 +119,7 @@ it('rewrites a VideoCodec=copy remux URL to static when seek is required, so Emb
         'broadcast_pid' => null,
         'broadcast_started_at' => null,
         'transcode_mode' => TranscodeMode::Direct->value,
-        'subtitles_enabled' => true,
+        'preferred_subtitle_track' => 'eng',
     ]);
 
     $programme = NetworkProgramme::factory()->create([
@@ -316,7 +316,7 @@ it('zeroes subtitle_seek_seconds when the subtitle url was already seeked server
         'broadcast_pid' => null,
         'broadcast_started_at' => null,
         'transcode_mode' => TranscodeMode::Direct->value,
-        'subtitles_enabled' => true,
+        'preferred_subtitle_track' => 'eng',
     ]);
 
     $programme = NetworkProgramme::factory()->create([
@@ -403,7 +403,7 @@ it('appends a #range= byte offset to the rewritten-static URL when seek is requi
         'broadcast_pid' => null,
         'broadcast_started_at' => null,
         'transcode_mode' => TranscodeMode::Direct->value,
-        'subtitles_enabled' => false,
+        'preferred_subtitle_track' => null,
     ]);
 
     $integration = MediaServerIntegration::factory()->create([
@@ -482,7 +482,7 @@ it('omits the #range= byte offset on the rewritten-static URL when size meta is 
         'broadcast_pid' => null,
         'broadcast_started_at' => null,
         'transcode_mode' => TranscodeMode::Direct->value,
-        'subtitles_enabled' => false,
+        'preferred_subtitle_track' => null,
     ]);
 
     $integration = MediaServerIntegration::factory()->create([
@@ -614,7 +614,7 @@ it('keeps the original resolved audio index when the URL is a raw passthrough wi
         0,
     );
 
-    // No preferred_audio_language configured -> resolveAudioStreamIndex returns null,
+    // No preferred_audio_track configured -> resolveAudioStreamIndex returns null,
     // and the URL has no VideoCodec=copy remux to begin with.
     expect($payload['audio_stream_index'])->toBeNull();
 });

--- a/tests/Feature/NetworkBroadcastTransitionTest.php
+++ b/tests/Feature/NetworkBroadcastTransitionTest.php
@@ -369,3 +369,42 @@ it('next_stream_config key is always present in the broadcast start payload', fu
     // Key must always be present (null when no next programme).
     expect($captured)->toHaveKey('next_stream_config');
 });
+
+it('computeNextStreamConfig resolves audio_stream_index for the NEXT programme, not the current one', function () {
+    $network = Network::factory()->create([
+        'broadcast_enabled' => true,
+        'preferred_audio_language' => 'eng',
+    ]);
+
+    $currentProgramme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinute(),
+        'duration_seconds' => 360,
+    ]);
+
+    $nextProgramme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->addMinute(),
+        'end_time' => now()->addMinutes(31),
+        'duration_seconds' => 1800,
+    ]);
+
+    $service = Mockery::mock(NetworkBroadcastService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('getStreamUrl')
+        ->with($network, Mockery::on(fn ($p) => $p->is($nextProgramme)), 0)
+        ->andReturn('http://example.com/next.ts');
+    $service->shouldReceive('resolveSubtitleInfo')
+        ->with($network, Mockery::on(fn ($p) => $p->is($nextProgramme)), 0)
+        ->andReturn(['url' => null, 'language' => null, 'server_seeked' => false]);
+    $service->shouldReceive('resolveAudioStreamIndex')
+        ->once()
+        ->with($network, Mockery::on(fn ($p) => $p->is($nextProgramme)))
+        ->andReturn(7);
+
+    $method = new ReflectionMethod(NetworkBroadcastService::class, 'computeNextStreamConfig');
+    $result = $method->invoke($service, $network, $currentProgramme);
+
+    expect($result['audio_stream_index'])->toBe(7);
+});

--- a/tests/Feature/NetworkBroadcastTransitionTest.php
+++ b/tests/Feature/NetworkBroadcastTransitionTest.php
@@ -373,7 +373,7 @@ it('next_stream_config key is always present in the broadcast start payload', fu
 it('computeNextStreamConfig resolves audio_stream_index for the NEXT programme, not the current one', function () {
     $network = Network::factory()->create([
         'broadcast_enabled' => true,
-        'preferred_audio_language' => 'eng',
+        'preferred_audio_track' => 'eng',
     ]);
 
     $currentProgramme = NetworkProgramme::factory()->create([

--- a/tests/Feature/NetworkHlsSubtitleVariantTest.php
+++ b/tests/Feature/NetworkHlsSubtitleVariantTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Models\Network;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+it('passes through a flat playlist unchanged in structure when subtitles are not active', function () {
+    $network = Network::factory()->for($this->user)->broadcasting()->create();
+
+    Http::fake([
+        '*/broadcast/*/live.m3u8' => Http::response(
+            "#EXTM3U\n#EXT-X-VERSION:6\n#EXTINF:6.000000,\nlive000001.ts\n",
+            200
+        ),
+    ]);
+
+    $response = $this->get(url("/network/{$network->uuid}/live.m3u8"));
+
+    $response->assertOk();
+    $body = $response->getContent();
+    expect($body)->toContain(url("/network/{$network->uuid}/live000001.ts"));
+    expect($body)->not->toContain('hls-variant');
+});
+
+it('rewrites a master playlist to point sub-playlists at the hls-variant route', function () {
+    $network = Network::factory()->for($this->user)->broadcasting()->create();
+
+    $master = <<<'M3U8'
+#EXTM3U
+#EXT-X-VERSION:6
+#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="subtitle_0",DEFAULT=YES,LANGUAGE="eng",URI="live_0_vtt.m3u8"
+#EXT-X-STREAM-INF:BANDWIDTH=2340800,RESOLUTION=320x240,CODECS="avc1.f4000d,mp4a.40.2",SUBTITLES="subs"
+live_0.m3u8
+M3U8;
+
+    Http::fake([
+        '*/broadcast/*/live.m3u8' => Http::response($master, 200),
+    ]);
+
+    $response = $this->get(url("/network/{$network->uuid}/live.m3u8"));
+
+    $response->assertOk();
+    $body = $response->getContent();
+
+    $variantBase = url("/network/{$network->uuid}/hls-variant");
+    expect($body)->toContain('URI="'.$variantBase.'/live_0_vtt.m3u8"');
+    expect($body)->toContain($variantBase.'/live_0.m3u8');
+    // Subtitles must be available-but-off by default, not forced on every viewer.
+    expect($body)->toContain('DEFAULT=NO,AUTOSELECT=YES');
+    expect($body)->not->toContain('DEFAULT=YES');
+});
+
+it('rewrites a video variant sub-playlist segments through the hls-variant route', function () {
+    $network = Network::factory()->for($this->user)->broadcasting()->create();
+
+    $videoVariant = "#EXTM3U\n#EXT-X-VERSION:6\n#EXTINF:6.000000,\nlive0_000000.ts\n";
+
+    Http::fake([
+        '*/broadcast/*/segment/live_0.m3u8' => Http::response($videoVariant, 200),
+    ]);
+
+    $response = $this->get(url("/network/{$network->uuid}/hls-variant/live_0.m3u8"));
+
+    $response->assertOk();
+    $body = $response->getContent();
+    $variantBase = url("/network/{$network->uuid}/hls-variant");
+    expect($body)->toContain($variantBase.'/live0_000000.ts');
+});
+
+it('rewrites a subtitle variant sub-playlist vtt segments through the hls-variant route', function () {
+    $network = Network::factory()->for($this->user)->broadcasting()->create();
+
+    $subtitleVariant = "#EXTM3U\n#EXT-X-VERSION:6\n#EXTINF:6.000000,\nlive_00.vtt\n#EXT-X-ENDLIST\n";
+
+    Http::fake([
+        '*/broadcast/*/segment/live_0_vtt.m3u8' => Http::response($subtitleVariant, 200),
+    ]);
+
+    $response = $this->get(url("/network/{$network->uuid}/hls-variant/live_0_vtt.m3u8"));
+
+    $response->assertOk();
+    $body = $response->getContent();
+    $variantBase = url("/network/{$network->uuid}/hls-variant");
+    expect($body)->toContain($variantBase.'/live_00.vtt');
+});
+
+it('redirects a .ts segment request under hls-variant straight to the proxy', function () {
+    $network = Network::factory()->for($this->user)->broadcasting()->create();
+
+    $response = $this->get(url("/network/{$network->uuid}/hls-variant/live0_000000.ts"));
+
+    $response->assertRedirect();
+    expect($response->headers->get('Location'))->toContain('live0_000000.ts');
+});
+
+it('redirects a .vtt segment request under hls-variant straight to the proxy', function () {
+    $network = Network::factory()->for($this->user)->broadcasting()->create();
+
+    $response = $this->get(url("/network/{$network->uuid}/hls-variant/live_00.vtt"));
+
+    $response->assertRedirect();
+    expect($response->headers->get('Location'))->toContain('live_00.vtt');
+});
+
+it('returns 404 for hls-variant when broadcast is not enabled', function () {
+    $network = Network::factory()->for($this->user)->create(['broadcast_enabled' => false]);
+
+    $response = $this->get(url("/network/{$network->uuid}/hls-variant/live_0.m3u8"));
+
+    $response->assertStatus(404);
+});


### PR DESCRIPTION
## What

Closes three subtitle/seek defects in the Emby/Jellyfin network broadcast path that all surface when a user seeks mid-programme:

1. **Subtitle desync after seek** — dual seek engines (media server seeks video via `StartTimeTicks`; proxy seeks subtitle via `-ss N -itsoffset -N`) drifted up to a full seek-second apart. Switched to a single media-server seek that uses Emby's `/Subtitles/{i}/{ticks}/Stream.{fmt}` URL to rebase subtitle cues to zero at the seek point, and pass `subtitle_seek_seconds=0` to the proxy so it never re-seeks the subtitle input.

2. **VideoCodec=copy remux starts at byte 0 when seeked** — Emby serves a VideoCodec=copy remux URL with `Accept-Ranges: none` and unknown duration, so client-side `-ss` can't seek it. Detect the remux in `getDirectStreamUrl` and rewrite it to the `static=true` variant which is seekable.

3. **HEVC byte-seek hangs** — Plex/Emby direct file endpoints with byte-seek on HEVC content hang the transcode. Added a `#range=N-` byte offset calculated from runtime ticks → byte size, falling back to no byte-seek when size can't be resolved.

## How

- `EmbyJellyfinService::getSubtitleUrl($itemId, $seekSeconds=0)` returns `{url, language, server_seeked}` — `server_seeked=true` means cues already rebased to 0, so the proxy should leave the subtitle input untouched. `getStreamByteSize()` returns `[bytes, duration_seconds]` for fast-seek math.
- `NetworkBroadcastService::startViaProxy()` builds `subtitle_url`/`subtitle_language`/`subtitle_seek_seconds`/`audio_stream_index` payloads, decides between server-side media-server seek vs proxy-side `-ss` based on whether the URL is a remux, and computes `#range=` from byte size when applicable.
- `NetworkHlsController::variant()` (route + method surgically extracted from a larger networks admin commit) serves the sub-playlist + `.ts`/`.vtt` segments referenced from a master playlist when subtitles are enabled.
- `MediaServerService::getAudioStreamIndexForLanguage()` interface method resolves the audio stream index for a given language preference so `computeNextStreamConfig()` can pre-resolve for the next programme before the auto-transition fires (otherwise the next programme would have no audio preference because it hasn't been built yet).

## Schema

No migrations in this PR. Uses the columns upstream already shipped:
- `preferred_audio_track` — audio stream selection by language code or stream ID/index
- `preferred_subtitle_track` — proxy subtitles_enabled toggle is derived from `!empty($network->preferred_subtitle_track)` (any preference means operator wants subtitles)

## Tests

55/55 passing across 7 feature test files: `NetworkBroadcastPayloadTest`, `NetworkBroadcastTransitionTest`, `EmbySubtitleUrlTest`, `NetworkHlsSubtitleVariantTest`, `PlexTrackPreferenceTest`, `EmbyJellyfinTrackPreferenceTest`, `NetworkBroadcastSeekTest`. The upstream track-prefs tests continue to pass — this PR is orthogonal to upstream's track-prefs work and only adds the seek/desync/HLS-variant plumbing around it.

## Out of scope

- Audio track selection is already covered upstream (`PlexService::resolvePreferredStreamId` / `EmbyJellyfinService::resolvePreferredStreamIndex`). This PR drops the original PHP-side audio stream index resolution that duplicated upstream's work and keeps only the unique pre-resolve for auto-transition.
- Admin UI for audio/subtitle preferences is upstream's `NetworkResource` fields.
- Network admin UI / schedule regeneration / HLS controller admin side is tracked in a separate PR (`chore/network-admin-checkpoint-cleanup`).