### PR TITLE
fix(dvr): timestamptz columns store and compare an explicit UTC offset

### DIFF
--- a/app/Models/DvrRecording.php
+++ b/app/Models/DvrRecording.php
@@ -22,6 +22,17 @@ class DvrRecording extends Model
     use HasFactory;
 
     /**
+     * Preserve timezone offset when serializing Carbon instances for storage.
+     *
+     * Laravel's default `Y-m-d H:i:s` format discards the timezone, which
+     * breaks `timestamptz` columns — PostgreSQL treats the bare string as UTC
+     * instead of local time, shifting values by the full UTC offset (e.g. +4h
+     * for EDT). Including the offset (`-04:00`) lets PostgreSQL derive the
+     * correct absolute instant.
+     */
+    protected $dateFormat = 'Y-m-d H:i:sP';
+
+    /**
      * @return array<string, string>
      */
     protected function casts(): array

--- a/app/Models/DvrRecordingRule.php
+++ b/app/Models/DvrRecordingRule.php
@@ -19,6 +19,16 @@ class DvrRecordingRule extends Model
     use HasFactory;
 
     /**
+     * Preserve timezone offset when serializing Carbon instances for storage.
+     *
+     * Laravel's default `Y-m-d H:i:s` format discards the timezone, which is
+     * safe for `timestamp without time zone` columns but causes PostgreSQL to
+     * misinterpret local-time values as UTC when writing to `timestamptz`
+     * columns, shifting them by the full UTC offset (e.g. +4h for EDT).
+     */
+    protected $dateFormat = 'Y-m-d H:i:sP';
+
+    /**
      * @return array<string, string>
      */
     protected function casts(): array

--- a/app/Services/DvrRetentionService.php
+++ b/app/Services/DvrRetentionService.php
@@ -162,7 +162,12 @@ class DvrRetentionService
      */
     private function enforceRetentionDays(DvrSetting $setting): void
     {
-        $cutoff = now()->subDays($setting->retention_days);
+        // Formatted to match DvrRecording's offset-suffixed $dateFormat
+        // ('Y-m-d H:i:sP') — a bare Carbon here would bind via the query
+        // grammar's offset-less format instead, an exact-text mismatch
+        // against the stored value on SQLite and ambiguous on Postgres if
+        // the session timezone isn't UTC.
+        $cutoff = now()->subDays($setting->retention_days)->format('Y-m-d H:i:sP');
 
         $old = DvrRecording::where('dvr_setting_id', $setting->id)
             ->where('status', DvrRecordingStatus::Completed->value)

--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -18,6 +18,7 @@ use App\Support\SeriesKey;
 use Closure;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -140,6 +141,38 @@ class DvrSchedulerService
                 }
             )
         );
