### PR TITLE
fix(dvr): broadcast dvr.status to every channel a TV session can be on

### DIFF
--- a/app/Events/Concerns/BroadcastsToEntitledTvChannels.php
+++ b/app/Events/Concerns/BroadcastsToEntitledTvChannels.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Events\Concerns;
+
+use App\Models\PlaylistAuth;
+use Illuminate\Broadcasting\PrivateChannel;
+
+/**
+ * Shared channel-set resolution for TV push events that must reach every
+ * session subscribed under a playlist (owner/admin channel, and one channel
+ * per entitled PlaylistAuth/alias — see PlaylistAuth::scopeEntitledToNotificationRecipient()).
+ *
+ * TvNotificationEvent originated this set; DvrRecordingStatusEvent previously
+ * broadcast only on the bare owner channel, so pushes never reached TV
+ * sessions logged in via PlaylistAuth credentials (channel `tv.{type}.{uuid}.{authId}`)
+ * even though TvNotificationEvent's pushes did. Sharing this resolution keeps
+ * both event families targeting the same recipients by construction.
+ */
+trait BroadcastsToEntitledTvChannels
+{
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    private static function entitledTvChannels(string $notifiableType, int|string $notifiableId, string $notifiableUuid): array
+    {
+        $channels = [
+            new PrivateChannel("tv.{$notifiableType}.{$notifiableUuid}"),
+            new PrivateChannel("tv.{$notifiableType}-admin.{$notifiableUuid}"),
+        ];
+
+        $entitled = PlaylistAuth::query()
+            ->entitledToNotificationRecipient($notifiableType, $notifiableId)
+            ->with('assignedPlaylist.authenticatable')
+            ->get();
+
+        foreach ($entitled as $playlistAuth) {
+            $authenticatable = $playlistAuth->assignedPlaylist?->authenticatable;
+
+            if (! $authenticatable) {
+                continue;
+            }
+
+            $channels[] = new PrivateChannel(
+                "tv.{$authenticatable->getMorphClass()}.{$authenticatable->uuid}.{$playlistAuth->id}"
+            );
+        }
+
+        return $channels;
+    }
+}

--- a/app/Events/DvrRecordingStatusEvent.php
+++ b/app/Events/DvrRecordingStatusEvent.php
@@ -2,6 +2,7 @@
 
 namespace App\Events;
 
+use App\Events\Concerns\BroadcastsToEntitledTvChannels;
 use App\Models\DvrRecording;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
@@ -14,16 +15,19 @@ use Illuminate\Queue\SerializesModels;
  * changes (scheduled, recording, completed, failed, cancelled), so clients
  * can mark channels as recording live instead of polling get_dvr_recordings.
  *
