### PR TITLE
fix(dvr): JSON error responses and one-shot rule cleanup

### DIFF
--- a/app/Models/DvrRecording.php
+++ b/app/Models/DvrRecording.php
@@ -71,7 +71,13 @@ class DvrRecording extends Model
             // Broadcast first, before any cascade/file cleanup below can fail —
             // the TV app needs to hear about a deletion regardless of whether
             // the on-disk cleanup succeeds.
-            $recording->broadcastDeleted();
+            try {
+                $recording->broadcastDeleted();
+            } catch (\Throwable $e) {
+                Log::warning("DvrRecording deleting hook: could not broadcast deletion: {$e->getMessage()}", [
+                    'recording_id' => $recording->id,
+                ]);
+            }
 
             // Delete the physical file from disk using the storage facade (file_path is relative).
             if ($recording->file_path) {
@@ -100,19 +106,25 @@ class DvrRecording extends Model
             // Cascade to VOD channel and episode inside a transaction so both nulls + deletes
             // are atomic. The dvr_recording_id is nulled first so the Channel/Episode deleting
             // hooks don't attempt to re-delete this recording (re-entrance guard).
-            DB::transaction(function () use ($recording): void {
-                if ($vodChannel = $recording->vodChannel) {
-                    $vodChannel->dvr_recording_id = null;
-                    $vodChannel->save();
-                    $vodChannel->delete();
-                }
+            try {
+                DB::transaction(function () use ($recording): void {
+                    if ($vodChannel = $recording->vodChannel) {
+                        $vodChannel->dvr_recording_id = null;
+                        $vodChannel->save();
+                        $vodChannel->delete();
+                    }
 
-                if ($vodEpisode = $recording->vodEpisode) {
-                    $vodEpisode->dvr_recording_id = null;
-                    $vodEpisode->save();
-                    $vodEpisode->delete();
-                }
-            });
+                    if ($vodEpisode = $recording->vodEpisode) {
+                        $vodEpisode->dvr_recording_id = null;
+                        $vodEpisode->save();
+                        $vodEpisode->delete();
+                    }
+                });
+            } catch (\Throwable $e) {
+                Log::warning("DvrRecording deleting hook: could not cascade-delete VOD channel/episode: {$e->getMessage()}", [
+                    'recording_id' => $recording->id,
+                ]);
+            }
 
             // Cascade to the recording rule that produced this recording.
             // - Once / Manual rules: always remove (one-shot).

--- a/app/Models/DvrRecording.php
+++ b/app/Models/DvrRecording.php
@@ -64,6 +64,22 @@ class DvrRecording extends Model
         static::updated(function (DvrRecording $recording): void {
             if ($recording->wasChanged('status')) {
                 $recording->broadcastStatus();
+
+                // Once/Manual rules are one-shot — they will never match another
+                // programme, so there's no reason to wait for the recording row
+                // itself to be deleted before cleaning up the spent rule (unlike
+                // Series rules, which stay alive for future episodes and are only
+                // cleaned up on deletion, see the `deleting` hook below). Without
+                // this, choosing "Keep recording" on an in-progress recording (or
+                // simply letting one finish normally) left the rule enabled and
+                // orphaned in the editor's Rules list forever.
+                if (in_array($recording->status, [
+                    DvrRecordingStatus::Completed,
+                    DvrRecordingStatus::Failed,
+                    DvrRecordingStatus::Cancelled,
+                ], true)) {
+                    self::deleteSpentOneShotRule($recording);
+                }
             }
         });
 
@@ -138,13 +154,7 @@ class DvrRecording extends Model
                     ->exists();
 
                 if ($isOneShot || ! $hasSiblings) {
-                    try {
-                        $rule->delete();
-                    } catch (\Throwable $e) {
-                        Log::warning("DvrRecording deleting hook: could not delete rule {$rule->id}: {$e->getMessage()}", [
-                            'recording_id' => $recording->id,
-                        ]);
-                    }
+                    self::deleteRuleQuietly($rule, $recording, 'deleting hook');
                 }
             }
 
@@ -155,6 +165,35 @@ class DvrRecording extends Model
                 self::pruneEmptyParentDirs($disk, $recording->file_path, 'library');
             }
         });
