### PR TITLE
fix: violation on distinct when sort in custom playlist editor

### DIFF
--- a/app/Filament/Resources/CustomPlaylists/RelationManagers/ChannelsRelationManager.php
+++ b/app/Filament/Resources/CustomPlaylists/RelationManagers/ChannelsRelationManager.php
@@ -126,7 +126,10 @@ class ChannelsRelationManager extends RelationManager
                             ->where('tags.type', '=', $ownerRecord->uuid);
                     })
                     ->orderByRaw("{$orderByClause} {$direction}")
-                    ->select('channels.*', DB::raw("{$orderByClause} as tag_name_sort"))
+                    ->select(
+                        'channels.*',
+                        DB::raw("{$orderByClause} as tag_name_sort"),
+                        DB::raw('COALESCE(channel_custom_playlist.sort, channels.sort) as pivot_sort'))
                     ->distinct();
             });
         $defaultColumns = ChannelResource::getTableColumns(showGroup: true, showPlaylist: true);

--- a/config/checkpoint.php
+++ b/config/checkpoint.php
@@ -232,6 +232,12 @@ return [
         'efa75f73069a',
         '507b196dbfbd',
         '48dd79fe5852',
+        // ChannelsRelationManager (PR #1298): reformatting the ->select() call
+        // to add a COALESCE(channel_custom_playlist.sort, channels.sort)
+        // pivot-sort column (fixing a Postgres DISTINCT/ORDER BY mismatch)
+        // shifted this same $orderByClause DB::raw() onto a new hash. Column
+        // identifiers are hardcoded; no user input reaches either DB::raw().
+        '05222ff0ad74',
 
         // EpgApiController: $coalesce is built exclusively from
         // $grammar->wrap('column.name') calls on hardcoded column identifiers.


### PR DESCRIPTION
## Issue

Sorting the Playlist Group in Custom Playlists Edit mode makes the entire page inaccessible until the session cookie is cleared. This is due to PostgreSQL's `DISTINCT` being used without `COALESCE` for certain states.

## Reproduction
Create a custom playlist, then add 4-5 channels to that custom playlist under a new single group. Navigate to the Custom Playlists page and click Edit for that custom playlist. Scroll to Playlist Group and click sort. If it doesn't crash, try adding 2 channels with the same name but from a different source.


## Testing

- Rebuilt with the change and redeployed. Went into the Custom Playlist, able to edit the list normally again. 
- Redeployed the latest and re-triggered the error
- Redeployed custom-built image, and the server seems to be happy

## Log
Also added a snippet of my log with some metadata removed. Please let me know if any credentials or other sensitive data are still in it to be aware of them.

[laravel-2026-07-16.log](https://github.com/user-attachments/files/30111256/laravel-2026-07-16.log)

## Note
I don't have much time to create a unit PHP test file for this issue specifically. Apologies for this. 


## Screenshot of Issue
<img width="959" height="679" alt="image" src="https://github.com/user-attachments/assets/eecc7ba7-0d4b-4a80-aaf6-6f3193871d98" />