- * Reuses the same `tv.{type}.{uuid}` channel as TvNotificationEvent — the TV
- * app is already subscribed to it after login, so no new subscription or
- * broadcasting/auth change is needed.
+ * Broadcasts on the same channel set as TvNotificationEvent's default (null
+ * playlistAuthId) branch — the owner/admin channels plus one channel per
+ * entitled PlaylistAuth/alias — since a TV session logged in via PlaylistAuth
+ * credentials subscribes only to its own `tv.{type}.{uuid}.{authId}` channel,
+ * not the bare owner channel.
  */
 class DvrRecordingStatusEvent implements ShouldBroadcast
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use BroadcastsToEntitledTvChannels, Dispatchable, InteractsWithSockets, SerializesModels;
 
     public function __construct(
         public readonly string $notifiableType,
+        private readonly int|string $notifiableId,
         public readonly string $notifiableUuid,
         public readonly string $uuid,
         public readonly string $status,
@@ -60,6 +64,7 @@ class DvrRecordingStatusEvent implements ShouldBroadcast
 
         return new self(
             notifiableType: $playlist->getMorphClass(),
+            notifiableId: $playlist->getKey(),
             notifiableUuid: $playlist->uuid,
             uuid: $recording->uuid,
             status: $status,
@@ -76,7 +81,7 @@ class DvrRecordingStatusEvent implements ShouldBroadcast
      */
     public function broadcastOn(): array
     {
-        return [new PrivateChannel("tv.{$this->notifiableType}.{$this->notifiableUuid}")];
+        return self::entitledTvChannels($this->notifiableType, $this->notifiableId, $this->notifiableUuid);
     }
 
     public function broadcastAs(): string

--- a/app/Events/TvNotificationEvent.php
+++ b/app/Events/TvNotificationEvent.php
@@ -2,7 +2,7 @@
 
 namespace App\Events;
 
-use App\Models\PlaylistAuth;
+use App\Events\Concerns\BroadcastsToEntitledTvChannels;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
@@ -11,7 +11,7 @@ use Illuminate\Queue\SerializesModels;
 
 class TvNotificationEvent implements ShouldBroadcast
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use BroadcastsToEntitledTvChannels, Dispatchable, InteractsWithSockets, SerializesModels;
 
     public function __construct(
         public readonly string $id,
@@ -34,43 +34,20 @@ class TvNotificationEvent implements ShouldBroadcast
     {
         $type = $this->notifiableType;
         $uuid = $this->notifiableUuid;
-        $adminChannel = new PrivateChannel("tv.{$type}-admin.{$uuid}");
 
         if ($this->adminOnly) {
-            return [$adminChannel];
+            return [new PrivateChannel("tv.{$type}-admin.{$uuid}")];
         }
 
         if ($this->playlistAuthId !== null) {
             return [new PrivateChannel("tv.{$type}.{$uuid}.{$this->playlistAuthId}")];
         }
 
-        $channels = [
-            new PrivateChannel("tv.{$type}.{$uuid}"),
-            $adminChannel,
-        ];
-
         // An entitled auth may be assigned directly to this model, or to a PlaylistAlias
         // wrapping it — in the latter case it only ever subscribed to its alias's own
         // channel, so the channel must be built from whichever model the auth is actually
         // assigned to, not from this broadcast's own $type/$uuid.
-        $entitled = PlaylistAuth::query()
-            ->entitledToNotificationRecipient($type, $this->notifiableId)
-            ->with('assignedPlaylist.authenticatable')
-            ->get();
-
-        foreach ($entitled as $playlistAuth) {
-            $authenticatable = $playlistAuth->assignedPlaylist?->authenticatable;
-
-            if (! $authenticatable) {
-                continue;
-            }
-
-            $channels[] = new PrivateChannel(
-                "tv.{$authenticatable->getMorphClass()}.{$authenticatable->uuid}.{$playlistAuth->id}"
-            );
-        }
-
-        return $channels;
+        return self::entitledTvChannels($type, $this->notifiableId, $uuid);
     }
 
     public function broadcastAs(): string

--- a/tests/Feature/DvrRecordingStatusEventTest.php
+++ b/tests/Feature/DvrRecordingStatusEventTest.php
@@ -13,6 +13,7 @@ use App\Models\DvrRecording;
 use App\Models\DvrSetting;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Models\PlaylistAuth;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
@@ -110,7 +111,7 @@ it('broadcasts a deleted status when the recording is removed', function () {
     );
 });
 
-it('broadcasts on the private channel scoped to the playlist uuid', function () {
+it('broadcasts on the owner and admin channels scoped to the playlist uuid', function () {
     $recording = DvrRecording::factory()
         ->for($this->user)
         ->for($this->dvrSetting)
@@ -119,13 +120,38 @@ it('broadcasts on the private channel scoped to the playlist uuid', function () 
     $recording->save();
 
     $event = DvrRecordingStatusEvent::fromRecording($recording->fresh());
-    $channels = $event->broadcastOn();
+    $channels = collect($event->broadcastOn())->pluck('name');
 
-    expect($channels)->toHaveCount(1);
-    expect($channels[0]->name)->toBe(
-        "private-tv.{$this->playlist->getMorphClass()}.{$this->playlist->uuid}"
+    expect($channels)->toHaveCount(2);
+    expect($channels)->toContain(
+        "private-tv.{$this->playlist->getMorphClass()}.{$this->playlist->uuid}",
+        "private-tv.{$this->playlist->getMorphClass()}-admin.{$this->playlist->uuid}",
     );
     expect($event->broadcastAs())->toBe('dvr.status');
+});
+
+it('also broadcasts on every entitled PlaylistAuth channel, not just the owner channel', function () {
+    // Regression: a TV session logged in via PlaylistAuth credentials (rather
+    // than owner_auth) subscribes only to its own `tv.{type}.{uuid}.{authId}`
+    // channel — never the bare owner channel. Before this fix, dvr.status
+    // pushes only went to the owner channel, so such sessions never saw the
+    // EPG "recording" dot or DVR status label update from the push alone.
+    $playlistAuth = PlaylistAuth::factory()->for($this->user)->create(['enabled' => true]);
+    $playlistAuth->assignTo($this->playlist);
+
+    $recording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->for($this->channel)
+        ->make(['status' => DvrRecordingStatus::Scheduled]);
+    $recording->save();
+
+    $event = DvrRecordingStatusEvent::fromRecording($recording->fresh());
+    $channels = collect($event->broadcastOn())->pluck('name');
+
+    expect($channels)->toContain(
+        "private-tv.{$this->playlist->getMorphClass()}.{$this->playlist->uuid}.{$playlistAuth->id}"
+    );
 });
 
 it('serializes the wire payload with snake_case keys matching DvrRecording.fromXtream on the client', function () {


### PR DESCRIPTION
## Summary
- `DvrRecordingStatusEvent` only ever broadcast on the bare `tv.{type}.{uuid}` channel. A TV session logged in via PlaylistAuth credentials (rather than owner_auth) subscribes only to its own `tv.{type}.{uuid}.{authId}` channel — `TvNotificationEvent` already knew this and broadcasts to that channel (plus admin) for every entitled PlaylistAuth. That's why toast notifications worked while the DVR "recording" dot / status label on the TV app never updated from the push alone — it only caught up when scheduling a second recording forced a full `get_dvr_recordings` refresh.
- Extracts the shared channel-set resolution into `App\Events\Concerns\BroadcastsToEntitledTvChannels` so `TvNotificationEvent` and `DvrRecordingStatusEvent` can't drift apart on this again.
- Also fixes the `deleted` status push (`DvrRecording::broadcastDeleted()`), which `AppStateController._onDvrStatusPush` on the TV client relies on to drop cancelled/deleted recordings locally — this is part of m3ue/m3u-tv#131's "reject stale REST results after newer status or delete events" scope, and was previously non-functional for any PlaylistAuth-scoped session.

## Test plan
- [x] `DvrRecordingStatusEventTest`, `DvrTvNotificationTest`, `TvNotificationTest` pass in isolation off `dev` (37 tests)
- [x] Verified live against the test stack with real seeded data: `/api/tv/{user}/{pass}/notifications` for a PlaylistAuth-scoped login reports channel `private-tv.playlist.{uuid}.{authId}`; `DvrRecordingStatusEvent::broadcastOn()` for a recording on that same playlist now includes that exact channel for status-change, cancel, and delete
- [x] Confirmed end-to-end via the live Docker stack: scheduling → recording → cancel → delete all correctly target the PlaylistAuth-scoped channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)