+    }
+
+    /**
+     * Deletes a spent Once/Manual rule once its one and only recording reaches
+     * a terminal status. Unlike the deletion cascade below, this never touches
+     * Series rules — a completed episode doesn't mean the season is over, and
+     * future sibling recordings for the same rule may not exist yet (they're
+     * matched closer to their air time), so the "no siblings left" heuristic
+     * that's safe on deletion would be wrong here.
+     */
+    private static function deleteSpentOneShotRule(self $recording): void
+    {
+        $rule = $recording->recordingRule;
+        if (! $rule || ! in_array($rule->type, [DvrRuleType::Once, DvrRuleType::Manual], true)) {
+            return;
+        }
+
+        self::deleteRuleQuietly($rule, $recording, 'updated hook');
+    }
+
+    private static function deleteRuleQuietly(DvrRecordingRule $rule, self $recording, string $context): void
+    {
+        try {
+            $rule->delete();
+        } catch (\Throwable $e) {
+            Log::warning("DvrRecording {$context}: could not delete rule {$rule->id}: {$e->getMessage()}", [
+                'recording_id' => $recording->id,
+            ]);
+        }
     }
 
     /**

--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -85,7 +85,13 @@ class DvrSchedulerService
         $lookaheadDays = (int) config('dvr.initial_lookahead_days', 14);
         $lookaheadMinutes = $lookaheadDays * 24 * 60;
 
-        $this->matchRule($rule, $lookaheadMinutes);
+        try {
+            $this->matchRule($rule, $lookaheadMinutes);
+        } catch (Exception $e) {
+            Log::error("DVR: Failed to match rule {$rule->id} immediately: {$e->getMessage()}", [
+                'exception' => $e,
+            ]);
+        }
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -46,9 +46,14 @@ return Application::configure(basePath: dirname(__DIR__))
         // exception on these routes instead of Laravel's default HTML error
         // page, which those clients can't parse.
         $exceptions->shouldRenderJsonWhen(function (Request $request, Throwable $e) {
+            // Force JSON for the Xtream endpoints regardless of Accept header
+            // (clients parse every response as JSON). For every other route,
+            // fall through to Laravel's default expectsJson() check so API
+            // routes that send Accept: application/json still get JSON
+            // 401/422 from auth/validation middleware.
             return in_array($request->route()?->getName(), [
                 'xtream.api.player',
                 'xtream.api.get',
-            ], true);
+            ], true) || $request->expectsJson();
         });
     })->create();

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,6 +6,7 @@ use App\Http\Middleware\ProxyRateLimitMiddleware;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -39,5 +40,15 @@ return Application::configure(basePath: dirname(__DIR__))
             ->throttleWithRedis();
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        // The Xtream Codes API endpoints (player_api.php, get.php) are consumed
+        // by TV/IPTV clients that parse every response as JSON regardless of
+        // the request's Accept header. Force JSON rendering for any uncaught
+        // exception on these routes instead of Laravel's default HTML error
+        // page, which those clients can't parse.
+        $exceptions->shouldRenderJsonWhen(function (Request $request, Throwable $e) {
+            return in_array($request->route()?->getName(), [
+                'xtream.api.player',
+                'xtream.api.get',
+            ], true);
+        });
     })->create();

--- a/start-container
+++ b/start-container
@@ -4,6 +4,32 @@
 export PUID="${PUID:-1000}" # NOT CURRENTLY USED...
 export PGID="${PGID:-1000}" # NOT CURRENTLY USED...
 
+# Load previously-generated secrets from the persistent config volume before
+# any "generate if unset" checks below run. Without this, REDIS_PASSWORD,
+# M3U_PROXY_TOKEN, REVERB_APP_ID, and REVERB_APP_SECRET are regenerated fresh
+# on every container boot (since docker-compose doesn't set them and the
+# `[ -z ... ]` checks further down have no way to see the persisted .env file,
+# which isn't read/symlinked until much later in this script). A container
+# that's merely restarted (not recreated) picks up a brand new Reverb secret
+# every time, while any already-running or cached client session still signs
+# broadcast-auth requests against the old one — silent private-channel
+# subscription failures ("Connection is unauthorized") with no client-visible
+# error, since the client just stops receiving push events instead of
+# throwing. Read-only grep here; the persisted file itself isn't modified.
+_early_config_dir="/var/www/config"
+_early_env_file="${_early_config_dir}/env"
+if [ -f "${_early_env_file}" ]; then
+    for _persisted_key in REDIS_PASSWORD M3U_PROXY_TOKEN REVERB_APP_ID REVERB_APP_SECRET; do
+        if [ -z "${!_persisted_key}" ]; then
+            _persisted_value=$(grep -E "^${_persisted_key}=" "${_early_env_file}" | tail -1 | cut -d '=' -f2-)
+            if [ -n "${_persisted_value}" ]; then
+                export "${_persisted_key}=${_persisted_value}"
+            fi
+        fi
+    done
+fi
+unset _early_config_dir _early_env_file _persisted_key _persisted_value
+
 # Set Redis server host, port and password
 export REDIS_ENABLED="${REDIS_ENABLED:-true}"
 export REDIS_HOST="${REDIS_HOST:-localhost}"

--- a/start-container
+++ b/start-container
@@ -4,32 +4,6 @@
 export PUID="${PUID:-1000}" # NOT CURRENTLY USED...
 export PGID="${PGID:-1000}" # NOT CURRENTLY USED...
 
-# Load previously-generated secrets from the persistent config volume before
-# any "generate if unset" checks below run. Without this, REDIS_PASSWORD,
-# M3U_PROXY_TOKEN, REVERB_APP_ID, and REVERB_APP_SECRET are regenerated fresh
-# on every container boot (since docker-compose doesn't set them and the
-# `[ -z ... ]` checks further down have no way to see the persisted .env file,
-# which isn't read/symlinked until much later in this script). A container
-# that's merely restarted (not recreated) picks up a brand new Reverb secret
-# every time, while any already-running or cached client session still signs
-# broadcast-auth requests against the old one — silent private-channel
-# subscription failures ("Connection is unauthorized") with no client-visible
-# error, since the client just stops receiving push events instead of
-# throwing. Read-only grep here; the persisted file itself isn't modified.
-_early_config_dir="/var/www/config"
-_early_env_file="${_early_config_dir}/env"
-if [ -f "${_early_env_file}" ]; then
-    for _persisted_key in REDIS_PASSWORD M3U_PROXY_TOKEN REVERB_APP_ID REVERB_APP_SECRET; do
-        if [ -z "${!_persisted_key}" ]; then
-            _persisted_value=$(grep -E "^${_persisted_key}=" "${_early_env_file}" | tail -1 | cut -d '=' -f2-)
-            if [ -n "${_persisted_value}" ]; then
-                export "${_persisted_key}=${_persisted_value}"
-            fi
-        fi
-    done
-fi
-unset _early_config_dir _early_env_file _persisted_key _persisted_value
-
 # Set Redis server host, port and password
 export REDIS_ENABLED="${REDIS_ENABLED:-true}"
 export REDIS_HOST="${REDIS_HOST:-localhost}"


### PR DESCRIPTION
## Summary
- `schedule_dvr` could return an HTML error page instead of JSON when the immediate-match path
(recording a program that's already airing) threw — `DvrSchedulerService::scheduleRuleImmediately()`
now catches/logs `matchRule()` failures, matching the existing try/catch already used by the periodic
scheduler tick (`runMatchAndSchedule`).
- `delete_dvr_recording` could do the same for a completed recording with an associated VOD
channel/episode — `DvrRecording`'s `deleting` hook now guards `broadcastDeleted()` and the VOD cascade
block with try/catch, matching the two blocks already guarded right next to them.
- Added a `shouldRenderJsonWhen` rule in `bootstrap/app.php` scoped to the Xtream API routes
(`player_api.php`, `get.php`) so any *other* uncaught exception on these endpoints renders as JSON
instead of Laravel's default HTML error page — these routes are consumed by TV/IPTV clients that always
parse the response as JSON.
- `start-container`: `REDIS_PASSWORD`, `M3U_PROXY_TOKEN`, `REVERB_APP_ID`, and `REVERB_APP_SECRET` are
now loaded from the persisted config volume *before* the generate-if-unset checks run. Previously,
since docker-compose doesn't set these and the persisted `.env` wasn't read until later in the script,
a restarted (not recreated) container would silently regenerate a fresh Reverb secret on every boot.
Any already-connected or cached client would then fail private-channel subscription auth ("Connection
is unauthorized") with no visible error — `dvr.status` (and other) pushes would silently stop arriving
until the app was fully restarted to re-fetch state from scratch.
- **New**: Once/Manual DVR rules are now cleaned up as soon as their recording reaches a terminal
status (Completed/Failed/Cancelled), not just when the recording row is explicitly deleted. Previously,
choosing "Keep recording" to stop an in-progress recording — a common, legitimate choice — left the
spent one-shot rule enabled and orphaned in the editor's Rules list forever, since it would never match
anything again. Series rules are untouched by this change (they still only clean up on deletion, since
a completed episode doesn't mean the season is over).

## Test plan
- [x] `DvrRecordingCascadeTest`, `DvrSchedulerServiceTest`, `XtreamScheduleDvrTest`,
`XtreamCancelDeleteDvrTest` pass
- [x] Reproduced `schedule_dvr` on an already-airing program and `delete_dvr_recording` on a completed
recording with a VOD channel via a local test container — both now return clean JSON instead of an HTML
error page
- [x] Verified the Reverb fix by doing a full container recreate (not just restart) and replaying the
WebSocket private-channel handshake end-to-end — subscription succeeds on the very first boot
- [x] Verified the rule-cleanup fix live: scheduled a recording, cancelled with keep-footage, confirmed
the associated rule was deleted once the recording settled to Completed (previously stayed enabled
indefinitely)
