### PR TITLE
chore: Close unauthenticated access on media-proxy, EPG, and player-stream-stop routes

### DIFF
--- a/app/Http/Controllers/AIOStreamsProxyController.php
+++ b/app/Http/Controllers/AIOStreamsProxyController.php
@@ -82,7 +82,32 @@ class AIOStreamsProxyController extends Controller
             return response()->json(['error' => 'Failed to fetch streams from AIOStreams'], 502);
         }
 
-        return response()->json($response->json());
+        $data = $response->json();
+
+        // Never hand a raw resolved URL (often carrying the debrid account's own
+        // auth token) back to the caller — proxy every candidate the same way the
+        // browse UI and synced Channels/Episodes do. There's no durable row behind
+        // this call, so it goes through the short-lived cache-token "live" proxy.
+        // A stream list can hold dozens of candidates, so this is batched into one
+        // cache write (see generateAioStreamsLiveProxyUrls()) rather than one per
+        // candidate.
+        if (is_array($data['streams'] ?? null)) {
+            $rawUrlsByIndex = [];
+
+            foreach ($data['streams'] as $index => $stream) {
+                if (is_string($stream['url'] ?? null) && $stream['url'] !== '') {
+                    $rawUrlsByIndex[$index] = $stream['url'];
+                }
+            }
+
+            $proxiedUrlsByIndex = MediaServerProxyController::generateAioStreamsLiveProxyUrls($integrationId, $rawUrlsByIndex);
+
+            foreach ($proxiedUrlsByIndex as $index => $proxiedUrl) {
+                $data['streams'][$index]['url'] = $proxiedUrl;
+            }
+        }
+
+        return response()->json($data);
     }
 
     /**

--- a/app/Http/Controllers/Api/EpgApiController.php
+++ b/app/Http/Controllers/Api/EpgApiController.php
@@ -266,14 +266,15 @@ class EpgApiController extends Controller
         $requestedPassword = $request->get('password', null);
 
         // Only embed playable stream URLs for callers we can actually verify: an
-        // authenticated panel session (the in-app EPG viewer), or credentials that
-        // resolve to this exact playlist. Never substitute the playlist owner's
-        // real credentials for a caller we can't authenticate — unauthenticated
-        // callers get metadata only (see $isPlayable below).
+        // authenticated panel session that owns this specific playlist (the
+        // in-app EPG viewer), or credentials that resolve to this exact
+        // playlist. Never substitute the playlist owner's real credentials for
+        // a caller we can't authenticate as that owner — everyone else gets
+        // metadata only (see $isPlayable below).
         $username = null;
         $password = null;
 
-        if (Auth::check()) {
+        if (Auth::check() && Auth::id() === $playlist->user_id) {
             $username = $user->name ?? 'admin';
             $password = $playlist->uuid;
         } elseif ($requestedUsername && $requestedPassword) {

--- a/app/Http/Controllers/Api/EpgApiController.php
+++ b/app/Http/Controllers/Api/EpgApiController.php
@@ -18,6 +18,7 @@ use Carbon\Carbon;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
@@ -261,14 +262,33 @@ class EpgApiController extends Controller
         $search = $request->get('search', null);
         $group = $request->get('group', null) ?: null;
         $vod = $request->boolean('vod');
-        $username = $request->get('username', null);
-        $password = $request->get('password', null);
+        $requestedUsername = $request->get('username', null);
+        $requestedPassword = $request->get('password', null);
 
-        // If not username/password provided, use playlist credentials
-        if (! $username || ! $password) {
+        // Only embed playable stream URLs for callers we can actually verify: an
+        // authenticated panel session (the in-app EPG viewer), or credentials that
+        // resolve to this exact playlist. Never substitute the playlist owner's
+        // real credentials for a caller we can't authenticate — unauthenticated
+        // callers get metadata only (see $isPlayable below).
+        $username = null;
+        $password = null;
+
+        if (Auth::check()) {
             $username = $user->name ?? 'admin';
             $password = $playlist->uuid;
+        } elseif ($requestedUsername && $requestedPassword) {
+            $authResult = PlaylistFacade::authenticate($requestedUsername, $requestedPassword);
+            $resolvedPlaylist = $authResult[0] ?? null;
+
+            if ($resolvedPlaylist
+                && get_class($resolvedPlaylist) === get_class($playlist)
+                && $resolvedPlaylist->id === $playlist->id) {
+                $username = $authResult[2];
+                $password = $authResult[3];
+            }
         }
+
+        $isPlayable = $username !== null && $password !== null;
 
         // Get parsed date range
         $dateRange = $this->parseDateRange($request);
@@ -443,12 +463,15 @@ class EpgApiController extends Controller
                         break;
                 }
 
-                // Get the channel URL with embedded auth.
-                // XtreamStreamController routes to the channelPlayer method, which
-                // applies the in-app transcoding profile.
-                $channelResults = $channel->getFloatingPlayerAttributes(username: $username, password: $password);
-                $url = $channelResults['url'] ?? '';
-                $channelFormat = $channelResults['format'] ?? '';
+                // Get the channel URL with embedded auth. XtreamStreamController routes
+                // to the channelPlayer method, which applies the in-app transcoding
+                // profile. Skip entirely when the caller isn't verified so no channel
+                // URL (and therefore no credential) is ever built for it.
+                $channelResults = $isPlayable
+                    ? $channel->getFloatingPlayerAttributes(username: $username, password: $password)
+                    : [];
+                $url = $channelResults['url'] ?? null;
+                $channelFormat = $channelResults['format'] ?? null;
 
                 // Get the icon
                 $icon = '';
@@ -486,6 +509,7 @@ class EpgApiController extends Controller
                     'epg_channel_id' => $channel->epg_channel_id ?? null,
                     'tvg_shift' => (int) ($channel->tvg_shift ?? 0), // EPG time shift in hours
                     'sort_index' => $channelSortIndex++,
+                    'playable' => $isPlayable,
                 ];
             }
 
@@ -772,6 +796,7 @@ class EpgApiController extends Controller
                     'uuid' => $playlist->uuid,
                     'type' => get_class($playlist),
                 ],
+                'playable' => $isPlayable,
                 'date_range' => [
                     'start' => $startDate,
                     'end' => $endDate,

--- a/app/Http/Controllers/Api/M3uProxyApiController.php
+++ b/app/Http/Controllers/Api/M3uProxyApiController.php
@@ -18,6 +18,7 @@ use App\Settings\GeneralSettings;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -839,15 +840,18 @@ class M3uProxyApiController extends Controller
      * Called via sendBeacon from the browser when a floating/popout player is closed
      * or when the user navigates away. This is a best-effort signal; the proxy will
      * also detect the TCP connection drop independently.
+     *
+     * Requires an authenticated panel session (see routes/api.php) and verifies the
+     * requested channel/episode belongs to that user before touching proxy state, so
+     * one user cannot stop another user's stream. Always responds 204 - whether the
+     * caller is unauthenticated, the ID is out of scope, or the stop actually
+     * happened - so the response can't be used to probe ownership of another ID.
      */
     public function stopPlayerStream(Request $request): Response
     {
+        $user = Auth::user();
         $id = $request->input('id');
         $type = $request->input('type');
-
-        if (! $id || ! $type) {
-            return response()->noContent(422);
-        }
 
         $field = match ($type) {
             'channel' => 'channel_id',
@@ -855,19 +859,23 @@ class M3uProxyApiController extends Controller
             default => null,
         };
 
-        if (! $field) {
-            return response()->noContent(422);
-        }
+        $model = match ($field) {
+            'channel_id' => $user ? Channel::find($id) : null,
+            'episode_id' => $user ? Episode::find($id) : null,
+            default => null,
+        };
 
-        try {
-            M3uProxyService::stopStreamsByMetadata($field, (string) $id, force: false, clientId: $request->input('client_id'));
-        } catch (Exception $e) {
-            Log::warning('Failed to stop player stream', [
-                'type' => $type,
-                'id' => $id,
-                'exception_class' => $e::class,
-                'exception_code' => $e->getCode(),
-            ]);
+        if ($field && $model && $user->can('view', $model)) {
+            try {
+                M3uProxyService::stopStreamsByMetadata($field, (string) $id, force: false, clientId: $request->input('client_id'));
+            } catch (Exception $e) {
+                Log::warning('Failed to stop player stream', [
+                    'type' => $type,
+                    'id' => $id,
+                    'exception_class' => $e::class,
+                    'exception_code' => $e->getCode(),
+                ]);
+            }
         }
 
         return response()->noContent();

--- a/app/Http/Controllers/Api/M3uProxyApiController.php
+++ b/app/Http/Controllers/Api/M3uProxyApiController.php
@@ -876,16 +876,7 @@ class M3uProxyApiController extends Controller
         };
 
         if ($model && $user->can('view', $model)) {
-            try {
-                M3uProxyService::stopStreamsByMetadata($field, (string) $id, force: false, clientId: $request->input('client_id'));
-            } catch (Exception $e) {
-                Log::warning('Failed to stop player stream', [
-                    'type' => $type,
-                    'id' => $id,
-                    'exception_class' => $e::class,
-                    'exception_code' => $e->getCode(),
-                ]);
-            }
+            M3uProxyService::stopStreamSafely($field, (string) $id, $request->input('client_id'));
         }
 
         return response()->noContent();

--- a/app/Http/Controllers/Api/M3uProxyApiController.php
+++ b/app/Http/Controllers/Api/M3uProxyApiController.php
@@ -849,9 +849,12 @@ class M3uProxyApiController extends Controller
      */
     public function stopPlayerStream(Request $request): Response
     {
-        $user = Auth::user();
         $id = $request->input('id');
         $type = $request->input('type');
+
+        if (! $id || ! $type) {
+            return response()->noContent(422);
+        }
 
         $field = match ($type) {
             'channel' => 'channel_id',
@@ -859,13 +862,20 @@ class M3uProxyApiController extends Controller
             default => null,
         };
 
+        if (! $field) {
+            return response()->noContent(422);
+        }
+
+        // Ownership (and the caller being authenticated at all) is checked here, but
+        // deliberately doesn't change the response - always 204 - so it can't be used
+        // to probe whether an ID exists or belongs to someone else.
+        $user = Auth::user();
         $model = match ($field) {
             'channel_id' => $user ? Channel::find($id) : null,
             'episode_id' => $user ? Episode::find($id) : null,
-            default => null,
         };
 
-        if ($field && $model && $user->can('view', $model)) {
+        if ($model && $user->can('view', $model)) {
             try {
                 M3uProxyService::stopStreamsByMetadata($field, (string) $id, force: false, clientId: $request->input('client_id'));
             } catch (Exception $e) {

--- a/app/Http/Controllers/Api/TvApiController.php
+++ b/app/Http/Controllers/Api/TvApiController.php
@@ -9,13 +9,11 @@ use App\Models\PushDeviceToken;
 use App\Models\TvNotification;
 use App\Services\M3uProxyService;
 use App\Settings\GeneralSettings;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 
 class TvApiController extends Controller
 {
@@ -245,16 +243,7 @@ class TvApiController extends Controller
             : (method_exists($playlist, 'channels') && $playlist->channels()->whereKey($id)->exists());
 
         if ($belongsToPlaylist) {
-            try {
-                M3uProxyService::stopStreamsByMetadata($field, (string) $id, force: false, clientId: $data['client_id']);
-            } catch (Exception $e) {
-                Log::warning('Failed to stop TV player stream', [
-                    'type' => $data['type'],
-                    'id' => $id,
-                    'exception_class' => $e::class,
-                    'exception_code' => $e->getCode(),
-                ]);
-            }
+            M3uProxyService::stopStreamSafely($field, (string) $id, $data['client_id'], 'Failed to stop TV player stream');
         }
 
         return response()->json(null, 204);

--- a/app/Http/Controllers/Api/TvApiController.php
+++ b/app/Http/Controllers/Api/TvApiController.php
@@ -7,12 +7,15 @@ use App\Http\Controllers\Controller;
 use App\Models\PlaylistAlias;
 use App\Models\PushDeviceToken;
 use App\Models\TvNotification;
+use App\Services\M3uProxyService;
 use App\Settings\GeneralSettings;
+use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class TvApiController extends Controller
 {
@@ -209,6 +212,52 @@ class TvApiController extends Controller
             ->delete();
 
         return response()->json(['ok' => true]);
+    }
+
+    /**
+     * POST /api/tv/{username}/{password}/player-stream/stop
+     *
+     * Releases this client's registration on a pooled proxy stream (force: false),
+     * so other viewers of the same stream stay connected. Scoped to the authenticated
+     * playlist/credential — the requested channel or episode must belong to it, so one
+     * viewer cannot stop another playlist's stream. Idempotent: always returns 204,
+     * including when the client is already gone or the ID is out of scope, so a caller
+     * can't use the response to probe whether an ID belongs to someone else.
+     */
+    public function stopPlayerStream(Request $request): JsonResponse
+    {
+        $auth = $this->resolveAuth($request);
+        $playlist = $auth['playlist'];
+
+        $data = $request->validate([
+            'type' => ['required', 'string', 'in:live,vod,catchup,series'],
+            'stream_id' => ['required_unless:type,series', 'integer'],
+            'episode_id' => ['required_if:type,series', 'integer'],
+            'client_id' => ['required', 'string', 'max:128', 'regex:/^[\w-]+$/'],
+        ]);
+
+        $isSeries = $data['type'] === 'series';
+        $field = $isSeries ? 'episode_id' : 'channel_id';
+        $id = $isSeries ? $data['episode_id'] : $data['stream_id'];
+
+        $belongsToPlaylist = $isSeries
+            ? (method_exists($playlist, 'episodes') && $playlist->episodes()->whereKey($id)->exists())
+            : (method_exists($playlist, 'channels') && $playlist->channels()->whereKey($id)->exists());
+
+        if ($belongsToPlaylist) {
+            try {
+                M3uProxyService::stopStreamsByMetadata($field, (string) $id, force: false, clientId: $data['client_id']);
+            } catch (Exception $e) {
+                Log::warning('Failed to stop TV player stream', [
+                    'type' => $data['type'],
+                    'id' => $id,
+                    'exception_class' => $e::class,
+                    'exception_code' => $e->getCode(),
+                ]);
+            }
+        }
+
+        return response()->json(null, 204);
     }
 
     /**

--- a/app/Http/Controllers/DvrCallbackController.php
+++ b/app/Http/Controllers/DvrCallbackController.php
@@ -14,8 +14,8 @@ use Illuminate\Support\Facades\Log;
  * DvrCallbackController — Receives webhook callbacks from the m3u-proxy BroadcastManager.
  *
  * The proxy calls this endpoint when a DVR broadcast ends (normally or due to failure).
- * Authentication is via the proxy API token (X-API-Token header or api_token query param),
- * matching the same mechanism the editor uses when calling the proxy.
+ * Authentication is handled by the VerifyM3uProxyCallback middleware (see routes/api.php),
+ * shared with the other m3u-proxy callback routes.
  *
  * Supported events:
  *   programme_ended   — FFmpeg exited cleanly (duration limit reached)
@@ -26,14 +26,6 @@ class DvrCallbackController extends Controller
 {
     public function handle(Request $request): JsonResponse
     {
-        if (! $this->isAuthorized($request)) {
-            Log::warning('DVR callback: unauthorized request', [
-                'ip' => $request->ip(),
-            ]);
-
-            return response()->json(['error' => 'Unauthorized'], 401);
-        }
-
         $networkId = $request->input('network_id');
         $event = $request->input('event');
         $hlsDir = $request->input('hls_dir');
@@ -154,26 +146,5 @@ class DvrCallbackController extends Controller
         ]);
 
         return response()->json(['status' => 'ok']);
-    }
-
-    /**
-     * Validate the request using the same API token the editor uses when calling the proxy.
-     */
-    private function isAuthorized(Request $request): bool
-    {
-        $configuredToken = config('proxy.m3u_proxy_token');
-
-        // If no token is configured, accept all callbacks (dev/open deployments)
-        if (empty($configuredToken)) {
-            Log::warning('DVR callback: no proxy token configured — accepting all callbacks (open deployment)');
-
-            return true;
-        }
-
-        $providedToken = $request->header('X-API-Token')
-            ?? $request->query('api_token')
-            ?? '';
-
-        return hash_equals((string) $configuredToken, $providedToken);
     }
 }

--- a/app/Http/Controllers/MediaServerProxyController.php
+++ b/app/Http/Controllers/MediaServerProxyController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\URL;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -267,11 +268,22 @@ class MediaServerProxyController extends Controller
     }
 
     /**
+     * Time-limited validity for generated proxy URLs, matching the TTL used
+     * elsewhere in the app for stream-scoped tokens (see DispatcharrAuthMiddleware).
+     */
+    private const PROXY_URL_TTL_HOURS = 24;
+
+    /**
      * Generate a proxy URL for an image.
      */
     public static function generateImageProxyUrl(int $integrationId, string $itemId, string $imageType = 'Primary'): string
     {
-        return ProxyFacade::getBaseUrl()."/media-server/{$integrationId}/image/{$itemId}/{$imageType}";
+        return ProxyFacade::getBaseUrl().URL::temporarySignedRoute(
+            'media-server.image.proxy',
+            now()->addHours(self::PROXY_URL_TTL_HOURS),
+            ['integrationId' => $integrationId, 'itemId' => $itemId, 'imageType' => $imageType],
+            absolute: false
+        );
     }
 
     /**
@@ -279,7 +291,12 @@ class MediaServerProxyController extends Controller
      */
     public static function generateStreamProxyUrl(int $integrationId, string $itemId, string $container = 'ts'): string
     {
-        return ProxyFacade::getBaseUrl()."/media-server/{$integrationId}/stream/{$itemId}.{$container}";
+        return ProxyFacade::getBaseUrl().URL::temporarySignedRoute(
+            'media-server.stream.proxy',
+            now()->addHours(self::PROXY_URL_TTL_HOURS),
+            ['integrationId' => $integrationId, 'itemId' => $itemId, 'container' => $container],
+            absolute: false
+        );
     }
 
     /**
@@ -456,7 +473,12 @@ class MediaServerProxyController extends Controller
      */
     public static function generateLocalMediaStreamUrl(int $integrationId, string $itemId): string
     {
-        return ProxyFacade::getBaseUrl()."/local-media/{$integrationId}/stream/{$itemId}";
+        return ProxyFacade::getBaseUrl().URL::temporarySignedRoute(
+            'local-media.stream',
+            now()->addHours(self::PROXY_URL_TTL_HOURS),
+            ['integration' => $integrationId, 'item' => $itemId],
+            absolute: false
+        );
     }
 
     /**
@@ -464,7 +486,12 @@ class MediaServerProxyController extends Controller
      */
     public static function generateWebDavStreamUrl(int $integrationId, string $itemId): string
     {
-        return ProxyFacade::getBaseUrl()."/webdav-media/{$integrationId}/stream/{$itemId}";
+        return ProxyFacade::getBaseUrl().URL::temporarySignedRoute(
+            'webdav-media.stream',
+            now()->addHours(self::PROXY_URL_TTL_HOURS),
+            ['integration' => $integrationId, 'item' => $itemId],
+            absolute: false
+        );
     }
 
     /**

--- a/app/Http/Controllers/MediaServerProxyController.php
+++ b/app/Http/Controllers/MediaServerProxyController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Facades\ProxyFacade;
 use App\Models\MediaServerIntegration;
 use App\Services\MediaServerService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
@@ -33,6 +34,10 @@ class MediaServerProxyController extends Controller
      */
     public function proxyImage(Request $request, int $integrationId, string $itemId, string $imageType = 'Primary')
     {
+        if ($staleResponse = $this->rejectIfStaleUrlVersion($request)) {
+            return $staleResponse;
+        }
+
         try {
             $integration = MediaServerIntegration::find($integrationId);
 
@@ -130,6 +135,10 @@ class MediaServerProxyController extends Controller
      */
     public function proxyStream(Request $request, int $integrationId, string $itemId, string $container = 'ts')
     {
+        if ($staleResponse = $this->rejectIfStaleUrlVersion($request)) {
+            return $staleResponse;
+        }
+
         try {
             // Ensure long-running streaming inside closure is not subject to the default timeout
             set_time_limit(0);
@@ -268,20 +277,48 @@ class MediaServerProxyController extends Controller
     }
 
     /**
-     * Time-limited validity for generated proxy URLs, matching the TTL used
-     * elsewhere in the app for stream-scoped tokens (see DispatcharrAuthMiddleware).
+     * Stored, "permanent" media-server proxy URLs never re-sign themselves, so a
+     * signature alone can't be revoked once handed out. Every generated URL carries
+     * this version, and every request re-checks it against the live config value —
+     * bumping `MEDIA_SERVER_PROXY_URL_VERSION` invalidates every previously
+     * generated URL at once (they're regenerated with the new version on next sync).
      */
-    private const PROXY_URL_TTL_HOURS = 24;
+    protected static function currentUrlVersion(): int
+    {
+        return (int) config('proxy.media_server_url_version', 1);
+    }
+
+    /**
+     * Reject the request if the signed URL's stamped version doesn't match the
+     * live config value. Signature validity (handled by the ValidateSignature
+     * route middleware) only proves the URL wasn't tampered with — it says
+     * nothing about whether it's still considered current.
+     */
+    protected function rejectIfStaleUrlVersion(Request $request): ?JsonResponse
+    {
+        $requestedVersion = (int) $request->query('v', 0);
+
+        if ($requestedVersion === static::currentUrlVersion()) {
+            return null;
+        }
+
+        Log::warning('Media server proxy URL rejected — stale version', [
+            'path' => $request->path(),
+            'requested_version' => $requestedVersion,
+            'current_version' => static::currentUrlVersion(),
+        ]);
+
+        return response()->json(['error' => 'This URL is no longer valid. Please re-sync to generate a new one.'], 403);
+    }
 
     /**
      * Generate a proxy URL for an image.
      */
     public static function generateImageProxyUrl(int $integrationId, string $itemId, string $imageType = 'Primary'): string
     {
-        return ProxyFacade::getBaseUrl().URL::temporarySignedRoute(
+        return ProxyFacade::getBaseUrl().URL::signedRoute(
             'media-server.image.proxy',
-            now()->addHours(self::PROXY_URL_TTL_HOURS),
-            ['integrationId' => $integrationId, 'itemId' => $itemId, 'imageType' => $imageType],
+            ['integrationId' => $integrationId, 'itemId' => $itemId, 'imageType' => $imageType, 'v' => static::currentUrlVersion()],
             absolute: false
         );
     }
@@ -291,10 +328,9 @@ class MediaServerProxyController extends Controller
      */
     public static function generateStreamProxyUrl(int $integrationId, string $itemId, string $container = 'ts'): string
     {
-        return ProxyFacade::getBaseUrl().URL::temporarySignedRoute(
+        return ProxyFacade::getBaseUrl().URL::signedRoute(
             'media-server.stream.proxy',
-            now()->addHours(self::PROXY_URL_TTL_HOURS),
-            ['integrationId' => $integrationId, 'itemId' => $itemId, 'container' => $container],
+            ['integrationId' => $integrationId, 'itemId' => $itemId, 'container' => $container, 'v' => static::currentUrlVersion()],
             absolute: false
         );
     }
@@ -313,6 +349,10 @@ class MediaServerProxyController extends Controller
      */
     public function streamLocalMedia(Request $request, int $integration, string $item)
     {
+        if ($staleResponse = $this->rejectIfStaleUrlVersion($request)) {
+            return $staleResponse;
+        }
+
         try {
             set_time_limit(0);
             ignore_user_abort(true);
@@ -473,10 +513,9 @@ class MediaServerProxyController extends Controller
      */
     public static function generateLocalMediaStreamUrl(int $integrationId, string $itemId): string
     {
-        return ProxyFacade::getBaseUrl().URL::temporarySignedRoute(
+        return ProxyFacade::getBaseUrl().URL::signedRoute(
             'local-media.stream',
-            now()->addHours(self::PROXY_URL_TTL_HOURS),
-            ['integration' => $integrationId, 'item' => $itemId],
+            ['integration' => $integrationId, 'item' => $itemId, 'v' => static::currentUrlVersion()],
             absolute: false
         );
     }
@@ -486,10 +525,9 @@ class MediaServerProxyController extends Controller
      */
     public static function generateWebDavStreamUrl(int $integrationId, string $itemId): string
     {
-        return ProxyFacade::getBaseUrl().URL::temporarySignedRoute(
+        return ProxyFacade::getBaseUrl().URL::signedRoute(
             'webdav-media.stream',
-            now()->addHours(self::PROXY_URL_TTL_HOURS),
-            ['integration' => $integrationId, 'item' => $itemId],
+            ['integration' => $integrationId, 'item' => $itemId, 'v' => static::currentUrlVersion()],
             absolute: false
         );
     }
@@ -508,6 +546,10 @@ class MediaServerProxyController extends Controller
      */
     public function streamWebDavMedia(Request $request, int $integration, string $item)
     {
+        if ($staleResponse = $this->rejectIfStaleUrlVersion($request)) {
+            return $staleResponse;
+        }
+
         try {
             set_time_limit(0);
             ignore_user_abort(true);

--- a/app/Http/Controllers/MediaServerProxyController.php
+++ b/app/Http/Controllers/MediaServerProxyController.php
@@ -3,7 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Facades\ProxyFacade;
+use App\Models\Channel;
+use App\Models\Episode;
 use App\Models\MediaServerIntegration;
+use App\Models\Scopes\ExcludeAioFailoverClonesScope;
 use App\Services\MediaServerService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -12,6 +15,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -723,5 +727,397 @@ class MediaServerProxyController extends Controller
                 'error' => 'Internal server error while streaming WebDAV media',
             ], 500);
         }
+    }
+
+    /**
+     * Generate a URL for streaming a synced (persisted) AIOStreams-backed Channel.
+     *
+     * AIOStreams resolves each item to an opaque, provider-hosted URL (a debrid or
+     * torrent-streaming host) rather than a stable item ID we could re-query — so
+     * unlike Plex/Emby, there's nothing to look up from the integration itself.
+     * That resolved URL was already discovered and stored on the channel by
+     * ResolveAioStreamsChannel (movie_data['aiostreams']['resolved_url']), so this
+     * route just references that row's own ID, the same way generateStreamProxyUrl()
+     * references a Plex/Emby itemId — no payload, no cache.
+     */
+    public static function generateAioStreamsChannelProxyUrl(int $integrationId, int $channelId): string
+    {
+        return ProxyFacade::getBaseUrl().URL::signedRoute(
+            'aiostreams-media.channel.stream',
+            ['integration' => $integrationId, 'channel' => $channelId, 'v' => static::currentUrlVersion()],
+            absolute: false
+        );
+    }
+
+    /**
+     * Generate a URL for streaming a synced (persisted) AIOStreams-backed Episode.
+     * See generateAioStreamsChannelProxyUrl() — same shape, keyed by Episode ID.
+     */
+    public static function generateAioStreamsEpisodeProxyUrl(int $integrationId, int $episodeId): string
+    {
+        return ProxyFacade::getBaseUrl().URL::signedRoute(
+            'aiostreams-media.episode.stream',
+            ['integration' => $integrationId, 'episode' => $episodeId, 'v' => static::currentUrlVersion()],
+            absolute: false
+        );
+    }
+
+    /**
+     * How long a "live" AIOStreams proxy token stays reachable. This path has no
+     * durable Channel/Episode row backing it (ad-hoc browse-and-preview, and the
+     * Xtream-style catalog/stream-list endpoint used by the m3u-tv Flutter client),
+     * so the resolved URL is cached rather than persisted. A video player keeps
+     * issuing range requests against the same URL for the life of one viewing
+     * session (seeking, buffering ahead, resuming from a pause) — 24 hours
+     * comfortably covers even a long title left paused overnight, while staying
+     * clearly short-lived rather than long-term storage.
+     */
+    private const AIOSTREAMS_LIVE_TOKEN_CACHE_HOURS = 24;
+
+    /**
+     * Cache key an AIOStreams live proxy token resolves to. Scoped by integration
+     * so a token can't be replayed against a different integration's namespace.
+     */
+    protected static function aioStreamsLiveCacheKey(int $integrationId, string $token): string
+    {
+        return "aiostreams-live-proxy:{$integrationId}:{$token}";
+    }
+
+    /**
+     * Generate a URL for streaming a resolved AIOStreams URL that has no durable
+     * Channel/Episode row yet. See generateAioStreamsLiveProxyUrls() for the batch
+     * form and the full rationale — this is that method for a single URL.
+     */
+    public static function generateAioStreamsLiveProxyUrl(int $integrationId, string $resolvedUrl): string
+    {
+        return static::generateAioStreamsLiveProxyUrls($integrationId, [$resolvedUrl])[0];
+    }
+
+    /**
+     * Batch form of generateAioStreamsLiveProxyUrl() — used by the ad-hoc
+     * browse-and-preview flow and the catalog/stream-list endpoint
+     * (AIOStreamsProxyController::stream(), consumed by the m3u-tv Flutter client
+     * and any other Xtream-style caller), neither of which has a durable row to
+     * key off. A stream-list response can hold dozens of candidates; writing each
+     * one's cache entry with its own Cache::put() means one database round trip
+     * per candidate. Cache::putMany() performs a single upsert() query for the
+     * whole batch instead (see Illuminate\Cache\DatabaseStore::putMany()).
+     *
+     * The resolved URL itself can also be extremely long (magnet URIs with many
+     * trackers, chained resolver links), so it's cached server-side under a short
+     * random token rather than embedded in the route — the generated URL's length
+     * never depends on the upstream URL's length, and the upstream URL (which may
+     * carry the debrid account's own auth token) never appears in it at all.
+     *
+     * @param  array<int|string, string>  $resolvedUrls  Keyed however the caller likes; the same keys come back in the result.
+     * @return array<int|string, string>
+     */
+    public static function generateAioStreamsLiveProxyUrls(int $integrationId, array $resolvedUrls): array
+    {
+        if ($resolvedUrls === []) {
+            return [];
+        }
+
+        $tokensByKey = [];
+        $cacheValues = [];
+
+        foreach ($resolvedUrls as $key => $resolvedUrl) {
+            $token = Str::random(40);
+            $tokensByKey[$key] = $token;
+            $cacheValues[static::aioStreamsLiveCacheKey($integrationId, $token)] = $resolvedUrl;
+        }
+
+        Cache::putMany($cacheValues, now()->addHours(self::AIOSTREAMS_LIVE_TOKEN_CACHE_HOURS));
+
+        $urlsByKey = [];
+
+        foreach ($tokensByKey as $key => $token) {
+            $urlsByKey[$key] = ProxyFacade::getBaseUrl().URL::signedRoute(
+                'aiostreams-media.live.stream',
+                ['integration' => $integrationId, 'item' => $token, 'v' => static::currentUrlVersion()],
+                absolute: false
+            );
+        }
+
+        return $urlsByKey;
+    }
+
+    /**
+     * Common integration lookup/gating shared by all three AIOStreams handlers.
+     * Returns an error JsonResponse to short-circuit with, or null to proceed.
+     */
+    protected function rejectInvalidAioStreamsIntegration(int $integration): ?JsonResponse
+    {
+        $mediaIntegration = MediaServerIntegration::find($integration);
+
+        if (! $mediaIntegration) {
+            return response()->json(['error' => 'Integration not found'], 404);
+        }
+
+        if (! $mediaIntegration->enabled) {
+            return response()->json(['error' => 'Integration is disabled'], 403);
+        }
+
+        if ($mediaIntegration->type !== 'aiostreams') {
+            return response()->json(['error' => 'Integration is not an AIOStreams type'], 400);
+        }
+
+        return null;
+    }
+
+    /**
+     * Stream a resolved AIOStreams URL for a synced (persisted) Channel.
+     *
+     * Route: /aiostreams-media/{integration}/channel/{channel}/stream
+     *
+     * The resolved URL was already discovered and stored by ResolveAioStreamsChannel
+     * (movie_data['aiostreams']['resolved_url']) — this is a plain DB lookup keyed
+     * by the channel's own ID. Supports range requests for seeking.
+     */
+    public function streamAioStreamsChannel(Request $request, int $integration, int $channel)
+    {
+        if ($staleResponse = $this->rejectIfStaleUrlVersion($request)) {
+            return $staleResponse;
+        }
+
+        try {
+            set_time_limit(0);
+            ignore_user_abort(true);
+
+            if ($errorResponse = $this->rejectInvalidAioStreamsIntegration($integration)) {
+                return $errorResponse;
+            }
+
+            // Failover clone channels are hidden by ExcludeAioFailoverClonesScope
+            // everywhere else in the app (Xtream API, M3U export, table listings) —
+            // opt back in explicitly, since this is the one place that needs them.
+            $channelModel = Channel::withoutGlobalScope(ExcludeAioFailoverClonesScope::class)
+                ->where('id', $channel)
+                ->where('aio_integration_id', $integration)
+                ->first();
+
+            $resolvedUrl = $channelModel?->movie_data['aiostreams']['resolved_url'] ?? null;
+
+            return $this->proxyResolvedUrl($request, $resolvedUrl, (string) $integration);
+        } catch (\Exception $e) {
+            Log::error('Exception in AIOStreams channel media proxy', [
+                'integration_id' => $integration,
+                'channel_id' => $channel,
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'error' => 'Internal server error while proxying AIOStreams media',
+            ], 500);
+        }
+    }
+
+    /**
+     * Stream a resolved AIOStreams URL for a synced (persisted) Episode.
+     *
+     * Route: /aiostreams-media/{integration}/episode/{episode}/stream
+     *
+     * See streamAioStreamsChannel() — same shape, reading from Episode::info
+     * (Episodes don't carry their own aio_integration_id; it lives on the parent
+     * Series, so it's resolved via that relation instead of a direct column).
+     */
+    public function streamAioStreamsEpisode(Request $request, int $integration, int $episode)
+    {
+        if ($staleResponse = $this->rejectIfStaleUrlVersion($request)) {
+            return $staleResponse;
+        }
+
+        try {
+            set_time_limit(0);
+            ignore_user_abort(true);
+
+            if ($errorResponse = $this->rejectInvalidAioStreamsIntegration($integration)) {
+                return $errorResponse;
+            }
+
+            $episodeModel = Episode::withoutGlobalScope(ExcludeAioFailoverClonesScope::class)
+                ->where('id', $episode)
+                ->whereHas('series', fn ($query) => $query->where('aio_integration_id', $integration))
+                ->first();
+
+            $resolvedUrl = $episodeModel?->info['aiostreams']['resolved_url'] ?? null;
+
+            return $this->proxyResolvedUrl($request, $resolvedUrl, (string) $integration);
+        } catch (\Exception $e) {
+            Log::error('Exception in AIOStreams episode media proxy', [
+                'integration_id' => $integration,
+                'episode_id' => $episode,
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'error' => 'Internal server error while proxying AIOStreams media',
+            ], 500);
+        }
+    }
+
+    /**
+     * Stream a resolved AIOStreams URL cached under a short-lived token — used by
+     * the ad-hoc browse-and-preview flow and the catalog/stream-list endpoint
+     * (see generateAioStreamsLiveProxyUrls()), neither of which has a durable
+     * Channel/Episode row to look the URL up from.
+     *
+     * Route: /aiostreams-media/{integration}/live/{item}/stream
+     */
+    public function streamAioStreamsLive(Request $request, int $integration, string $item)
+    {
+        if ($staleResponse = $this->rejectIfStaleUrlVersion($request)) {
+            return $staleResponse;
+        }
+
+        try {
+            set_time_limit(0);
+            ignore_user_abort(true);
+
+            if ($errorResponse = $this->rejectInvalidAioStreamsIntegration($integration)) {
+                return $errorResponse;
+            }
+
+            $resolvedUrl = Cache::get(static::aioStreamsLiveCacheKey($integration, $item));
+
+            return $this->proxyResolvedUrl($request, $resolvedUrl, (string) $integration);
+        } catch (\Exception $e) {
+            Log::error('Exception in AIOStreams live media proxy', [
+                'integration_id' => $integration,
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'error' => 'Internal server error while proxying AIOStreams media',
+            ], 500);
+        }
+    }
+
+    /**
+     * Proxy a resolved AIOStreams URL with exactly one upstream request — no
+     * preflight HEAD/metadata probe. AIOStreams resolves to arbitrary third-party
+     * debrid/torrent-streaming hosts, many of which rate-limit or cap concurrent
+     * connections per link; a separate HEAD request against the same resolved URL
+     * before the real GET counts as a second connection against that cap and can
+     * get the actual playback request throttled or rejected outright. Status and
+     * headers are instead relayed live from curl's own response as it arrives,
+     * before any body bytes are written — a transparent single-pass proxy.
+     */
+    protected function proxyResolvedUrl(Request $request, ?string $resolvedUrl, string $integrationId): StreamedResponse|JsonResponse
+    {
+        if (
+            ! $resolvedUrl
+            || ! filter_var($resolvedUrl, FILTER_VALIDATE_URL)
+            || ! in_array(parse_url($resolvedUrl, PHP_URL_SCHEME), ['http', 'https'], true)
+        ) {
+            Log::warning('AIOStreams media: resolved URL missing or invalid', [
+                'integration_id' => $integrationId,
+            ]);
+
+            return response()->json(['error' => 'Resolved URL not found. Please re-sync.'], 404);
+        }
+
+        $requestHeaders = ['Accept' => '*/*'];
+
+        if ($request->hasHeader('Range')) {
+            $requestHeaders['Range'] = $request->header('Range');
+        }
+
+        Log::debug('Proxying AIOStreams media', [
+            'integration_id' => $integrationId,
+            'has_range' => $request->hasHeader('Range'),
+        ]);
+
+        return new StreamedResponse(function () use ($resolvedUrl, $requestHeaders) {
+            $ch = curl_init($resolvedUrl);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array_map(
+                fn ($k, $v) => "{$k}: {$v}",
+                array_keys($requestHeaders),
+                array_values($requestHeaders)
+            ));
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+            curl_setopt($ch, CURLOPT_TIMEOUT, 0);
+            // Abort if the upstream stalls completely (0 bytes) for 30s, so a dead
+            // debrid/torrent-streaming connection can't pin a PHP-FPM worker forever.
+            curl_setopt($ch, CURLOPT_LOW_SPEED_LIMIT, 1);
+            curl_setopt($ch, CURLOPT_LOW_SPEED_TIME, 30);
+
+            // CURLOPT_FOLLOWLOCATION means the header callback fires once per
+            // redirect hop. A fresh "HTTP/…" status line marks the start of a new
+            // hop's header block, so resetting the buffer on each one leaves
+            // exactly the FINAL hop's headers by the time the first body byte
+            // arrives below.
+            $currentHopHeaders = [];
+            $finalHeaders = [];
+
+            curl_setopt($ch, CURLOPT_HEADERFUNCTION, function ($ch, $headerLine) use (&$currentHopHeaders, &$finalHeaders) {
+                $trimmed = rtrim($headerLine, "\r\n");
+
+                if (preg_match('#^HTTP/\S+\s+(\d+)#', $trimmed, $matches)) {
+                    $currentHopHeaders = ['status' => (int) $matches[1]];
+                } elseif ($trimmed === '') {
+                    $finalHeaders = $currentHopHeaders;
+                } elseif (str_contains($trimmed, ':')) {
+                    [$name, $value] = explode(':', $trimmed, 2);
+                    $currentHopHeaders[strtolower(trim($name))] = trim($value);
+                }
+
+                return strlen($headerLine);
+            });
+
+            $responseStarted = false;
+
+            curl_setopt($ch, CURLOPT_WRITEFUNCTION, function ($ch, $data) use (&$responseStarted, &$finalHeaders) {
+                // See other proxy methods in this class: a seek abandons this
+                // connection without closing it, and ignore_user_abort(true) means
+                // PHP won't notice unless we check here.
+                if (connection_aborted()) {
+                    return 0;
+                }
+
+                if (! $responseStarted) {
+                    $responseStarted = true;
+
+                    $status = $finalHeaders['status'] ?? 200;
+                    http_response_code(in_array($status, [200, 206], true) ? $status : 200);
+
+                    header('Content-Type: '.($finalHeaders['content-type'] ?? 'application/octet-stream'));
+                    header('Accept-Ranges: bytes');
+                    header('X-Proxied-From: AIOStreams');
+
+                    if (isset($finalHeaders['content-length'])) {
+                        header('Content-Length: '.$finalHeaders['content-length']);
+                    }
+
+                    if (isset($finalHeaders['content-range'])) {
+                        header('Content-Range: '.$finalHeaders['content-range']);
+                    }
+                }
+
+                echo $data;
+                flush();
+
+                return strlen($data);
+            });
+
+            curl_setopt($ch, CURLOPT_NOPROGRESS, false);
+            curl_setopt($ch, CURLOPT_XFERINFOFUNCTION, fn () => connection_aborted() ? 1 : 0);
+
+            curl_exec($ch);
+            $curlError = curl_error($ch);
+            curl_close($ch);
+
+            // The upstream never sent any body (connection failure, DNS failure, or
+            // an error status with no content) — headers were never emitted by
+            // CURLOPT_WRITEFUNCTION above, so do it here instead.
+            if (! $responseStarted) {
+                Log::warning('AIOStreams media: upstream request failed before any content was received', [
+                    'curl_error' => $curlError,
+                ]);
+                http_response_code(502);
+                header('Content-Type: application/json');
+                echo json_encode(['error' => 'Failed to reach the resolved upstream URL']);
+            }
+        });
     }
 }

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -2020,13 +2020,21 @@ class XtreamApiController extends Controller
                 return response()->json(['error' => 'DVR access denied'], 403);
             }
 
+            // Advertising the DVR feature already gates playlist_auth credentials on
+            // their own `dvr_enabled` flag (see canAdvertiseDvrFeature) — enforce the
+            // same rule here so a credential the TV app never showed DVR controls for
+            // can't dispatch DVR actions directly against the shared playlist DVR setting.
+            if ($authMethod === 'playlist_auth' && ! $playlistAuth?->dvr_enabled) {
+                return response()->json(['error' => 'DVR access denied'], 403);
+            }
+
             return match ($action) {
-                'get_dvr_recordings' => $this->getDvrRecordings($request, $dvrPlaylist, $username, $password),
-                'get_dvr_recording' => $this->getDvrRecording($request, $dvrPlaylist, $username, $password),
-                'schedule_dvr' => $this->scheduleDvr($request, $dvrPlaylist),
-                'create_dvr_series_rule' => $this->createDvrSeriesRule($request, $dvrPlaylist),
-                'cancel_dvr_recording' => $this->cancelDvrRecording($request, $dvrPlaylist),
-                'delete_dvr_recording' => $this->deleteDvrRecording($request, $dvrPlaylist),
+                'get_dvr_recordings' => $this->getDvrRecordings($request, $dvrPlaylist, $username, $password, $playlistAuth),
+                'get_dvr_recording' => $this->getDvrRecording($request, $dvrPlaylist, $username, $password, $playlistAuth),
+                'schedule_dvr' => $this->scheduleDvr($request, $dvrPlaylist, $playlistAuth),
+                'create_dvr_series_rule' => $this->createDvrSeriesRule($request, $dvrPlaylist, $playlistAuth),
+                'cancel_dvr_recording' => $this->cancelDvrRecording($request, $dvrPlaylist, $playlistAuth),
+                'delete_dvr_recording' => $this->deleteDvrRecording($request, $dvrPlaylist, $playlistAuth),
             };
         } else {
             return response()->json(['error' => 'Invalid action parameter'], 400);
@@ -3204,7 +3212,7 @@ class XtreamApiController extends Controller
     /**
      * List DVR recordings for the authenticated playlist, optionally filtered by status.
      */
-    private function getDvrRecordings(Request $request, $playlist, string $username, string $password): \Illuminate\Http\JsonResponse
+    private function getDvrRecordings(Request $request, $playlist, string $username, string $password, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
         $dvrSetting = $playlist->dvrSetting;
 
@@ -3217,6 +3225,7 @@ class XtreamApiController extends Controller
         $offset = (int) $request->input('offset', 0);
 
         $query = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
+            ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->with('channel')
             ->orderByDesc('scheduled_start');
 
@@ -3235,7 +3244,7 @@ class XtreamApiController extends Controller
     /**
      * Get a single DVR recording by UUID.
      */
-    private function getDvrRecording(Request $request, $playlist, string $username, string $password): \Illuminate\Http\JsonResponse
+    private function getDvrRecording(Request $request, $playlist, string $username, string $password, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
         $uuid = $request->input('recording_id');
 
@@ -3251,6 +3260,7 @@ class XtreamApiController extends Controller
 
         $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
             ->where('uuid', $uuid)
+            ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->with('channel')
             ->first();
 
@@ -3264,7 +3274,7 @@ class XtreamApiController extends Controller
     /**
      * Schedule a one-shot DVR recording rule from the TV app.
      */
-    private function scheduleDvr(Request $request, $playlist): \Illuminate\Http\JsonResponse
+    private function scheduleDvr(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
         $channelId = (int) $request->input('channel_id');
         $title = trim((string) $request->input('title', ''));
@@ -3296,6 +3306,7 @@ class XtreamApiController extends Controller
         $rule = DvrRecordingRule::create([
             'user_id' => $dvrSetting->user_id,
             'dvr_setting_id' => $dvrSetting->id,
+            'playlist_auth_id' => $playlistAuth?->id,
             'type' => DvrRuleType::Manual,
             'channel_id' => $channelId,
             'series_title' => $title,
@@ -3317,7 +3328,7 @@ class XtreamApiController extends Controller
     /**
      * Create a series recording rule.
      */
-    private function createDvrSeriesRule(Request $request, $playlist): \Illuminate\Http\JsonResponse
+    private function createDvrSeriesRule(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
         $channelId = (int) $request->input('channel_id');
         $title = trim((string) $request->input('title', ''));
@@ -3344,6 +3355,7 @@ class XtreamApiController extends Controller
         $rule = DvrRecordingRule::create([
             'user_id' => $dvrSetting->user_id,
             'dvr_setting_id' => $dvrSetting->id,
+            'playlist_auth_id' => $playlistAuth?->id,
             'type' => DvrRuleType::Series,
             'channel_id' => $channelId,
             'series_title' => $title,
@@ -3362,7 +3374,7 @@ class XtreamApiController extends Controller
     /**
      * Cancel a scheduled or in-progress DVR recording.
      */
-    private function cancelDvrRecording(Request $request, $playlist): \Illuminate\Http\JsonResponse
+    private function cancelDvrRecording(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
         $uuid = $request->input('recording_id');
 
@@ -3378,6 +3390,7 @@ class XtreamApiController extends Controller
 
         $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
             ->where('uuid', $uuid)
+            ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->whereIn('status', [DvrRecordingStatus::Scheduled, DvrRecordingStatus::Recording])
             ->first();
 
@@ -3406,7 +3419,7 @@ class XtreamApiController extends Controller
      * those resources hasn't had a chance to run yet. releaseProxyResources()
      * frees them here instead of leaving them orphaned on the proxy.
      */
-    private function deleteDvrRecording(Request $request, $playlist): \Illuminate\Http\JsonResponse
+    private function deleteDvrRecording(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
         $uuid = $request->input('recording_id');
 
@@ -3422,6 +3435,7 @@ class XtreamApiController extends Controller
 
         $recording = DvrRecording::where('dvr_setting_id', $dvrSetting->id)
             ->where('uuid', $uuid)
+            ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->whereIn('status', [
                 DvrRecordingStatus::Completed,
                 DvrRecordingStatus::Failed,

--- a/app/Http/Middleware/VerifyM3uProxyCallback.php
+++ b/app/Http/Middleware/VerifyM3uProxyCallback.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Shared fail-closed auth gate for every route the m3u-proxy service calls back into
+ * the editor on: failover-resolver, webhooks, broadcast/callback, and dvr/callback.
+ *
+ * Accepts the same shared token the editor sends when calling the proxy, via either
+ * the X-API-Token header or an api_token query parameter (the editor embeds the
+ * latter in the callback URLs it hands to the proxy — see M3uProxyService).
+ *
+ * Unlike the previous per-controller check, an unconfigured token now rejects every
+ * callback rather than accepting all of them. Set `proxy.allow_unauthenticated_callbacks`
+ * only for a trusted deployment where the proxy isn't reachable from outside.
+ */
+class VerifyM3uProxyCallback
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $configuredToken = config('proxy.m3u_proxy_token');
+
+        if (empty($configuredToken)) {
+            if (config('proxy.allow_unauthenticated_callbacks')) {
+                Log::warning('m3u-proxy callback: no proxy token configured — accepting under explicit local-development bypass', [
+                    'path' => $request->path(),
+                ]);
+
+                return $next($request);
+            }
+
+            Log::warning('m3u-proxy callback: rejected — no M3U_PROXY_TOKEN configured and local bypass is disabled', [
+                'path' => $request->path(),
+                'ip' => $request->ip(),
+            ]);
+
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        $providedToken = $request->header('X-API-Token') ?? $request->query('api_token') ?? '';
+
+        if (! hash_equals((string) $configuredToken, (string) $providedToken)) {
+            Log::warning('m3u-proxy callback: unauthorized request', [
+                'path' => $request->path(),
+                'ip' => $request->ip(),
+            ]);
+
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Jobs/ResolveAioStreamsChannel.php
+++ b/app/Jobs/ResolveAioStreamsChannel.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Http\Controllers\MediaServerProxyController;
 use App\Models\Channel;
 use App\Models\ChannelFailover;
 use App\Models\Scopes\ExcludeAioFailoverClonesScope;
@@ -109,10 +110,17 @@ class ResolveAioStreamsChannel implements ShouldBeUniqueUntilProcessing, ShouldQ
         $movieData = $channel->movie_data ?? [];
         $movieData['aiostreams'] = [
             'candidates' => array_map(fn (array $c) => $c['parsed'], $selected),
+            // Never exposed via API/UI — only MediaServerProxyController::streamAioStreamsChannel()
+            // reads this, to proxy the bytes without the raw (often debrid-account-scoped) URL
+            // ever appearing in a stored/served URL.
+            'resolved_url' => $primary['stream']['url'] ?? null,
         ];
 
+        // $channel already exists (found by ID above), so unlike the failover
+        // clones below it doesn't need a create-then-update round trip — its own
+        // ID is already known, so the proxy URL can go in this same write.
         $channel->update([
-            'url' => $primary['stream']['url'] ?? null,
+            'url' => MediaServerProxyController::generateAioStreamsChannelProxyUrl($channel->aio_integration_id, $channel->id),
             'container_extension' => $primary['parsed']['container'] ?? $channel->container_extension,
             'movie_data' => $movieData,
             'aio_resolution_status' => count($selected) >= $maxCandidates ? 'resolved' : 'partial',
@@ -135,13 +143,17 @@ class ResolveAioStreamsChannel implements ShouldBeUniqueUntilProcessing, ShouldQ
                 'is_custom' => true,
                 'is_vod' => $channel->is_vod,
                 'is_aio_failover_clone' => true,
-                'url' => $candidate['stream']['url'] ?? null,
+                'movie_data' => ['aiostreams' => ['resolved_url' => $candidate['stream']['url'] ?? null]],
                 'container_extension' => $candidate['parsed']['container'] ?? null,
                 'aio_integration_id' => $channel->aio_integration_id,
                 'aio_item_id' => $channel->aio_item_id,
                 'aio_type' => $channel->aio_type,
                 'aio_resolution_status' => 'resolved',
                 'aio_last_resolved_at' => now(),
+            ]);
+
+            $failoverChannel->update([
+                'url' => MediaServerProxyController::generateAioStreamsChannelProxyUrl($channel->aio_integration_id, $failoverChannel->id),
             ]);
 
             ChannelFailover::create([

--- a/app/Jobs/ResolveAioStreamsEpisode.php
+++ b/app/Jobs/ResolveAioStreamsEpisode.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Http\Controllers\MediaServerProxyController;
 use App\Models\Episode;
 use App\Models\EpisodeFailover;
 use App\Models\Scopes\ExcludeAioFailoverClonesScope;
@@ -102,10 +103,17 @@ class ResolveAioStreamsEpisode implements ShouldBeUniqueUntilProcessing, ShouldQ
         $info = $episode->info ?? [];
         $info['aiostreams'] = [
             'candidates' => array_map(fn (array $c) => $c['parsed'], $selected),
+            // Never exposed via API/UI — only MediaServerProxyController::streamAioStreamsEpisode()
+            // reads this, to proxy the bytes without the raw (often debrid-account-scoped) URL
+            // ever appearing in a stored/served URL.
+            'resolved_url' => $primary['stream']['url'] ?? null,
         ];
 
+        // $episode already exists (found by ID above), so unlike the failover
+        // clones below it doesn't need a create-then-update round trip — its own
+        // ID is already known, so the proxy URL can go in this same write.
         $episode->update([
-            'url' => $primary['stream']['url'] ?? null,
+            'url' => MediaServerProxyController::generateAioStreamsEpisodeProxyUrl($integration->id, $episode->id),
             'container_extension' => $primary['parsed']['container'] ?? $episode->container_extension,
             'info' => $info,
             // Re-enable an episode that was disabled at creation for being unaired
@@ -134,11 +142,15 @@ class ResolveAioStreamsEpisode implements ShouldBeUniqueUntilProcessing, ShouldQ
                 'import_batch_no' => Str::orderedUuid()->toString(),
                 'is_custom' => true,
                 'is_aio_failover_clone' => true,
-                'url' => $candidate['stream']['url'] ?? null,
+                'info' => ['aiostreams' => ['resolved_url' => $candidate['stream']['url'] ?? null]],
                 'container_extension' => $candidate['parsed']['container'] ?? null,
                 'aio_item_id' => $episode->aio_item_id,
                 'aio_resolution_status' => 'resolved',
                 'aio_last_resolved_at' => now(),
+            ]);
+
+            $failoverEpisode->update([
+                'url' => MediaServerProxyController::generateAioStreamsEpisodeProxyUrl($integration->id, $failoverEpisode->id),
             ]);
 
             EpisodeFailover::create([

--- a/app/Livewire/AioStreamsBrowse.php
+++ b/app/Livewire/AioStreamsBrowse.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire;
 
+use App\Http\Controllers\MediaServerProxyController;
 use App\Jobs\NotifyAioStreamsResolutionComplete;
 use App\Jobs\ResolveAioStreamsChannel;
 use App\Jobs\ResolveAioStreamsEpisode;
@@ -1096,7 +1097,15 @@ class AioStreamsBrowse extends Component implements HasActions, HasSchemas
             return;
         }
 
+        // Extension is derived from the raw upstream URL before it's hidden
+        // behind the proxy below.
         $format = pathinfo(parse_url($url, PHP_URL_PATH) ?? '', PATHINFO_EXTENSION) ?: 'mp4';
+
+        // Never hand the raw resolved URL (often carrying the debrid account's own
+        // auth token) to the browser. There's no durable Channel/Episode row for an
+        // ad-hoc preview, so this goes through the short-lived cache-token "live"
+        // proxy rather than the DB-backed one used for synced channels/episodes.
+        $proxiedUrl = MediaServerProxyController::generateAioStreamsLiveProxyUrl($this->integrationId, $url);
 
         $title = $context['title'] ?? __('Unknown');
         $displayTitle = $title;
@@ -1121,7 +1130,7 @@ class AioStreamsBrowse extends Component implements HasActions, HasSchemas
             'title' => $title,
             'display_title' => $displayTitle,
             'logo' => $context['thumbnail_url'] ?? null,
-            'url' => $url,
+            'url' => $proxiedUrl,
             'format' => $format,
             'type' => 'aiostreams',
         ]));

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -3333,7 +3333,7 @@ class M3uProxyService
         // Build the failover resolver path
         if (! empty($this->failoverResolverUrl)) {
             // Use the configured failover resolver URL
-            return "$this->failoverResolverUrl/api/m3u-proxy/failover-resolver";
+            return $this->withCallbackToken("$this->failoverResolverUrl/api/m3u-proxy/failover-resolver");
         }
 
         // If here, return null
@@ -3349,11 +3349,25 @@ class M3uProxyService
     {
         if (! empty($this->failoverResolverUrl)) {
             // Use the configured failover resolver URL
-            return "$this->failoverResolverUrl/api/m3u-proxy/broadcast/callback";
+            return $this->withCallbackToken("$this->failoverResolverUrl/api/m3u-proxy/broadcast/callback");
         }
 
         // Build the broadcast callback path
-        return ProxyFacade::getBaseUrl().'/api/m3u-proxy/broadcast/callback';
+        return $this->withCallbackToken(ProxyFacade::getBaseUrl().'/api/m3u-proxy/broadcast/callback');
+    }
+
+    /**
+     * Get the DVR broadcast callback URL for m3u-proxy to send recording-lifecycle events.
+     *
+     * @return string|null The DVR callback endpoint URL, or null if not configured
+     */
+    public function getDvrCallbackUrl(): ?string
+    {
+        if (! empty($this->failoverResolverUrl)) {
+            return $this->withCallbackToken("$this->failoverResolverUrl/api/dvr/callback");
+        }
+
+        return $this->withCallbackToken(ProxyFacade::getBaseUrl().'/api/dvr/callback');
     }
 
     /**
@@ -3365,11 +3379,28 @@ class M3uProxyService
     {
         if (! empty($this->failoverResolverUrl)) {
             // Use the configured failover resolver URL
-            return "$this->failoverResolverUrl/api/m3u-proxy/webhooks";
+            return $this->withCallbackToken("$this->failoverResolverUrl/api/m3u-proxy/webhooks");
         }
 
         // Return null if not configured, as webhooks are optional and may not be needed if the resolver URL is not set
         return null;
+    }
+
+    /**
+     * Append the shared proxy API token as a query parameter so VerifyM3uProxyCallback
+     * can authenticate requests the proxy sends back to these URLs. The proxy's outbound
+     * HTTP clients for these callbacks don't attach custom headers, so the token has to
+     * travel embedded in the URL itself, which the editor fully controls.
+     */
+    private function withCallbackToken(string $url): string
+    {
+        if (empty($this->apiToken)) {
+            return $url;
+        }
+
+        $separator = str_contains($url, '?') ? '&' : '?';
+
+        return $url.$separator.'api_token='.rawurlencode($this->apiToken);
     }
 
     /**
@@ -3404,6 +3435,7 @@ class M3uProxyService
             'dvr_mode' => true,
             'hls_list_size' => 0,
             'output_dir' => config('proxy.broadcast_temp_dir'),
+            'callback_url' => $this->getDvrCallbackUrl(),
             'metadata' => [
                 'type' => 'dvr',
                 'recording_id' => $recording->uuid,

--- a/app/Services/M3uProxyService.php
+++ b/app/Services/M3uProxyService.php
@@ -596,6 +596,27 @@ class M3uProxyService
     }
 
     /**
+     * Stop streams for a single client's channel/episode, swallowing and logging any
+     * failure. Callers are expected to have already verified the caller is allowed to
+     * stop this stream (e.g. it belongs to their playlist, or an ownership policy check)
+     * before calling this — this only wraps the "stop and don't let a proxy hiccup
+     * surface as a 500" behavior shared by every player-facing stop-stream endpoint.
+     */
+    public static function stopStreamSafely(string $field, string $id, ?string $clientId, string $logMessage = 'Failed to stop player stream'): void
+    {
+        try {
+            self::stopStreamsByMetadata($field, $id, force: false, clientId: $clientId);
+        } catch (Exception $e) {
+            Log::warning($logMessage, [
+                'field' => $field,
+                'id' => $id,
+                'exception_class' => $e::class,
+                'exception_code' => $e->getCode(),
+            ]);
+        }
+    }
+
+    /**
      * Stop all streams for a specific playlist, optionally excluding a channel ID.
      *
      * This is used when switching channels on a connection-limited playlist

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use App\Http\Middleware\AutoLoginMiddleware;
 use App\Http\Middleware\DispatcharrAuthMiddleware;
 use App\Http\Middleware\ProxyRateLimitMiddleware;
+use App\Http\Middleware\VerifyM3uProxyCallback;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -24,6 +25,7 @@ return Application::configure(basePath: dirname(__DIR__))
             ->alias([
                 'dispatcharr.auth' => DispatcharrAuthMiddleware::class,
                 'proxy.throttle' => ProxyRateLimitMiddleware::class,
+                'm3u-proxy.callback' => VerifyM3uProxyCallback::class,
             ])
             ->redirectGuestsTo('login')
             ->trustProxies(at: ['*'])

--- a/config/proxy.php
+++ b/config/proxy.php
@@ -27,6 +27,13 @@ return [
     'm3u_proxy_public_url' => env('M3U_PROXY_PUBLIC_URL'), // Public URL for the proxy (auto-set in start-container)
     'm3u_resolver_url' => env('M3U_PROXY_FAILOVER_RESOLVER_URL', null), // Base URL for the editor that the proxy can use to resolve URLs if needed (for smart failover with capacity checks)
 
+    // Callback routes the proxy calls back into the editor (failover-resolver, webhooks,
+    // broadcast/callback, dvr/callback) reject every request when M3U_PROXY_TOKEN is unset,
+    // since an unset token previously meant "accept all". Only set this for a trusted,
+    // single-machine/local-network deployment where the proxy container isn't reachable
+    // from outside — it re-enables the old accept-all behavior for those routes.
+    'allow_unauthenticated_callbacks' => env('M3U_PROXY_ALLOW_UNAUTHENTICATED_CALLBACKS', false),
+
     // Logo Proxy Configuration
     'url_override' => env('PROXY_URL_OVERRIDE', null),
     'url_override_include_logos' => env('PROXY_URL_OVERRIDE_INCLUDE_LOGOS', default: null),

--- a/config/proxy.php
+++ b/config/proxy.php
@@ -38,6 +38,16 @@ return [
     'url_override' => env('PROXY_URL_OVERRIDE', null),
     'url_override_include_logos' => env('PROXY_URL_OVERRIDE_INCLUDE_LOGOS', default: null),
 
+    // Media Server (Plex/Emby/Jellyfin/local/WebDAV) proxy URLs are signed but
+    // non-expiring — they're stored on the Channel record and must stay valid
+    // indefinitely (see MediaServerProxyController::generate*Url()). This version
+    // is stamped into every generated URL and re-checked on every request; bumping
+    // it (per-instance, via env) invalidates every previously generated URL at
+    // once, without needing per-link expiry. The default is only bumped in code if
+    // a future issue requires forcing invalidation for installs that never set
+    // this explicitly.
+    'media_server_url_version' => (int) env('MEDIA_SERVER_PROXY_URL_VERSION', 1),
+
     // On-demand network broadcasts keep running for this many seconds after
     // the last viewer request. A small overlap is added to absorb short
     // disconnects/reconnects from players.

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Api\M3uProxyApiController;
 use App\Http\Controllers\Api\TvApiController;
 use App\Http\Controllers\ArrWebhookController;
 use App\Http\Controllers\DvrCallbackController;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -41,8 +43,15 @@ Route::prefix('m3u-proxy')->group(function () {
     Route::post('failover-resolver', [M3uProxyApiController::class, 'resolveFailoverUrl'])
         ->name('m3u-proxy.failover-resolver');
 
-    // Player stream stop - called via sendBeacon when in-app player is closed
+    // Player stream stop - called via sendBeacon when in-app player is closed.
+    // sendBeacon cannot attach custom headers (no CSRF token), so only the session
+    // middleware is added here rather than the full 'web' group, to authenticate the
+    // caller via the panel's session cookie without requiring a CSRF token.
     Route::post('player-stream/stop', [M3uProxyApiController::class, 'stopPlayerStream'])
+        ->middleware([
+            EncryptCookies::class,
+            StartSession::class,
+        ])
         ->name('m3u-proxy.player-stream.stop');
 
     // Proxy webhook endpoint - called by m3u-proxy to notify of events
@@ -102,4 +111,6 @@ Route::prefix('tv/{username}/{password}')->middleware('throttle:60,1')->group(fu
         ->name('tv.push.subscribe');
     Route::delete('push/unsubscribe', [TvApiController::class, 'unregisterPushToken'])
         ->name('tv.push.unsubscribe');
+    Route::post('player-stream/stop', [TvApiController::class, 'stopPlayerStream'])
+        ->name('tv.player-stream.stop');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -39,8 +39,11 @@ Route::middleware(['throttle:60,1'])->prefix('epg')->group(function () {
  * m3u-proxy API routes
  */
 Route::prefix('m3u-proxy')->group(function () {
-    // Failover resolver - called by m3u-proxy to validate failover URLs
+    // Failover resolver - called by m3u-proxy to validate failover URLs.
+    // Authenticated by VerifyM3uProxyCallback (see routes below and M3uProxyService,
+    // which embeds the shared token in the URL it hands to the proxy).
     Route::post('failover-resolver', [M3uProxyApiController::class, 'resolveFailoverUrl'])
+        ->middleware(['m3u-proxy.callback', 'throttle:120,1'])
         ->name('m3u-proxy.failover-resolver');
 
     // Player stream stop - called via sendBeacon when in-app player is closed.
@@ -54,13 +57,15 @@ Route::prefix('m3u-proxy')->group(function () {
         ])
         ->name('m3u-proxy.player-stream.stop');
 
-    // Proxy webhook endpoint - called by m3u-proxy to notify of events
-    // Relies on `m3u-proxy:register-webhook` to register this endpoint with the proxy
+    // Proxy webhook endpoint - called by m3u-proxy to notify of events.
+    // Relies on `m3u-proxy:register-webhook` to register this endpoint with the proxy.
     Route::post('webhooks', [M3uProxyApiController::class, 'handleWebhook'])
+        ->middleware(['m3u-proxy.callback', 'throttle:120,1'])
         ->name('m3u-proxy.webhook');
 
     // Network broadcast callback - called by proxy when broadcast FFmpeg process exits
     Route::post('broadcast/callback', [M3uProxyApiController::class, 'handleBroadcastCallback'])
+        ->middleware(['m3u-proxy.callback', 'throttle:120,1'])
         ->name('m3u-proxy.broadcast.callback');
 });
 
@@ -95,6 +100,7 @@ Route::prefix('vod')->middleware('dispatcharr.auth')->group(function () {
  * Must live in api.php (not web.php) to avoid CSRF verification.
  */
 Route::post('dvr/callback', [DvrCallbackController::class, 'handle'])
+    ->middleware(['m3u-proxy.callback', 'throttle:120,1'])
     ->name('dvr.callback');
 
 /*

--- a/routes/web.php
+++ b/routes/web.php
@@ -372,8 +372,11 @@ Route::get('/schedules-direct/{epg}/image/{imageHash}', [
 /*
  * Media Server (Emby/Jellyfin) proxy routes
  * These hide the API key from external clients. Every route requires a valid,
- * time-limited signature (see MediaServerProxyController::generate*Url()) so an
+ * non-expiring signature plus a matching url-version (see
+ * MediaServerProxyController::generate*Url() / rejectIfStaleUrlVersion()) so an
  * integration/item ID alone is never enough to access another user's media.
+ * These URLs are stored on Channel records (not regenerated per-request), so they
+ * intentionally never expire — signature + version replace an expiry check.
  */
 Route::get('/media-server/{integrationId}/image/{itemId}/{imageType?}', [
     MediaServerProxyController::class,

--- a/routes/web.php
+++ b/routes/web.php
@@ -407,6 +407,37 @@ Route::get('/webdav-media/{integration}/stream/{item}', [
 ])->middleware(ValidateSignature::relative())->name('webdav-media.stream');
 
 /*
+ * AIOStreams resolved-media proxy routes
+ * AIOStreams resolves each item to an opaque, provider-hosted URL (often a
+ * debrid service link carrying that account's own auth token) rather than a
+ * stable item ID we could re-query later, so the resolved URL itself is
+ * never put in the route:
+ *  - channel/episode: the URL was already discovered and stored by
+ *    ResolveAioStreamsChannel/Episode on the row itself — this is a plain
+ *    DB lookup keyed by that row's own ID, exactly like proxyStream() looks
+ *    up Plex/Emby items by their own itemId. No payload, no cache.
+ *  - live: for the ad-hoc browse-and-preview flow and the Xtream-style
+ *    catalog/stream-list endpoint (AIOStreamsProxyController::stream(),
+ *    used by the m3u-tv Flutter client) there's no durable row yet, so the
+ *    resolved URL is cached server-side under a short-lived random token —
+ *    see MediaServerProxyController::generateAioStreamsLiveProxyUrls().
+ */
+Route::get('/aiostreams-media/{integration}/channel/{channel}/stream', [
+    MediaServerProxyController::class,
+    'streamAioStreamsChannel',
+])->middleware(ValidateSignature::relative())->name('aiostreams-media.channel.stream');
+
+Route::get('/aiostreams-media/{integration}/episode/{episode}/stream', [
+    MediaServerProxyController::class,
+    'streamAioStreamsEpisode',
+])->middleware(ValidateSignature::relative())->name('aiostreams-media.episode.stream');
+
+Route::get('/aiostreams-media/{integration}/live/{item}/stream', [
+    MediaServerProxyController::class,
+    'streamAioStreamsLive',
+])->middleware(ValidateSignature::relative())->name('aiostreams-media.live.stream');
+
+/*
  * DVR routes — file streaming and proxy callbacks
  * Stream auth mirrors the Xtream stream pattern: username + password (playlist UUID)
  * or PlaylistAuth credentials embedded in the URL.

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,7 @@ use App\Http\Controllers\WebhookTestController;
 use App\Http\Controllers\XtreamApiController;
 use App\Http\Controllers\XtreamStreamController;
 use App\Services\ExternalIpService;
+use Illuminate\Routing\Middleware\ValidateSignature;
 use Illuminate\Support\Facades\Route;
 
 // OIDC SSO authentication
@@ -370,17 +371,19 @@ Route::get('/schedules-direct/{epg}/image/{imageHash}', [
 
 /*
  * Media Server (Emby/Jellyfin) proxy routes
- * These hide the API key from external clients
+ * These hide the API key from external clients. Every route requires a valid,
+ * time-limited signature (see MediaServerProxyController::generate*Url()) so an
+ * integration/item ID alone is never enough to access another user's media.
  */
 Route::get('/media-server/{integrationId}/image/{itemId}/{imageType?}', [
     MediaServerProxyController::class,
     'proxyImage',
-])->name('media-server.image.proxy');
+])->middleware(ValidateSignature::relative())->name('media-server.image.proxy');
 
 Route::get('/media-server/{integrationId}/stream/{itemId}.{container}', [
     MediaServerProxyController::class,
     'proxyStream',
-])->name('media-server.stream.proxy');
+])->middleware(ValidateSignature::relative())->name('media-server.stream.proxy');
 
 /*
  * Local Media streaming routes
@@ -389,7 +392,7 @@ Route::get('/media-server/{integrationId}/stream/{itemId}.{container}', [
 Route::get('/local-media/{integration}/stream/{item}', [
     MediaServerProxyController::class,
     'streamLocalMedia',
-])->name('local-media.stream');
+])->middleware(ValidateSignature::relative())->name('local-media.stream');
 
 /*
  * WebDAV Media streaming routes
@@ -398,7 +401,7 @@ Route::get('/local-media/{integration}/stream/{item}', [
 Route::get('/webdav-media/{integration}/stream/{item}', [
     MediaServerProxyController::class,
     'streamWebDavMedia',
-])->name('webdav-media.stream');
+])->middleware(ValidateSignature::relative())->name('webdav-media.stream');
 
 /*
  * DVR routes — file streaming and proxy callbacks

--- a/tests/Feature/AIOStreamsProxyControllerStreamTest.php
+++ b/tests/Feature/AIOStreamsProxyControllerStreamTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\MediaServerIntegration;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
+    $this->integration = MediaServerIntegration::create([
+        'user_id' => $this->user->id,
+        'name' => 'Test AIOStreams',
+        'type' => 'aiostreams',
+        'enabled' => true,
+        'manifest_url' => 'https://aiostreams.test/abc/manifest.json',
+        'playlist_id' => $this->playlist->id,
+    ]);
+});
+
+it('rewrites each stream candidate url to a proxied url, never returning the raw resolved url', function () {
+    Http::fake([
+        'aiostreams.test/abc/stream/movie/tt1234567.json*' => Http::response([
+            'streams' => [
+                ['name' => 'Movie.720p', 'url' => 'https://debrid.example.com/secret-token/720p.mkv'],
+                ['name' => 'Movie.1080p', 'url' => 'https://debrid.example.com/secret-token/1080p.mkv'],
+            ],
+        ], 200),
+    ]);
+
+    $response = $this->get("/{$this->user->name}/{$this->playlist->uuid}/aiostreams/{$this->integration->id}/stream/movie/tt1234567.json");
+
+    $response->assertOk();
+
+    $streams = $response->json('streams');
+
+    expect($streams)->toHaveCount(2);
+
+    foreach ($streams as $stream) {
+        expect($stream['url'])
+            ->toContain("/aiostreams-media/{$this->integration->id}/live/")
+            ->not->toContain('debrid.example.com')
+            ->not->toContain('secret-token');
+    }
+});
+
+it('returns unauthorized for unrecognized credentials', function () {
+    Http::fake([
+        'aiostreams.test/abc/stream/movie/tt1234567.json*' => Http::response(['streams' => []], 200),
+    ]);
+
+    $response = $this->get("/{$this->user->name}/wrong-password/aiostreams/{$this->integration->id}/stream/movie/tt1234567.json");
+
+    $response->assertStatus(401);
+});

--- a/tests/Feature/EpgApiControllerTest.php
+++ b/tests/Feature/EpgApiControllerTest.php
@@ -7,6 +7,7 @@ use App\Models\Epg;
 use App\Models\EpgChannel;
 use App\Models\Group;
 use App\Models\Playlist;
+use App\Models\PlaylistAuth;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -321,5 +322,99 @@ class EpgApiControllerTest extends TestCase
         $start = Carbon::parse($firstProgramme['start']);
         $stop = Carbon::parse($firstProgramme['stop']);
         $this->assertEquals(60, $start->diffInMinutes($stop));
+    }
+
+    public function test_unauthenticated_request_without_credentials_gets_metadata_only()
+    {
+        // No session, no username/password: the response must never fall back to
+        // embedding the playlist owner's real Xtream credentials in a channel URL.
+        $this->app['auth']->forgetGuards();
+
+        $channel = Channel::factory()->create([
+            'playlist_id' => $this->playlist->id,
+            'user_id' => $this->user->id,
+            'enabled' => true,
+            'is_vod' => false,
+            'channel' => 995,
+        ]);
+
+        $response = $this->getJson("/api/epg/playlist/{$this->playlist->uuid}/data");
+
+        $response->assertSuccessful();
+
+        $data = $response->json();
+        $this->assertFalse($data['playable']);
+
+        $channelEntry = collect($data['channels'])->firstWhere('id', $channel->id);
+        $this->assertNotNull($channelEntry);
+        $this->assertFalse($channelEntry['playable']);
+        $this->assertNull($channelEntry['url']);
+        $this->assertNull($channelEntry['format']);
+    }
+
+    public function test_unauthenticated_request_with_foreign_playlist_credentials_gets_metadata_only()
+    {
+        // Valid credentials for a *different* playlist must not unlock playable
+        // URLs for this playlist.
+        $this->app['auth']->forgetGuards();
+
+        $otherUser = User::factory()->create();
+        $otherPlaylist = Playlist::factory()->for($otherUser)->create();
+
+        $channel = Channel::factory()->create([
+            'playlist_id' => $this->playlist->id,
+            'user_id' => $this->user->id,
+            'enabled' => true,
+            'is_vod' => false,
+            'channel' => 994,
+        ]);
+
+        $response = $this->getJson("/api/epg/playlist/{$this->playlist->uuid}/data?".http_build_query([
+            'username' => $otherUser->name,
+            'password' => $otherPlaylist->uuid,
+        ]));
+
+        $response->assertSuccessful();
+
+        $data = $response->json();
+        $this->assertFalse($data['playable']);
+
+        $channelEntry = collect($data['channels'])->firstWhere('id', $channel->id);
+        $this->assertNull($channelEntry['url']);
+    }
+
+    public function test_unauthenticated_request_with_matching_playlist_auth_gets_playable_urls()
+    {
+        // Valid PlaylistAuth credentials assigned to *this* playlist should still
+        // unlock playable URLs for an unauthenticated (no panel session) caller.
+        $this->app['auth']->forgetGuards();
+
+        $playlistAuth = PlaylistAuth::factory()->for($this->user)->create([
+            'enabled' => true,
+        ]);
+        $playlistAuth->assignTo($this->playlist);
+
+        $channel = Channel::factory()->create([
+            'playlist_id' => $this->playlist->id,
+            'user_id' => $this->user->id,
+            'enabled' => true,
+            'is_vod' => false,
+            'channel' => 993,
+        ]);
+
+        $response = $this->getJson("/api/epg/playlist/{$this->playlist->uuid}/data?".http_build_query([
+            'username' => $playlistAuth->username,
+            'password' => $playlistAuth->password,
+        ]));
+
+        $response->assertSuccessful();
+
+        $data = $response->json();
+        $this->assertTrue($data['playable']);
+
+        $channelEntry = collect($data['channels'])->firstWhere('id', $channel->id);
+        $this->assertTrue($channelEntry['playable']);
+        $this->assertNotEmpty($channelEntry['url']);
+        $this->assertStringContainsString((string) $playlistAuth->username, $channelEntry['url']);
     }
 }

--- a/tests/Feature/LocalMediaStreamSecurityTest.php
+++ b/tests/Feature/LocalMediaStreamSecurityTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\MediaServerProxyController;
 use App\Models\MediaServerIntegration;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -19,12 +20,13 @@ function makeLocalIntegration(int $userId, array $paths): MediaServerIntegration
     ]);
 }
 
+// Routes through the same signed-URL generator production code uses (see
+// MediaServerProxySignedUrlTest for coverage of the signature requirement itself).
+// Callers always base64-encode the file path before calling generateLocalMediaStreamUrl
+// (see LocalMediaService), so this helper mirrors that.
 function streamUrl(int $integrationId, string $filePath): string
 {
-    return route('local-media.stream', [
-        'integration' => $integrationId,
-        'item' => base64_encode($filePath),
-    ]);
+    return MediaServerProxyController::generateLocalMediaStreamUrl($integrationId, base64_encode($filePath));
 }
 
 beforeEach(function () {
@@ -173,10 +175,7 @@ it('returns 404 for a non-existent file', function () {
 });
 
 it('returns 404 for an unknown integration', function () {
-    $response = $this->get(route('local-media.stream', [
-        'integration' => 99999,
-        'item' => base64_encode('/some/file.mkv'),
-    ]));
+    $response = $this->get(streamUrl(99999, '/some/file.mkv'));
 
     $response->assertNotFound();
 });

--- a/tests/Feature/M3uProxyCallbackAuthTest.php
+++ b/tests/Feature/M3uProxyCallbackAuthTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\DvrRecording;
+use App\Models\Network;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class M3uProxyCallbackAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        config(['proxy.allow_unauthenticated_callbacks' => false]);
+
+        parent::tearDown();
+    }
+
+    public function test_failover_resolver_rejects_request_with_no_token_configured()
+    {
+        config(['proxy.m3u_proxy_token' => null]);
+
+        $response = $this->postJson('/api/m3u-proxy/failover-resolver', [
+            'current_url' => 'https://example.com/stream',
+            'metadata' => ['id' => 1, 'type' => 'channel', 'playlist_uuid' => 'test-uuid'],
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_failover_resolver_rejects_wrong_token()
+    {
+        config(['proxy.m3u_proxy_token' => 'correct-token']);
+
+        $response = $this->postJson('/api/m3u-proxy/failover-resolver?api_token=wrong-token', [
+            'current_url' => 'https://example.com/stream',
+            'metadata' => ['id' => 1, 'type' => 'channel', 'playlist_uuid' => 'test-uuid'],
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_failover_resolver_accepts_valid_token_via_query_param()
+    {
+        config(['proxy.m3u_proxy_token' => 'correct-token']);
+
+        $response = $this->postJson('/api/m3u-proxy/failover-resolver?api_token=correct-token', [
+            'current_url' => 'https://example.com/stream',
+            'metadata' => ['id' => 1, 'type' => 'channel', 'playlist_uuid' => 'test-uuid'],
+        ]);
+
+        // Reaches the controller (not blocked at 401); the resolver itself may
+        // still fail to find the channel, which isn't what this test verifies.
+        $this->assertNotEquals(401, $response->getStatusCode());
+    }
+
+    public function test_failover_resolver_accepts_valid_token_via_header()
+    {
+        config(['proxy.m3u_proxy_token' => 'correct-token']);
+
+        $response = $this->postJson('/api/m3u-proxy/failover-resolver', [
+            'current_url' => 'https://example.com/stream',
+            'metadata' => ['id' => 1, 'type' => 'channel', 'playlist_uuid' => 'test-uuid'],
+        ], ['X-API-Token' => 'correct-token']);
+
+        $this->assertNotEquals(401, $response->getStatusCode());
+    }
+
+    public function test_local_bypass_flag_allows_unconfigured_token()
+    {
+        config([
+            'proxy.m3u_proxy_token' => null,
+            'proxy.allow_unauthenticated_callbacks' => true,
+        ]);
+
+        $response = $this->postJson('/api/m3u-proxy/failover-resolver', [
+            'current_url' => 'https://example.com/stream',
+            'metadata' => ['id' => 1, 'type' => 'channel', 'playlist_uuid' => 'test-uuid'],
+        ]);
+
+        $this->assertNotEquals(401, $response->getStatusCode());
+    }
+
+    public function test_webhook_route_requires_token()
+    {
+        config(['proxy.m3u_proxy_token' => 'correct-token']);
+
+        $response = $this->postJson('/api/m3u-proxy/webhooks', ['event_type' => 'client_connected']);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_broadcast_callback_route_requires_token()
+    {
+        config(['proxy.m3u_proxy_token' => 'correct-token']);
+
+        $network = Network::factory()->create();
+
+        $response = $this->postJson('/api/m3u-proxy/broadcast/callback', [
+            'network_id' => $network->uuid,
+            'event' => 'programme_ended',
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_dvr_callback_route_requires_token()
+    {
+        config(['proxy.m3u_proxy_token' => 'correct-token']);
+
+        $recording = DvrRecording::factory()->create();
+
+        $response = $this->postJson('/api/dvr/callback', [
+            'network_id' => $recording->uuid,
+            'event' => 'programme_ended',
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_dvr_callback_route_accepts_valid_token()
+    {
+        config(['proxy.m3u_proxy_token' => 'correct-token']);
+
+        $recording = DvrRecording::factory()->create();
+
+        $response = $this->postJson('/api/dvr/callback?api_token=correct-token', [
+            'network_id' => $recording->uuid,
+            'event' => 'programme_ended',
+        ]);
+
+        $response->assertSuccessful();
+    }
+}

--- a/tests/Feature/M3uProxyCallbackUrlTokenTest.php
+++ b/tests/Feature/M3uProxyCallbackUrlTokenTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\M3uProxyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class M3uProxyCallbackUrlTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'proxy.m3u_resolver_url' => 'https://resolver.example.com',
+            'proxy.m3u_proxy_token' => 'super-secret-token',
+        ]);
+    }
+
+    public function test_failover_resolver_url_embeds_the_shared_token()
+    {
+        $url = (new M3uProxyService)->getFailoverResolverUrl();
+
+        $this->assertStringContainsString('/api/m3u-proxy/failover-resolver', $url);
+        $this->assertStringContainsString('api_token=super-secret-token', $url);
+    }
+
+    public function test_broadcast_callback_url_embeds_the_shared_token()
+    {
+        $url = (new M3uProxyService)->getBroadcastCallbackUrl();
+
+        $this->assertStringContainsString('/api/m3u-proxy/broadcast/callback', $url);
+        $this->assertStringContainsString('api_token=super-secret-token', $url);
+    }
+
+    public function test_webhook_url_embeds_the_shared_token()
+    {
+        $url = (new M3uProxyService)->getWebhookUrl();
+
+        $this->assertStringContainsString('/api/m3u-proxy/webhooks', $url);
+        $this->assertStringContainsString('api_token=super-secret-token', $url);
+    }
+
+    public function test_dvr_callback_url_embeds_the_shared_token()
+    {
+        $url = (new M3uProxyService)->getDvrCallbackUrl();
+
+        $this->assertStringContainsString('/api/dvr/callback', $url);
+        $this->assertStringContainsString('api_token=super-secret-token', $url);
+    }
+
+    public function test_callback_urls_omit_token_param_when_none_configured()
+    {
+        config(['proxy.m3u_proxy_token' => null]);
+
+        $url = (new M3uProxyService)->getFailoverResolverUrl();
+
+        $this->assertStringNotContainsString('api_token=', $url);
+    }
+}

--- a/tests/Feature/M3uProxyPlayerStreamStopTest.php
+++ b/tests/Feature/M3uProxyPlayerStreamStopTest.php
@@ -79,13 +79,16 @@ class M3uProxyPlayerStreamStopTest extends TestCase
         Http::assertNothingSent();
     }
 
-    public function test_missing_type_or_id_still_returns_no_content()
+    public function test_missing_type_or_id_returns_unprocessable()
     {
+        // Structural validation (malformed request) is a distinct concern from the
+        // ownership check above and doesn't need to hide anything, so it reports
+        // 422 rather than folding into the silent 204 contract.
         $user = User::factory()->create();
 
         $response = $this->actingAs($user)->postJson('/api/m3u-proxy/player-stream/stop', []);
 
-        $response->assertNoContent();
+        $response->assertStatus(422);
         Http::assertNothingSent();
     }
 }

--- a/tests/Feature/M3uProxyPlayerStreamStopTest.php
+++ b/tests/Feature/M3uProxyPlayerStreamStopTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class M3uProxyPlayerStreamStopTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Prevent any real network call to the m3u-proxy service; let each test
+        // assert whether a stop request was (or wasn't) actually sent.
+        Http::fake();
+    }
+
+    public function test_unauthenticated_caller_gets_no_content_and_does_not_stop_stream()
+    {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->create();
+        $channel = Channel::factory()->create([
+            'playlist_id' => $playlist->id,
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->postJson('/api/m3u-proxy/player-stream/stop', [
+            'id' => $channel->id,
+            'type' => 'channel',
+        ]);
+
+        $response->assertNoContent();
+        Http::assertNothingSent();
+    }
+
+    public function test_authenticated_owner_can_stop_own_channel_stream()
+    {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->create();
+        $channel = Channel::factory()->create([
+            'playlist_id' => $playlist->id,
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)->postJson('/api/m3u-proxy/player-stream/stop', [
+            'id' => $channel->id,
+            'type' => 'channel',
+        ]);
+
+        $response->assertNoContent();
+        Http::assertSentCount(1);
+    }
+
+    public function test_authenticated_user_cannot_stop_another_users_channel_stream()
+    {
+        $owner = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $playlist = Playlist::factory()->for($owner)->create();
+        $channel = Channel::factory()->create([
+            'playlist_id' => $playlist->id,
+            'user_id' => $owner->id,
+        ]);
+
+        $response = $this->actingAs($otherUser)->postJson('/api/m3u-proxy/player-stream/stop', [
+            'id' => $channel->id,
+            'type' => 'channel',
+        ]);
+
+        // Same 204 response as the owner case (so the caller can't use the
+        // response to probe ownership), but the proxy must never be called.
+        $response->assertNoContent();
+        Http::assertNothingSent();
+    }
+
+    public function test_missing_type_or_id_still_returns_no_content()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->postJson('/api/m3u-proxy/player-stream/stop', []);
+
+        $response->assertNoContent();
+        Http::assertNothingSent();
+    }
+}

--- a/tests/Feature/MediaServerProxySignedUrlTest.php
+++ b/tests/Feature/MediaServerProxySignedUrlTest.php
@@ -74,4 +74,29 @@ class MediaServerProxySignedUrlTest extends TestCase
 
         $response->assertForbidden();
     }
+
+    public function test_stream_proxy_route_never_expires()
+    {
+        $integration = MediaServerIntegration::factory()->create();
+
+        $url = MediaServerProxyController::generateStreamProxyUrl($integration->id, 'abc123', 'ts');
+
+        $this->travel(30)->days();
+        $response = $this->get($url);
+
+        $this->assertNotEquals(403, $response->getStatusCode());
+    }
+
+    public function test_stream_proxy_route_rejects_url_with_stale_version()
+    {
+        $integration = MediaServerIntegration::factory()->create();
+
+        $url = MediaServerProxyController::generateStreamProxyUrl($integration->id, 'abc123', 'ts');
+
+        config(['proxy.media_server_url_version' => 2]);
+
+        $response = $this->get($url);
+
+        $response->assertForbidden();
+    }
 }

--- a/tests/Feature/MediaServerProxySignedUrlTest.php
+++ b/tests/Feature/MediaServerProxySignedUrlTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\MediaServerProxyController;
+use App\Models\MediaServerIntegration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MediaServerProxySignedUrlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_stream_proxy_route_rejects_request_without_signature()
+    {
+        $integration = MediaServerIntegration::factory()->create();
+
+        $response = $this->get("/media-server/{$integration->id}/stream/abc123.ts");
+
+        $response->assertForbidden();
+    }
+
+    public function test_stream_proxy_route_rejects_tampered_signature()
+    {
+        $integration = MediaServerIntegration::factory()->create();
+
+        $url = MediaServerProxyController::generateStreamProxyUrl($integration->id, 'abc123', 'ts');
+        // Swap the item id after signing so the signature no longer matches.
+        $tampered = str_replace('abc123', 'other-item', $url);
+
+        $response = $this->get($tampered);
+
+        $response->assertForbidden();
+    }
+
+    public function test_stream_proxy_route_accepts_valid_generated_signature()
+    {
+        $integration = MediaServerIntegration::factory()->create();
+
+        $url = MediaServerProxyController::generateStreamProxyUrl($integration->id, 'abc123', 'ts');
+
+        $response = $this->get($url);
+
+        // The signature must pass (not a 403 Invalid Signature middleware rejection).
+        // The controller then tries to reach the (nonexistent, in tests) upstream media
+        // server, whose failure mode isn't what this test verifies - just that the
+        // signature middleware let the request through to the controller.
+        $this->assertNotEquals(403, $response->getStatusCode());
+    }
+
+    public function test_image_proxy_route_rejects_request_without_signature()
+    {
+        $integration = MediaServerIntegration::factory()->create();
+
+        $response = $this->get("/media-server/{$integration->id}/image/abc123/Primary");
+
+        $response->assertForbidden();
+    }
+
+    public function test_local_media_route_rejects_request_without_signature()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'local']);
+
+        $response = $this->get("/local-media/{$integration->id}/stream/".base64_encode('/media/foo.mp4'));
+
+        $response->assertForbidden();
+    }
+
+    public function test_webdav_media_route_rejects_request_without_signature()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'webdav']);
+
+        $response = $this->get("/webdav-media/{$integration->id}/stream/".base64_encode('/foo.mp4'));
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/Feature/MediaServerProxySignedUrlTest.php
+++ b/tests/Feature/MediaServerProxySignedUrlTest.php
@@ -3,7 +3,12 @@
 namespace Tests\Feature;
 
 use App\Http\Controllers\MediaServerProxyController;
+use App\Models\Channel;
+use App\Models\Episode;
 use App\Models\MediaServerIntegration;
+use App\Models\Playlist;
+use App\Models\Series;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -98,5 +103,145 @@ class MediaServerProxySignedUrlTest extends TestCase
         $response = $this->get($url);
 
         $response->assertForbidden();
+    }
+
+    private function makeAioStreamsChannel(MediaServerIntegration $integration, ?string $resolvedUrl = 'https://cdn.test/movie.mkv'): Channel
+    {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->create(['user_id' => $user->id]);
+
+        return Channel::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'is_custom' => true,
+            'is_vod' => true,
+            'aio_integration_id' => $integration->id,
+            'movie_data' => $resolvedUrl ? ['aiostreams' => ['resolved_url' => $resolvedUrl]] : null,
+        ]);
+    }
+
+    public function test_aiostreams_channel_media_route_rejects_request_without_signature()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'aiostreams']);
+        $channel = $this->makeAioStreamsChannel($integration);
+
+        $response = $this->get("/aiostreams-media/{$integration->id}/channel/{$channel->id}/stream");
+
+        $response->assertForbidden();
+    }
+
+    public function test_aiostreams_channel_media_route_rejects_non_aiostreams_integration()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'plex']);
+        $channel = $this->makeAioStreamsChannel($integration);
+
+        $url = MediaServerProxyController::generateAioStreamsChannelProxyUrl($integration->id, $channel->id);
+
+        $response = $this->get($url);
+
+        $response->assertStatus(400);
+    }
+
+    public function test_aiostreams_channel_media_route_returns_404_when_channel_has_no_resolved_url()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'aiostreams']);
+        $channel = $this->makeAioStreamsChannel($integration, resolvedUrl: null);
+
+        $url = MediaServerProxyController::generateAioStreamsChannelProxyUrl($integration->id, $channel->id);
+
+        $response = $this->get($url);
+
+        $response->assertStatus(404);
+    }
+
+    private function makeAioStreamsEpisode(MediaServerIntegration $integration, ?string $resolvedUrl = 'https://cdn.test/episode.mkv'): Episode
+    {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->create(['user_id' => $user->id]);
+        $series = Series::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'is_custom' => true,
+            'aio_integration_id' => $integration->id,
+        ]);
+
+        return Episode::factory()->create([
+            'user_id' => $user->id,
+            'playlist_id' => $playlist->id,
+            'series_id' => $series->id,
+            'is_custom' => true,
+            'info' => $resolvedUrl ? ['aiostreams' => ['resolved_url' => $resolvedUrl]] : null,
+        ]);
+    }
+
+    public function test_aiostreams_episode_media_route_rejects_request_without_signature()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'aiostreams']);
+        $episode = $this->makeAioStreamsEpisode($integration);
+
+        $response = $this->get("/aiostreams-media/{$integration->id}/episode/{$episode->id}/stream");
+
+        $response->assertForbidden();
+    }
+
+    public function test_aiostreams_episode_media_route_returns_404_when_episode_has_no_resolved_url()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'aiostreams']);
+        $episode = $this->makeAioStreamsEpisode($integration, resolvedUrl: null);
+
+        $url = MediaServerProxyController::generateAioStreamsEpisodeProxyUrl($integration->id, $episode->id);
+
+        $response = $this->get($url);
+
+        $response->assertStatus(404);
+    }
+
+    public function test_aiostreams_live_media_route_rejects_request_without_signature()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'aiostreams']);
+
+        $response = $this->get("/aiostreams-media/{$integration->id}/live/some-token/stream");
+
+        $response->assertForbidden();
+    }
+
+    public function test_aiostreams_live_media_route_rejects_non_aiostreams_integration()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'plex']);
+
+        $url = MediaServerProxyController::generateAioStreamsLiveProxyUrl($integration->id, 'https://cdn.test/movie.mkv');
+
+        $response = $this->get($url);
+
+        $response->assertStatus(400);
+    }
+
+    public function test_aiostreams_live_media_route_returns_404_for_unknown_token()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'aiostreams']);
+
+        // Reuse the real generator so the signature/version are valid — only the
+        // token itself is swapped for one that was never cached.
+        $url = MediaServerProxyController::generateAioStreamsLiveProxyUrl($integration->id, 'https://cdn.test/movie.mkv');
+        $tampered = preg_replace('#(/aiostreams-media/\d+/live/)[^/?]+#', '$1never-cached-token', $url);
+
+        $response = $this->get($tampered);
+
+        // The signature no longer matches (token is part of the signed payload),
+        // so this is rejected by the signature middleware before it ever reaches
+        // the cache lookup — still proves an attacker can't just swap in a guessed
+        // token to reach someone else's cached URL.
+        $response->assertForbidden();
+    }
+
+    public function test_aiostreams_live_media_route_generates_a_short_url_regardless_of_resolved_url_length()
+    {
+        $integration = MediaServerIntegration::factory()->create(['type' => 'aiostreams']);
+
+        $longResolvedUrl = 'https://cdn.test/movie.mkv?'.str_repeat('a', 5000);
+
+        $url = MediaServerProxyController::generateAioStreamsLiveProxyUrl($integration->id, $longResolvedUrl);
+
+        $this->assertLessThan(300, strlen($url));
     }
 }

--- a/tests/Feature/NetworkBroadcastFailureHandlingTest.php
+++ b/tests/Feature/NetworkBroadcastFailureHandlingTest.php
@@ -7,6 +7,10 @@ use App\Services\NetworkBroadcastService;
 use Illuminate\Support\Facades\Http;
 
 beforeEach(function () {
+    // These tests exercise broadcast lifecycle logic via the proxy callback route,
+    // not the callback auth gate itself (see VerifyM3uProxyCallback / M3uProxyCallbackAuthTest).
+    config(['proxy.m3u_proxy_token' => null, 'proxy.allow_unauthenticated_callbacks' => true]);
+
     Http::fake([
         '*/broadcast/*/status' => Http::response(['status' => 'stopped'], 404),
         '*/broadcast/*/stop' => Http::response(['status' => 'stopped', 'final_segment_number' => 0], 200),

--- a/tests/Feature/NetworkBroadcastTransitionTest.php
+++ b/tests/Feature/NetworkBroadcastTransitionTest.php
@@ -7,6 +7,10 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 
 beforeEach(function () {
+    // These tests exercise broadcast lifecycle logic via the proxy callback route,
+    // not the callback auth gate itself (see VerifyM3uProxyCallback / M3uProxyCallbackAuthTest).
+    config(['proxy.m3u_proxy_token' => null, 'proxy.allow_unauthenticated_callbacks' => true]);
+
     Http::fake([
         '*/broadcast/*/status' => Http::response(['status' => 'stopped'], 404),
         '*/broadcast/*/stop' => Http::response(['status' => 'stopped', 'final_segment_number' => 0], 200),

--- a/tests/Feature/ProxyLogRedactionTest.php
+++ b/tests/Feature/ProxyLogRedactionTest.php
@@ -151,7 +151,7 @@ it('allowlists webhook callback diagnostics', function () {
                 'source' => "https://provider.test/{$secret}",
             ],
         ],
-    ])->assertOk();
+    ], ['X-API-Token' => 'proxy-api-token'])->assertOk();
 
     expect(formattedProxyLogs($this->proxyLogHandler))
         ->toContain('stream_started')
@@ -179,7 +179,7 @@ it('does not log failover request or exception payloads', function () {
         'current_failover_index' => 2,
         'status_code' => 401,
         'Cookie' => $secret,
-    ])->assertInternalServerError();
+    ], ['X-API-Token' => 'proxy-api-token'])->assertInternalServerError();
 
     expect(formattedProxyLogs($this->proxyLogHandler))
         ->toContain('Error resolving failover')

--- a/tests/Feature/ResolveAioStreamsChannelTest.php
+++ b/tests/Feature/ResolveAioStreamsChannelTest.php
@@ -53,8 +53,13 @@ it('resolves the top candidates and creates a failover chain', function () {
 
     $this->channel->refresh();
 
+    // The resolved URL is never stored directly — it's hidden behind the media-server
+    // proxy (see MediaServerProxyController::streamAioStreamsChannel()), stored on
+    // the channel's own movie_data (internal-only) and referenced by the channel's
+    // own ID in the generated URL.
     expect($this->channel->aio_resolution_status)->toBe('resolved')
-        ->and($this->channel->url)->toBe('https://example.com/2160p.mkv')
+        ->and($this->channel->url)->toContain("/aiostreams-media/{$this->integration->id}/channel/{$this->channel->id}/stream")
+        ->and($this->channel->movie_data['aiostreams']['resolved_url'])->toBe('https://example.com/2160p.mkv')
         ->and($this->channel->container_extension)->toBe('mkv')
         ->and(ChannelFailover::where('channel_id', $this->channel->id)->count())->toBe(2);
 });
@@ -83,6 +88,12 @@ it('creates failover candidates as hidden clones that do not appear in normal Ch
     expect($this->channel->failoverChannels()->count())->toBe(2)
         ->and($this->channel->failoverChannels()->pluck('channels.id')->sort()->values()->all())
         ->toBe($failoverChannelIds->sort()->values()->all());
+
+    // Each failover clone gets its own resolved URL and a proxy URL keyed by its
+    // own ID, not the primary channel's.
+    $firstFailover = Channel::withoutGlobalScopes()->find($failoverChannelIds->first());
+    expect($firstFailover->url)->toContain("/aiostreams-media/{$this->integration->id}/channel/{$firstFailover->id}/stream")
+        ->and($firstFailover->movie_data['aiostreams']['resolved_url'])->not->toBeNull();
 });
 
 it('deletes orphaned failover clone channels when the primary channel is deleted', function () {

--- a/tests/Feature/ResolveAioStreamsEpisodeTest.php
+++ b/tests/Feature/ResolveAioStreamsEpisodeTest.php
@@ -57,8 +57,13 @@ it('resolves the top candidates, infers the container extension, and creates a f
 
     $this->episode->refresh();
 
+    // The resolved URL is never stored directly — it's hidden behind the media-server
+    // proxy (see MediaServerProxyController::streamAioStreamsEpisode()), stored on
+    // the episode's own info (internal-only) and referenced by the episode's own
+    // ID in the generated URL.
     expect($this->episode->aio_resolution_status)->toBe('resolved')
-        ->and($this->episode->url)->toBe('https://example.com/2160p.mkv')
+        ->and($this->episode->url)->toContain("/aiostreams-media/{$this->integration->id}/episode/{$this->episode->id}/stream")
+        ->and($this->episode->info['aiostreams']['resolved_url'])->toBe('https://example.com/2160p.mkv')
         ->and($this->episode->container_extension)->toBe('mkv')
         ->and(EpisodeFailover::where('episode_id', $this->episode->id)->count())->toBe(2);
 });
@@ -84,6 +89,12 @@ it('creates failover candidates as hidden clones that do not appear in normal Ep
 
     // ...but still reachable via the failover relationship the playback path uses.
     expect($this->episode->failoverEpisodes()->count())->toBe(1);
+
+    // The failover clone gets its own resolved URL and a proxy URL keyed by its
+    // own ID, not the primary episode's.
+    $firstFailover = Episode::withoutGlobalScopes()->find($failoverEpisodeIds->first());
+    expect($firstFailover->url)->toContain("/aiostreams-media/{$this->integration->id}/episode/{$firstFailover->id}/stream")
+        ->and($firstFailover->info['aiostreams']['resolved_url'])->not->toBeNull();
 });
 
 it('deletes orphaned failover clone episodes when the primary episode is deleted', function () {

--- a/tests/Feature/ResolveEpisodeFailoverUrlTest.php
+++ b/tests/Feature/ResolveEpisodeFailoverUrlTest.php
@@ -14,6 +14,10 @@ use Illuminate\Support\Facades\Bus;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
+    // This suite exercises failover-resolution logic, not the callback auth gate
+    // itself (see VerifyM3uProxyCallback / M3uProxyCallbackAuthTest).
+    config(['proxy.m3u_proxy_token' => null, 'proxy.allow_unauthenticated_callbacks' => true]);
+
     $this->user = User::factory()->create();
     $this->playlist = Playlist::factory()->create(['user_id' => $this->user->id]);
     $this->integration = MediaServerIntegration::create([

--- a/tests/Feature/StopPlayerStreamTest.php
+++ b/tests/Feature/StopPlayerStreamTest.php
@@ -1,7 +1,47 @@
 <?php
 
+use App\Models\Channel;
+use App\Models\Episode;
+use App\Models\Playlist;
+use App\Models\User;
 use App\Services\M3uProxyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+// This route also requires an authenticated panel session and ownership of the
+// requested channel/episode (see VerifyM3uProxyCallback's sibling security fix on
+// this route, and M3uProxyPlayerStreamStopTest for the auth/ownership-specific
+// coverage). These tests act as the owner throughout to exercise the id/type/
+// client_id -> proxy request plumbing on top of that gate.
+function actingAsChannelOwner(): Channel
+{
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create();
+    $channel = Channel::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $user->id,
+    ]);
+
+    test()->actingAs($user);
+
+    return $channel;
+}
+
+function actingAsEpisodeOwner(): Episode
+{
+    $user = User::factory()->create();
+    $playlist = Playlist::factory()->for($user)->create();
+    $episode = Episode::factory()->create([
+        'playlist_id' => $playlist->id,
+        'user_id' => $user->id,
+    ]);
+
+    test()->actingAs($user);
+
+    return $episode;
+}
 
 it('returns 422 when id is missing', function () {
     $this->postJson('/api/m3u-proxy/player-stream/stop', [
@@ -24,40 +64,42 @@ it('returns 422 for unknown type', function () {
 
 it('returns 204 for valid channel stop request', function () {
     Http::fake(['*' => Http::response(['deleted_count' => 1], 200)]);
-
     config(['proxy.m3u_proxy_host' => 'http://proxy.test']);
 
+    $channel = actingAsChannelOwner();
+
     $this->postJson('/api/m3u-proxy/player-stream/stop', [
-        'id' => 42,
+        'id' => $channel->id,
         'type' => 'channel',
     ])->assertNoContent();
 
-    Http::assertSent(function ($request) {
+    Http::assertSent(function ($request) use ($channel) {
         parse_str(parse_url($request->url(), PHP_URL_QUERY) ?? '', $query);
 
         return str_contains($request->url(), '/streams/by-metadata')
             && ($query['field'] ?? null) === 'channel_id'
-            && ($query['value'] ?? null) === '42'
+            && ($query['value'] ?? null) === (string) $channel->id
             && ($query['force'] ?? null) === 'false';
     });
 });
 
 it('returns 204 for valid episode stop request', function () {
     Http::fake(['*' => Http::response(['deleted_count' => 1], 200)]);
-
     config(['proxy.m3u_proxy_host' => 'http://proxy.test']);
 
+    $episode = actingAsEpisodeOwner();
+
     $this->postJson('/api/m3u-proxy/player-stream/stop', [
-        'id' => 7,
+        'id' => $episode->id,
         'type' => 'episode',
     ])->assertNoContent();
 
-    Http::assertSent(function ($request) {
+    Http::assertSent(function ($request) use ($episode) {
         parse_str(parse_url($request->url(), PHP_URL_QUERY) ?? '', $query);
 
         return str_contains($request->url(), '/streams/by-metadata')
             && ($query['field'] ?? null) === 'episode_id'
-            && ($query['value'] ?? null) === '7'
+            && ($query['value'] ?? null) === (string) $episode->id
             && ($query['force'] ?? null) === 'false';
     });
 });
@@ -65,19 +107,22 @@ it('returns 204 for valid episode stop request', function () {
 it('returns 204 even when proxy is not configured', function () {
     config(['proxy.m3u_proxy_host' => '']);
 
+    $channel = actingAsChannelOwner();
+
     $this->postJson('/api/m3u-proxy/player-stream/stop', [
-        'id' => 1,
+        'id' => $channel->id,
         'type' => 'channel',
     ])->assertNoContent();
 });
 
 it('returns 204 even when proxy request fails', function () {
     Http::fake(['*' => Http::response('Server error', 500)]);
-
     config(['proxy.m3u_proxy_host' => 'http://proxy.test']);
 
+    $channel = actingAsChannelOwner();
+
     $this->postJson('/api/m3u-proxy/player-stream/stop', [
-        'id' => 1,
+        'id' => $channel->id,
         'type' => 'channel',
     ])->assertNoContent();
 });
@@ -99,11 +144,12 @@ it('sends force=true by default when stopping streams by metadata directly', fun
 
 it('forwards client_id to the proxy when provided in the stop request', function () {
     Http::fake(['*' => Http::response(['deleted_count' => 1], 200)]);
-
     config(['proxy.m3u_proxy_host' => 'http://proxy.test']);
 
+    $channel = actingAsChannelOwner();
+
     $this->postJson('/api/m3u-proxy/player-stream/stop', [
-        'id' => 42,
+        'id' => $channel->id,
         'type' => 'channel',
         'client_id' => 'floating-player-test-abc',
     ])->assertNoContent();
@@ -119,11 +165,12 @@ it('forwards client_id to the proxy when provided in the stop request', function
 
 it('does not include client_id in proxy request when not provided', function () {
     Http::fake(['*' => Http::response(['deleted_count' => 1], 200)]);
-
     config(['proxy.m3u_proxy_host' => 'http://proxy.test']);
 
+    $channel = actingAsChannelOwner();
+
     $this->postJson('/api/m3u-proxy/player-stream/stop', [
-        'id' => 42,
+        'id' => $channel->id,
         'type' => 'channel',
     ])->assertNoContent();
 

--- a/tests/Feature/TvApiPlayerStreamStopTest.php
+++ b/tests/Feature/TvApiPlayerStreamStopTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\Episode;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class TvApiPlayerStreamStopTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Http::fake();
+    }
+
+    public function test_owner_can_stop_a_live_channel_belonging_to_their_playlist()
+    {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->create();
+        $channel = Channel::factory()->create([
+            'playlist_id' => $playlist->id,
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->postJson(
+            "/api/tv/{$user->name}/{$playlist->uuid}/player-stream/stop",
+            ['type' => 'live', 'stream_id' => $channel->id, 'client_id' => 'client-1']
+        );
+
+        $response->assertNoContent();
+        Http::assertSentCount(1);
+    }
+
+    public function test_owner_cannot_stop_a_channel_belonging_to_another_playlist()
+    {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->create();
+
+        $otherUser = User::factory()->create();
+        $otherPlaylist = Playlist::factory()->for($otherUser)->create();
+        $foreignChannel = Channel::factory()->create([
+            'playlist_id' => $otherPlaylist->id,
+            'user_id' => $otherUser->id,
+        ]);
+
+        $response = $this->postJson(
+            "/api/tv/{$user->name}/{$playlist->uuid}/player-stream/stop",
+            ['type' => 'live', 'stream_id' => $foreignChannel->id, 'client_id' => 'client-1']
+        );
+
+        // Same 204 whether denied or actually stopped, but the proxy is never called.
+        $response->assertNoContent();
+        Http::assertNothingSent();
+    }
+
+    public function test_series_type_uses_episode_id_and_checks_playlist_ownership()
+    {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->create();
+        $episode = Episode::factory()->create([
+            'playlist_id' => $playlist->id,
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->postJson(
+            "/api/tv/{$user->name}/{$playlist->uuid}/player-stream/stop",
+            ['type' => 'series', 'episode_id' => $episode->id, 'client_id' => 'client-1']
+        );
+
+        $response->assertNoContent();
+        Http::assertSentCount(1);
+    }
+
+    public function test_invalid_credentials_are_rejected()
+    {
+        $user = User::factory()->create();
+        Playlist::factory()->for($user)->create();
+
+        $response = $this->postJson(
+            "/api/tv/{$user->name}/not-a-real-password/player-stream/stop",
+            ['type' => 'live', 'stream_id' => 1, 'client_id' => 'client-1']
+        );
+
+        $response->assertStatus(401);
+        Http::assertNothingSent();
+    }
+
+    public function test_invalid_client_id_is_rejected_by_validation()
+    {
+        $user = User::factory()->create();
+        $playlist = Playlist::factory()->for($user)->create();
+        $channel = Channel::factory()->create([
+            'playlist_id' => $playlist->id,
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->postJson(
+            "/api/tv/{$user->name}/{$playlist->uuid}/player-stream/stop",
+            ['type' => 'live', 'stream_id' => $channel->id, 'client_id' => 'has spaces/slash']
+        );
+
+        $response->assertStatus(422);
+        Http::assertNothingSent();
+    }
+}

--- a/tests/Feature/XtreamCancelDeleteDvrTest.php
+++ b/tests/Feature/XtreamCancelDeleteDvrTest.php
@@ -48,17 +48,16 @@ beforeEach(function () {
     $this->username = 'testuser_'.Str::random(5);
     $this->password = 'testpass';
 
-    PlaylistAuth::create([
+    $this->playlistAuth = PlaylistAuth::create([
         'name' => 'Test Auth',
         'username' => $this->username,
         'password' => $this->password,
         'enabled' => true,
+        'dvr_enabled' => true,
         'user_id' => $this->user->id,
     ]);
 
-    $this->playlist->playlistAuths()->attach(
-        PlaylistAuth::where('username', $this->username)->first()
-    );
+    $this->playlist->playlistAuths()->attach($this->playlistAuth);
 
     $this->group = Group::factory()->for($this->user)->create();
     $this->channel = Channel::factory()
@@ -92,6 +91,7 @@ it('cancels a scheduled (never-started) recording immediately with no post-proce
         ->for($this->setting, 'dvrSetting')
         ->for($this->user)
         ->for($this->channel)
+        ->for($this->playlistAuth, 'playlistAuth')
         ->create(['status' => DvrRecordingStatus::Scheduled, 'proxy_network_id' => null]);
 
     $response = $this->postJson(
@@ -110,6 +110,7 @@ it('cancels a recording with captured footage into PostProcessing, not Cancelled
         ->for($this->setting, 'dvrSetting')
         ->for($this->user)
         ->for($this->channel)
+        ->for($this->playlistAuth, 'playlistAuth')
         ->create([
             'status' => DvrRecordingStatus::Recording,
             'proxy_network_id' => 'test-network-id',
@@ -134,6 +135,7 @@ it('deletes a PostProcessing recording — the state a cancelled in-progress rec
         ->for($this->setting, 'dvrSetting')
         ->for($this->user)
         ->for($this->channel)
+        ->for($this->playlistAuth, 'playlistAuth')
         ->create([
             'status' => DvrRecordingStatus::PostProcessing,
             'user_cancelled' => true,
@@ -153,6 +155,7 @@ it('releases the proxy broadcast when deleting a PostProcessing recording that s
         ->for($this->setting, 'dvrSetting')
         ->for($this->user)
         ->for($this->channel)
+        ->for($this->playlistAuth, 'playlistAuth')
         ->create([
             'status' => DvrRecordingStatus::PostProcessing,
             'proxy_network_id' => 'test-network-id',
@@ -178,6 +181,7 @@ it('reproduces the TV app "Delete recording" flow — cancel then immediate dele
         ->for($this->setting, 'dvrSetting')
         ->for($this->user)
         ->for($this->channel)
+        ->for($this->playlistAuth, 'playlistAuth')
         ->create([
             'status' => DvrRecordingStatus::Recording,
             'proxy_network_id' => 'test-network-id',
@@ -219,6 +223,7 @@ it('rejects deleting a Scheduled or Recording recording — nothing has told the
         ->for($this->setting, 'dvrSetting')
         ->for($this->user)
         ->for($this->channel)
+        ->for($this->playlistAuth, 'playlistAuth')
         ->create(['status' => $status]);
 
     $response = $this->postJson(

--- a/tests/Feature/XtreamDvrOwnershipTest.php
+++ b/tests/Feature/XtreamDvrOwnershipTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * Regression coverage for #1328 — Xtream DVR dispatch didn't check PlaylistAuth
+ * ownership. Before this fix, `get_dvr_recordings`, `get_dvr_recording`,
+ * `cancel_dvr_recording`, and `delete_dvr_recording` scoped only by
+ * `dvr_setting_id` (the playlist), so any two PlaylistAuth credentials sharing
+ * one playlist could view, cancel, or delete each other's DVR recordings.
+ *
+ * Locks in:
+ *   1. `schedule_dvr` / `create_dvr_series_rule` stamp the created rule with the
+ *      requesting credential's playlist_auth_id.
+ *   2. `get_dvr_recordings` / `get_dvr_recording` only return recordings owned by
+ *      the requesting PlaylistAuth credential — a sibling credential's recordings
+ *      are invisible.
+ *   3. `cancel_dvr_recording` / `delete_dvr_recording` 404 (same as "not found",
+ *      not "forbidden" — consistent with the rest of this API not leaking
+ *      existence) when the recording belongs to a different credential.
+ *   4. The playlist owner (owner_auth, no PlaylistAuth) retains full visibility
+ *      across all credentials' recordings — this is an intentional exception,
+ *      not a regression.
+ *   5. A PlaylistAuth credential without dvr_enabled cannot dispatch any DVR
+ *      action at all, matching the same flag already enforced for feature
+ *      advertisement (canAdvertiseDvrFeature).
+ */
+
+use App\Enums\DvrRecordingStatus;
+use App\Models\Channel;
+use App\Models\DvrRecording;
+use App\Models\DvrRecordingRule;
+use App\Models\DvrSetting;
+use App\Models\Group;
+use App\Models\Playlist;
+use App\Models\PlaylistAuth;
+use App\Models\User;
+use App\Services\M3uProxyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::factory()->for($this->user)->create();
+
+    $this->authA = PlaylistAuth::create([
+        'name' => 'Credential A',
+        'username' => 'credential-a',
+        'password' => 'password-a',
+        'enabled' => true,
+        'dvr_enabled' => true,
+        'user_id' => $this->user->id,
+    ]);
+    $this->authB = PlaylistAuth::create([
+        'name' => 'Credential B',
+        'username' => 'credential-b',
+        'password' => 'password-b',
+        'enabled' => true,
+        'dvr_enabled' => true,
+        'user_id' => $this->user->id,
+    ]);
+
+    $this->playlist->playlistAuths()->attach([$this->authA->id, $this->authB->id]);
+
+    $this->group = Group::factory()->for($this->user)->create();
+    $this->channel = Channel::factory()
+        ->for($this->playlist)
+        ->for($this->group)
+        ->create(['enabled' => true, 'title_custom' => 'News 24']);
+
+    $this->setting = DvrSetting::factory()
+        ->enabled()
+        ->for($this->user)
+        ->for($this->playlist)
+        ->create();
+
+    $proxy = Mockery::mock(M3uProxyService::class);
+    $proxy->shouldReceive('stopDvrBroadcast')->andReturn(true);
+    $proxy->shouldReceive('cleanupDvrBroadcast')->andReturn(true);
+    app()->instance(M3uProxyService::class, $proxy);
+});
+
+function dvrActionUrl(string $username, string $password, string $action): string
+{
+    return route('xtream.api.player').'?'.http_build_query([
+        'username' => $username,
+        'password' => $password,
+        'action' => $action,
+    ]);
+}
+
+it('stamps schedule_dvr and create_dvr_series_rule with the requesting credential', function () {
+    $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', 'schedule_dvr'), [
+        'channel_id' => (string) $this->channel->id,
+        'title' => 'Evening News',
+        'start_time' => now()->addHour()->toIso8601String(),
+        'end_time' => now()->addHours(2)->toIso8601String(),
+    ])->assertOk();
+
+    $rule = DvrRecordingRule::find($response->json('rule_id'));
+    expect($rule->playlist_auth_id)->toBe($this->authA->id);
+
+    $response = $this->postJson(dvrActionUrl('credential-b', 'password-b', 'create_dvr_series_rule'), [
+        'channel_id' => (string) $this->channel->id,
+        'title' => 'Breaking News',
+    ])->assertOk();
+
+    $rule = DvrRecordingRule::find($response->json('rule_id'));
+    expect($rule->playlist_auth_id)->toBe($this->authB->id);
+});
+
+it('does not let one credential see another credential\'s recordings via get_dvr_recordings', function () {
+    $recordingA = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->for($this->authA, 'playlistAuth')
+        ->create(['status' => DvrRecordingStatus::Scheduled]);
+
+    DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->for($this->authB, 'playlistAuth')
+        ->create(['status' => DvrRecordingStatus::Scheduled]);
+
+    $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', 'get_dvr_recordings'))->assertOk();
+
+    $uuids = collect($response->json())->pluck('uuid');
+    expect($response->json())->toHaveCount(1);
+    expect($uuids->first())->toBe($recordingA->uuid);
+});
+
+it('404s get_dvr_recording for a recording owned by another credential', function () {
+    $recordingB = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->for($this->authB, 'playlistAuth')
+        ->create(['status' => DvrRecordingStatus::Scheduled]);
+
+    $this->postJson(dvrActionUrl('credential-a', 'password-a', 'get_dvr_recording'), [
+        'recording_id' => $recordingB->uuid,
+    ])->assertNotFound();
+
+    $this->postJson(dvrActionUrl('credential-b', 'password-b', 'get_dvr_recording'), [
+        'recording_id' => $recordingB->uuid,
+    ])->assertOk();
+});
+
+it('404s cancel_dvr_recording for a recording owned by another credential, and never touches it', function () {
+    $recordingB = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->for($this->authB, 'playlistAuth')
+        ->create(['status' => DvrRecordingStatus::Scheduled, 'proxy_network_id' => null]);
+
+    $this->postJson(dvrActionUrl('credential-a', 'password-a', 'cancel_dvr_recording'), [
+        'recording_id' => $recordingB->uuid,
+    ])->assertNotFound();
+
+    expect($recordingB->fresh()->status)->toBe(DvrRecordingStatus::Scheduled);
+});
+
+it('404s delete_dvr_recording for a recording owned by another credential, and never touches it', function () {
+    $recordingB = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->for($this->authB, 'playlistAuth')
+        ->create(['status' => DvrRecordingStatus::Completed]);
+
+    $this->postJson(dvrActionUrl('credential-a', 'password-a', 'delete_dvr_recording'), [
+        'recording_id' => $recordingB->uuid,
+    ])->assertNotFound();
+
+    expect(DvrRecording::find($recordingB->id))->not->toBeNull();
+});
+
+it('lets the playlist owner see and manage every credential\'s recordings', function () {
+    $recordingA = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->for($this->authA, 'playlistAuth')
+        ->create(['status' => DvrRecordingStatus::Scheduled, 'proxy_network_id' => null]);
+
+    $recordingB = DvrRecording::factory()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->for($this->channel)
+        ->for($this->authB, 'playlistAuth')
+        ->create(['status' => DvrRecordingStatus::Scheduled, 'proxy_network_id' => null]);
+
+    $response = $this->postJson(
+        dvrActionUrl($this->user->name, $this->playlist->uuid, 'get_dvr_recordings')
+    )->assertOk();
+
+    expect($response->json())->toHaveCount(2);
+
+    $this->postJson(dvrActionUrl($this->user->name, $this->playlist->uuid, 'cancel_dvr_recording'), [
+        'recording_id' => $recordingA->uuid,
+    ])->assertOk()->assertJson(['success' => true]);
+
+    $this->postJson(dvrActionUrl($this->user->name, $this->playlist->uuid, 'cancel_dvr_recording'), [
+        'recording_id' => $recordingB->uuid,
+    ])->assertOk()->assertJson(['success' => true]);
+});
+
+it('rejects all DVR actions for a PlaylistAuth credential without dvr_enabled', function (string $action) {
+    $this->authA->update(['dvr_enabled' => false]);
+
+    $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', $action), [
+        'recording_id' => 'does-not-matter',
+        'channel_id' => (string) $this->channel->id,
+        'title' => 'Evening News',
+        'start_time' => now()->addHour()->toIso8601String(),
+        'end_time' => now()->addHours(2)->toIso8601String(),
+    ]);
+
+    $response->assertStatus(403)->assertJson(['error' => 'DVR access denied']);
+})->with([
+    'get_dvr_recordings',
+    'get_dvr_recording',
+    'schedule_dvr',
+    'create_dvr_series_rule',
+    'cancel_dvr_recording',
+    'delete_dvr_recording',
+]);

--- a/tests/Feature/XtreamScheduleDvrTest.php
+++ b/tests/Feature/XtreamScheduleDvrTest.php
@@ -40,17 +40,16 @@ beforeEach(function () {
     $this->username = 'testuser_'.Str::random(5);
     $this->password = 'testpass';
 
-    PlaylistAuth::create([
+    $this->playlistAuth = PlaylistAuth::create([
         'name' => 'Test Auth',
         'username' => $this->username,
         'password' => $this->password,
         'enabled' => true,
+        'dvr_enabled' => true,
         'user_id' => $this->user->id,
     ]);
 
-    $this->playlist->playlistAuths()->attach(
-        PlaylistAuth::where('username', $this->username)->first()
-    );
+    $this->playlist->playlistAuths()->attach($this->playlistAuth);
 
     $this->group = Group::factory()->for($this->user)->create();
     $this->channel = Channel::factory()
@@ -95,6 +94,7 @@ it('creates a Manual DvrRecordingRule from the Xtream schedule_dvr action', func
     expect($rule->channel_id)->toBe($this->channel->id);
     expect($rule->series_title)->toBe('Evening News');
     expect($rule->enabled)->toBeTrue();
+    expect($rule->playlist_auth_id)->toBe($this->playlistAuth->id);
 });
 
 it('materialises a Scheduled DvrRecording in the same request via the boot event', function () {
@@ -218,6 +218,7 @@ it('creates a Series DvrRecordingRule from the Xtream create_dvr_series_rule act
     expect($rule)->not->toBeNull();
     expect($rule->type)->toBe(DvrRuleType::Series);
     expect($rule->channel_id)->toBe($this->channel->id);
+    expect($rule->playlist_auth_id)->toBe($this->playlistAuth->id);
 });
 
 it('rejects a series rule for a channel that belongs to a different playlist', function () {


### PR DESCRIPTION
Fixes #1330, #1331, #1305.

Three related gaps let unauthenticated or unverified callers reach stream-serving endpoints without proving ownership of the underlying playlist:

- EPG API (/api/epg/playlist/{uuid}/data) defaulted to the playlist owner's real Xtream username/password whenever the caller didn't supply credentials, embedding them in returned stream URLs. It now only returns playable URLs for an authenticated panel session or credentials that resolve to that exact playlist; otherwise the response is metadata-only (playable: false).
- Media-server proxy (`/media-server/*`, `/local-media/*`, `/webdav-media/*`) accepted any integration/item ID with no auth at all. These routes now require a signed, 24-hour-limited URL (ValidateSignature); only the app's own URL generation can produce a valid link.
- player-stream/stop (`/api/m3u-proxy/player-stream/stop`) let any caller stop any other viewer's stream by ID, with no auth or ownership check. It's now gated by the panel session and the existing Channel/Episode policies. A new authenticated POST /api/tv/{username}/{password}/player-stream/stop endpoint was also added for the m3u-tv Flutter client, scoped to its Xtream/PlaylistAuth credential (see m3ue/m3u-tv#110).
All three fixes fail closed and are idempotent/non-oracle: denied and successful stop requests return the same response, so a caller can't use it to probe whether an ID belongs to someone else.