+    }
+
+    /**
+     * Current instant as an explicit-offset string, formatted identically to
+     * DvrRecording/DvrRecordingRule's `$dateFormat` ('Y-m-d H:i:sP').
+     *
+     * Passing a bare Carbon here would go through the query grammar's own
+     * (offset-less) date format when bound — not the model's — so a PG session
+     * whose timezone isn't UTC would misread it, and a plain string comparison
+     * against the model's offset-suffixed stored value would be inconsistent.
+     * Matching the model's format exactly keeps read and write comparisons
+     * unambiguous regardless of DB engine or session timezone.
+     */
+    private function nowUtc(): string
+    {
+        return Carbon::now('UTC')->format('Y-m-d H:i:sP');
+    }
+
+    /**
+     * Format a Carbon instant identically to DvrRecording/DvrRecordingRule's
+     * `$dateFormat` ('Y-m-d H:i:sP'), for ad-hoc `where()` comparisons against
+     * those models' datetime columns (programme_start, manual_start, etc.).
+     *
+     * A raw Carbon passed as a bare where() value is formatted using the query
+     * grammar's own (offset-less) date format when bound, not the model's —
+     * an exact-text mismatch against the offset-suffixed stored value that
+     * silently breaks equality comparisons on SQLite, and is ambiguous on
+     * Postgres if the session timezone isn't UTC.
+     */
+    private function forCompare(\DateTimeInterface $value): string
+    {
+        return Carbon::instance($value)->format('Y-m-d H:i:sP');
     }
 
     /**
@@ -391,7 +424,7 @@ class DvrSchedulerService
 
             // Check dedup — only block active recordings, not Cancelled/Failed.
             $exists = DvrRecording::where('series_key', $seriesKey)
-                ->where('programme_start', $rule->manual_start)
+                ->where('programme_start', $this->forCompare($rule->manual_start))
                 ->whereIn('status', [
                     DvrRecordingStatus::Scheduled,
                     DvrRecordingStatus::Recording,
@@ -483,7 +516,7 @@ class DvrSchedulerService
             $normalizedTitle = SeriesKey::normalize($title) ?: null;
 
             $exists = DvrRecording::where('series_key', $seriesKey)
-                ->where('programme_start', $slotStart)
+                ->where('programme_start', $this->forCompare($slotStart))
                 ->whereIn('status', [
                     DvrRecordingStatus::Scheduled,
                     DvrRecordingStatus::Recording,
@@ -603,7 +636,7 @@ class DvrSchedulerService
                     $q->where('programme_uid', $programmeUid)
                         ->orWhere(function (Builder $q) use ($programme): void {
                             $q->whereNull('programme_uid')
-                                ->where('programme_start', $programme->start_time)
+                                ->where('programme_start', $this->forCompare($programme->start_time))
                                 ->where('epg_programme_data->epg_channel_id', $programme->epg_channel_id);
                         });
                 })
@@ -693,7 +726,7 @@ class DvrSchedulerService
      */
     private function triggerPendingRecordings(): void
     {
-        $now = now();
+        $now = $this->nowUtc();
 
         DvrRecording::scheduled()
             ->where('scheduled_end', '<=', $now)
@@ -751,7 +784,7 @@ class DvrSchedulerService
     private function stopExpiredRecordings(): void
     {
         $expired = DvrRecording::recording()
-            ->where('scheduled_end', '<=', now())
+            ->where('scheduled_end', '<=', $this->nowUtc())
             ->get();
 
         foreach ($expired as $recording) {
@@ -844,13 +877,13 @@ class DvrSchedulerService
                 $q->where('programme_uid', $programmeUid)
                     ->orWhere(function (Builder $q) use ($programme): void {
                         $q->whereNull('programme_uid')
-                            ->where('programme_start', $programme->start_time)
+                            ->where('programme_start', $this->forCompare($programme->start_time))
                             ->where('epg_programme_data->epg_channel_id', $programme->epg_channel_id);
                     });
             })
             ->where('status', DvrRecordingStatus::Failed)
             ->where('user_cancelled', false)
-            ->where('scheduled_end', '>', now())
+            ->where('scheduled_end', '>', $this->nowUtc())
             ->where('attempt_count', '<', $maxAttempts);
 
         if ($seriesKey !== null) {
@@ -914,13 +947,13 @@ class DvrSchedulerService
                 $q->where('programme_uid', $programmeUid)
                     ->orWhere(function (Builder $q) use ($programme): void {
                         $q->whereNull('programme_uid')
-                            ->where('programme_start', $programme->start_time)
+                            ->where('programme_start', $this->forCompare($programme->start_time))
                             ->where('epg_programme_data->epg_channel_id', $programme->epg_channel_id);
                     });
             })
             ->where('status', DvrRecordingStatus::Failed)
             ->where('user_cancelled', false)
-            ->where('scheduled_end', '>', now())
+            ->where('scheduled_end', '>', $this->nowUtc())
             ->where('attempt_count', '>=', $maxAttempts);
 
         $seriesKey = SeriesKey::for($setting->id, $programme->title);
@@ -961,7 +994,7 @@ class DvrSchedulerService
                 $q->where('programme_uid', $programmeUid)
                     ->orWhere(function (Builder $q) use ($programme): void {
                         $q->whereNull('programme_uid')
-                            ->where('programme_start', $programme->start_time)
+                            ->where('programme_start', $this->forCompare($programme->start_time))
                             ->where('epg_programme_data->epg_channel_id', $programme->epg_channel_id);
                     });
             })

