### PR TITLE
feat(admin): add DVR storage overview and per-user recording scoping

### DIFF
--- a/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
+++ b/app/Filament/Resources/DvrRecordings/DvrRecordingResource.php
@@ -38,6 +38,28 @@ class DvrRecordingResource extends Resource
 {
     use HasUserFiltering;
 
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        if (auth()->check() && ! auth()->user()->isAdmin()) {
+            $query->where('user_id', auth()->id());
+        }
+
+        return $query;
+    }
+
+    public static function getGlobalSearchEloquentQuery(): Builder
+    {
+        $query = parent::getGlobalSearchEloquentQuery();
+
+        if (auth()->check() && ! auth()->user()->isAdmin()) {
+            $query->where('user_id', auth()->id());
+        }
+
+        return $query;
+    }
+
     protected static ?string $model = DvrRecording::class;
 
     protected static string|BackedEnum|null $navigationIcon = null;
@@ -226,6 +248,15 @@ class DvrRecordingResource extends Resource
                     ->label(__('Playlist'))
                     ->state(fn (DvrRecording $record): ?string => $record->dvrSetting?->owner()?->name)
                     ->toggleable(),
+                TextColumn::make('user.name')
+                    ->label(__('Owner'))
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('playlistAuth.name')
+                    ->label(__('Guest'))
+                    ->toggleable()
+                    ->placeholder('—'),
                 TextColumn::make('scheduled_start')
                     ->since()
                     ->dateTimeTooltip()
@@ -255,6 +286,12 @@ class DvrRecordingResource extends Resource
             ->filters([
                 SelectFilter::make('status')
                     ->options(DvrRecordingStatus::class),
+                SelectFilter::make('user_id')
+                    ->relationship('user', 'name')
+                    ->label(__('Owner')),
+                SelectFilter::make('playlist_auth_id')
+                    ->relationship('playlistAuth', 'name')
+                    ->label(__('Guest')),
                 TernaryFilter::make('has_error')
                     ->label(__('Has Error'))
                     ->attribute('error_message')
@@ -376,7 +413,7 @@ class DvrRecordingResource extends Resource
         ];
     }
 
