### PR TITLE
fix: redact proxy payload secrets from application logs

### DIFF
--- a/app/Console/Commands/RegisterM3uProxyWebhook.php
+++ b/app/Console/Commands/RegisterM3uProxyWebhook.php
@@ -48,7 +48,7 @@ class RegisterM3uProxyWebhook extends Command
             return self::SUCCESS;
         }
 
-        $this->info("Webhook URL: {$webhookUrl}");
+        $this->info('Webhook URL configured.');
 
         try {
             $apiBaseUrl = $service->getApiBaseUrl();
@@ -101,21 +101,21 @@ class RegisterM3uProxyWebhook extends Command
                 $this->info('✅ Webhook registered successfully!');
 
                 Log::info('M3U Proxy webhook registered', [
-                    'webhook_url' => $webhookUrl,
                     'events' => $payload['events'],
+                    'status_code' => $response->status(),
                 ]);
 
                 return self::SUCCESS;
             }
 
-            $this->error('❌ Failed to register webhook: '.$response->body());
+            $this->error('❌ Failed to register webhook (HTTP '.$response->status().').');
 
             return self::FAILURE;
         } catch (\Exception $e) {
-            $this->error('❌ Error registering webhook: '.$e->getMessage());
+            $this->error('❌ Error registering webhook.');
             Log::error('Failed to register m3u-proxy webhook', [
-                'error' => $e->getMessage(),
-                'webhook_url' => $webhookUrl,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
 
             return self::FAILURE;

--- a/app/Http/Controllers/Api/M3uProxyApiController.php
+++ b/app/Http/Controllers/Api/M3uProxyApiController.php
@@ -290,7 +290,15 @@ class M3uProxyApiController extends Controller
 
             return response()->json($result);
         } catch (Exception $e) {
-            Log::error('Error resolving failover: '.$e->getMessage(), $request->all());
+            Log::error('Error resolving failover', [
+                'channel_id' => $channelId ?? null,
+                'playlist_uuid' => $playlistUuid ?? null,
+                'failover_index' => $failoverCount ?? null,
+                'status_code' => $statusCode ?? null,
+                'trace_id' => $request->input('trace_id', $request->header('X-Request-ID')),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return response()->json([
                 'next_url' => null,
@@ -313,7 +321,14 @@ class M3uProxyApiController extends Controller
         Log::info('Received m3u-proxy webhook', [
             'event_type' => $eventType,
             'stream_id' => $streamId,
-            'data' => $data,
+            'type' => $data['type'] ?? $metadata['type'] ?? null,
+            'channel_id' => $data['channel_id'] ?? $metadata['channel_id'] ?? $metadata['id'] ?? null,
+            'episode_id' => $data['episode_id'] ?? $metadata['episode_id'] ?? null,
+            'playlist_uuid' => $data['playlist_uuid'] ?? $metadata['playlist_uuid'] ?? null,
+            'profile_id' => $metadata['profile_id'] ?? null,
+            'provider_profile_id' => $metadata['provider_profile_id'] ?? null,
+            'status' => $data['status'] ?? null,
+            'trace_id' => $data['trace_id'] ?? $request->header('X-Request-ID'),
         ]);
 
         // Handle profile connection tracking if provider_profile_id is present
@@ -347,7 +362,12 @@ class M3uProxyApiController extends Controller
             // We might also want to invalidate specific channel caches?
         }
 
-        Log::info('Cache invalidated for m3u-proxy event', $data);
+        Log::info('Cache invalidated for m3u-proxy event', [
+            'type' => $data['type'] ?? null,
+            'id' => $data['id'] ?? null,
+            'playlist_uuid' => $data['playlist_uuid'] ?? null,
+            'trace_id' => $data['trace_id'] ?? null,
+        ]);
     }
 
     /**
@@ -388,7 +408,8 @@ class M3uProxyApiController extends Controller
                 'profile_id' => $profileId,
                 'stream_id' => $streamId,
                 'event_type' => $eventType,
-                'exception' => $e->getMessage(),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
         }
     }
@@ -421,7 +442,13 @@ class M3uProxyApiController extends Controller
         Log::info('Received broadcast callback from proxy', [
             'network_id' => $networkId,
             'event' => $event,
-            'data' => $data,
+            'status' => $data['status'] ?? null,
+            'exit_code' => $data['exit_code'] ?? null,
+            'error_type' => $data['error_type'] ?? null,
+            'final_segment_number' => $data['final_segment_number'] ?? null,
+            'duration_streamed' => $data['duration_streamed'] ?? null,
+            'auto_transitioned' => $data['auto_transitioned'] ?? null,
+            'trace_id' => $data['trace_id'] ?? $request->header('X-Request-ID'),
         ]);
 
         if (! $networkId) {
@@ -463,7 +490,9 @@ class M3uProxyApiController extends Controller
             Log::error('Error handling broadcast callback', [
                 'network_id' => $networkId,
                 'event' => $event,
-                'exception' => $e->getMessage(),
+                'trace_id' => $data['trace_id'] ?? $request->header('X-Request-ID'),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
 
             return response()->json(['error' => $e->getMessage()], 500);
@@ -488,7 +517,6 @@ class M3uProxyApiController extends Controller
 
         Log::info('Programme completed via proxy', [
             'network_id' => $network->id,
-            'network_name' => $network->name,
             'final_segment' => $finalSegment,
             'duration_streamed' => $durationStreamed,
             'auto_transitioned' => $autoTransitioned,
@@ -532,7 +560,6 @@ class M3uProxyApiController extends Controller
                 'network_id' => $network->id,
                 'new_pid' => $newPid,
                 'next_programme_id' => $nextProgramme?->id,
-                'next_programme_title' => $nextProgramme?->title,
             ]);
 
             return;
@@ -565,7 +592,6 @@ class M3uProxyApiController extends Controller
                 Log::info('Starting next programme via proxy', [
                     'network_id' => $network->id,
                     'programme_id' => $nextProgramme->id,
-                    'programme_title' => $nextProgramme->title,
                 ]);
 
                 $service->start($network);
@@ -616,8 +642,6 @@ class M3uProxyApiController extends Controller
 
         Log::warning('Broadcast failed via proxy', [
             'network_id' => $network->id,
-            'network_name' => $network->name,
-            'error' => $error,
             'exit_code' => $exitCode,
             'fatal' => $isFatal,
             'final_segment' => $finalSegment,
@@ -698,7 +722,6 @@ class M3uProxyApiController extends Controller
             Log::error('Broadcast failed with fatal exit code — stopping retries', [
                 'network_id' => $network->id,
                 'exit_code' => $exitCode,
-                'error' => $error,
             ]);
 
             $network->update([
@@ -824,7 +847,12 @@ class M3uProxyApiController extends Controller
         try {
             M3uProxyService::stopStreamsByMetadata($field, (string) $id, force: false, clientId: $request->input('client_id'));
         } catch (Exception $e) {
-            Log::warning("Failed to stop player stream ({$type}:{$id}): ".$e->getMessage());
+            Log::warning('Failed to stop player stream', [
+                'type' => $type,
+                'id' => $id,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
         }
 
         return response()->noContent();

--- a/app/Logging/AddAnonymizingProcessor.php
+++ b/app/Logging/AddAnonymizingProcessor.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Logging;
+
+use Illuminate\Log\Logger;
+
+class AddAnonymizingProcessor
+{
+    public function __invoke(Logger $logger): void
+    {
+        $logger->pushProcessor(app(AnonymizingProcessor::class));
+    }
+}

--- a/app/Logging/AnonymizingProcessor.php
+++ b/app/Logging/AnonymizingProcessor.php
@@ -6,8 +6,7 @@ use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 
 /**
- * Monolog processor that redacts URLs and usernames from log messages and
- * context arrays. Controlled by LOG_ANONYMIZE env variable (default: true).
+ * Redacts sensitive fields before a record reaches any configured handler.
  */
 class AnonymizingProcessor implements ProcessorInterface
 {
@@ -19,6 +18,19 @@ class AnonymizingProcessor implements ProcessorInterface
     /** UUIDs identify specific resources and can be used to probe APIs */
     private const string UUID_PATTERN = '/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i';
 
+    private const array SENSITIVE_KEY_TERMS = [
+        'authorization',
+        'cookie',
+        'credential',
+        'headers',
+        'password',
+        'secret',
+        'session',
+        'source',
+        'token',
+        'url',
+    ];
+
     private bool $enabled;
 
     public function __construct()
@@ -28,10 +40,6 @@ class AnonymizingProcessor implements ProcessorInterface
 
     public function __invoke(LogRecord $record): LogRecord
     {
-        if (! $this->enabled) {
-            return $record;
-        }
-
         return $record->with(
             message: $this->scrub($record->message),
             context: $this->scrubArray($record->context),
@@ -40,9 +48,16 @@ class AnonymizingProcessor implements ProcessorInterface
 
     private function scrub(string $text): string
     {
-        $text = (string) preg_replace(self::URL_PATTERN, '****', $text);
-        $text = (string) preg_replace(self::USER_PATTERN, '$1=$2****$2', $text);
-        $text = (string) preg_replace(self::UUID_PATTERN, '****', $text);
+        $text = (string) preg_replace(self::URL_PATTERN, '[REDACTED]', $text);
+
+        if ($this->enabled) {
+            $text = (string) preg_replace(self::USER_PATTERN, '$1=$2[REDACTED]$2', $text);
+            $text = (string) preg_replace_callback(
+                self::UUID_PATTERN,
+                static fn (array $matches): string => '[id:'.substr(hash('sha256', strtolower($matches[0])), 0, 12).']',
+                $text,
+            );
+        }
 
         return $text;
     }
@@ -50,6 +65,12 @@ class AnonymizingProcessor implements ProcessorInterface
     private function scrubArray(array $data): array
     {
         foreach ($data as $key => $value) {
+            if (is_string($key) && $this->isSensitiveKey($key)) {
+                unset($data[$key]);
+
+                continue;
+            }
+
             if (\is_string($value)) {
                 $data[$key] = $this->scrub($value);
             } elseif (\is_array($value)) {
@@ -58,5 +79,18 @@ class AnonymizingProcessor implements ProcessorInterface
         }
 
         return $data;
+    }
+
+    private function isSensitiveKey(string $key): bool
+    {
+        $normalizedKey = (string) preg_replace('/[^a-z0-9]/', '', strtolower($key));
+
+        foreach (self::SENSITIVE_KEY_TERMS as $term) {
+            if (str_contains($normalizedKey, $term)) {
+                return true;
+            }
+        }
+
+        return str_ends_with($normalizedKey, 'key');
     }
 }

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -142,7 +142,10 @@ class M3uProxyService
                 'message' => 'Proxy returned status '.$response->status(),
             ];
         } catch (Exception $e) {
-            Log::warning('Failed to test resolver URL: '.$e->getMessage());
+            Log::warning('Failed to test resolver URL', [
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -214,7 +217,11 @@ class M3uProxyService
 
             return 0;
         } catch (Exception $e) {
-            Log::warning('Failed to fetch playlist streams from m3u-proxy: '.$e->getMessage());
+            Log::warning('Failed to fetch playlist streams from m3u-proxy', [
+                'playlist_uuid' => $playlist->uuid,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return 0;
         }
@@ -266,9 +273,12 @@ class M3uProxyService
                 }
 
             } catch (Exception $e) {
-                Log::warning('Failed to fetch playlist streams from m3u-proxy: '.$e->getMessage(), [
+                Log::warning('Failed to fetch playlist streams from m3u-proxy', [
+                    'playlist_uuid' => $playlist->uuid,
                     'attempt' => $attempt + 1,
                     'max_attempts' => $retries,
+                    'exception_class' => $e::class,
+                    'exception_code' => $e->getCode(),
                 ]);
 
                 $attempt++;
@@ -327,7 +337,11 @@ class M3uProxyService
 
             return false;
         } catch (Exception $e) {
-            Log::warning('Failed to check channel active status: '.$e->getMessage());
+            Log::warning('Failed to check channel active status', [
+                'channel_id' => $channel->id,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return false;
         }
@@ -368,7 +382,11 @@ class M3uProxyService
 
             return 0;
         } catch (Exception $e) {
-            Log::warning("Failed to get active streams count for {$field}={$value}: ".$e->getMessage());
+            Log::warning('Failed to get active streams count by metadata', [
+                'metadata_field' => $field,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return 0;
         }
@@ -422,7 +440,12 @@ class M3uProxyService
 
             return array_fill_keys($values, 0);
         } catch (Exception $e) {
-            Log::warning("Failed to get batch stream counts for {$field}: ".$e->getMessage());
+            Log::warning('Failed to get batch stream counts', [
+                'metadata_field' => $field,
+                'value_count' => count($values),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return array_fill_keys($values, 0);
         }
@@ -531,7 +554,6 @@ class M3uProxyService
 
                 Log::debug('Successfully stopped streams by metadata', [
                     'field' => $field,
-                    'value' => $value,
                     'exclude_channel_id' => $excludeChannelId,
                     'deleted_count' => $data['deleted_count'] ?? 0,
                 ]);
@@ -552,7 +574,12 @@ class M3uProxyService
                 'deleted_count' => 0,
             ];
         } catch (Exception $e) {
-            Log::warning("Failed to stop streams by metadata ({$field}={$value}): ".$e->getMessage());
+            Log::warning('Failed to stop streams by metadata', [
+                'metadata_field' => $field,
+                'exclude_channel_id' => $excludeChannelId,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -633,8 +660,8 @@ class M3uProxyService
                 Log::debug('Successfully stopped oldest stream for playlist', [
                     'playlist_uuid' => $playlistUuid,
                     'exclude_channel_id' => $excludeChannelId,
-                    'deleted_stream' => $data['deleted_stream'] ?? null,
                     'stream_age_seconds' => $data['stream_age_seconds'] ?? null,
+                    'deleted_count' => $data['deleted_count'] ?? 0,
                 ]);
 
                 return [
@@ -654,7 +681,12 @@ class M3uProxyService
                 'deleted_count' => 0,
             ];
         } catch (Exception $e) {
-            Log::warning("Failed to stop oldest stream for playlist ({$playlistUuid}): ".$e->getMessage());
+            Log::warning('Failed to stop oldest stream for playlist', [
+                'playlist_uuid' => $playlistUuid,
+                'exclude_channel_id' => $excludeChannelId,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -716,7 +748,12 @@ class M3uProxyService
                 'deleted_count' => 0,
             ];
         } catch (Exception $e) {
-            Log::warning("Failed to stop oldest stream (field={$field}, value={$value}): ".$e->getMessage());
+            Log::warning('Failed to stop oldest stream by metadata', [
+                'metadata_field' => $field,
+                'exclude_channel_id' => $excludeChannelId,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -808,7 +845,6 @@ class M3uProxyService
                 Log::debug('Stopped oldest stream to free per-auth capacity', [
                     'playlist_auth_id' => $playlistAuthId,
                     'max_connections' => $auth->max_connections,
-                    'stopped_stream' => $result['deleted_stream'] ?? null,
                     'stream_age_seconds' => $result['stream_age_seconds'] ?? null,
                 ]);
 
@@ -976,7 +1012,6 @@ class M3uProxyService
                 if (! $selectedProfile) {
                     Log::warning('No profiles with capacity available for new stream (after reconciliation)', [
                         'playlist_id' => $profileSourcePlaylist->id,
-                        'source_playlist' => $profileSourcePlaylist->name,
                         'channel_id' => $id,
                     ]);
                     abort(503, 'All provider profiles have reached their maximum stream limit. Please try again later.');
@@ -984,7 +1019,6 @@ class M3uProxyService
 
                 Log::debug('Selected provider profile for new stream creation', [
                     'playlist_id' => $profileSourcePlaylist->id,
-                    'source_playlist' => $profileSourcePlaylist->name,
                     'provider_profile_id' => $selectedProfile?->id,
                     'channel_id' => $id,
                 ]);
@@ -1057,7 +1091,6 @@ class M3uProxyService
                         Log::debug('Stopped oldest stream to free capacity for new channel request', [
                             'channel_id' => $id,
                             'playlist_uuid' => $playlist->uuid,
-                            'stopped_stream' => $stopResult['deleted_stream'] ?? null,
                             'stream_age_seconds' => $stopResult['stream_age_seconds'] ?? null,
                         ]);
 
@@ -1168,7 +1201,6 @@ class M3uProxyService
                         Log::debug('Stopped oldest stream to free provider profile capacity', [
                             'channel_id' => $id,
                             'playlist_uuid' => $playlist->uuid,
-                            'stopped_stream' => $stopResult['deleted_stream'] ?? null,
                             'stream_age_seconds' => $stopResult['stream_age_seconds'] ?? null,
                         ]);
 
@@ -1183,7 +1215,6 @@ class M3uProxyService
                 if (! $selectedProfile) {
                     Log::warning('No profiles with capacity available (after reconciliation)', [
                         'playlist_id' => $profileSourcePlaylist->id,
-                        'source_playlist' => $profileSourcePlaylist->name,
                         'channel_id' => $id,
                     ]);
                     abort(503, 'All provider profiles have reached their maximum stream limit. Please try again later.');
@@ -1193,7 +1224,6 @@ class M3uProxyService
             Log::debug('Selected profile for streaming', [
                 'profile_id' => $selectedProfile->id,
                 'profile_name' => $selectedProfile->name,
-                'source_playlist' => $profileSourcePlaylist->name,
                 'playlist_id' => $profileSourcePlaylist->id,
                 'channel_id' => $id,
             ]);
@@ -1285,7 +1315,6 @@ class M3uProxyService
                 'stream_profile_id' => $profile->id,
                 'provider_profile_id' => $selectedProfile?->id,
                 'is_failover' => $isFailover,
-                'primary_url' => $primaryUrl,
                 'failover_count' => is_array($failovers) ? count($failovers) : ($failovers ? 'using_resolver' : 0),
             ]);
 
@@ -1320,7 +1349,6 @@ class M3uProxyService
                 'is_vod' => $actualChannel->is_vod ?? false,
                 'provider_profile_id' => $selectedProfile?->id,
                 'provider_profile_name' => $selectedProfile?->name,
-                'primary_url' => preg_replace('#/[^/]+/[^/]+/(live|series|movie)/#', '/***/***/\1/', $primaryUrl),
                 'url_transformed' => $selectedProfile !== null,
             ]);
 
@@ -1440,7 +1468,6 @@ class M3uProxyService
                         Log::debug('Stopped oldest stream to free capacity for new episode request', [
                             'episode_id' => $id,
                             'playlist_uuid' => $playlist->uuid,
-                            'stopped_stream' => $stopResult['deleted_stream'] ?? null,
                             'stream_age_seconds' => $stopResult['stream_age_seconds'] ?? null,
                         ]);
 
@@ -1578,7 +1605,6 @@ class M3uProxyService
                         Log::debug('Stopped oldest stream to free provider profile capacity for episode', [
                             'episode_id' => $id,
                             'playlist_uuid' => $playlist->uuid,
-                            'stopped_stream' => $stopResult['deleted_stream'] ?? null,
                         ]);
 
                         usleep(200000); // 200ms
@@ -1756,16 +1782,26 @@ class M3uProxyService
                 ->post($endpoint);
 
             if ($response->successful()) {
-                Log::debug("Failover triggered successfully for stream {$streamId}");
+                Log::debug('Failover triggered successfully', [
+                    'stream_id' => $streamId,
+                    'status_code' => $response->status(),
+                ]);
 
                 return true;
             }
 
-            Log::warning("Failed to trigger failover for stream {$streamId}: ".$response->body());
+            Log::warning('Failed to trigger failover', [
+                'stream_id' => $streamId,
+                'status_code' => $response->status(),
+            ]);
 
             return false;
         } catch (Exception $e) {
-            Log::error("Error triggering failover for stream {$streamId}: ".$e->getMessage());
+            Log::error('Error triggering failover', [
+                'stream_id' => $streamId,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return false;
         }
@@ -1826,7 +1862,11 @@ class M3uProxyService
                 'stream_ids' => $triggered,
             ];
         } catch (Exception $e) {
-            Log::error("Error triggering failover for channel {$channelId}: ".$e->getMessage());
+            Log::error('Error triggering failover for channel', [
+                'channel_id' => $channelId,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return ['success' => false, 'triggered_count' => 0, 'stream_ids' => [], 'error' => $e->getMessage()];
         }
@@ -1853,16 +1893,26 @@ class M3uProxyService
                 ->delete($endpoint);
 
             if ($response->successful()) {
-                Log::debug("Stream {$streamId} stopped successfully");
+                Log::debug('Stream stopped successfully', [
+                    'stream_id' => $streamId,
+                    'status_code' => $response->status(),
+                ]);
 
                 return true;
             }
 
-            Log::warning("Failed to stop stream {$streamId}: ".$response->body());
+            Log::warning('Failed to stop stream', [
+                'stream_id' => $streamId,
+                'status_code' => $response->status(),
+            ]);
 
             return false;
         } catch (Exception $e) {
-            Log::error("Error stopping stream {$streamId}: ".$e->getMessage());
+            Log::error('Error stopping stream', [
+                'stream_id' => $streamId,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return false;
         }
@@ -1917,7 +1967,11 @@ class M3uProxyService
                 'streams' => [],
             ];
         } catch (ConnectionException $e) {
-            Log::warning('m3u-proxy connection error on /streams: '.$e->getMessage());
+            Log::warning('m3u-proxy connection error', [
+                'operation' => 'fetch_streams',
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -1926,7 +1980,10 @@ class M3uProxyService
                 'streams' => [],
             ];
         } catch (Exception $e) {
-            Log::warning('Unexpected error fetching active streams from m3u-proxy: '.$e->getMessage());
+            Log::warning('Unexpected error fetching active streams from m3u-proxy', [
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -1980,7 +2037,11 @@ class M3uProxyService
                 'clients' => [],
             ];
         } catch (ConnectionException $e) {
-            Log::warning('m3u-proxy connection error on /clients: '.$e->getMessage());
+            Log::warning('m3u-proxy connection error', [
+                'operation' => 'fetch_clients',
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -1989,7 +2050,10 @@ class M3uProxyService
                 'clients' => [],
             ];
         } catch (Exception $e) {
-            Log::warning('Unexpected error fetching active clients from m3u-proxy: '.$e->getMessage());
+            Log::warning('Unexpected error fetching active clients from m3u-proxy', [
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -2049,7 +2113,11 @@ class M3uProxyService
                 'broadcasts' => [],
             ];
         } catch (ConnectionException $e) {
-            Log::warning('m3u-proxy connection error on /broadcast: '.$e->getMessage());
+            Log::warning('m3u-proxy connection error', [
+                'operation' => 'fetch_broadcasts',
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -2058,7 +2126,10 @@ class M3uProxyService
                 'broadcasts' => [],
             ];
         } catch (Exception $e) {
-            Log::warning('Unexpected error fetching broadcasts from m3u-proxy: '.$e->getMessage());
+            Log::warning('Unexpected error fetching broadcasts from m3u-proxy', [
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -2089,7 +2160,10 @@ class M3uProxyService
                 ->post($endpoint);
 
             if ($response->successful()) {
-                Log::debug("Broadcast {$networkId} stopped successfully");
+                Log::debug('Broadcast stopped successfully', [
+                    'network_id' => $networkId,
+                    'status_code' => $response->status(),
+                ]);
 
                 // Always update local state
                 $network = Network::where('uuid', $networkId)->first();
@@ -2114,11 +2188,18 @@ class M3uProxyService
                 return true;
             }
 
-            Log::warning("Failed to stop broadcast {$networkId}: ".$response->body());
+            Log::warning('Failed to stop broadcast', [
+                'network_id' => $networkId,
+                'status_code' => $response->status(),
+            ]);
 
             return false;
         } catch (Exception $e) {
-            Log::error("Error stopping broadcast {$networkId}: ".$e->getMessage());
+            Log::error('Error stopping broadcast', [
+                'network_id' => $networkId,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return false;
         }
@@ -2221,7 +2302,12 @@ class M3uProxyService
                 if (isset($data['stream_id'])) {
                     Log::debug('m3u-proxy stream created/updated successfully', [
                         'stream_id' => $data['stream_id'],
-                        'url' => $url,
+                        'channel_id' => $metadata['channel_id'] ?? $metadata['id'] ?? null,
+                        'episode_id' => $metadata['episode_id'] ?? null,
+                        'playlist_uuid' => $metadata['playlist_uuid'] ?? null,
+                        'profile_id' => $metadata['profile_id'] ?? null,
+                        'provider_profile_id' => $metadata['provider_profile_id'] ?? null,
+                        'status_code' => $response->status(),
                     ]);
 
                     return $data['stream_id'];
@@ -2233,8 +2319,13 @@ class M3uProxyService
             throw new Exception('Failed to create stream: '.$response->body());
         } catch (Exception $e) {
             Log::error('Error creating/updating stream on m3u-proxy', [
-                'error' => $e->getMessage(),
-                'url' => $url,
+                'channel_id' => $metadata['channel_id'] ?? $metadata['id'] ?? null,
+                'episode_id' => $metadata['episode_id'] ?? null,
+                'playlist_uuid' => $metadata['playlist_uuid'] ?? null,
+                'profile_id' => $metadata['profile_id'] ?? null,
+                'provider_profile_id' => $metadata['provider_profile_id'] ?? null,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
             throw $e;
         }
@@ -2381,7 +2472,12 @@ class M3uProxyService
                     Log::debug('Created transcoded stream on m3u-proxy', [
                         'stream_id' => $data['stream_id'],
                         'format' => $profile->format,
-                        'payload' => $payload,
+                        'channel_id' => $metadata['channel_id'] ?? $metadata['id'] ?? null,
+                        'episode_id' => $metadata['episode_id'] ?? null,
+                        'playlist_uuid' => $metadata['playlist_uuid'] ?? null,
+                        'profile_id' => $profile->id,
+                        'provider_profile_id' => $metadata['provider_profile_id'] ?? null,
+                        'status_code' => $response->status(),
                     ]);
 
                     return $data['stream_id'];
@@ -2393,9 +2489,14 @@ class M3uProxyService
             throw new Exception('Failed to create transcoded stream: '.$response->body());
         } catch (Exception $e) {
             Log::error('Error creating transcoded stream on m3u-proxy', [
-                'error' => $e->getMessage(),
-                'profile' => $profile->getProfileIdentifier(),
-                'url' => $url,
+                'channel_id' => $metadata['channel_id'] ?? $metadata['id'] ?? null,
+                'episode_id' => $metadata['episode_id'] ?? null,
+                'playlist_uuid' => $metadata['playlist_uuid'] ?? null,
+                'profile_id' => $profile->id,
+                'profile_name' => $profile->name,
+                'provider_profile_id' => $metadata['provider_profile_id'] ?? null,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
             throw $e;
         }
@@ -2660,7 +2761,14 @@ class M3uProxyService
 
             return null;
         } catch (Exception $e) {
-            Log::warning('Error finding existing pooled stream: '.$e->getMessage());
+            Log::warning('Error finding existing pooled stream', [
+                'model_id' => $modelId,
+                'model_type' => $type,
+                'profile_id' => $profileId,
+                'provider_profile_id' => $providerProfileId,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return null;
         }
@@ -2706,7 +2814,10 @@ class M3uProxyService
                 'info' => [],
             ];
         } catch (Exception $e) {
-            Log::warning('Failed to fetch proxy info from m3u-proxy: '.$e->getMessage());
+            Log::warning('Failed to fetch proxy info from m3u-proxy', [
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
 
             return [
                 'success' => false,
@@ -2777,7 +2888,7 @@ class M3uProxyService
                 if ($idx < $index) {
                     // If the index is higher than the current loop, chances are it has already been attempted, continue to the next...
                     Log::debug('Channel already attempted, skipping', [
-                        'channel' => $failoverPlaylist->title_custom ?? $failoverPlaylist->title,
+                        'channel_id' => $failoverChannel->id,
                         'index' => $idx,
                         'requested_index' => $index,
                     ]);
@@ -2792,7 +2903,7 @@ class M3uProxyService
                 if ($invalidExpiresAt && now()->timestamp < (int) $invalidExpiresAt) {
                     Log::debug('Failover playlist marked invalid by fail condition, skipping', [
                         'playlist_uuid' => $failoverPlaylist->uuid,
-                        'playlist' => $failoverPlaylist->title_custom ?? $failoverPlaylist->title,
+                        'channel_id' => $failoverChannel->id,
                     ]);
 
                     continue;
@@ -2804,8 +2915,8 @@ class M3uProxyService
                 // Check if the url is the current URL (skip it)
                 if ($url === $currentUrl) {
                     Log::debug('Failover URL matches current URL, skipping', [
-                        'url' => substr($url, 0, 100),
                         'playlist_uuid' => $failoverPlaylist->uuid,
+                        'channel_id' => $failoverChannel->id,
                     ]);
 
                     continue;
@@ -2831,8 +2942,8 @@ class M3uProxyService
 
                 // At capacity, skip this URL
                 Log::debug('Failover URL playlist at capacity, skipping', [
-                    'url' => substr($url, 0, 100),
                     'playlist_uuid' => $failoverPlaylist->uuid,
+                    'channel_id' => $failoverChannel->id,
                     'active' => $activeStreams,
                     'limit' => $failoverPlaylist->available_streams,
                 ]);
@@ -2843,9 +2954,13 @@ class M3uProxyService
                 'next_url' => $nextUrl,
             ];
         } catch (Exception $e) {
-            Log::warning('Error resolving failover url: '.$e->getMessage(), [
+            Log::warning('Error resolving failover URL', [
                 'channel_id' => $channelId,
                 'playlist_uuid' => $playlistUuid,
+                'failover_index' => $index,
+                'status_code' => $statusCode,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
 
             // Return null so the proxy stops retrying instead of looping on the same URL
@@ -2909,7 +3024,13 @@ class M3uProxyService
                 }
             }
         } catch (Exception $e) {
-            Log::warning('Error marking failover playlist as invalid: '.$e->getMessage());
+            Log::warning('Error marking failover playlist as invalid', [
+                'channel_id' => $channelId,
+                'failover_index' => $index,
+                'status_code' => $statusCode,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
         }
     }
 

--- a/app/Services/NetworkBroadcastService.php
+++ b/app/Services/NetworkBroadcastService.php
@@ -279,7 +279,6 @@ class NetworkBroadcastService
             // so the next tick will retry. Don't clear the request flag.
             Log::info('Broadcast start deferred due to transient proxy failure (will retry)', [
                 'network_id' => $network->id,
-                'network_name' => $network->name,
             ]);
         } else {
             // Permanent failure - clear broadcast_requested so it doesn't stay stuck on "Starting"
@@ -404,7 +403,8 @@ class NetworkBroadcastService
             } catch (\Exception $e) {
                 Log::warning('Failed to compute #range= byte offset for rewritten-static URL', [
                     'network_id' => $network->id,
-                    'exception' => $e->getMessage(),
+                    'exception_class' => $e::class,
+                    'exception_code' => $e->getCode(),
                 ]);
             }
         }
@@ -550,20 +550,17 @@ class NetworkBroadcastService
         } catch (\Exception $e) {
             Log::warning('Failed to attach provider-specific headers for broadcast', [
                 'network_id' => $network->id,
-                'exception' => $e->getMessage(),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
         }
 
         Log::info('Starting broadcast via proxy', [
             'network_id' => $network->id,
             'network_uuid' => $network->uuid,
-            'payload' => array_merge($payload, ['stream_url' => '***']), // Hide URL in logs
-        ]);
-
-        // Debug: log the unmasked stream URL at debug level so we can diagnose start failures
-        Log::debug('Broadcast stream URL (debug only)', [
-            'network_id' => $network->id,
-            'stream_url' => $streamUrl,
+            'programme_id' => $programme->id,
+            'seek_seconds' => $seekPosition,
+            'duration_seconds' => $remainingDuration,
         ]);
 
         // Extract the Plex transcode session ID from the stream URL upfront.
@@ -590,35 +587,33 @@ class NetworkBroadcastService
                     'broadcast_transcode_session_id' => $transcodeSessionId,
                 ]);
 
-                $logMessage = "🟢 BROADCAST STARTED VIA PROXY: {$network->name}";
+                $logMessage = 'Broadcast started via proxy';
                 $logData = [
                     'network_id' => $network->id,
                     'uuid' => $network->uuid,
                     'ffmpeg_pid' => $data['ffmpeg_pid'] ?? null,
                     'status' => $data['status'] ?? 'unknown',
-                    'transcode_session_id' => $transcodeSessionId,
                 ];
 
                 // Add recovery message if this was a boot recovery restart
                 if ($network->broadcast_boot_recovery_until && now()->lt($network->broadcast_boot_recovery_until)) {
-                    $logMessage = "🟢 BROADCAST RECOVERED VIA PROXY: {$network->name}";
+                    $logMessage = 'Broadcast recovered via proxy';
                     $logData['recovery'] = 'boot_recovery';
 
                     // Also log a prominent recovery message that will show in console
-                    Log::info("🎉 BROADCAST RECOVERY COMPLETE: {$network->name} is back online after container restart");
+                    Log::info('Broadcast recovery complete', ['network_id' => $network->id]);
 
                     // Direct console output to ensure it shows up in container logs
-                    echo "🎉 [RECOVERY] {$network->name} is now broadcasting again after container restart\n";
+                    echo "[RECOVERY] Network {$network->id} is now broadcasting again after container restart\n";
                 }
 
                 Log::info($logMessage, $logData);
 
-                Log::info("🟢 BROADCAST STARTED VIA PROXY: {$network->name}", [
+                Log::info('Broadcast started via proxy', [
                     'network_id' => $network->id,
                     'uuid' => $network->uuid,
                     'ffmpeg_pid' => $data['ffmpeg_pid'] ?? null,
                     'status' => $data['status'] ?? 'unknown',
-                    'transcode_session_id' => $transcodeSessionId,
                 ]);
 
                 return true;
@@ -628,7 +623,6 @@ class NetworkBroadcastService
             Log::error('Proxy returned error when starting broadcast', [
                 'network_id' => $network->id,
                 'status' => $response->status(),
-                'error' => $errorMessage,
             ]);
 
             $network->update([
@@ -654,7 +648,6 @@ class NetworkBroadcastService
                     'network_id' => $network->id,
                     'status' => $response->status(),
                     'grace_period_until' => $network->broadcast_boot_recovery_until->toIso8601String(),
-                    'reuse_session_id' => $transcodeSessionId,
                 ]);
 
                 return null;
@@ -673,7 +666,8 @@ class NetworkBroadcastService
             // Return null so the caller knows to retry on the next tick
             Log::warning('Failed to connect to proxy for broadcast (transient, will retry)', [
                 'network_id' => $network->id,
-                'exception' => $e->getMessage(),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
 
             // Persist the session ID so the next retry reuses it instead of creating
@@ -742,7 +736,7 @@ class NetworkBroadcastService
                 $data = $response->json();
                 $finalSegment = $data['final_segment_number'] ?? 0;
 
-                Log::info("🔴 BROADCAST STOPPED VIA PROXY: {$network->name}", [
+                Log::info('Broadcast stopped via proxy', [
                     'network_id' => $network->id,
                     'uuid' => $network->uuid,
                     'final_segment' => $finalSegment,
@@ -751,7 +745,8 @@ class NetworkBroadcastService
         } catch (\Exception $e) {
             Log::warning('Failed to stop broadcast via proxy (may already be stopped)', [
                 'network_id' => $network->id,
-                'exception' => $e->getMessage(),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
         }
 
@@ -793,7 +788,8 @@ class NetworkBroadcastService
         } catch (\Exception $e) {
             Log::warning('Failed to cleanup broadcast files via proxy', [
                 'network_id' => $network->id,
-                'exception' => $e->getMessage(),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
         }
 
@@ -837,7 +833,8 @@ class NetworkBroadcastService
             // Connection error - assume not running
             Log::debug('Could not check broadcast status via proxy', [
                 'network_id' => $network->id,
-                'exception' => $e->getMessage(),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
 
             return false;
@@ -1078,8 +1075,8 @@ class NetworkBroadcastService
         } catch (\Exception $e) {
             Log::warning('Failed to stop Plex transcode session during cleanup', [
                 'network_id' => $network->id,
-                'session_id' => $sessionId,
-                'exception' => $e->getMessage(),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
         }
     }
@@ -1127,14 +1124,13 @@ class NetworkBroadcastService
             if ($stopped) {
                 Log::info('Stopped orphaned Plex transcode session after failed start', [
                     'network_id' => $network->id,
-                    'session_id' => $sessionId,
                 ]);
             }
         } catch (\Exception $e) {
             Log::debug('Could not stop orphaned Plex transcode session (may not exist)', [
                 'network_id' => $network->id,
-                'session_id' => $sessionId,
-                'exception' => $e->getMessage(),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
         }
     }
@@ -1298,9 +1294,7 @@ class NetworkBroadcastService
 
             Log::info('🔄 BROADCAST RECOVERY: Restarting broadcast via proxy', [
                 'network_id' => $network->id,
-                'network_name' => $network->name,
                 'programme_id' => $programme->id,
-                'programme_title' => $programme->title,
             ]);
 
             $success = $this->startRequested($network);
@@ -1310,7 +1304,7 @@ class NetworkBroadcastService
 
             // Direct console output for recovery success
             if ($success && ! app()->runningUnitTests()) {
-                echo "🔄 [TICK RECOVERY] {$network->name} broadcast restarted successfully\n";
+                echo "[TICK RECOVERY] Network {$network->id} broadcast restarted successfully\n";
             }
 
             return $result;
@@ -1404,7 +1398,8 @@ class NetworkBroadcastService
             } catch (\Exception $e) {
                 Log::debug('BOOT RECOVERY: Could not stop broadcast via proxy (expected if not running)', [
                     'network_id' => $net->id,
-                    'exception' => $e->getMessage(),
+                    'exception_class' => $e::class,
+                    'exception_code' => $e->getCode(),
                 ]);
             }
 
@@ -1415,7 +1410,8 @@ class NetworkBroadcastService
             } catch (\Exception $e) {
                 Log::debug('BOOT RECOVERY: Could not cleanup broadcast files via proxy', [
                     'network_id' => $net->id,
-                    'exception' => $e->getMessage(),
+                    'exception_class' => $e::class,
+                    'exception_code' => $e->getCode(),
                 ]);
             }
 
@@ -1604,7 +1600,8 @@ class NetworkBroadcastService
         } catch (\Exception $e) {
             Log::warning('computeNextStreamConfig: failed to attach provider headers', [
                 'network_id' => $network->id,
-                'exception' => $e->getMessage(),
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
             ]);
         }
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,7 +1,7 @@
 <?php
 
+use App\Logging\AddAnonymizingProcessor;
 use App\Logging\AlertsHandler;
-use App\Logging\AnonymizingProcessor;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -62,17 +62,19 @@ return [
 
         'stdout' => [
             'driver' => 'monolog',
+            'tap' => [AddAnonymizingProcessor::class],
             'level' => env('LOG_LEVEL', 'info'),
             'handler' => StreamHandler::class,
             'formatter' => env('LOG_STDERR_FORMATTER'),
             'with' => [
                 'stream' => 'php://stdout',
             ],
-            'processors' => [AnonymizingProcessor::class, PsrLogMessageProcessor::class],
+            'processors' => [PsrLogMessageProcessor::class],
         ],
 
         'single' => [
             'driver' => 'single',
+            'tap' => [AddAnonymizingProcessor::class],
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'error'),
             'replace_placeholders' => true,
@@ -80,15 +82,16 @@ return [
 
         'daily' => [
             'driver' => 'daily',
+            'tap' => [AddAnonymizingProcessor::class],
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'error'),
             'days' => env('LOG_DAILY_DAYS', 3),
             'replace_placeholders' => true,
-            'processors' => [AnonymizingProcessor::class],
         ],
 
         'slack' => [
             'driver' => 'slack',
+            'tap' => [AddAnonymizingProcessor::class],
             'url' => env('LOG_SLACK_WEBHOOK_URL'),
             'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
             'emoji' => env('LOG_SLACK_EMOJI', ':boom:'),
@@ -98,6 +101,7 @@ return [
 
         'papertrail' => [
             'driver' => 'monolog',
+            'tap' => [AddAnonymizingProcessor::class],
             'level' => env('LOG_LEVEL', 'error'),
             'handler' => env('LOG_PAPERTRAIL_HANDLER', SyslogUdpHandler::class),
             'handler_with' => [
@@ -110,6 +114,7 @@ return [
 
         'stderr' => [
             'driver' => 'monolog',
+            'tap' => [AddAnonymizingProcessor::class],
             'level' => env('LOG_LEVEL', 'error'),
             'handler' => StreamHandler::class,
             'formatter' => env('LOG_STDERR_FORMATTER'),
@@ -121,6 +126,7 @@ return [
 
         'syslog' => [
             'driver' => 'syslog',
+            'tap' => [AddAnonymizingProcessor::class],
             'level' => env('LOG_LEVEL', 'error'),
             'facility' => env('LOG_SYSLOG_FACILITY', LOG_USER),
             'replace_placeholders' => true,
@@ -128,6 +134,7 @@ return [
 
         'errorlog' => [
             'driver' => 'errorlog',
+            'tap' => [AddAnonymizingProcessor::class],
             'level' => env('LOG_LEVEL', 'error'),
             'replace_placeholders' => true,
         ],
@@ -143,15 +150,16 @@ return [
 
         'ffmpeg' => [
             'driver' => 'daily',
+            'tap' => [AddAnonymizingProcessor::class],
             'path' => storage_path('logs/ffmpeg.log'),
             'level' => 'debug', // env('LOG_LEVEL', 'error'),
             'days' => env('LOG_DAILY_DAYS', 3),
-            'processors' => [AnonymizingProcessor::class],
         ],
 
         // Forwards error-level+ entries to Discord/Slack when configured in Settings.
         'alerts' => [
             'driver' => 'monolog',
+            'tap' => [AddAnonymizingProcessor::class],
             'level' => 'error',
             'handler' => AlertsHandler::class,
         ],

--- a/tests/Feature/ProxyLogRedactionTest.php
+++ b/tests/Feature/ProxyLogRedactionTest.php
@@ -1,0 +1,243 @@
+<?php
+
+use App\Console\Commands\RegisterM3uProxyWebhook;
+use App\Enums\TranscodeMode;
+use App\Logging\AlertsHandler;
+use App\Models\Network;
+use App\Models\NetworkProgramme;
+use App\Models\StreamProfile;
+use App\Services\AlertService;
+use App\Services\M3uProxyService;
+use App\Services\NetworkBroadcastService;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Handler\TestHandler;
+
+beforeEach(function () {
+    config()->set('proxy.m3u_proxy_host', 'http://proxy.test');
+    config()->set('proxy.m3u_proxy_port', null);
+    config()->set('proxy.m3u_proxy_token', 'proxy-api-token');
+    config()->set('logging.default', 'proxy-redaction-test');
+    config()->set('logging.channels.proxy-redaction-test', [
+        'driver' => 'monolog',
+        'level' => 'debug',
+        'handler' => TestHandler::class,
+        'formatter' => JsonFormatter::class,
+        'tap' => config('logging.channels.stdout.tap', []),
+    ]);
+
+    Log::forgetChannel('proxy-redaction-test');
+
+    $this->proxyLogHandler = Log::channel('proxy-redaction-test')->getHandlers()[0];
+});
+
+function formattedProxyLogs(TestHandler $handler): string
+{
+    return implode("\n", array_map(
+        static fn ($record): string => (string) $record->formatted,
+        $handler->getRecords(),
+    ));
+}
+
+it('does not log transcode payloads or proxy response bodies', function () {
+    $secret = 'TRANSCODE-SENTINEL-SECRET';
+    $profile = StreamProfile::factory()->create();
+
+    Http::fake([
+        '*/transcode' => Http::response([
+            'error' => 'transcode failed',
+            'Authorization' => "Bearer {$secret}",
+            'source_url' => "https://provider.test/live/{$secret}",
+        ], 502),
+    ]);
+
+    $service = new class extends M3uProxyService
+    {
+        public function createTestTranscode(StreamProfile $profile, string $secret): void
+        {
+            $this->createTranscodedStream(
+                "https://provider.test/live/{$secret}",
+                $profile,
+                ["https://failover.test/{$secret}"],
+                headers: [['header' => 'Cookie', 'value' => "session={$secret}"]],
+                metadata: ['channel_id' => 42],
+            );
+        }
+    };
+
+    expect(fn () => $service->createTestTranscode($profile, $secret))
+        ->toThrow(Exception::class);
+
+    $logs = formattedProxyLogs($this->proxyLogHandler);
+
+    expect($logs)->toContain('Error creating transcoded stream on m3u-proxy')
+        ->not->toContain($secret)
+        ->not->toContain('source_url')
+        ->not->toContain('Authorization');
+});
+
+it('does not log broadcast payloads or source URLs', function () {
+    $secret = 'BROADCAST-PAYLOAD-SENTINEL';
+    $network = Network::factory()->create([
+        'enabled' => true,
+        'broadcast_enabled' => true,
+        'broadcast_requested' => true,
+        'transcode_mode' => TranscodeMode::Direct->value,
+    ]);
+    $programme = NetworkProgramme::factory()->create([
+        'network_id' => $network->id,
+        'start_time' => now()->subMinutes(5),
+        'end_time' => now()->addMinutes(55),
+        'duration_seconds' => 3600,
+    ]);
+
+    Http::fake([
+        '*/broadcast/*/start' => Http::response(['status' => 'started', 'ffmpeg_pid' => 12345]),
+    ]);
+
+    (new ReflectionMethod(NetworkBroadcastService::class, 'startViaProxy'))->invoke(
+        app(NetworkBroadcastService::class),
+        $network,
+        "https://provider.test/video?api_key={$secret}",
+        0,
+        3600,
+        $programme,
+    );
+
+    expect(formattedProxyLogs($this->proxyLogHandler))
+        ->toContain('Starting broadcast via proxy')
+        ->toContain((string) $network->id)
+        ->not->toContain($secret)
+        ->not->toContain('stream_url')
+        ->not->toContain('callback_url')
+        ->not->toContain('payload');
+});
+
+it('does not log failover response bodies', function () {
+    $secret = 'FAILOVER-RESPONSE-SENTINEL';
+
+    Http::fake([
+        '*/streams/stream-123/failover' => Http::response([
+            'message' => "failure token={$secret}",
+            'headers' => ['Cookie' => $secret],
+        ], 503),
+    ]);
+
+    expect(app(M3uProxyService::class)->triggerFailover('stream-123'))->toBeFalse();
+
+    expect(formattedProxyLogs($this->proxyLogHandler))
+        ->toContain('Failed to trigger failover')
+        ->not->toContain($secret)
+        ->toContain('503');
+});
+
+it('allowlists webhook callback diagnostics', function () {
+    $secret = 'CALLBACK-SENTINEL-SECRET';
+
+    $this->postJson('/api/m3u-proxy/webhooks', [
+        'event_type' => 'stream_started',
+        'stream_id' => 'stream-456',
+        'data' => [
+            'type' => 'channel',
+            'id' => 99,
+            'trace_id' => '123e4567-e89b-12d3-a456-426614174000',
+            'nested' => [
+                'aUtHoRiZaTiOn' => "Bearer {$secret}",
+                'COOKIE' => $secret,
+                'accessToken' => $secret,
+                'api_KEY' => $secret,
+                'Password' => $secret,
+                'source' => "https://provider.test/{$secret}",
+            ],
+        ],
+    ])->assertOk();
+
+    expect(formattedProxyLogs($this->proxyLogHandler))
+        ->toContain('stream_started')
+        ->toContain('stream-456')
+        ->not->toContain($secret)
+        ->not->toContain('aUtHoRiZaTiOn')
+        ->not->toContain('accessToken');
+});
+
+it('does not log failover request or exception payloads', function () {
+    $secret = 'EXCEPTION-SENTINEL-SECRET';
+
+    $this->mock(M3uProxyService::class)
+        ->shouldReceive('resolveFailoverUrl')
+        ->once()
+        ->andThrow(new Exception("Failed for https://provider.test/{$secret}?token={$secret}"));
+
+    $this->postJson('/api/m3u-proxy/failover-resolver', [
+        'current_url' => "https://provider.test/live/{$secret}",
+        'metadata' => [
+            'id' => 42,
+            'playlist_uuid' => '123e4567-e89b-12d3-a456-426614174000',
+            'headers' => ['Authorization' => "Bearer {$secret}"],
+        ],
+        'current_failover_index' => 2,
+        'status_code' => 401,
+        'Cookie' => $secret,
+    ])->assertInternalServerError();
+
+    expect(formattedProxyLogs($this->proxyLogHandler))
+        ->toContain('Error resolving failover')
+        ->toContain('42')
+        ->toContain('401')
+        ->not->toContain($secret)
+        ->not->toContain('current_url')
+        ->not->toContain('Authorization');
+});
+
+it('does not log webhook URLs when registering callbacks', function () {
+    $secret = 'WEBHOOK-URL-SENTINEL';
+
+    config()->set('proxy.m3u_resolver_url', "https://editor.test/callback/{$secret}");
+    Http::fake([
+        '*/webhooks' => Http::sequence()
+            ->push(['webhooks' => []])
+            ->push(['status' => 'ok']),
+    ]);
+
+    $this->artisan(RegisterM3uProxyWebhook::class)->assertSuccessful();
+
+    expect(formattedProxyLogs($this->proxyLogHandler))
+        ->toContain('M3U Proxy webhook registered')
+        ->not->toContain($secret)
+        ->not->toContain('webhook_url');
+});
+
+it('redacts the final message sent by the alerts handler', function () {
+    $secret = 'ALERT-SENTINEL-SECRET';
+    $alertMessage = null;
+
+    $this->mock(AlertService::class, function ($mock) use (&$alertMessage) {
+        $mock->shouldReceive('isEnabled')->once()->andReturnTrue();
+        $mock->shouldReceive('send')->once()->withArgs(function (string $message) use (&$alertMessage): bool {
+            $alertMessage = $message;
+
+            return true;
+        });
+    });
+
+    config()->set('logging.channels.proxy-alert-test', [
+        'driver' => 'monolog',
+        'level' => 'error',
+        'handler' => AlertsHandler::class,
+        'tap' => config('logging.channels.alerts.tap', []),
+    ]);
+    Log::forgetChannel('proxy-alert-test');
+
+    Log::channel('proxy-alert-test')->error('Proxy failed', [
+        'channel_id' => 42,
+        'HeAdErS' => ['Authorization' => "Bearer {$secret}"],
+        'sourceUrl' => "https://provider.test/{$secret}",
+    ]);
+
+    expect($alertMessage)->toContain('Proxy failed')
+        ->toContain('channel_id')
+        ->not->toContain($secret)
+        ->not->toContain('Authorization')
+        ->not->toContain('provider.test');
+});

--- a/tests/Unit/AnonymizingProcessorTest.php
+++ b/tests/Unit/AnonymizingProcessorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Logging\AddAnonymizingProcessor;
+use App\Logging\AnonymizingProcessor;
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+it('redacts nested case-variant secrets in the final formatted record', function () {
+    $secret = 'NESTED-SENTINEL-SECRET';
+    $record = new LogRecord(
+        datetime: now()->toDateTimeImmutable(),
+        channel: 'test',
+        level: Level::Error,
+        message: "Proxy exception for https://provider.test/{$secret}",
+        context: [
+            'channel_id' => 42,
+            'status_code' => 502,
+            'trace_id' => '123e4567-e89b-12d3-a456-426614174000',
+            'nested' => [
+                'aUtHoRiZaTiOn' => "Bearer {$secret}",
+                'COOKIE' => $secret,
+                'accessToken' => $secret,
+                'api_KEY' => $secret,
+                'Password' => $secret,
+                'sourceUrl' => "https://provider.test/{$secret}",
+                'request_headers' => ['X-API-Token' => $secret],
+            ],
+        ],
+    );
+
+    $formatted = (new JsonFormatter)->format((new AnonymizingProcessor)($record));
+
+    expect($formatted)->toContain('channel_id')
+        ->toContain('status_code')
+        ->toContain('trace_id')
+        ->not->toContain($secret)
+        ->not->toContain('provider.test')
+        ->not->toContain('aUtHoRiZaTiOn')
+        ->not->toContain('accessToken')
+        ->not->toContain('sourceUrl');
+});
+
+it('attaches redaction before every configured log handler', function () {
+    $handlerChannels = collect(config('logging.channels'))
+        ->reject(fn (array $channel, string $name): bool => in_array($name, ['stack', 'null', 'emergency'], true));
+
+    expect($handlerChannels)->not->toBeEmpty();
+
+    $handlerChannels->each(function (array $channel): void {
+        expect($channel['tap'] ?? [])
+            ->toContain(AddAnonymizingProcessor::class);
+    });
+});


### PR DESCRIPTION
## Summary

- replace proxy, failover, callback, webhook, and broadcast payload logging with allowlisted diagnostics
- recursively redact nested case-variant secret fields and URLs before configured local, alert, and remote handlers
- cover transcode, broadcast, failover, callback, exception, webhook registration, and alert paths with regression tests

## Checks

- [x] `php artisan test --parallel --processes=4 --recreate-databases` (1,877 passed, 28 skipped, 5,802 assertions)
- [x] `vendor/bin/pint --test`
- [x] `npm run build`
- [x] `composer security:scan` (25 passed, expected local environment warning only)
- [x] `php artisan plugins:discover` and `php artisan plugins:validate`

## Risks

Log detail is intentionally reduced. URLs and sensitive-key context fields are always removed, while existing username and UUID anonymization continues to follow `LOG_ANONYMIZE`.

Closes #1333