### PR TITLE
fix(dvr): use the rule's real programme title, not the channel name

### DIFF
--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -379,13 +379,18 @@ class DvrSchedulerService
                 return;
             }
 
-            // Manual recordings have no canonical "title" until we resolve from the
-            // channel below — derive series_key from the channel display name when
-            // available, falling back to a per-rule key so dedup is at least scoped.
+            // Manual rules scheduled via the Xtream API (schedule_dvr) always carry the
+            // real programme title in series_title — the TV app only creates these when
+            // recording a specific, known EPG entry (see XtreamApiController::scheduleDvr()).
+            // The Filament admin form has no series_title field for Manual rules (a bare
+            // channel + time window, no known show), so only fall back to the channel's
+            // display name when it's genuinely absent. Getting this wrong means the
+            // recording's title — and everything keyed off it, including TMDB/TVMaze
+            // metadata matching and series-based retention grouping — silently uses the
+            // channel/station name instead of the actual show.
             $channel = $rule->channel;
-            $title = $channel
-                ? ($channel->title_custom ?? $channel->title ?? 'Manual Recording')
-                : 'Manual Recording';
+            $title = $rule->series_title
+                ?: ($channel ? ($channel->title_custom ?? $channel->title ?? 'Manual Recording') : 'Manual Recording');
             $seriesKey = SeriesKey::for($setting->id, $title) ?? "setting:{$setting->id}|rule:{$rule->id}";
             $normalizedTitle = SeriesKey::normalize($title) ?: null;
 

--- a/tests/Feature/DvrSchedulerServiceTest.php
+++ b/tests/Feature/DvrSchedulerServiceTest.php
@@ -31,6 +31,7 @@ use App\Models\EpgChannel;
 use App\Models\EpgProgramme;
 use App\Models\User;
 use App\Services\DvrSchedulerService;
+use App\Support\SeriesKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
 
@@ -265,6 +266,57 @@ it('creates a scheduled recording for a manual rule within the lookahead window'
     expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(1);
     expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->first()->title)
         ->toBe('Manual Recording');
+});
+
+it('uses the channel display name when a manual rule has no series_title', function () {
+    $channel = Channel::factory()
+        ->for($this->setting->playlist)
+        ->create(['title_custom' => 'News 24']);
+
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($channel, 'channel')
+        ->create([
+            'type' => DvrRuleType::Manual,
+            'series_title' => null,
+            'manual_start' => now()->addMinutes(10),
+            'manual_end' => now()->addMinutes(70),
+        ]);
+
+    $this->service->matchAndSchedule(30);
+
+    $recording = DvrRecording::where('dvr_recording_rule_id', $rule->id)->first();
+    expect($recording->title)->toBe('News 24');
+});
+
+it('uses the rule\'s series_title (the real programme title) over the channel name for a manual rule', function () {
+    // Regression: XtreamApiController::scheduleDvr() (used by the TV app when
+    // recording a specific EPG entry) always stores the real programme title on
+    // series_title. Before this fix, the scheduler ignored it and derived the
+    // recording's title from the channel/station name instead — breaking TMDB/
+    // TVMaze metadata matching (DvrMetadataEnricherService searches by title)
+    // and series-based retention grouping, both keyed off the wrong name.
+    $channel = Channel::factory()
+        ->for($this->setting->playlist)
+        ->create(['title_custom' => 'ABC NETWORK']);
+
+    $rule = DvrRecordingRule::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($channel, 'channel')
+        ->create([
+            'type' => DvrRuleType::Manual,
+            'series_title' => 'Breaking Bad',
+            'manual_start' => now()->addMinutes(10),
+            'manual_end' => now()->addMinutes(70),
+        ]);
+
+    $this->service->matchAndSchedule(30);
+
+    $recording = DvrRecording::where('dvr_recording_rule_id', $rule->id)->first();
+    expect($recording->title)->toBe('Breaking Bad');
+    expect($recording->series_key)->toBe(SeriesKey::for($this->setting->id, 'Breaking Bad'));
 });
 
 it('creates a scheduled recording for a manual rule more than 30 minutes in the future', function () {

--- a/tests/Feature/XtreamScheduleDvrTest.php
+++ b/tests/Feature/XtreamScheduleDvrTest.php
@@ -115,6 +115,11 @@ it('materialises a Scheduled DvrRecording in the same request via the boot event
     expect($recording)->not->toBeNull('Manual rule should immediately produce a DvrRecording row');
     expect($recording->status)->toBe(DvrRecordingStatus::Scheduled);
     expect($recording->channel_id)->toBe($this->channel->id);
+    // Regression: the recording's title must be the real programme title the TV
+    // app supplied ("Late Show"), not the channel/station name — the scheduler
+    // used to ignore the rule's series_title here, which broke TMDB/TVMaze
+    // metadata matching and series-based retention grouping.
+    expect($recording->title)->toBe('Late Show');
     expect($recording->scheduled_start->equalTo($rule->manual_start->copy()->subSeconds($rule->start_early_seconds)))->toBeTrue();
     expect($recording->scheduled_end->equalTo($rule->manual_end->copy()->addSeconds($rule->end_late_seconds)))->toBeTrue();
 });


### PR DESCRIPTION
## Summary
- Manual DVR rules created via the Xtream API (`schedule_dvr`) always carry the real programme title in `series_title` — the TV app only creates these when recording a specific, known EPG entry (see `XtreamApiController::scheduleDvr()`). Manual rules created through the Filament admin form have no `series_title` field (a bare channel + time window, no known show).
- `DvrSchedulerService::matchManualRule()` was ignoring `series_title` entirely and always falling back to the channel's display name (`title_custom`/`title`), so a recorded show's `title` ended up as the station/channel name instead of the actual programme.
- Getting this wrong silently breaks everything keyed off `title`, including TMDB/TVMaze metadata matching (`DvrMetadataEnricherService`) and series-based retention grouping — a recorded episode never gets matched to its real show, and looks like a fresh "series" every time.
- Fix: prefer `$rule->series_title` when present, falling back to the channel name only when it's genuinely absent (admin-created Manual rules).

## Test plan
- [x] New tests in `DvrSchedulerServiceTest` (channel-name fallback when `series_title` is null; `series_title` takes precedence over channel name when both are present)
- [x] `XtreamScheduleDvrTest` extended to assert `title` matches the real programme title, not the channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)