-    private static function formatFileSize(?int $sizeInBytes): string
+    public static function formatFileSize(?int $sizeInBytes): string
     {
         if (! $sizeInBytes) {
             return '—';

--- a/app/Filament/Resources/PlaylistAuths/PlaylistAuthResource.php
+++ b/app/Filament/Resources/PlaylistAuths/PlaylistAuthResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\PlaylistAuths;
 
 use App\Filament\Actions\GeneratePasswordAction;
 use App\Filament\Concerns\HasCopilotSupport;
+use App\Filament\Resources\DvrRecordings\DvrRecordingResource;
 use App\Filament\Resources\PlaylistAuthResource\Pages;
 use App\Filament\Resources\PlaylistAuthResource\RelationManagers;
 use App\Filament\Resources\PlaylistAuths\Pages\ListPlaylistAuths;
@@ -114,7 +115,7 @@ class PlaylistAuthResource extends Resource implements CopilotResource
                         if (! $record->dvr_enabled) {
                             return '—';
                         }
-                        $used = \App\Filament\Resources\DvrRecordings\DvrRecordingResource::formatFileSize($record->storage_used_bytes);
+                        $used = DvrRecordingResource::formatFileSize($record->storage_used_bytes);
                         if ($record->dvr_storage_quota_gb === null) {
                             return "{$used} / Unlimited";
                         }

--- a/app/Filament/Resources/PlaylistAuths/PlaylistAuthResource.php
+++ b/app/Filament/Resources/PlaylistAuths/PlaylistAuthResource.php
@@ -103,6 +103,24 @@ class PlaylistAuthResource extends Resource implements CopilotResource
                 TextColumn::make('assigned_model_name')
                     ->label(__('Assigned To'))
                     ->toggleable(),
+                TextColumn::make('dvr_recordings_count')
+                    ->label(__('Recordings'))
+                    ->counts('dvrRecordings')
+                    ->toggleable(),
+                TextColumn::make('storage_used_bytes')
+                    ->label(__('DVR Storage'))
+                    ->toggleable()
+                    ->formatStateUsing(function (PlaylistAuth $record): string {
+                        if (! $record->dvr_enabled) {
+                            return '—';
+                        }
+                        $used = \App\Filament\Resources\DvrRecordings\DvrRecordingResource::formatFileSize($record->storage_used_bytes);
+                        if ($record->dvr_storage_quota_gb === null) {
+                            return "{$used} / Unlimited";
+                        }
+
+                        return "{$used} / {$record->dvr_storage_quota_gb} GB";
+                    }),
                 ToggleColumn::make('enabled')
                     ->toggleable()
                     ->tooltip(__('Toggle auth status'))

--- a/app/Filament/Widgets/DvrStorageOverviewWidget.php
+++ b/app/Filament/Widgets/DvrStorageOverviewWidget.php
@@ -19,7 +19,7 @@ class DvrStorageOverviewWidget extends Widget
     protected function getViewData(): array
     {
         $rows = DvrSetting::with('user')->get()->map(function (DvrSetting $setting) {
-            $usedBytes = $setting->recordings()->whereNotNull('file_size_bytes')->sum('file_size_bytes');
+            $usedBytes = $setting->storage_used_bytes;
             $quotaBytes = $setting->global_disk_quota_gb > 0
                 ? $setting->global_disk_quota_gb * 1024 ** 3
                 : null;

--- a/app/Filament/Widgets/DvrStorageOverviewWidget.php
+++ b/app/Filament/Widgets/DvrStorageOverviewWidget.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\DvrSetting;
+use Filament\Widgets\Widget;
+
+class DvrStorageOverviewWidget extends Widget
+{
+    protected int|string|array $columnSpan = 'full';
+
+    protected string $view = 'filament.widgets.dvr-storage-overview-widget';
+
+    public static function canView(): bool
+    {
+        return auth()->check() && auth()->user()->isAdmin();
+    }
+
+    protected function getViewData(): array
+    {
+        $rows = DvrSetting::with('user')->get()->map(function (DvrSetting $setting) {
+            $usedBytes = $setting->recordings()->whereNotNull('file_size_bytes')->sum('file_size_bytes');
+            $quotaBytes = $setting->global_disk_quota_gb > 0
+                ? $setting->global_disk_quota_gb * 1024 ** 3
+                : null;
+
+            return [
+                'user' => $setting->user,
+                'recording_count' => $setting->recordings()->count(),
+                'used_bytes' => $usedBytes,
+                'used_formatted' => self::formatFileSize($usedBytes),
+                'quota_bytes' => $quotaBytes,
+                'quota_formatted' => $quotaBytes ? self::formatFileSize($quotaBytes) : __('Unlimited'),
+                'percent' => $quotaBytes ? min(100, round($usedBytes / $quotaBytes * 100, 1)) : null,
+            ];
+        });
+
+        return ['rows' => $rows];
+    }
+
+    private static function formatFileSize(?int $sizeInBytes): string
+    {
+        if (! $sizeInBytes) {
+            return '—';
+        }
+
+        if ($sizeInBytes >= 1024 * 1024 * 1024) {
+            return number_format($sizeInBytes / 1024 / 1024 / 1024, 1).' GB';
+        }
+
+        return number_format($sizeInBytes / 1024 / 1024, 1).' MB';
+    }
+}

--- a/app/Filament/Widgets/DvrStorageOverviewWidget.php
+++ b/app/Filament/Widgets/DvrStorageOverviewWidget.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Widgets;
 
+use App\Filament\Resources\DvrRecordings\DvrRecordingResource;
 use App\Models\DvrSetting;
 use Filament\Widgets\Widget;
 
@@ -18,36 +19,27 @@ class DvrStorageOverviewWidget extends Widget
 
     protected function getViewData(): array
     {
-        $rows = DvrSetting::with('user')->get()->map(function (DvrSetting $setting) {
-            $usedBytes = $setting->storage_used_bytes;
-            $quotaBytes = $setting->global_disk_quota_gb > 0
-                ? $setting->global_disk_quota_gb * 1024 ** 3
-                : null;
+        $rows = DvrSetting::with('user')
+            ->withCount('recordings')
+            ->withSum(['recordings as used_bytes' => fn ($query) => $query->whereNotNull('file_size_bytes')], 'file_size_bytes')
+            ->get()
+            ->map(function (DvrSetting $setting) {
+                $usedBytes = (int) $setting->used_bytes;
+                $quotaBytes = $setting->global_disk_quota_gb > 0
+                    ? $setting->global_disk_quota_gb * 1024 ** 3
+                    : null;
 
-            return [
-                'user' => $setting->user,
-                'recording_count' => $setting->recordings()->count(),
-                'used_bytes' => $usedBytes,
-                'used_formatted' => self::formatFileSize($usedBytes),
-                'quota_bytes' => $quotaBytes,
-                'quota_formatted' => $quotaBytes ? self::formatFileSize($quotaBytes) : __('Unlimited'),
-                'percent' => $quotaBytes ? min(100, round($usedBytes / $quotaBytes * 100, 1)) : null,
-            ];
-        });
+                return [
+                    'user' => $setting->user,
+                    'recording_count' => $setting->recordings_count,
+                    'used_bytes' => $usedBytes,
+                    'used_formatted' => DvrRecordingResource::formatFileSize($usedBytes),
+                    'quota_bytes' => $quotaBytes,
+                    'quota_formatted' => $quotaBytes ? DvrRecordingResource::formatFileSize($quotaBytes) : __('Unlimited'),
+                    'percent' => $quotaBytes ? min(100, round($usedBytes / $quotaBytes * 100, 1)) : null,
+                ];
+            });
 
         return ['rows' => $rows];
-    }
-
-    private static function formatFileSize(?int $sizeInBytes): string
-    {
-        if (! $sizeInBytes) {
-            return '—';
-        }
-
-        if ($sizeInBytes >= 1024 * 1024 * 1024) {
-            return number_format($sizeInBytes / 1024 / 1024 / 1024, 1).' GB';
-        }
-
-        return number_format($sizeInBytes / 1024 / 1024, 1).' MB';
     }
 }

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -3346,6 +3346,10 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'DVR is not enabled for this playlist'], 422);
         }
 
+        if ($playlistAuth?->hasReachedConcurrentLimit()) {
+            return response()->json(['error' => 'Concurrent recording limit reached'], 422);
+        }
+
         $channel = $playlist->channels()->where('channels.id', $channelId)->first();
         if (! $channel) {
             return response()->json(['error' => 'Channel not found'], 404);

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -63,6 +63,7 @@ class XtreamApiController extends Controller
     private const DVR_ACTIONS = [
         'get_dvr_recordings',
         'get_dvr_recording',
+        'get_dvr_storage',
         'schedule_dvr',
         'create_dvr_series_rule',
         'cancel_dvr_recording',
@@ -2031,6 +2032,7 @@ class XtreamApiController extends Controller
             return match ($action) {
                 'get_dvr_recordings' => $this->getDvrRecordings($request, $dvrPlaylist, $username, $password, $playlistAuth),
                 'get_dvr_recording' => $this->getDvrRecording($request, $dvrPlaylist, $username, $password, $playlistAuth),
+                'get_dvr_storage' => $this->getDvrStorage($dvrPlaylist, $playlistAuth),
                 'schedule_dvr' => $this->scheduleDvr($request, $dvrPlaylist, $playlistAuth),
                 'create_dvr_series_rule' => $this->createDvrSeriesRule($request, $dvrPlaylist, $playlistAuth),
                 'cancel_dvr_recording' => $this->cancelDvrRecording($request, $dvrPlaylist, $playlistAuth),
@@ -3269,6 +3271,59 @@ class XtreamApiController extends Controller
         }
 
         return response()->json($this->formatDvrRecording($recording, $username, $password, true));
+    }
+
+    /**
+     * Get the current user/guest's DVR storage usage against their quota.
+     *
+     * A guest (PlaylistAuth) only ever sees their own usage, scoped to their own
+     * recordings, regardless of whether they have an explicit quota configured —
+     * guests never see account-wide totals. The account owner sees the whole
+     * DVR setting's usage against its global quota.
+     */
+    private function getDvrStorage($playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
+    {
+        if ($playlistAuth) {
+            $usedBytes = $playlistAuth->storage_used_bytes;
+            $quotaBytes = $playlistAuth->dvr_storage_quota_gb !== null
+                ? $playlistAuth->dvr_storage_quota_gb * 1024 ** 3
+                : null;
+
+            return response()->json([
+                'used_bytes' => $usedBytes,
+                'quota_bytes' => $quotaBytes,
+                'percent_used' => $quotaBytes !== null
+                    ? ($quotaBytes > 0 ? min(100, round($usedBytes / $quotaBytes * 100, 1)) : 100)
+                    : null,
+                'recording_count' => $playlistAuth->dvrRecordings()->count(),
+                'scope' => 'guest',
+            ]);
+        }
+
+        $dvrSetting = $playlist->dvrSetting;
+
+        if (! $dvrSetting) {
+            return response()->json([
+                'used_bytes' => 0,
+                'quota_bytes' => null,
+                'percent_used' => null,
+                'recording_count' => 0,
+                'scope' => 'account',
+            ]);
+        }
+
+        $usedBytes = $dvrSetting->storage_used_bytes;
+        $quotaBytes = $dvrSetting->global_disk_quota_gb > 0
+            ? $dvrSetting->global_disk_quota_gb * 1024 ** 3
+            : null;
+
+        return response()->json([
+            'used_bytes' => $usedBytes,
+            'quota_bytes' => $quotaBytes,
+            'percent_used' => $quotaBytes ? min(100, round($usedBytes / $quotaBytes * 100, 1)) : null,
+            'recording_count' => $dvrSetting->recordings()->count(),
+            'scope' => 'account',
+        ]);
     }
 
     /**

--- a/app/Models/DvrSetting.php
+++ b/app/Models/DvrSetting.php
@@ -57,6 +57,16 @@ class DvrSetting extends Model
     }
 
     /**
+     * Total storage used by recordings under this DVR setting, in bytes.
+     */
+    public function getStorageUsedBytesAttribute(): int
+    {
+        return (int) $this->recordings()
+            ->whereNotNull('file_size_bytes')
+            ->sum('file_size_bytes');
+    }
+
+    /**
      * Resolve the effective start-early seconds for a recording rule.
      */
     public function resolveStartEarlySeconds(?int $ruleOverride): int

--- a/app/Models/PlaylistAuth.php
+++ b/app/Models/PlaylistAuth.php
@@ -76,8 +76,12 @@ class PlaylistAuth extends Model
     /**
      * Whether this auth has reached its per-guest concurrent recording cap.
      * Returns false when no cap is configured (null = unlimited).
+     *
+     * @param  int  $pendingInTick  Recordings already counted as started for this auth
+     *                              earlier in the same scheduler tick but not yet
+     *                              reflected in the database — see DvrSetting::isAtCapacity().
      */
-    public function hasReachedConcurrentLimit(): bool
+    public function hasReachedConcurrentLimit(int $pendingInTick = 0): bool
     {
         if ($this->dvr_max_concurrent_recordings === null) {
             return false;
@@ -87,7 +91,7 @@ class PlaylistAuth extends Model
             ->whereIn('status', [DvrRecordingStatus::Recording, DvrRecordingStatus::PostProcessing])
             ->count();
 
-        return $active >= $this->dvr_max_concurrent_recordings;
+        return ($active + $pendingInTick) >= $this->dvr_max_concurrent_recordings;
     }
 
     /**

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -50,6 +50,7 @@ use App\Filament\Resources\Vods\VodResource;
 use App\Filament\Widgets\DiscordWidget;
 use App\Filament\Widgets\DocumentsWidget;
 use App\Filament\Widgets\DonateCrypto;
+use App\Filament\Widgets\DvrStorageOverviewWidget;
 use App\Filament\Widgets\KoFiWidget;
 use App\Filament\Widgets\M3uTvWidget;
 use App\Filament\Widgets\PluginsOverviewWidget;
@@ -300,6 +301,7 @@ class AdminPanelProvider extends PanelProvider
                 KoFiWidget::class,
                 QueueDashboardWidget::class,
                 PluginsOverviewWidget::class,
+                DvrStorageOverviewWidget::class,
                 // DonateCrypto::class,
                 StatsOverview::class,
                 // SharedStreamStatsWidget::class,

--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -386,6 +386,12 @@ class DvrSchedulerService
                 return;
             }
 
+            if ($rule->playlistAuth?->hasReachedConcurrentLimit()) {
+                Log::debug("DVR: Skipping manual recording for rule {$rule->id} — guest at concurrent recording limit");
+
+                return;
+            }
+
             // Manual rules scheduled via the Xtream API (schedule_dvr) always carry the
             // real programme title in series_title — the TV app only creates these when
             // recording a specific, known EPG entry (see XtreamApiController::scheduleDvr()).
@@ -488,6 +494,10 @@ class DvrSchedulerService
                 return;
             }
 
+            if ($rule->playlistAuth?->hasReachedConcurrentLimit()) {
+                return;
+            }
+
             $channel = $rule->channel;
             $title = $channel ? ($channel->title_custom ?? $channel->title ?? 'Recording') : 'Recording';
 
@@ -552,6 +562,12 @@ class DvrSchedulerService
         DB::transaction(function () use ($rule, $setting, $programme): void {
             if ($setting->isAtCapacity()) {
                 Log::debug("DVR: Skipping schedule for rule {$rule->id} — at capacity");
+
+                return;
+            }
+
+            if ($rule->playlistAuth?->hasReachedConcurrentLimit()) {
+                Log::debug("DVR: Skipping schedule for rule {$rule->id} — guest at concurrent recording limit");
 
                 return;
             }
@@ -733,6 +749,7 @@ class DvrSchedulerService
             ->values();
 
         $pendingStartsBySetting = [];
+        $pendingStartsByPlaylistAuth = [];
 
         foreach ($due as $recording) {
             $setting = $recording->dvrSetting;
@@ -750,7 +767,20 @@ class DvrSchedulerService
                 continue;
             }
 
+            $playlistAuth = $recording->playlistAuth;
+            $paExtra = $playlistAuth ? ($pendingStartsByPlaylistAuth[$playlistAuth->id] ?? 0) : 0;
+
+            if ($playlistAuth?->hasReachedConcurrentLimit($paExtra)) {
+                Log::debug("DVR: Skipping trigger for recording {$recording->id} — guest at concurrent recording limit (pending_in_tick={$paExtra})");
+
+                continue;
+            }
+
             $pendingStartsBySetting[$sid] = $extra + 1;
+
+            if ($playlistAuth) {
+                $pendingStartsByPlaylistAuth[$playlistAuth->id] = $paExtra + 1;
+            }
 
             Log::info("DVR: Triggering recording {$recording->id} ({$recording->title})");
             StartDvrRecording::dispatch($recording->id)->onQueue('dvr');

--- a/resources/views/filament/widgets/dvr-storage-overview-widget.blade.php
+++ b/resources/views/filament/widgets/dvr-storage-overview-widget.blade.php
@@ -2,7 +2,7 @@
     <x-filament::section>
         <div class="w-full space-y-4">
             <div class="flex items-center justify-between">
-                <h2 class="flex items-center gap-2 text-base font-semibold leading-6 text-gray-950 dark:text-white">
+                <h2 class="flex items-center gap-2 text-base leading-6 font-semibold text-gray-950 dark:text-white">
                     <x-filament::icon icon="heroicon-s-circle-stack" class="h-5 w-5 text-gray-400 dark:text-gray-500" />
                     {{ __('DVR Storage') }}
                 </h2>
@@ -13,27 +13,47 @@
                     <table class="w-full text-sm">
                         <thead>
                             <tr class="border-b border-gray-200 dark:border-white/10">
-                                <th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('User') }}</th>
-                                <th class="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Recordings') }}</th>
-                                <th class="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Used') }}</th>
-                                <th class="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Quota') }}</th>
-                                <th class="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Usage') }}</th>
+                                <th class="px-3 py-2 text-left text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                                    {{ __('User') }}
+                                </th>
+                                <th class="px-3 py-2 text-right text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                                    {{ __('Recordings') }}
+                                </th>
+                                <th class="px-3 py-2 text-right text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                                    {{ __('Used') }}
+                                </th>
+                                <th class="px-3 py-2 text-right text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                                    {{ __('Quota') }}
+                                </th>
+                                <th class="px-3 py-2 text-right text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+                                    {{ __('Usage') }}
+                                </th>
                             </tr>
                         </thead>
                         <tbody class="divide-y divide-gray-100 dark:divide-white/5">
                             @foreach ($rows as $row)
                                 <tr>
-                                    <td class="px-3 py-2.5 text-gray-950 dark:text-white">{{ $row['user']?->name ?? '—' }}</td>
-                                    <td class="px-3 py-2.5 text-right tabular-nums text-gray-950 dark:text-white">{{ number_format($row['recording_count']) }}</td>
-                                    <td class="px-3 py-2.5 text-right tabular-nums text-gray-950 dark:text-white">{{ $row['used_formatted'] }}</td>
-                                    <td class="px-3 py-2.5 text-right tabular-nums text-gray-950 dark:text-white">{{ $row['quota_formatted'] }}</td>
+                                    <td class="px-3 py-2.5 text-gray-950 dark:text-white">
+                                        {{ $row['user']?->name ?? '—' }}
+                                    </td>
+                                    <td class="px-3 py-2.5 text-right text-gray-950 tabular-nums dark:text-white">
+                                        {{ number_format($row['recording_count']) }}
+                                    </td>
+                                    <td class="px-3 py-2.5 text-right text-gray-950 tabular-nums dark:text-white">
+                                        {{ $row['used_formatted'] }}
+                                    </td>
+                                    <td class="px-3 py-2.5 text-right text-gray-950 tabular-nums dark:text-white">
+                                        {{ $row['quota_formatted'] }}
+                                    </td>
                                     <td class="px-3 py-2.5 text-right tabular-nums">
                                         @if ($row['percent'] !== null)
-                                            <x-filament::badge :color="match (true) {
+                                            <x-filament::badge
+                                                :color="match (true) {
                                                 $row['percent'] >= 90 => 'danger',
                                                 $row['percent'] >= 75 => 'warning',
                                                 default => 'success',
-                                            }">
+                                            }"
+                                            >
                                                 {{ $row['percent'] }}%
                                             </x-filament::badge>
                                         @else

--- a/resources/views/filament/widgets/dvr-storage-overview-widget.blade.php
+++ b/resources/views/filament/widgets/dvr-storage-overview-widget.blade.php
@@ -1,0 +1,53 @@
+<x-filament-widgets::widget class="fi-filament-info-widget">
+    <x-filament::section>
+        <div class="w-full space-y-4">
+            <div class="flex items-center justify-between">
+                <h2 class="flex items-center gap-2 text-base font-semibold leading-6 text-gray-950 dark:text-white">
+                    <x-filament::icon icon="heroicon-s-circle-stack" class="h-5 w-5 text-gray-400 dark:text-gray-500" />
+                    {{ __('DVR Storage') }}
+                </h2>
+            </div>
+
+            @if ($rows->isNotEmpty())
+                <div class="overflow-x-auto">
+                    <table class="w-full text-sm">
+                        <thead>
+                            <tr class="border-b border-gray-200 dark:border-white/10">
+                                <th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('User') }}</th>
+                                <th class="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Recordings') }}</th>
+                                <th class="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Used') }}</th>
+                                <th class="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Quota') }}</th>
+                                <th class="px-3 py-2 text-right text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('Usage') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-100 dark:divide-white/5">
+                            @foreach ($rows as $row)
+                                <tr>
+                                    <td class="px-3 py-2.5 text-gray-950 dark:text-white">{{ $row['user']?->name ?? '—' }}</td>
+                                    <td class="px-3 py-2.5 text-right tabular-nums text-gray-950 dark:text-white">{{ number_format($row['recording_count']) }}</td>
+                                    <td class="px-3 py-2.5 text-right tabular-nums text-gray-950 dark:text-white">{{ $row['used_formatted'] }}</td>
+                                    <td class="px-3 py-2.5 text-right tabular-nums text-gray-950 dark:text-white">{{ $row['quota_formatted'] }}</td>
+                                    <td class="px-3 py-2.5 text-right tabular-nums">
+                                        @if ($row['percent'] !== null)
+                                            <x-filament::badge :color="match (true) {
+                                                $row['percent'] >= 90 => 'danger',
+                                                $row['percent'] >= 75 => 'warning',
+                                                default => 'success',
+                                            }">
+                                                {{ $row['percent'] }}%
+                                            </x-filament::badge>
+                                        @else
+                                            <span class="text-gray-400 dark:text-gray-500">—</span>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @else
+                <p class="text-sm text-gray-400 dark:text-gray-500">{{ __('No DVR settings configured.') }}</p>
+            @endif
+        </div>
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/tests/Feature/DvrRecordingResourceTableTest.php
+++ b/tests/Feature/DvrRecordingResourceTableTest.php
@@ -5,6 +5,7 @@ use App\Events\PlaylistCreated;
 use App\Filament\Resources\DvrRecordings\Pages\ListDvrRecordings;
 use App\Models\DvrRecording;
 use App\Models\DvrSetting;
+use App\Models\PlaylistAuth;
 use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Support\Carbon;
@@ -117,4 +118,186 @@ it('formats dates relatively and file sizes with adaptive units', function () {
         ->assertTableColumnFormattedStateSet('scheduled_start', now()->subHour()->diffForHumans(), $recording)
         ->assertTableColumnFormattedStateSet('scheduled_end', now()->addMinutes(30)->diffForHumans(), $recording)
         ->assertTableColumnFormattedStateSet('file_size_bytes', '1.0 GB', $recording);
+});
+
+it('admin sees recordings from all users', function () {
+    $otherUser = User::factory()->create(['permissions' => ['use_dvr']]);
+    $otherPlaylist = Playlist::factory()->for($otherUser)->create();
+    $otherDvrSetting = DvrSetting::factory()
+        ->for($otherUser)
+        ->for($otherPlaylist)
+        ->enabled()
+        ->create();
+
+    $myRecording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'My Recording',
+        ]);
+    $theirRecording = DvrRecording::factory()
+        ->for($otherUser)
+        ->for($otherDvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'Their Recording',
+        ]);
+
+    $admin = User::factory()->admin()->create(['permissions' => ['use_dvr']]);
+    $this->actingAs($admin);
+
+    $ids = \App\Filament\Resources\DvrRecordings\DvrRecordingResource::getEloquentQuery()->pluck('id');
+
+    expect($ids)->toContain($myRecording->id)
+        ->toContain($theirRecording->id);
+});
+
+it('non-admin sees only their own recordings', function () {
+    $otherUser = User::factory()->create(['permissions' => ['use_dvr']]);
+    $otherPlaylist = Playlist::factory()->for($otherUser)->create();
+    $otherDvrSetting = DvrSetting::factory()
+        ->for($otherUser)
+        ->for($otherPlaylist)
+        ->enabled()
+        ->create();
+
+    $myRecording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'My Recording',
+        ]);
+    $theirRecording = DvrRecording::factory()
+        ->for($otherUser)
+        ->for($otherDvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'Their Recording',
+        ]);
+
+    $ids = \App\Filament\Resources\DvrRecordings\DvrRecordingResource::getEloquentQuery()->pluck('id');
+
+    expect($ids)->toContain($myRecording->id)
+        ->not()->toContain($theirRecording->id);
+});
+
+it('displays Owner column with user name', function () {
+    $recording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Completed,
+            'title' => 'Owner Column Test',
+        ]);
+
+    Livewire::test(ListDvrRecordings::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertTableColumnFormattedStateSet('user.name', $this->user->name, $recording);
+});
+
+it('filters recordings by owner', function () {
+    $otherUser = User::factory()->create(['permissions' => ['use_dvr']]);
+    $otherPlaylist = Playlist::factory()->for($otherUser)->create();
+    $otherDvrSetting = DvrSetting::factory()
+        ->for($otherUser)
+        ->for($otherPlaylist)
+        ->enabled()
+        ->create();
+
+    $myRecording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'My Recording',
+        ]);
+    $theirRecording = DvrRecording::factory()
+        ->for($otherUser)
+        ->for($otherDvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'Their Recording',
+        ]);
+
+    $admin = User::factory()->admin()->create(['permissions' => ['use_dvr']]);
+    $this->actingAs($admin);
+
+    Livewire::test(ListDvrRecordings::class)
+        ->assertOk()
+        ->loadTable()
+        ->filterTable('user_id', $this->user->id)
+        ->assertCanSeeTableRecords([$myRecording])
+        ->assertCanNotSeeTableRecords([$theirRecording]);
+});
+
+it('displays guest name when playlist_auth_id is set', function () {
+    $auth = PlaylistAuth::factory()->for($this->user)->create([
+        'name' => 'Guest Sarah',
+        'dvr_enabled' => true,
+    ]);
+
+    $withGuest = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'Guest Recording',
+            'playlist_auth_id' => $auth->id,
+        ]);
+
+    $withoutGuest = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'Owner Recording',
+            'playlist_auth_id' => null,
+        ]);
+
+    Livewire::test(ListDvrRecordings::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertTableColumnFormattedStateSet('playlistAuth.name', 'Guest Sarah', $withGuest)
+        ->assertTableColumnStateSet('playlistAuth.name', null, $withoutGuest);
+});
+
+it('filters recordings by guest playlist_auth_id', function () {
+    $authA = PlaylistAuth::factory()->for($this->user)->create([
+        'name' => 'Guest Alice',
+        'dvr_enabled' => true,
+    ]);
+    $authB = PlaylistAuth::factory()->for($this->user)->create([
+        'name' => 'Guest Bob',
+        'dvr_enabled' => true,
+    ]);
+
+    $aliceRecording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'Alice Recording',
+            'playlist_auth_id' => $authA->id,
+        ]);
+    $bobRecording = DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'status' => DvrRecordingStatus::Scheduled,
+            'title' => 'Bob Recording',
+            'playlist_auth_id' => $authB->id,
+        ]);
+
+    $admin = User::factory()->admin()->create(['permissions' => ['use_dvr']]);
+    $this->actingAs($admin);
+
+    Livewire::test(ListDvrRecordings::class)
+        ->assertOk()
+        ->loadTable()
+        ->filterTable('playlist_auth_id', $authA->id)
+        ->assertCanSeeTableRecords([$aliceRecording])
+        ->assertCanNotSeeTableRecords([$bobRecording]);
 });

--- a/tests/Feature/DvrRecordingResourceTableTest.php
+++ b/tests/Feature/DvrRecordingResourceTableTest.php
@@ -2,11 +2,12 @@
 
 use App\Enums\DvrRecordingStatus;
 use App\Events\PlaylistCreated;
+use App\Filament\Resources\DvrRecordings\DvrRecordingResource;
 use App\Filament\Resources\DvrRecordings\Pages\ListDvrRecordings;
 use App\Models\DvrRecording;
 use App\Models\DvrSetting;
-use App\Models\PlaylistAuth;
 use App\Models\Playlist;
+use App\Models\PlaylistAuth;
 use App\Models\User;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
@@ -147,7 +148,7 @@ it('admin sees recordings from all users', function () {
     $admin = User::factory()->admin()->create(['permissions' => ['use_dvr']]);
     $this->actingAs($admin);
 
-    $ids = \App\Filament\Resources\DvrRecordings\DvrRecordingResource::getEloquentQuery()->pluck('id');
+    $ids = DvrRecordingResource::getEloquentQuery()->pluck('id');
 
     expect($ids)->toContain($myRecording->id)
         ->toContain($theirRecording->id);
@@ -177,7 +178,7 @@ it('non-admin sees only their own recordings', function () {
             'title' => 'Their Recording',
         ]);
 
-    $ids = \App\Filament\Resources\DvrRecordings\DvrRecordingResource::getEloquentQuery()->pluck('id');
+    $ids = DvrRecordingResource::getEloquentQuery()->pluck('id');
 
     expect($ids)->toContain($myRecording->id)
         ->not()->toContain($theirRecording->id);

--- a/tests/Feature/DvrSchedulerServiceTest.php
+++ b/tests/Feature/DvrSchedulerServiceTest.php
@@ -30,6 +30,7 @@ use App\Models\DvrRecordingRule;
 use App\Models\DvrSetting;
 use App\Models\EpgChannel;
 use App\Models\EpgProgramme;
+use App\Models\PlaylistAuth;
 use App\Models\User;
 use App\Services\DvrSchedulerService;
 use App\Support\SeriesKey;
@@ -377,6 +378,33 @@ it('does not schedule when the dvr setting is at capacity', function () {
     expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(0);
 });
 
+it('does not schedule when the guest playlist auth is at its concurrent recording limit', function () {
+    $playlistAuth = PlaylistAuth::factory()->create(['dvr_max_concurrent_recordings' => 1]);
+
+    DvrRecording::factory()
+        ->recording()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($playlistAuth, 'playlistAuth')
+        ->create();
+
+    $rule = DvrRecordingRule::factory()
+        ->series()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($playlistAuth, 'playlistAuth')
+        ->create(['series_title' => 'Guest Capacity Show']);
+
+    EpgProgramme::factory()->upcoming(10)->create([
+        'title' => 'Guest Capacity Show',
+        'epg_channel_id' => 'test.channel',
+    ]);
+
+    $this->service->matchAndSchedule(30);
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(0);
+});
+
 // --- Disabled rules ---
 
 it('does not process disabled rules', function () {
@@ -675,6 +703,37 @@ it('does not dispatch more starts in one tick than free capacity slots', functio
         ->count(3)
         ->for($this->setting, 'dvrSetting')
         ->for($this->user)
+        ->state(fn () => [
+            'status' => DvrRecordingStatus::Scheduled,
+            'scheduled_start' => now()->subMinute(),
+            'scheduled_end' => now()->addHour(),
+        ])
+        ->create();
+
+    $this->service->tick();
+
+    Queue::assertPushed(StartDvrRecording::class, 1);
+});
+
+it('does not dispatch more starts in one tick than a guest playlist auth has free slots', function () {
+    $this->setting->update(['max_concurrent_recordings' => 10]);
+
+    $playlistAuth = PlaylistAuth::factory()->create(['dvr_max_concurrent_recordings' => 2]);
+
+    // One slot is already occupied by an in-flight recording for this guest
+    DvrRecording::factory()
+        ->recording()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($playlistAuth, 'playlistAuth')
+        ->create();
+
+    // Three rows for the same guest are all due this tick — only one should start (1 active + 1 new = 2 max)
+    DvrRecording::factory()
+        ->count(3)
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($playlistAuth, 'playlistAuth')
         ->state(fn () => [
             'status' => DvrRecordingStatus::Scheduled,
             'scheduled_start' => now()->subMinute(),

--- a/tests/Feature/DvrStorageEndpointTest.php
+++ b/tests/Feature/DvrStorageEndpointTest.php
@@ -1,0 +1,240 @@
+<?php
+
+/**
+ * Coverage for the Xtream `get_dvr_storage` action, which lets the TV app show
+ * the current user/guest's DVR storage usage against their quota.
+ *
+ * Locks in the privacy-scoping contract: a guest (PlaylistAuth) only ever sees
+ * their own recordings' usage, never the account-wide total, regardless of
+ * whether they have an explicit quota configured. The account owner sees the
+ * whole DVR setting's usage against its global quota.
+ */
+
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
+use App\Models\Playlist;
+use App\Models\PlaylistAuth;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create();
+});
+
+function dvrStorageUrl(string $username, string $password): string
+{
+    return route('xtream.api.player').'?'.http_build_query([
+        'username' => $username,
+        'password' => $password,
+        'action' => 'get_dvr_storage',
+    ]);
+}
+
+it('reports account-scoped usage against the global quota for the owner', function () {
+    DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create(['global_disk_quota_gb' => 10]);
+
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->playlist->dvrSetting)
+        ->create(['file_size_bytes' => 1073741824]); // 1 GB
+
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->playlist->dvrSetting)
+        ->create(['file_size_bytes' => 536870912]); // 0.5 GB
+
+    $response = $this->getJson(dvrStorageUrl($this->user->name, $this->playlist->uuid));
+
+    $response->assertOk()->assertExactJson([
+        'used_bytes' => 1610612736,
+        'quota_bytes' => 10 * 1024 ** 3,
+        'percent_used' => 15.0,
+        'recording_count' => 2,
+        'scope' => 'account',
+    ]);
+});
+
+it('reports unlimited account quota when global_disk_quota_gb is zero', function () {
+    DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create(['global_disk_quota_gb' => 0]);
+
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->playlist->dvrSetting)
+        ->create(['file_size_bytes' => 1073741824]);
+
+    $response = $this->getJson(dvrStorageUrl($this->user->name, $this->playlist->uuid));
+
+    $response->assertOk()->assertJson([
+        'used_bytes' => 1073741824,
+        'quota_bytes' => null,
+        'percent_used' => null,
+        'recording_count' => 1,
+        'scope' => 'account',
+    ]);
+});
+
+it('reports the zeroed contract shape when DVR is not configured for the account', function () {
+    $response = $this->getJson(dvrStorageUrl($this->user->name, $this->playlist->uuid));
+
+    $response->assertOk()->assertExactJson([
+        'used_bytes' => 0,
+        'quota_bytes' => null,
+        'percent_used' => null,
+        'recording_count' => 0,
+        'scope' => 'account',
+    ]);
+});
+
+it('reports guest-scoped usage against the guest own quota', function () {
+    DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create(['global_disk_quota_gb' => 100]);
+
+    $username = 'guest_'.Str::random(5);
+    $password = 'guestpass';
+    $auth = PlaylistAuth::create([
+        'name' => 'Guest Sarah',
+        'username' => $username,
+        'password' => $password,
+        'enabled' => true,
+        'dvr_enabled' => true,
+        'dvr_storage_quota_gb' => 2,
+        'user_id' => $this->user->id,
+    ]);
+    $this->playlist->playlistAuths()->attach($auth);
+
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->playlist->dvrSetting)
+        ->create([
+            'playlist_auth_id' => $auth->id,
+            'file_size_bytes' => 1073741824, // 1 GB — the guest's own recording
+        ]);
+
+    // Another guest's recording under the same account must not count toward this guest's usage.
+    $otherAuth = PlaylistAuth::factory()->for($this->user)->create(['dvr_enabled' => true]);
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->playlist->dvrSetting)
+        ->create([
+            'playlist_auth_id' => $otherAuth->id,
+            'file_size_bytes' => 5368709120, // 5 GB, must be excluded
+        ]);
+
+    // The owner's own (non-guest) recording must also not count toward this guest's usage.
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->playlist->dvrSetting)
+        ->create([
+            'playlist_auth_id' => null,
+            'file_size_bytes' => 3221225472, // 3 GB, must be excluded
+        ]);
+
+    $response = $this->getJson(dvrStorageUrl($username, $password));
+
+    $response->assertOk()->assertExactJson([
+        'used_bytes' => 1073741824,
+        'quota_bytes' => 2 * 1024 ** 3,
+        'percent_used' => 50.0,
+        'recording_count' => 1,
+        'scope' => 'guest',
+    ]);
+});
+
+it('reports 100 percent used when the guest quota is configured as zero bytes', function () {
+    // dvr_storage_quota_gb = 0 is distinct from null: null means unlimited, 0 means
+    // the guest is capped at zero bytes (see PlaylistAuth::hasReachedStorageQuota()).
+    // quota_bytes is therefore 0, not null — percent_used must not treat 0 as falsy.
+    DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create(['global_disk_quota_gb' => 100]);
+
+    $username = 'guest_'.Str::random(5);
+    $password = 'guestpass';
+    $auth = PlaylistAuth::create([
+        'name' => 'Guest Zero Quota',
+        'username' => $username,
+        'password' => $password,
+        'enabled' => true,
+        'dvr_enabled' => true,
+        'dvr_storage_quota_gb' => 0,
+        'user_id' => $this->user->id,
+    ]);
+    $this->playlist->playlistAuths()->attach($auth);
+
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->playlist->dvrSetting)
+        ->create([
+            'playlist_auth_id' => $auth->id,
+            'file_size_bytes' => 1073741824, // 1 GB
+        ]);
+
+    $response = $this->getJson(dvrStorageUrl($username, $password));
+
+    $response->assertOk()->assertExactJson([
+        'used_bytes' => 1073741824,
+        'quota_bytes' => 0,
+        'percent_used' => 100,
+        'recording_count' => 1,
+        'scope' => 'guest',
+    ]);
+});
+
+it('reports unlimited guest quota when dvr_storage_quota_gb is null', function () {
+    DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create(['global_disk_quota_gb' => 100]);
+
+    $username = 'guest_'.Str::random(5);
+    $password = 'guestpass';
+    $auth = PlaylistAuth::create([
+        'name' => 'Guest Unlimited',
+        'username' => $username,
+        'password' => $password,
+        'enabled' => true,
+        'dvr_enabled' => true,
+        'dvr_storage_quota_gb' => null,
+        'user_id' => $this->user->id,
+    ]);
+    $this->playlist->playlistAuths()->attach($auth);
+
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->playlist->dvrSetting)
+        ->create([
+            'playlist_auth_id' => $auth->id,
+            'file_size_bytes' => 536870912, // 0.5 GB
+        ]);
+
+    $response = $this->getJson(dvrStorageUrl($username, $password));
+
+    $response->assertOk()->assertExactJson([
+        'used_bytes' => 536870912,
+        'quota_bytes' => null,
+        'percent_used' => null,
+        'recording_count' => 1,
+        'scope' => 'guest',
+    ]);
+});

