### PR TITLE
Fix max connections defaulting to 1 when proxy is disabled

### DIFF
--- a/app/Http/Controllers/PlaylistGenerateController.php
+++ b/app/Http/Controllers/PlaylistGenerateController.php
@@ -683,6 +683,7 @@ class PlaylistGenerateController extends Controller
 
         // Return the HDHR device info
         $uuid = $playlist->uuid;
+        $xtreamStatus = $playlist->xtream_status;
         $tunerCount = (int) $playlist->streams === 0
             ? ($xtreamStatus['user_info']['max_connections'] ?? $playlist->streams ?? 1)
             : $playlist->streams;

--- a/app/Models/CustomPlaylist.php
+++ b/app/Models/CustomPlaylist.php
@@ -48,6 +48,15 @@ class CustomPlaylist extends Model
         'processing_config' => 'array',
     ];
 
+    /**
+     * The model's default values for attributes.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'streams' => 0,
+    ];
+
     public function enabledProcessingRules(): SupportCollection
     {
         return collect($this->processing_config ?? [])

--- a/app/Models/MergedPlaylist.php
+++ b/app/Models/MergedPlaylist.php
@@ -43,6 +43,15 @@ class MergedPlaylist extends Model
         'disable_m3u_xtream_format' => 'boolean',
     ];
 
+    /**
+     * The model's default values for attributes.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'streams' => 0,
+    ];
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -89,6 +89,15 @@ class Playlist extends Model
         'auto_retry_503_last_at' => 'datetime',
     ];
 
+    /**
+     * The model's default values for attributes.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'streams' => 0,
+    ];
+
     public function getFolderPathAttribute(): string
     {
         return "playlist/{$this->uuid}";

--- a/database/migrations/2026_07_19_000000_change_streams_default_to_zero_on_playlists_tables.php
+++ b/database/migrations/2026_07_19_000000_change_streams_default_to_zero_on_playlists_tables.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->integer('streams')->default(0)->change();
+        });
+
+        Schema::table('custom_playlists', function (Blueprint $table) {
+            $table->integer('streams')->default(0)->change();
+        });
+
+        Schema::table('merged_playlists', function (Blueprint $table) {
+            $table->integer('streams')->default(0)->change();
+        });
+
+        // Update existing playlists that are using the old default of 1 stream.
+        // This allows them to correctly fall back to the provider's max_connections.
+        DB::table('playlists')->where('streams', 1)->update(['streams' => 0]);
+        DB::table('custom_playlists')->where('streams', 1)->update(['streams' => 0]);
+        DB::table('merged_playlists')->where('streams', 1)->update(['streams' => 0]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Revert existing records updated to 0 back to 1.
+        DB::table('playlists')->where('streams', 0)->update(['streams' => 1]);
+        DB::table('custom_playlists')->where('streams', 0)->update(['streams' => 1]);
+        DB::table('merged_playlists')->where('streams', 0)->update(['streams' => 1]);
+
+        Schema::table('playlists', function (Blueprint $table) {
+            $table->integer('streams')->default(1)->change();
+        });
+
+        Schema::table('custom_playlists', function (Blueprint $table) {
+            $table->integer('streams')->default(1)->change();
+        });
+
+        Schema::table('merged_playlists', function (Blueprint $table) {
+            $table->integer('streams')->default(1)->change();
+        });
+    }
+};

--- a/tests/Feature/DisabledProxyMaxConnectionsTest.php
+++ b/tests/Feature/DisabledProxyMaxConnectionsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+    config(['cache.default' => 'array']);
+});
+
+test('new playlist defaults streams to 0', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create();
+
+    expect($playlist->streams)->toBe(0);
+});
+
+test('xtream api returns provider max connections when proxy is disabled and streams is 0', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create([
+        'enable_proxy' => false,
+        'streams' => 0,
+    ]);
+
+    $status = [
+        'user_info' => [
+            'max_connections' => 5,
+            'active_cons' => 2,
+            'exp_date' => null,
+        ],
+    ];
+
+    $playlist->update(['xtream_status' => $status]);
+    Cache::put("p:{$playlist->id}:xtream_status", $status, 60);
+
+    $response = $this->get(route('xtream.api.player', [
+        'uuid' => $playlist->uuid,
+        'action' => 'get_user_info',
+        'username' => $user->name,
+        'password' => $playlist->uuid,
+    ]));
+
+    $response->assertOk();
+    $response->assertJsonPath('user_info.max_connections', '5');
+});
+
+test('hdhr device info returns tuner count matching provider max connections when proxy is disabled and streams is 0', function () {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create([
+        'enable_proxy' => false,
+        'streams' => 0,
+    ]);
+
+    $status = [
+        'user_info' => [
+            'max_connections' => 7,
+            'active_cons' => 0,
+        ],
+    ];
+
+    $playlist->update(['xtream_status' => $status]);
+    Cache::put("p:{$playlist->id}:xtream_status", $status, 60);
+
+    $response = $this->get("/{$playlist->uuid}/hdhr/discover.json", [
+        'PHP_AUTH_USER' => $user->name,
+        'PHP_AUTH_PW' => $playlist->uuid,
+    ]);
+
+    $response->assertOk();
+    $response->assertJsonPath('TunerCount', 7);
+});


### PR DESCRIPTION
This PR resolves an issue where fully disabling proxy features (e.g., when the proxy integration is globally disabled via configuration or permissions) causes the max connections / tuner count for all newly created playlists to default to `1`, regardless of whether the provider supports more connections.

### Root Cause
1. In `PlaylistResource.php` (and other resources), the `streams` TextInput default value of `0` is ignored and omitted when the form section containing it is hidden (e.g., because `canUseProxy()` evaluates to `false`).
2. When the value is omitted during playlist creation, the database column default of `1` (defined in the `2025_03_20_131924_add_hdhr_tuners_to_playlists` migration) is saved.
3. The Xtream API and M3U/HDHomeRun generation endpoints contain fallback logic to retrieve `max_connections` from `xtream_status` if `$playlist->streams` is `0`. However, since it is saved as `1` in the database, this fallback is never triggered, forcing the tuner count / max connections to `1`.
4. In `PlaylistGenerateController.php` (HDHomeRun discover endpoint), an undefined variable `$xtreamStatus` was referenced, causing the fallback to fail when resolving tuner count.

### Solution
1. Add a database migration changing the default value of the `streams` column to `0` for the `playlists`, `custom_playlists`, and `merged_playlists` tables, and migrate existing records with the default value of `1` to `0` to enable the provider max connections fallback.
2. Set the default attribute value `'streams' => 0` on the `Playlist`, `CustomPlaylist`, and `MergedPlaylist` models to ensure new instances default to `0` even if column defaults aren't processed immediately by the application.
3. Define the missing `$xtreamStatus = $playlist->xtream_status;` variable in `PlaylistGenerateController::getDeviceInfo()` so the fallback retrieves the correct provider `max_connections` for HDHomeRun.
4. Add feature tests covering new playlist default values, Xtream API, and HDHomeRun tuner counts under disabled proxy configurations.