### PR TITLE
fix(alias): resolve alias ownership through the effective playlist

### DIFF
--- a/app/Policies/PlaylistAliasPolicy.php
+++ b/app/Policies/PlaylistAliasPolicy.php
@@ -20,8 +20,7 @@ class PlaylistAliasPolicy
      */
     public function view(User $user, PlaylistAlias $playlistAlias): bool
     {
-        // PlaylistAlias doesn't have direct user_id, check through playlist relationship
-        return $user->isAdmin() || $user->id === $playlistAlias->playlist->user_id;
+        return $this->owns($user, $playlistAlias);
     }
 
     /**
@@ -37,7 +36,7 @@ class PlaylistAliasPolicy
      */
     public function update(User $user, PlaylistAlias $playlistAlias): bool
     {
-        return $user->isAdmin() || $user->id === $playlistAlias->playlist->user_id;
+        return $this->owns($user, $playlistAlias);
     }
 
     /**
@@ -45,7 +44,7 @@ class PlaylistAliasPolicy
      */
     public function delete(User $user, PlaylistAlias $playlistAlias): bool
     {
-        return $user->isAdmin() || $user->id === $playlistAlias->playlist->user_id;
+        return $this->owns($user, $playlistAlias);
     }
 
     /**
@@ -53,7 +52,7 @@ class PlaylistAliasPolicy
      */
     public function restore(User $user, PlaylistAlias $playlistAlias): bool
     {
-        return $user->isAdmin() || $user->id === $playlistAlias->playlist->user_id;
+        return $this->owns($user, $playlistAlias);
     }
 
     /**
@@ -61,6 +60,15 @@ class PlaylistAliasPolicy
      */
     public function forceDelete(User $user, PlaylistAlias $playlistAlias): bool
     {
-        return $user->isAdmin() || $user->id === $playlistAlias->playlist->user_id;
+        return $this->owns($user, $playlistAlias);
+    }
+
+    /**
+     * PlaylistAlias doesn't have direct user_id, check through the source playlist, which
+     * may be either a standard or a custom playlist.
+     */
+    private function owns(User $user, PlaylistAlias $playlistAlias): bool
+    {
+        return $user->isAdmin() || $user->id === $playlistAlias->getEffectivePlaylist()?->user_id;
     }
 }