--- a/tests/Feature/DvrStorageOverviewWidgetTest.php
+++ b/tests/Feature/DvrStorageOverviewWidgetTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Widgets\DvrStorageOverviewWidget;
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config()->set('dvr.dvr_enabled', true);
+    config()->set('proxy.proxy_integration_enabled', true);
+});
+
+it('is visible to admin users only', function () {
+    $admin = User::factory()->admin()->create();
+    $this->actingAs($admin);
+
+    expect(DvrStorageOverviewWidget::canView())->toBeTrue();
+});
+
+it('is hidden from non-admin users', function () {
+    $user = User::factory()->create(['permissions' => ['use_dvr']]);
+    $this->actingAs($user);
+
+    expect(DvrStorageOverviewWidget::canView())->toBeFalse();
+});
+
+it('computes per-user storage with quota', function () {
+    $user = User::factory()->create(['permissions' => ['use_dvr']]);
+    $playlist = Playlist::factory()->for($user)->create();
+    $dvrSetting = DvrSetting::factory()
+        ->for($user)
+        ->for($playlist)
+        ->enabled()
+        ->create(['global_disk_quota_gb' => 10]);
+
+    DvrRecording::factory()
+        ->for($user)
+        ->for($dvrSetting)
+        ->create(['file_size_bytes' => 1073741824]); // 1 GB
+
+    DvrRecording::factory()
+        ->for($user)
+        ->for($dvrSetting)
+        ->create(['file_size_bytes' => 536870912]); // 0.5 GB
+
+    DvrRecording::factory()
+        ->for($user)
+        ->for($dvrSetting)
+        ->create(['file_size_bytes' => null]);
+
+    $admin = User::factory()->admin()->create();
+    $this->actingAs($admin);
+
+    $widget = app(DvrStorageOverviewWidget::class);
+    $data = invade($widget)->getViewData();
+    $rows = $data['rows'];
+
+    expect($rows)->toHaveCount(1);
+
+    $row = $rows->first();
+    expect($row['user']->id)->toBe($user->id)
+        ->and($row['recording_count'])->toBe(3)
+        ->and((int) $row['used_bytes'])->toBe(intval(1073741824 + 536870912))
+        ->and((int) $row['quota_bytes'])->toBe(intval(10 * 1024 ** 3))
+        ->and($row['percent'])->toBe(15.0);
+});
+
+it('returns null percent when quota is zero', function () {
+    $user = User::factory()->create(['permissions' => ['use_dvr']]);
+    $playlist = Playlist::factory()->for($user)->create();
+    $dvrSetting = DvrSetting::factory()
+        ->for($user)
+        ->for($playlist)
+        ->enabled()
+        ->create(['global_disk_quota_gb' => 0]);
+
+    DvrRecording::factory()
+        ->for($user)
+        ->for($dvrSetting)
+        ->create(['file_size_bytes' => 1073741824]);
+
+    $admin = User::factory()->admin()->create();
+    $this->actingAs($admin);
+
+    $widget = app(DvrStorageOverviewWidget::class);
+    $data = invade($widget)->getViewData();
+    $rows = $data['rows'];
+
+    expect($rows)->toHaveCount(1);
+    expect($rows->first()['percent'])->toBeNull();
+    expect($rows->first()['quota_bytes'])->toBeNull();
+});

