### PR TITLE
fix(dvr): cancel preserves captured footage through post-processing

### DIFF
--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -3391,7 +3391,15 @@ class XtreamApiController extends Controller
     }
 
     /**
-     * Delete a completed or failed DVR recording.
+     * Delete a completed, failed, cancelled, or post-processing DVR recording.
+     *
+     * PostProcessing is included alongside the terminal statuses because
+     * DvrRecorderService::cancel() now routes a recording that had already
+     * captured footage through post-processing (so a "kept" cancelled
+     * recording ends up Completed/playable) rather than marking it Cancelled
+     * immediately — the TV app's "Delete recording" choice calls cancel then
+     * delete back-to-back, so by the time this runs such a recording is
+     * already in PostProcessing, not Cancelled.
      */
     private function deleteDvrRecording(Request $request, $playlist): \Illuminate\Http\JsonResponse
     {
@@ -3409,7 +3417,12 @@ class XtreamApiController extends Controller
 
         $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
             ->where('uuid', $uuid)
-            ->whereIn('status', [DvrRecordingStatus::Completed, DvrRecordingStatus::Failed, DvrRecordingStatus::Cancelled])
+            ->whereIn('status', [
+                DvrRecordingStatus::Completed,
+                DvrRecordingStatus::Failed,
+                DvrRecordingStatus::Cancelled,
+                DvrRecordingStatus::PostProcessing,
+            ])
             ->first();
 
         if (! $recording) {

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -3400,6 +3400,11 @@ class XtreamApiController extends Controller
      * immediately — the TV app's "Delete recording" choice calls cancel then
      * delete back-to-back, so by the time this runs such a recording is
      * already in PostProcessing, not Cancelled.
+     *
+     * A PostProcessing recording deleted this way almost always still has its
+     * proxy_network_id set - the post-processing job that would normally free
+     * those resources hasn't had a chance to run yet. releaseProxyResources()
+     * frees them here instead of leaving them orphaned on the proxy.
      */
     private function deleteDvrRecording(Request $request, $playlist): \Illuminate\Http\JsonResponse
     {
@@ -3428,6 +3433,8 @@ class XtreamApiController extends Controller
         if (! $recording) {
             return response()->json(['error' => 'Recording not found or not deletable'], 404);
         }
+
+        app(DvrRecorderService::class)->releaseProxyResources($recording);
 
         $recording->delete();
 

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -212,15 +212,26 @@ class DvrRecorderService
     }
 
     /**
-     * Cancel a recording - stops the proxy broadcast and marks as cancelled.
+     * Cancel a recording - stops the proxy broadcast (if any) and marks as cancelled.
      *
      * NOTE: We do NOT cleanup the proxy files here. The callback will fire when
      * FFmpeg actually stops, and post-processing will handle cleanup. This ensures
      * we don't delete segments that are still being written.
+     *
+     * A recording that had already started (proxy_network_id was set) has real
+     * footage worth keeping — the user may choose to keep this recording rather
+     * than discard it (see XtreamApiController::cancelDvrRecording / the TV app's
+     * "Keep recording" option), so it goes through the same stop → post-processing
+     * pipeline as a natural completion instead of being marked Cancelled directly.
+     * It ends up Completed (playable) like any other recording; user_cancelled and
+     * error_message are preserved through post-processing as a "stopped early" marker.
+     * A recording that never started (still Scheduled) has nothing to process, so
+     * it's marked Cancelled immediately as before.
      */
     public function cancel(DvrRecording $recording): void
     {
         $networkId = $recording->proxy_network_id;
+        $hadFootage = (bool) $networkId;
 
         if ($networkId) {
             $this->proxy->stopDvrBroadcast($networkId);
@@ -228,17 +239,7 @@ class DvrRecorderService
             // so we don't delete segments that are still being written
         }
 
-        $recording->update([
-            'status' => DvrRecordingStatus::Cancelled->value,
-            'actual_end' => now(),
-            'proxy_network_id' => null,
-            'error_message' => 'Cancelled by user',
-            'user_cancelled' => true,
-        ]);
-
-        $recording->notifyTv(__('Recording Cancelled'), 'warning');
-
-        // Delete "once" rules when the recording is cancelled - they're one-shot
+        // Delete "once" rules on cancel regardless of outcome below - they're one-shot.
         $rule = $recording->recordingRule;
         if ($rule && $rule->type === DvrRuleType::Once) {
             $rule->delete();
@@ -248,6 +249,30 @@ class DvrRecorderService
                 'rule_id' => $rule->id,
             ]);
         }
+
+        if (! $hadFootage) {
+            $recording->update([
+                'status' => DvrRecordingStatus::Cancelled->value,
+                'actual_end' => now(),
+                'proxy_network_id' => null,
+                'error_message' => 'Cancelled by user',
+                'user_cancelled' => true,
+            ]);
+
+            $recording->notifyTv(__('Recording Cancelled'), 'warning');
+
+            return;
+        }
+
+        $recording->update([
+            'actual_end' => now(),
+            'error_message' => 'Cancelled by user',
+            'user_cancelled' => true,
+        ]);
+
+        $recording->notifyTv(__('Recording Cancelled'), 'warning');
+
+        $this->finalizeStop($recording);
     }
 
     /**

--- a/app/Services/DvrRecorderService.php
+++ b/app/Services/DvrRecorderService.php
@@ -276,6 +276,26 @@ class DvrRecorderService
     }
 
     /**
+     * Release a recording's proxy-side broadcast/segment files without running
+     * post-processing.
+     *
+     * PostProcessDvrRecording normally owns this cleanup (see
+     * DvrPostProcessorService), but that job may never get the chance to run
+     * on a recording that's about to be deleted - e.g. the TV app's "Delete
+     * recording" choice calls cancel_dvr_recording then delete_dvr_recording
+     * back-to-back, well before the (delayed/callback-triggered) job executes.
+     * Call this before deleting a recording that still has a proxy_network_id
+     * so those resources aren't leaked. Safe to call on a recording the job
+     * already cleaned up - proxy_network_id will already be null by then.
+     */
+    public function releaseProxyResources(DvrRecording $recording): void
+    {
+        if ($recording->proxy_network_id) {
+            $this->proxy->cleanupDvrBroadcast($recording->proxy_network_id);
+        }
+    }
+
+    /**
      * Transition a stopped recording to POST_PROCESSING and dispatch the concat job.
      *
      * proxy_network_id is intentionally preserved through post-processing so the

--- a/tests/Feature/DvrRecorderServiceTest.php
+++ b/tests/Feature/DvrRecorderServiceTest.php
@@ -7,11 +7,13 @@
  * - Recording uses the raw source URL (url_custom ?? url) — no double-proxying
  * - start() stores proxy_network_id, sets status to Recording, and sends a bell notification
  * - stop() preserves proxy_network_id (downloader needs it) and transitions to PostProcessing
- * - cancel() calls proxy stop AND cleanup (no post-processing for cancelled)
+ * - cancel() on a recording with captured footage routes through post-processing like stop()
+ * - cancel() on a recording with no footage (never started) marks Cancelled immediately
  * - DvrSetting use_proxy defaults to false
  */
 
 use App\Enums\DvrRecordingStatus;
