### PR TITLE
fix(start-container): persist Reverb/Redis/proxy secrets across restarts

### DIFF
--- a/start-container
+++ b/start-container
@@ -4,6 +4,32 @@
 export PUID="${PUID:-1000}" # NOT CURRENTLY USED...
 export PGID="${PGID:-1000}" # NOT CURRENTLY USED...
 
+# Load previously-generated secrets from the persistent config volume before
+# any "generate if unset" checks below run. Without this, REDIS_PASSWORD,
+# M3U_PROXY_TOKEN, REVERB_APP_ID, and REVERB_APP_SECRET are regenerated fresh
+# on every container boot (since docker-compose doesn't set them and the
+# `[ -z ... ]` checks further down have no way to see the persisted .env file,
+# which isn't read/symlinked until much later in this script). A container
+# that's merely restarted (not recreated) picks up a brand new Reverb secret
+# every time, while any already-running or cached client session still signs
+# broadcast-auth requests against the old one — silent private-channel
+# subscription failures ("Connection is unauthorized") with no client-visible
+# error, since the client just stops receiving push events instead of
+# throwing. Read-only grep here; the persisted file itself isn't modified.
+_early_config_dir="/var/www/config"
+_early_env_file="${_early_config_dir}/env"
+if [ -f "${_early_env_file}" ]; then
+    for _persisted_key in REDIS_PASSWORD M3U_PROXY_TOKEN REVERB_APP_ID REVERB_APP_SECRET; do
+        if [ -z "${!_persisted_key}" ]; then
+            _persisted_value=$(grep -E "^${_persisted_key}=" "${_early_env_file}" | tail -1 | cut -d '=' -f2-)
+            if [ -n "${_persisted_value}" ]; then
+                export "${_persisted_key}=${_persisted_value}"
+            fi
+        fi
+    done
+fi
+unset _early_config_dir _early_env_file _persisted_key _persisted_value
+
 # Set Redis server host, port and password
 export REDIS_ENABLED="${REDIS_ENABLED:-true}"
 export REDIS_HOST="${REDIS_HOST:-localhost}"


### PR DESCRIPTION
## Summary

Restore the 26-line early-secrets-load block to `start-container` that was descoped from #1355 in upstream commit 604348f56a ("chore: Remove the start-container updates") so it can be reviewed and tested separately.

## Symptom this fixes

On a **container restart** (not recreate):

1. docker-compose does not re-supply `REDIS_PASSWORD`, `M3U_PROXY_TOKEN`, `REVERB_APP_ID`, or `REVERB_APP_SECRET`.
2. The persisted env file at `/var/www/config/env` is not read/symlinked until much later in `start-container`, so the `[ -z ... ]` "generate if unset" checks downstream see these vars as empty.
3. Fresh secrets are minted for the now-running container.
4. Any already-connected Reverb client is still signing broadcast-auth requests with the **old** `REVERB_APP_SECRET`, the server rejects them as "Connection is unauthorized", and the client just stops receiving push events with no error surfaced.

In the m3u-tv Flutter app, this surfaces as the DVR status indicator going stale until the user force-closes and reopens the app.

## What this PR does

Adds a small read-only block at the top of `start-container` (right after PUID/PGID exports, before the Redis section) that, if a persisted env file exists, re-exports the four secrets from it **only when they are not already set** by docker-compose or the runtime environment. The persisted env file itself is never modified.

Three invariants verified locally:

| Case | Expected | Result |
|---|---|---|
| Persisted env file missing | No-op, no errors, vars still unset | OK |
| Persisted env file present, vars unset | All four vars exported from file | OK |
| Persisted env file present, one var pre-exported by docker-compose | That var preserved, others taken from file | OK |

## Why a separate PR

Per maintainer @sparkison's note in 604348f56a, the original PR was scoped down to keep the merge focused. This is a deliberately narrow follow-up so the approach can be reviewed and tested in isolation from the broader DVR/Reverb reliability work in #1355.

## Verification

- `bash -n start-container` — passes.
- `shellcheck` — not installed in this environment; recommended for CI before merge.
- Manual semantic smoke test (in isolation, not full container start) — 3/3 cases pass.
- `git diff` against upstream/dev HEAD — exactly 26 lines added, `@@ -4,6 +4,32 @@`, the precise inverse of 604348f56a's `@@ -4,32 +4,6 @@`.

## Diff

```diff
diff --git a/start-container b/start-container
@@ -4,6 +4,32 @@
 export PUID="${PUID:-1000}" # NOT CURRENTLY USED...
 export PGID="${PGID:-1000}" # NOT CURRENTLY USED...
 
+# Load previously-generated secrets from the persistent config volume before
+... (26 lines) ...
+unset _early_config_dir _early_env_file _persisted_key _persisted_value
+
 # Set Redis server host, port and password
 export REDIS_ENABLED="${REDIS_ENABLED:-true}"
```

## Related

- PR #1355 — original merge that included this block
- Upstream commit 604348f56a — the "remove" commit that this PR reverts