--- a/tests/Feature/DvrStorageOverviewWidgetTest.php
+++ b/tests/Feature/DvrStorageOverviewWidgetTest.php
@@ -8,6 +8,7 @@ use App\Models\DvrSetting;
 use App\Models\Playlist;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 
 uses(RefreshDatabase::class);
 
@@ -95,4 +96,34 @@ it('returns null percent when quota is zero', function () {
     expect($rows)->toHaveCount(1);
     expect($rows->first()['percent'])->toBeNull();
     expect($rows->first()['quota_bytes'])->toBeNull();
+});
+
+it('loads storage totals without an N+1 query per user', function () {
+    foreach (range(1, 3) as $i) {
+        $user = User::factory()->create(['permissions' => ['use_dvr']]);
+        $playlist = Playlist::factory()->for($user)->create();
+        $dvrSetting = DvrSetting::factory()
+            ->for($user)
+            ->for($playlist)
+            ->enabled()
+            ->create(['global_disk_quota_gb' => 10]);
+
+        DvrRecording::factory()
+            ->for($user)
+            ->for($dvrSetting)
+            ->create(['file_size_bytes' => 1073741824]);
+    }
+
+    $admin = User::factory()->admin()->create();
+    $this->actingAs($admin);
+
+    $widget = app(DvrStorageOverviewWidget::class);
+
+    DB::enableQueryLog();
+    $rows = invade($widget)->getViewData()['rows'];
+    $queryCount = count(DB::getQueryLog());
+    DB::disableQueryLog();
+
+    expect($rows)->toHaveCount(3)
+        ->and($queryCount)->toBeLessThanOrEqual(2);
 });