+use App\Jobs\PostProcessDvrRecording;
 use App\Models\Channel;
 use App\Models\DvrRecording;
 use App\Models\DvrSetting;
@@ -161,7 +163,12 @@ it('calls proxy stop and transitions to PostProcessing while preserving proxy_ne
     expect($fresh->actual_end)->toBeNull();
 });
 
-it('cancel() calls proxy stop but does NOT cleanup (let callback handle it)', function () {
+it('cancel() on a recording with captured footage stops the proxy and routes through post-processing instead of marking Cancelled directly', function () {
+    // "Keep recording" in the TV app: a recording that had already started has real
+    // footage worth keeping, so cancel() preserves it through the same stop() →
+    // post-processing pipeline as a natural completion — it ends up Completed
+    // (playable), not stuck as Cancelled with no file. user_cancelled and
+    // error_message survive as a "stopped early" marker.
     $recording = makeScheduledRecording();
     $networkId = $recording->uuid;
     $recording->update([
@@ -177,8 +184,36 @@ it('cancel() calls proxy stop but does NOT cleanup (let callback handle it)', fu
     app(DvrRecorderService::class)->cancel($recording);
 
     $fresh = $recording->fresh();
+    expect($fresh->status)->toBe(DvrRecordingStatus::PostProcessing);
+    // proxy_network_id is preserved through post-processing — the HLS downloader needs it.
+    expect($fresh->proxy_network_id)->toBe($networkId);
+    expect($fresh->user_cancelled)->toBeTrue();
+    expect($fresh->error_message)->toBe('Cancelled by user');
+    expect($fresh->actual_end)->not->toBeNull();
+
+    Queue::assertPushed(PostProcessDvrRecording::class);
+});
+
+it('cancel() on a recording that never started (no footage) marks it Cancelled immediately with no post-processing', function () {
+    // Scheduled but never started: there's no footage to preserve, so this stays
+    // the original immediate-Cancelled behavior — nothing for the proxy to stop
+    // and nothing for post-processing to do.
+    $recording = makeScheduledRecording();
+    expect($recording->status)->toBe(DvrRecordingStatus::Scheduled);
+    expect($recording->proxy_network_id)->toBeNull();
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldNotReceive('stopDvrBroadcast');
+    app()->instance(M3uProxyService::class, $proxy);
+
+    app(DvrRecorderService::class)->cancel($recording);
+
+    $fresh = $recording->fresh();
     expect($fresh->status)->toBe(DvrRecordingStatus::Cancelled);
     expect($fresh->proxy_network_id)->toBeNull();
+    expect($fresh->user_cancelled)->toBeTrue();
+
+    Queue::assertNotPushed(PostProcessDvrRecording::class);
 });
 
 // ── use_proxy default ─────────────────────────────────────────────────────────

--- a/tests/Feature/DvrRecorderServiceTest.php
+++ b/tests/Feature/DvrRecorderServiceTest.php
@@ -9,6 +9,8 @@
  * - stop() preserves proxy_network_id (downloader needs it) and transitions to PostProcessing
  * - cancel() on a recording with captured footage routes through post-processing like stop()
  * - cancel() on a recording with no footage (never started) marks Cancelled immediately
+ * - releaseProxyResources() cleans up the proxy when proxy_network_id is still set (used by
+ *   delete_dvr_recording so a recording deleted before post-processing runs isn't orphaned)
  * - DvrSetting use_proxy defaults to false
  */
 
@@ -214,6 +216,36 @@ it('cancel() on a recording that never started (no footage) marks it Cancelled i
     expect($fresh->user_cancelled)->toBeTrue();
 
     Queue::assertNotPushed(PostProcessDvrRecording::class);
+});
+
+// ── releaseProxyResources() ───────────────────────────────────────────────────
+
+it('releaseProxyResources() cleans up the proxy broadcast when proxy_network_id is still set', function () {
+    $recording = makeScheduledRecording();
+    $recording->update([
+        'status' => DvrRecordingStatus::PostProcessing,
+        'proxy_network_id' => 'test-network-id',
+    ]);
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldReceive('cleanupDvrBroadcast')->once()->with('test-network-id')->andReturn(true);
+    app()->instance(M3uProxyService::class, $proxy);
+
+    app(DvrRecorderService::class)->releaseProxyResources($recording->fresh());
+});
+
+it('releaseProxyResources() is a no-op once proxy_network_id has already been cleared', function () {
+    $recording = makeScheduledRecording();
+    $recording->update([
+        'status' => DvrRecordingStatus::Completed,
+        'proxy_network_id' => null,
+    ]);
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldNotReceive('cleanupDvrBroadcast');
+    app()->instance(M3uProxyService::class, $proxy);
+
+    app(DvrRecorderService::class)->releaseProxyResources($recording->fresh());
 });
 
 // ── use_proxy default ─────────────────────────────────────────────────────────

--- a/tests/Feature/XtreamCancelDeleteDvrTest.php
+++ b/tests/Feature/XtreamCancelDeleteDvrTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * Regression coverage for Xtream `cancel_dvr_recording` / `delete_dvr_recording`.
+ *
+ * Locks in:
+ *   1. Cancelling a recording that never started (Scheduled, no footage) marks it
+ *      Cancelled immediately — nothing for post-processing to do.
+ *   2. Cancelling a recording that already captured footage (Recording, has a
+ *      proxy_network_id) routes it through post-processing instead — it ends up
+ *      PostProcessing, not Cancelled, so it can become a playable Completed
+ *      recording (see DvrRecorderServiceTest for the service-level coverage).
+ *   3. delete_dvr_recording accepts Completed/Failed/Cancelled/PostProcessing —
+ *      PostProcessing is included because the TV app's "Delete recording" choice
+ *      calls cancel_dvr_recording then delete_dvr_recording back-to-back, and a
+ *      footage-having recording is already in PostProcessing by the time the
+ *      delete call arrives.
+ *   4. delete_dvr_recording still rejects Scheduled/Recording (nothing has told
+ *      the proxy to stop yet).
+ */
+
+use App\Enums\DvrRecordingStatus;
+use App\Jobs\PostProcessDvrRecording;
+use App\Models\Channel;
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\PlaylistAuth;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create();
+    $this->username = 'testuser_'.Str::random(5);
+    $this->password = 'testpass';
+
+    PlaylistAuth::create([
+        'name' => 'Test Auth',
+        'username' => $this->username,
+        'password' => $this->password,
+        'enabled' => true,
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->playlist->playlistAuths()->attach(
+        PlaylistAuth::where('username', $this->username)->first()
+    );
+
+    $this->group = Group::factory()->for($this->user)->create();
+    $this->channel = Channel::factory()
+        ->for($this->playlist)
+        ->for($this->group)
+        ->create(['enabled' => true, 'title_custom' => 'News 24']);
+
+    $this->setting = DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create();
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldReceive('stopDvrBroadcast')->andReturn(true);
+    $proxy->shouldReceive('cleanupDvrBroadcast')->andReturn(true);
+    app()->instance(M3uProxyService::class, $proxy);
+});
+
+function xtreamActionUrl(string $username, string $password, string $action): string
+{
+    return route('xtream.api.player').'?'.http_build_query([
+        'username' => $username,
+        'password' => $password,
+        'action' => $action,
+    ]);
+}
+
+it('cancels a scheduled (never-started) recording immediately with no post-processing', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create(['status' => DvrRecordingStatus::Scheduled, 'proxy_network_id' => null]);
+
+    $response = $this->postJson(
+        xtreamActionUrl($this->username, $this->password, 'cancel_dvr_recording'),
+        ['recording_id' => $recording->uuid]
+    );
+
+    $response->assertOk()->assertJson(['success' => true]);
+    expect($recording->fresh()->status)->toBe(DvrRecordingStatus::Cancelled);
+
+    Queue::assertNotPushed(PostProcessDvrRecording::class);
+});
+
+it('cancels a recording with captured footage into PostProcessing, not Cancelled', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create([
+            'status' => DvrRecordingStatus::Recording,
+            'proxy_network_id' => 'test-network-id',
+        ]);
+
+    $response = $this->postJson(
+        xtreamActionUrl($this->username, $this->password, 'cancel_dvr_recording'),
+        ['recording_id' => $recording->uuid]
+    );
+
+    $response->assertOk()->assertJson(['success' => true]);
+    $fresh = $recording->fresh();
+    expect($fresh->status)->toBe(DvrRecordingStatus::PostProcessing);
+    expect($fresh->proxy_network_id)->toBe('test-network-id');
+    expect($fresh->user_cancelled)->toBeTrue();
+
+    Queue::assertPushed(PostProcessDvrRecording::class);
+});
+
+it('deletes a PostProcessing recording — the state a cancelled in-progress recording is in when "Delete recording" chains cancel then delete', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create([
+            'status' => DvrRecordingStatus::PostProcessing,
+            'user_cancelled' => true,
+        ]);
+
+    $response = $this->postJson(
+        xtreamActionUrl($this->username, $this->password, 'delete_dvr_recording'),
+        ['recording_id' => $recording->uuid]
+    );
+
+    $response->assertOk()->assertJson(['success' => true]);
+    expect(DvrRecording::find($recording->id))->toBeNull();
+});
+
+it('rejects deleting a Scheduled or Recording recording — nothing has told the proxy to stop yet', function (DvrRecordingStatus $status) {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create(['status' => $status]);
+
+    $response = $this->postJson(
+        xtreamActionUrl($this->username, $this->password, 'delete_dvr_recording'),
+        ['recording_id' => $recording->uuid]
+    );
+
+    $response->assertNotFound();
+    expect(DvrRecording::find($recording->id))->not->toBeNull();
+})->with([DvrRecordingStatus::Scheduled, DvrRecordingStatus::Recording]);

--- a/tests/Feature/XtreamCancelDeleteDvrTest.php
+++ b/tests/Feature/XtreamCancelDeleteDvrTest.php
@@ -17,6 +17,10 @@
  *      delete call arrives.
  *   4. delete_dvr_recording still rejects Scheduled/Recording (nothing has told
  *      the proxy to stop yet).
+ *   5. delete_dvr_recording releases the proxy broadcast itself when deleting a
+ *      PostProcessing recording — PostProcessDvrRecording (which normally owns
+ *      that cleanup) hasn't had a chance to run yet in the cancel-then-delete
+ *      flow, so without this the proxy-side segment files would be orphaned.
  */
 
 use App\Enums\DvrRecordingStatus;
@@ -28,6 +32,7 @@ use App\Models\Group;
 use App\Models\Playlist;
 use App\Models\PlaylistAuth;
 use App\Models\User;
+use App\Services\DvrPostProcessorService;
 use App\Services\M3uProxyService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
@@ -141,6 +146,72 @@ it('deletes a PostProcessing recording — the state a cancelled in-progress rec
 
     $response->assertOk()->assertJson(['success' => true]);
     expect(DvrRecording::find($recording->id))->toBeNull();
+});
+
+it('releases the proxy broadcast when deleting a PostProcessing recording that still holds a proxy_network_id', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create([
+            'status' => DvrRecordingStatus::PostProcessing,
+            'proxy_network_id' => 'test-network-id',
+            'user_cancelled' => true,
+        ]);
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldNotReceive('stopDvrBroadcast');
+    $proxy->shouldReceive('cleanupDvrBroadcast')->once()->with('test-network-id')->andReturn(true);
+    app()->instance(M3uProxyService::class, $proxy);
+
+    $response = $this->postJson(
+        xtreamActionUrl($this->username, $this->password, 'delete_dvr_recording'),
+        ['recording_id' => $recording->uuid]
+    );
+
+    $response->assertOk()->assertJson(['success' => true]);
+    expect(DvrRecording::find($recording->id))->toBeNull();
+});
+
+it('reproduces the TV app "Delete recording" flow — cancel then immediate delete releases the proxy broadcast exactly once, before PostProcessDvrRecording ever runs', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->create([
+            'status' => DvrRecordingStatus::Recording,
+            'proxy_network_id' => 'test-network-id',
+        ]);
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldReceive('stopDvrBroadcast')->once()->with('test-network-id')->andReturn(true);
+    $proxy->shouldReceive('cleanupDvrBroadcast')->once()->with('test-network-id')->andReturn(true);
+    app()->instance(M3uProxyService::class, $proxy);
+
+    // AppShell._cancelAndDeleteRecording: cancel_dvr_recording immediately
+    // followed by delete_dvr_recording, well before the queue worker could
+    // ever pick up the delayed/callback-triggered post-processing job.
+    $this->postJson(
+        xtreamActionUrl($this->username, $this->password, 'cancel_dvr_recording'),
+        ['recording_id' => $recording->uuid]
+    )->assertOk();
+
+    $this->postJson(
+        xtreamActionUrl($this->username, $this->password, 'delete_dvr_recording'),
+        ['recording_id' => $recording->uuid]
+    )->assertOk()->assertJson(['success' => true]);
+
+    expect(DvrRecording::find($recording->id))->toBeNull();
+
+    // The safety-net job was queued by cancel()'s finalizeStop() but the row is
+    // already gone. Running it now must be a graceful no-op — in particular it
+    // must NOT call cleanupDvrBroadcast() again (the ->once() expectation above
+    // would fail the test if it did).
+    Queue::assertPushed(
+        PostProcessDvrRecording::class,
+        fn (PostProcessDvrRecording $job) => $job->recordingId === $recording->id
+    );
+    (new PostProcessDvrRecording($recording->id))->handle(app(DvrPostProcessorService::class));
 });
 
 it('rejects deleting a Scheduled or Recording recording — nothing has told the proxy to stop yet', function (DvrRecordingStatus $status) {


### PR DESCRIPTION
## Summary
- `DvrRecorderService::cancel()` previously marked any cancelled recording `Cancelled` immediately and cleared `proxy_network_id` — including recordings that had already captured real footage. That footage was never post-processed, leaving a permanently unplayable, dead row whenever a user stopped an in-progress recording.
- Cancel now branches on whether the recording ever actually started (`proxy_network_id` set):
  - **No footage** (still `Scheduled`, never started): marked `Cancelled` immediately, as before — nothing for post-processing to do.
  - **Has footage** (`Recording`, proxy broadcast started): stops the proxy broadcast and routes through the same `finalizeStop()` → `PostProcessDvrRecording` pipeline as a natural `stop()`, ending up `Completed` (playable) instead of `Cancelled`. `user_cancelled` and `error_message` ("Cancelled by user") are preserved through post-processing as a "stopped early" marker.
  - `Once`-type recording rules are still deleted on cancel either way (one-shot, nothing to keep scheduling).
- `XtreamApiController::deleteDvrRecording()`'s status whitelist is widened to include `PostProcessing` (previously only `Completed`/`Failed`/`Cancelled`) — the TV app's "Delete recording" choice calls `cancel_dvr_recording` then `delete_dvr_recording` back-to-back, and a footage-having recording is already in `PostProcessing` by the time the delete call arrives.

## Test plan
- [x] `DvrRecorderServiceTest`: cancel-with-footage routes to `PostProcessing` (job pushed, `proxy_network_id` preserved, `user_cancelled=true`); cancel-without-footage still goes straight to `Cancelled` (no job pushed)
- [x] New `XtreamCancelDeleteDvrTest`: end-to-end HTTP coverage for both cancel paths, plus delete accepting `PostProcessing` while still rejecting `Scheduled`/`Recording`

🤖 Generated with [Claude Code](https://claude.com/claude-code)