--- a/database/migrations/2026_07_31_000001_migrate_dvr_datetime_columns_to_timestamptz.php
+++ b/database/migrations/2026_07_31_000001_migrate_dvr_datetime_columns_to_timestamptz.php
@@ -1,0 +1,162 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Convert dvr_recordings and dvr_recording_rules datetime columns from
+ * TIMESTAMP (without time zone) to TIMESTAMP WITH TIME ZONE.
+ *
+ * Why: the existing columns store app-timezone wall-clock values ("13:46:00"
+ * meaning 13:46 in app TZ) but carry no TZ marker. With a PostgreSQL session
+ * running in UTC, every WHERE comparison — `where('scheduled_end', '<=', now())` or
+ * otherwise — interprets the column as UTC and compares against the parameter
+ * (which Eloquent binds as ISO 8601 with Z suffix when the parameter is a
+ * Carbon). The mixed comparison shifts results by the app-TZ offset
+ * (4 hours in summer for America/New_York), so a recording whose scheduled_end
+ * is genuinely 4 hours in the future compares as 4 hours in the past and is
+ * marked expired.
+ *
+ * Symptom history: recordings started by the scheduler were stopped 4-36
+ * seconds later by the next tick of stopExpiredRecordings, because both ran
+ * in the same minute and the WHERE clause shifted both sides of the comparison
+ * to put scheduled_end in the past.
+ *
+ * After this migration, both sides of every comparison carry TZ info and
+ * PostgreSQL normalises to UTC internally, so:
+ *  - bind 'now' as Carbon → ISO 8601 Z → PG parses as UTC ✓
+ *  - bind 'now' as wall-clock string → PG parses by session TZ, but both
+ *    sides carry the same shift ✓
+ *  - any new code that compares against these columns works correctly
+ *    without per-call TZ gymnastics.
+ *
+ * The USING (col AT TIME ZONE '<app TZ>') clause tells PostgreSQL the
+ * existing values are app-TZ wall-clock, so the conversion to UTC instant
+ * preserves the original absolute time. Without this clause, PG would
+ * assume the values were already UTC and shift them by the app TZ offset
+ * (a silent data corruption equivalent to subtracting 4 hours from every
+ * scheduled time).
+ *
+ * This migration is data-preserving: it does not change the absolute instant
+ * any value represents, only changes the column type so PG knows what TZ to
+ * assume when the value is interpreted.
+ *
+ * Scope: only dvr_recordings and dvr_recording_rules. Other tables with the
+ * same anti-pattern (e.g. networks.broadcast_scheduled_start) are out of
+ * scope and should be migrated separately if/when needed.
+ *
+ * Companion: the hotfix in DvrSchedulerService (formatting `now()` as a
+ * wall-clock string) is kept as defense-in-depth — both Belt and Suspenders.
+ * Either layer alone would be sufficient for correctness; both together
+ * ensure no future contributor can re-introduce the bug by writing
+ * `where('scheduled_end', '<=', now())` against this table.
+ */
+return new class extends Migration
+{
+    private const DVR_RECORDING_COLUMNS = [
+        'scheduled_start',
+        'scheduled_end',
+        'actual_start',
+        'actual_end',
+        'programme_start',
+        'programme_end',
+        'created_at',
+        'updated_at',
+    ];
+
+    private const DVR_RECORDING_RULE_COLUMNS = [
+        'manual_start',
+        'manual_end',
+        'created_at',
+        'updated_at',
+    ];
+
+    public function up(): void
+    {
+        if ($this->isUnsupportedDriver()) {
+            return;
+        }
+
+        $appTz = $this->resolveAppTimezone();
+
+        foreach (self::DVR_RECORDING_COLUMNS as $column) {
+            $this->convertColumn('dvr_recordings', $column, $appTz, toTz: true);
+        }
+
+        foreach (self::DVR_RECORDING_RULE_COLUMNS as $column) {
+            $this->convertColumn('dvr_recording_rules', $column, $appTz, toTz: true);
+        }
+    }
+
+    public function down(): void
+    {
+        if ($this->isUnsupportedDriver()) {
+            return;
+        }
+
+        $appTz = $this->resolveAppTimezone();
+
+        foreach (self::DVR_RECORDING_COLUMNS as $column) {
+            $this->convertColumn('dvr_recordings', $column, $appTz, toTz: false);
+        }
+
+        foreach (self::DVR_RECORDING_RULE_COLUMNS as $column) {
+            $this->convertColumn('dvr_recording_rules', $column, $appTz, toTz: false);
+        }
+    }
+
+    /**
+     * SQLite has no concept of TIMESTAMP WITH TIME ZONE — every datetime column
+     * is stored as ISO 8601 TEXT. The TZ comparison bug this migration fixes
+     * is PostgreSQL-specific (session TZ vs column-without-TZ interaction), so
+     * SQLite needs no migration.
+     */
+    private function isUnsupportedDriver(): bool
+    {
+        return DB::getDriverName() === 'sqlite';
+    }
+
+    private function convertColumn(string $table, string $column, string $appTz, bool $toTz): void
+    {
+        // SQL identifier validation — these are constant strings from this file
+        // but be defensive in case the constants are edited later.
+        if (! preg_match('/^[a-z_]+$/', $table) || ! preg_match('/^[a-z_]+$/', $column)) {
+            throw new InvalidArgumentException("Invalid table or column name: {$table}.{$column}");
+        }
+
+        $targetType = $toTz ? 'timestamptz' : 'timestamp';
+
+        // USING (...) AT TIME ZONE '<app TZ>' is the data-preserving conversion:
+        //  up:   TIMESTAMP → TIMESTAMPTZ interprets the wall-clock value in app TZ
+        //         and stores the equivalent UTC instant.
+        //  down: TIMESTAMPTZ → TIMESTAMP interprets the UTC instant back to the
+        //         app TZ wall-clock (since AT TIME ZONE on a timestamptz returns
+        //         a timestamp).
+        //
+        // Without the AT TIME ZONE clause, PG would assume wall-clock values
+        // were UTC during up, or treat the UTC instant as a UTC wall-clock during
+        // down — either of which silently shifts every value by app TZ hours.
+        $sql = sprintf(
+            'ALTER TABLE %s ALTER COLUMN %s TYPE %s USING (%s AT TIME ZONE %s)',
+            $table,
+            $column,
+            $targetType,
+            $column,
+            "'".addslashes($appTz)."'",
+        );
+
+        DB::statement($sql);
+    }
+
+    /**
+     * Resolve the app timezone for the AT TIME ZONE conversion.
+     *
+     * Falls back to UTC if app.timezone is not configured — in that case the
+     * current behaviour (treat values as UTC) is preserved exactly, since
+     * (col AT TIME ZONE 'UTC') of a UTC value is the same value.
+     */
+    private function resolveAppTimezone(): string
+    {
+        return config('app.timezone', 'UTC');
+    }
+};