--- a/tests/Feature/PlaylistAliasPolicyTest.php
+++ b/tests/Feature/PlaylistAliasPolicyTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Regression tests for PlaylistAliasPolicy against aliases of a custom playlist.
+ *
+ * Every method resolved the owner with $playlistAlias->playlist->user_id. That relation
+ * is the belongsTo for a *standard* playlist and is null for an alias of a custom one, so
+ * reading ->user_id on it raised a PHP warning that Laravel promotes to an ErrorException.
+ * Admins never reached it because isAdmin() short-circuits, and canAccessPanel() lets
+ * non-admins into the panel, so a non-admin owner could not open their own alias at all.
+ */
+
+use App\Filament\Resources\PlaylistAliases\Pages\EditPlaylistAlias;
+use App\Models\CustomPlaylist;
+use App\Models\Playlist;
+use App\Models\PlaylistAlias;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+
+function makePolicyAlias(User $user, array $attributes): PlaylistAlias
+{
+    return PlaylistAlias::create(array_merge([
+        'name' => 'Policy Alias',
+        'uuid' => fake()->uuid(),
+        'user_id' => $user->id,
+        'xtream_config' => null,
+    ], $attributes));
+}
+
+dataset('policy abilities', ['view', 'update', 'delete', 'restore', 'forceDelete']);
+
+it('grants a non-admin owner every ability on an alias of a custom playlist', function (string $ability) {
+    $user = User::factory()->create();
+    $customPlaylist = CustomPlaylist::factory()->for($user)->create();
+    $alias = makePolicyAlias($user, ['custom_playlist_id' => $customPlaylist->id]);
+
+    expect($user->isAdmin())->toBeFalse()
+        ->and($alias->playlist)->toBeNull()
+        ->and(Gate::forUser($user)->allows($ability, $alias))->toBeTrue();
+})->with('policy abilities');
+
+it('grants a non-admin owner every ability on an alias of a standard playlist', function (string $ability) {
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create();
+    $alias = makePolicyAlias($user, ['playlist_id' => $playlist->id]);
+
+    expect(Gate::forUser($user)->allows($ability, $alias))->toBeTrue();
+})->with('policy abilities');
+
+it('denies a non-admin who does not own the alias', function (string $ability) {
+    $owner = User::factory()->create();
+    $stranger = User::factory()->create();
+    $customPlaylist = CustomPlaylist::factory()->for($owner)->create();
+    $alias = makePolicyAlias($owner, ['custom_playlist_id' => $customPlaylist->id]);
+
+    expect(Gate::forUser($stranger)->allows($ability, $alias))->toBeFalse();
+})->with('policy abilities');
+
+it('still grants an admin every ability regardless of the alias target', function (string $ability) {
+    $admin = User::factory()->admin()->create();
+    $owner = User::factory()->create();
+    $customPlaylist = CustomPlaylist::factory()->for($owner)->create();
+    $alias = makePolicyAlias($owner, ['custom_playlist_id' => $customPlaylist->id]);
+
+    expect(Gate::forUser($admin)->allows($ability, $alias))->toBeTrue();
+})->with('policy abilities');
+
+it('lets a non-admin owner open the edit page for an alias of a custom playlist', function () {
+    $user = User::factory()->create();
+    $customPlaylist = CustomPlaylist::factory()->for($user)->create();
+    $alias = makePolicyAlias($user, ['custom_playlist_id' => $customPlaylist->id]);
+
+    $this->actingAs($user);
+
+    Livewire::test(EditPlaylistAlias::class, ['record' => $alias->getRouteKey()])
+        ->assertSuccessful();
+});


### PR DESCRIPTION
## Problem

`PlaylistAliasPolicy` resolves the alias owner through `$playlistAlias->playlist->user_id` in all six methods. `playlist` is the `belongsTo` for a **standard** playlist, so it is `null` on an alias of a **custom** playlist. Reading `->user_id` on null raises a PHP warning, which Laravel promotes to an `ErrorException`:

```
Attempt to read property "user_id" on null
at app/Policies/PlaylistAliasPolicy.php:40
```

`User::canAccessPanel()` returns `true` for everyone, so non-admin users do reach the resource. `$user->isAdmin()` short-circuits the expression, so **admins never see this** — which is why it has gone unnoticed. A non-admin cannot view, edit or delete their own alias when it points at a custom playlist.

Reproduced in the browser on `dev` with a non-admin user who owns a custom-playlist alias.

## Fix

Resolve through the existing `getEffectivePlaylist()`, which returns the standard playlist or the custom one. Behaviour for standard-playlist aliases is byte-for-byte unchanged; the six duplicated expressions collapse into one private helper.

```php
private function owns(User $user, PlaylistAlias $playlistAlias): bool
{
    return $user->isAdmin() || $user->id === $playlistAlias->getEffectivePlaylist()?->user_id;
}
```

The null-safe operator matters independently: an alias whose target playlist has been deleted now denies access rather than erroring.

## Tests

`tests/Feature/PlaylistAliasPolicyTest.php` covers all five abilities against both alias types:

- a non-admin owner is granted every ability on a custom-playlist alias
- a non-admin owner is granted every ability on a standard-playlist alias (no regression)
- a non-owner is still denied
- an admin is still granted regardless of target
- a non-admin owner can open the alias edit page

**11 of the 21 fail on the current policy** and pass with the fix.

## Notes

- No user-facing strings, so no `lang/` changes.
- `vendor/bin/pint --test` passes.
- `php artisan checkpoint:scan` reports no findings introduced by this branch (verified by diffing finding IDs against `dev`; the scan is already non-zero on `dev` for pre-existing issues).