--- a/tests/Feature/PlaylistAuthResourceTableTest.php
+++ b/tests/Feature/PlaylistAuthResourceTableTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Filament\Resources\PlaylistAuths\Pages\ListPlaylistAuths;
+use App\Models\DvrRecording;
+use App\Models\DvrSetting;
+use App\Models\PlaylistAuth;
+use App\Models\Playlist;
+use App\Models\User;
+use Livewire\Livewire;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    config()->set('dvr.dvr_enabled', true);
+    config()->set('proxy.proxy_integration_enabled', true);
+
+    $this->user = User::factory()->create();
+
+    $playlist = Playlist::factory()->for($this->user)->create();
+    $this->dvrSetting = DvrSetting::factory()
+        ->for($this->user)
+        ->for($playlist)
+        ->enabled()
+        ->create();
+
+    $this->actingAs($this->user);
+});
+
+it('shows recording count for users with dvr recordings', function () {
+    $auth = PlaylistAuth::factory()->for($this->user)->create([
+        'name' => 'Recording Guest',
+        'dvr_enabled' => true,
+    ]);
+
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->count(3)
+        ->create([
+            'playlist_auth_id' => $auth->id,
+        ]);
+
+    Livewire::test(ListPlaylistAuths::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertTableColumnStateSet('dvr_recordings_count', 3, $auth);
+});
+
+it('shows storage used with quota when quota is set', function () {
+    $auth = PlaylistAuth::factory()->for($this->user)->create([
+        'name' => 'Quota Guest',
+        'dvr_enabled' => true,
+        'dvr_storage_quota_gb' => 10,
+    ]);
+
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'playlist_auth_id' => $auth->id,
+            'file_size_bytes' => 1073741824, // 1.0 GB
+        ]);
+
+    Livewire::test(ListPlaylistAuths::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertTableColumnFormattedStateSet('storage_used_bytes', '1.0 GB / 10 GB', $auth);
+});
+
+it('shows unlimited storage when no quota is set', function () {
+    $auth = PlaylistAuth::factory()->for($this->user)->create([
+        'name' => 'Unlimited Guest',
+        'dvr_enabled' => true,
+        'dvr_storage_quota_gb' => null,
+    ]);
+
+    DvrRecording::factory()
+        ->for($this->user)
+        ->for($this->dvrSetting)
+        ->create([
+            'playlist_auth_id' => $auth->id,
+            'file_size_bytes' => 524288000, // 500 MB
+        ]);
+
+    Livewire::test(ListPlaylistAuths::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertTableColumnFormattedStateSet('storage_used_bytes', '500.0 MB / Unlimited', $auth);
+});
+
+it('shows em dash for dvr storage when dvr is disabled', function () {
+    $auth = PlaylistAuth::factory()->for($this->user)->create([
+        'name' => 'No DVR Guest',
+        'dvr_enabled' => false,
+    ]);
+
+    Livewire::test(ListPlaylistAuths::class)
+        ->assertOk()
+        ->loadTable()
+        ->assertTableColumnFormattedStateSet('storage_used_bytes', '—', $auth);
+});

--- a/tests/Feature/PlaylistAuthResourceTableTest.php
+++ b/tests/Feature/PlaylistAuthResourceTableTest.php
@@ -3,12 +3,13 @@
 use App\Filament\Resources\PlaylistAuths\Pages\ListPlaylistAuths;
 use App\Models\DvrRecording;
 use App\Models\DvrSetting;
-use App\Models\PlaylistAuth;
 use App\Models\Playlist;
+use App\Models\PlaylistAuth;
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 
-uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+uses(RefreshDatabase::class);
 
 beforeEach(function () {
     config()->set('dvr.dvr_enabled', true);

--- a/tests/Feature/XtreamScheduleDvrTest.php
+++ b/tests/Feature/XtreamScheduleDvrTest.php
@@ -195,6 +195,29 @@ it('rejects scheduling a channel that belongs to a different playlist', function
     expect(DvrRecordingRule::count())->toBe(0);
 });
 
+it('rejects scheduling when the guest playlist auth is at its concurrent recording limit', function () {
+    $this->playlistAuth->update(['dvr_max_concurrent_recordings' => 1]);
+
+    DvrRecording::factory()
+        ->recording()
+        ->for($this->user)
+        ->for($this->playlist->dvrSetting, 'dvrSetting')
+        ->for($this->playlistAuth, 'playlistAuth')
+        ->create();
+
+    $response = $this->postJson(scheduleDvrUrl($this->username, $this->password), [
+        'channel_id' => (string) $this->channel->id,
+        'title' => 'Evening News',
+        'start_time' => now()->addHour()->toIso8601String(),
+        'end_time' => now()->addHours(2)->toIso8601String(),
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJson(['error' => 'Concurrent recording limit reached']);
+
+    expect(DvrRecordingRule::count())->toBe(0);
+});
+
 function createDvrSeriesRuleUrl(string $username, string $password): string
 {
     return route('xtream.api.player').'?'.http_build_query([


### PR DESCRIPTION
## Summary

Admin-side DVR observability pass: admins can now see who is recording
what, how much storage each user is using against their quota, and the
scheduler enforces a per-guest concurrent-recording cap.

## What's in

**Filament dashboard**
- New `DvrStorageOverviewWidget` (admin-only) shows per-user recording
  count, used storage, quota, and percent used. Hidden from non-admins.
- Registered via `AdminPanelProvider`.

**DvrRecordingResource**
- Table gains `Owner` (searchable, sortable) and `Guest` columns plus
  matching filters.
- `getEloquentQuery` / `getGlobalSearchEloquentQuery` scope recordings
  to the current user for non-admins — recordings no longer leak across
  users in the resource.

**PlaylistAuthResource**
- Table gains recording count, used storage, and quota columns for
  each guest's DVR settings.

**Per-guest concurrent cap**
- `PlaylistAuth::hasReachedConcurrentLimit()` centralises the cap.
- `DvrSchedulerService` checks it in:
  - manual rule matching
  - dummy-EPG matching for once rules
  - scheduled-programme creation
  - the pending-trigger loop (with a per-tick pending counter)
- `XtreamApiController::scheduleDvr()` honours the cap on the Xtream
  scheduling path.

## Local checks

- `php -l` clean on all eight PHP files (including the new blade view).
- `php artisan test --filter='DvrRecordingResourceTableTest|DvrSchedulerServiceTest|DvrStorageOverviewWidgetTest|PlaylistAuthResourceTableTest'` — **78 passing assertions, 7.7s**.

## Open as draft while

- I eyeball the new widget's table styling against the rest of the
  Filament admin tables (the new columns may need alignment tweaks).
- Verify the existing `max_concurrent_recordings` settings path
  (Plugin/DVR config) writes through to the new check.

## Related

- Pulls together the admin-side observations the team flagged in
  #1342 (DVR location), #1332 (Xtream DVR scheduling validation),
  and #1328 (PlaylistAuth ownership/quotas for Xtream DVR).