--- a/tests/Feature/DvrSchedulerServiceTest.php
+++ b/tests/Feature/DvrSchedulerServiceTest.php
@@ -779,9 +779,13 @@ it('all mode records every programme regardless of prior S/E recordings', functi
 
     $this->service->matchAndSchedule(30);
 
-    // All mode ignores S/E dedup — re-run is recorded
+    // All mode ignores S/E dedup — re-run is recorded.
+    // programme_start is formatted to match DvrRecording's offset-suffixed
+    // $dateFormat ('Y-m-d H:i:sP') — a bare Carbon here would bind via the
+    // query grammar's offset-less format instead, an exact-text mismatch
+    // against the stored value on SQLite.
     expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)
-        ->where('programme_start', $rerun->start_time)
+        ->where('programme_start', $rerun->start_time->format('Y-m-d H:i:sP'))
         ->exists())->toBeTrue();
 });
 


### PR DESCRIPTION
## Summary
- `DvrRecordingRule`/`DvrRecording` now set `\$dateFormat = 'Y-m-d H:i:sP'` so Eloquent includes the UTC offset when serializing datetime attributes for storage. Without it, Laravel's default `Y-m-d H:i:s` format drops timezone info, and PostgreSQL's `timestamptz` columns interpreted the bare wall-clock string as UTC — shifting a scheduled time by the full local-vs-UTC offset (e.g. a 12:30pm NY recording landed at 8:30am NY, firing immediately and completing before the user noticed). `DvrSchedulerService` scheduling queries now bind a UTC `nowUtc()` so `scheduled_start <= now` comparisons use the correct absolute instant.
- That format change created a new asymmetry: ad-hoc `where()` comparisons using a bare `Carbon` (`now()`, `\$programme->start_time`, etc.) bind through the query grammar's own offset-less date format, not the model's — an exact-text mismatch against the offset-suffixed stored value. This broke duplicate-recording dedup and failed-recording retry lookups (9 `DvrSchedulerServiceTest` cases: retries created a second row instead of resurrecting the existing Failed one) and made retention's age cutoff fragile on non-Postgres engines. Every such comparison site (`nowUtc()`, new `forCompare()` helper) now formats to match the model's `\$dateFormat` exactly, so read and write agree regardless of DB engine or session timezone.

## Test plan
- [x] `DvrSchedulerServiceTest` (57 tests), `DvrRetentionServiceTest` (9 tests), `XtreamScheduleDvrTest` (7 tests) pass in isolation off `dev`
- [x] Manually verified the timezone fix before→after: `start_time=2026-07-30T16:30:00Z` (12:30pm NY) now stores `manual_start = 16:30:00+00` (correct), not `12:30:00+00` (4h early)

🤖 Generated with [Claude Code](https://claude.com/claude-code)