### PR TITLE
feat(dvr): series-rule Xtream actions, options on create, and update endpoint

### DIFF
--- a/app/Filament/GuestPanel/Resources/DvrRules/GuestDvrRuleResource.php
+++ b/app/Filament/GuestPanel/Resources/DvrRules/GuestDvrRuleResource.php
@@ -166,7 +166,10 @@ class GuestDvrRuleResource extends Resource
                         ->when($record !== null, fn ($col) => $col->prepend(__('From Original Source'), 0))
                     : [])
                 ->searchable()
-                ->nullable(),
+                ->nullable()
+                ->helperText(fn (Get $get): ?string => self::isRuleType($get('type'), DvrRuleType::Series)
+                    ? __('Series rules only match against channels with EPG data mapped. If a rule never records, confirm this channel has an EPG source assigned.')
+                    : null),
 
             TextInput::make('series_title')
                 ->label(__('Series Title'))

--- a/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
+++ b/app/Filament/Resources/DvrRecordingRules/DvrRecordingRuleResource.php
@@ -119,7 +119,10 @@ class DvrRecordingRuleResource extends Resource
                         ->pluck('title', 'id')
                         ->prepend(__('From Original Source'), 0))
                     ->searchable()
-                    ->nullable(),
+                    ->nullable()
+                    ->helperText(fn (Get $get): ?string => self::isRuleType($get('type'), DvrRuleType::Series)
+                        ? __('Series rules only match against channels with EPG data mapped. If a rule never records, confirm this channel has an EPG source assigned.')
+                        : null),
 
                 TextInput::make('series_title')
                     ->label(__('Series Title'))

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -18,6 +18,7 @@ use App\Models\CustomPlaylist;
 use App\Models\DvrRecording;
 use App\Models\DvrRecordingRule;
 use App\Models\Epg;
+use App\Models\EpgProgramme;
 use App\Models\Group;
 use App\Models\MergedPlaylist;
 use App\Models\Network;
@@ -37,6 +38,7 @@ use App\Services\EpgCacheService;
 use App\Services\LogoCacheService;
 use App\Services\M3uProxyService;
 use App\Settings\GeneralSettings;
+use App\Support\SeriesKey;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -68,6 +70,9 @@ class XtreamApiController extends Controller
         'create_dvr_series_rule',
         'cancel_dvr_recording',
         'delete_dvr_recording',
+        'list_dvr_series_rules',
+        'delete_dvr_series_rule',
+        'search_epg_shows',
     ];
 
     private const FAVORITE_COLUMNS = [
@@ -2037,6 +2042,9 @@ class XtreamApiController extends Controller
                 'create_dvr_series_rule' => $this->createDvrSeriesRule($request, $dvrPlaylist, $playlistAuth),
                 'cancel_dvr_recording' => $this->cancelDvrRecording($request, $dvrPlaylist, $playlistAuth),
                 'delete_dvr_recording' => $this->deleteDvrRecording($request, $dvrPlaylist, $playlistAuth),
+                'list_dvr_series_rules' => $this->listDvrSeriesRules($request, $dvrPlaylist, $playlistAuth),
+                'delete_dvr_series_rule' => $this->deleteDvrSeriesRule($request, $dvrPlaylist, $playlistAuth),
+                'search_epg_shows' => $this->searchEpgShows($request, $dvrPlaylist, $playlistAuth),
             };
         } else {
             return response()->json(['error' => 'Invalid action parameter'], 400);
@@ -3327,6 +3335,212 @@ class XtreamApiController extends Controller
     }
 
     /**
+     * List all enabled series recording rules for the authenticated playlist.
+     */
+    private function listDvrSeriesRules(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
+    {
+        $dvrSetting = $playlist->dvrSetting;
+
+        if (! $dvrSetting) {
+            return response()->json([]);
+        }
+
+        $rules = DvrRecordingRule::where('dvr_setting_id', $dvrSetting->id)
+            ->where('type', DvrRuleType::Series)
+            ->where('enabled', true)
+            ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
+            ->with('channel')
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        return response()->json($rules->map(fn (DvrRecordingRule $rule) => $this->formatDvrSeriesRule($rule)));
+    }
+
+    /**
+     * Delete a series recording rule by ID.
+     */
+    private function deleteDvrSeriesRule(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
+    {
+        $ruleId = (int) $request->input('rule_id');
+
+        if (! $ruleId) {
+            return response()->json(['error' => 'rule_id parameter is required'], 400);
+        }
+
+        $dvrSetting = $playlist->dvrSetting;
+
+        if (! $dvrSetting) {
+            return response()->json(['error' => 'DVR not configured for this playlist'], 404);
+        }
+
+        $rule = DvrRecordingRule::where('dvr_setting_id', $dvrSetting->id)
+            ->where('id', $ruleId)
+            ->where('type', DvrRuleType::Series)
+            ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
+            ->first();
+
+        if (! $rule) {
+            return response()->json(['error' => 'Series rule not found'], 404);
+        }
+
+        $rule->delete();
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
+     * Search EPG programme listings across all mapped channels to discover shows
+     * available for series recording. Uses SeriesKey::normalize() on programme
+     * titles so the returned groups match DvrRecordingRule::saving hook's own
+     * normalization — this guarantees that a series rule created from search
+     * results will match future EPG programme data for the same show.
+     */
+    private function searchEpgShows(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
+    {
+        $q = trim((string) $request->input('q', ''));
+
+        if (mb_strlen($q) < 2) {
+            return response()->json(['error' => 'q parameter is required (minimum 2 characters)'], 400);
+        }
+
+        $dvrSetting = $playlist->dvrSetting;
+
+        if (! $dvrSetting?->enabled) {
+            return response()->json(['error' => 'DVR is not enabled for this playlist'], 422);
+        }
+
+        // Collect the set of EPG channel_id strings this playlist's channels are mapped to.
+        $playlistChannels = $playlist->channels()
+            ->whereNotNull('epg_channel_id')
+            ->with('epgChannel')
+            ->get();
+
+        $epgChannelIds = $playlistChannels
+            ->map(fn (Channel $ch) => $ch->epgChannel?->channel_id)
+            ->filter()
+            ->unique()
+            ->values();
+
+        if ($epgChannelIds->isEmpty()) {
+            return response()->json([]);
+        }
+
+        // Build lookup: epg_channel_id string → [channel_id, channel_name] from the playlist.
+        $channelLookup = [];
+        foreach ($playlistChannels as $ch) {
+            $epgChanId = $ch->epgChannel?->channel_id;
+            if ($epgChanId && ! isset($channelLookup[$epgChanId])) {
+                $channelLookup[$epgChanId] = [
+                    'channel_id' => $ch->id,
+                    'channel_name' => $ch->title ?: ($ch->name ?? ''),
+                ];
+            }
+        }
+
+        // Fetch matching programmes across all mapped EPG channels, including those
+        // that just finished (up to 24 hours ago) for discoverability.
+        $cutoff = Carbon::now()->subHours(24);
+        $programmes = EpgProgramme::whereIn('epg_channel_id', $epgChannelIds->toArray())
+            ->where('start_time', '>=', $cutoff)
+            ->where('title', 'like', '%'.$q.'%')
+            ->limit(500)
+            ->get();
+
+        // Group by SeriesKey-normalized title — this must match the normalization
+        // in DvrRecordingRule::saving so rules created from these results will
+        // match future programme data.
+        $groups = [];
+        foreach ($programmes as $p) {
+            $norm = SeriesKey::normalize($p->title);
+
+            if ($norm === '') {
+                continue;
+            }
+
+            if (! isset($groups[$norm])) {
+                $groups[$norm] = [
+                    'display_title' => $p->title,
+                    'programmes' => [],
+                    'channel_ids' => [],
+                ];
+            }
+
+            $groups[$norm]['programmes'][] = $p;
+            $resolved = $channelLookup[$p->epg_channel_id] ?? null;
+            if ($resolved) {
+                $groups[$norm]['channel_ids'][$resolved['channel_id']] = $resolved;
+            }
+        }
+
+        $results = [];
+        foreach ($groups as $norm => $group) {
+            /** @var array<int, EpgProgramme> $progs */
+            $progs = $group['programmes'];
+
+            // Sort within group: most recent first.
+            usort($progs, fn (EpgProgramme $a, EpgProgramme $b) => $b->start_time->timestamp <=> $a->start_time->timestamp);
+
+            $channels = array_values($group['channel_ids']);
+
+            // next_airing_at: earliest start_time in the future, null if none.
+            $now = Carbon::now();
+            $nextAiringAt = null;
+            foreach ($progs as $p) {
+                if ($p->start_time->gt($now)) {
+                    $nextAiringAt = $nextAiringAt
+                        ? ($p->start_time->lt($nextAiringAt) ? $p->start_time : $nextAiringAt)
+                        : $p->start_time;
+                }
+            }
+
+            $recentEpisodes = array_slice(array_map(function (EpgProgramme $p) use ($channelLookup) {
+                $resolved = $channelLookup[$p->epg_channel_id] ?? null;
+
+                return [
+                    'channel_id' => $resolved['channel_id'] ?? null,
+                    'channel_name' => $resolved['channel_name'] ?? null,
+                    'title' => $p->title,
+                    'start_time' => $p->start_time->toIso8601String(),
+                    'end_time' => $p->end_time?->toIso8601String(),
+                    'season' => $p->season,
+                    'episode' => $p->episode,
+                    'description' => $p->description,
+                ];
+            }, $progs), 0, 5);
+
+            $results[] = [
+                'normalized_title' => $norm,
+                'display_title' => $group['display_title'],
+                'channel_count' => count($channels),
+                'channels' => $channels,
+                'episode_count' => count($progs),
+                'next_airing_at' => $nextAiringAt?->toIso8601String(),
+                'recent_episodes' => $recentEpisodes,
+            ];
+        }
+
+        // Sort: next-airing first, then most episodes.
+        usort($results, function (array $a, array $b) {
+            $aNext = $a['next_airing_at'];
+            $bNext = $b['next_airing_at'];
+
+            if ($aNext && ! $bNext) {
+                return -1;
+            }
+            if (! $aNext && $bNext) {
+                return 1;
+            }
+            if ($aNext && $bNext) {
+                return $aNext <=> $bNext;
+            }
+
+            return $b['episode_count'] <=> $a['episode_count'];
+        });
+
+        return response()->json(array_slice($results, 0, 100));
+    }
+
+    /**
      * Schedule a one-shot DVR recording rule from the TV app.
      */
     private function scheduleDvr(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
@@ -3569,6 +3783,29 @@ class XtreamApiController extends Controller
         }
 
         return $data;
+    }
+
+    /**
+     * Format a DvrRecordingRule (series rule) into the API response shape.
+     */
+    private function formatDvrSeriesRule(DvrRecordingRule $rule): array
+    {
+        return [
+            'id' => $rule->id,
+            'channel_id' => $rule->channel_id,
+            'channel_name' => $rule->channel?->title ?? $rule->channel?->name,
+            'series_title' => $rule->series_title,
+            'match_mode' => $rule->match_mode->value,
+            'series_mode' => $rule->series_mode->value,
+            'keep_last' => $rule->keep_last,
+            'enabled' => (bool) $rule->enabled,
+            'enable_comskip' => (bool) $rule->enable_comskip,
+            'start_early_seconds' => $rule->start_early_seconds,
+            'end_late_seconds' => $rule->end_late_seconds,
+            'created_at' => $rule->created_at?->toIso8601String(),
+            'updated_at' => $rule->updated_at?->toIso8601String(),
+            'recording_count' => $rule->recordings()->count(),
+        ];
     }
 
     /**

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -3407,6 +3407,7 @@ class XtreamApiController extends Controller
             ->where('enabled', true)
             ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
             ->with('channel')
+            ->withCount('recordings')
             ->orderBy('created_at', 'desc')
             ->get();
 
@@ -4056,7 +4057,7 @@ class XtreamApiController extends Controller
             'end_late_seconds' => $rule->end_late_seconds,
             'created_at' => $rule->created_at?->toIso8601String(),
             'updated_at' => $rule->updated_at?->toIso8601String(),
-            'recording_count' => $rule->recordings()->count(),
+            'recording_count' => $rule->recordings_count,
         ];
     }
 

--- a/app/Http/Controllers/XtreamApiController.php
+++ b/app/Http/Controllers/XtreamApiController.php
@@ -68,6 +68,7 @@ class XtreamApiController extends Controller
         'get_dvr_storage',
         'schedule_dvr',
         'create_dvr_series_rule',
+        'update_dvr_series_rule',
         'cancel_dvr_recording',
         'delete_dvr_recording',
         'list_dvr_series_rules',
@@ -164,6 +165,61 @@ class XtreamApiController extends Controller
      * This provides the same user information as the panel.
      * Contains: `username`, `password`, `message`, `auth`, `status`, `exp_date`, `is_trial`,
      * `active_cons`, `created_at`, `max_connections`, `allowed_output_formats`.
+     *
+     * ### create_dvr_series_rule
+     * Creates a Series-type DVR recording rule for a show title. Query parameters:
+     *   - `title` (string, required): The show title; matched by the chosen match mode.
+     *   - `channel_id` (int, optional): Pin the rule to a specific playlist channel. **Omit
+     *     for "any channel"** — DvrSchedulerService::resolveSeriesEpgScope() then scopes to
+     *     all EPG-mapped channels in the playlist. `source_channel_id` is intentionally NOT
+     *     accepted from the API; setting it would narrow scope back to a single channel.
+     *   - `match_mode` (string, optional, default `contains`): One of `contains`, `exact`,
+     *     `starts_with`, `tmdb`.
+     *   - `series_mode` (string, optional): One of `all`, `new_flag`, `unique_se`. Defaults
+     *     to `dvr_setting.default_series_mode` server-side.
+     *   - `keep_last` (int, optional): Defaults to `dvr_setting.default_series_keep_last`.
+     *   - `priority` (int, optional): Defaults to 50 via the column migration default.
+     *     Clamped 0-100 when supplied. **Omit to inherit the column default; do not send
+     *     a hardcoded value.**
+     *   - `start_early_seconds` (int, optional): Seconds to start early. **Omit to inherit
+     *     `dvr_setting.default_start_early_seconds`** (resolved at runtime). Blank is not
+     *     coerced to 0 — `0` is a meaningful value (no padding) distinct from "inherit".
+     *   - `end_late_seconds` (int, optional): Seconds to end late. Same omit-to-inherit
+     *     semantics as `start_early_seconds`.
+     * Returns `{success: true, rule_id: <int>}`. Returns 409 `{error, rule_id, duplicate: true}`
+     * when a Series rule for the same normalized title already exists under this DVR
+     * setting (+ auth).
+     *
+     * ### update_dvr_series_rule
+     * Updates an existing Series-type DVR recording rule in place — never delete-and-recreate,
+     * because deleting a rule cascades to its recordings and destroys recording history (and
+     * changes the rule id). Query parameters:
+     *   - `rule_id` (int, required): The id of the rule to update.
+     *   - `channel_id` (int, optional): Pin the rule to a specific playlist channel. **Send as
+     *     an empty value to switch to "any channel"**; the request body/param must be present
+     *     (even if blank) to distinguish "set to any channel" from "leave channel unchanged".
+     *   - `match_mode` (string, optional): One of `contains`, `exact`, `starts_with`, `tmdb`.
+     *   - `series_mode` (string, optional): One of `all`, `new_flag`, `unique_se`.
+     *   - `keep_last` (int, optional).
+     *   - `priority` (int, optional): Clamped 0-100 when supplied.
+     *   - `start_early_seconds` (int, optional).
+     *   - `end_late_seconds` (int, optional).
+     * **Omit-to-inherit on update:** only fields present in the request are applied; fields
+     * that are absent are left at their current values. Never send placeholder values — a
+     * field you intend to keep must be omitted, not sent as its current value. `series_mode`
+     * is stored in lockstep with the legacy `new_only` flag (see task 16).
+     * Returns `{success: true, rule_id: <int>}`.
+     *
+     * ### search_epg_shows
+     * Searches EPG programmes across all EPG-mapped channels in the playlist (plus those
+     * that aired in the last 24 hours for discoverability) and groups results by
+     * SeriesKey-normalized title. Query parameter: `q` (string, required, min 2 chars).
+     * Returns at most 100 results, sorted by next-airing first then by episode count.
+     * Each result object contains: `normalized_title`, `display_title`, `has_series_rule`
+     * (bool — whether a Series rule already exists for this title), `series_rule_id` (int|null
+     * — the existing rule's id when `has_series_rule` is true, for delete-without-round-trip),
+     * `channel_count`, `channels` (array of `{channel_id, channel_name}`), `episode_count`,
+     * `next_airing_at` (ISO 8601 or null), `recent_episodes` (up to 5 most-recent airings).
      *
      *
      * @param  string  $uuid  The UUID of the playlist (required path parameter)
@@ -2040,6 +2096,7 @@ class XtreamApiController extends Controller
                 'get_dvr_storage' => $this->getDvrStorage($dvrPlaylist, $playlistAuth),
                 'schedule_dvr' => $this->scheduleDvr($request, $dvrPlaylist, $playlistAuth),
                 'create_dvr_series_rule' => $this->createDvrSeriesRule($request, $dvrPlaylist, $playlistAuth),
+                'update_dvr_series_rule' => $this->updateDvrSeriesRule($request, $dvrPlaylist, $playlistAuth),
                 'cancel_dvr_recording' => $this->cancelDvrRecording($request, $dvrPlaylist, $playlistAuth),
                 'delete_dvr_recording' => $this->deleteDvrRecording($request, $dvrPlaylist, $playlistAuth),
                 'list_dvr_series_rules' => $this->listDvrSeriesRules($request, $dvrPlaylist, $playlistAuth),
@@ -3409,6 +3466,18 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'DVR is not enabled for this playlist'], 422);
         }
 
+        // Pre-fetch the set of existing Series rules for this DVR setting (scoped by
+        // playlist_auth when applicable) keyed by their auto-derived normalized_title,
+        // so each result can advertise `has_series_rule` + `series_rule_id` without
+        // a per-group query. Uses the same SeriesKey::normalize normalization as the
+        // grouping below — which matches DvrRecordingRule::saving's column population —
+        // so a normalized-title lookup here is consistent with what a future rule
+        // created from this result would store.
+        $seriesRuleTitles = DvrRecordingRule::where('dvr_setting_id', $dvrSetting->id)
+            ->where('type', DvrRuleType::Series)
+            ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
+            ->pluck('id', 'normalized_title');
+
         // Collect the set of EPG channel_id strings this playlist's channels are mapped to.
         $playlistChannels = $playlist->channels()
             ->whereNotNull('epg_channel_id')
@@ -3442,7 +3511,7 @@ class XtreamApiController extends Controller
         $cutoff = Carbon::now()->subHours(24);
         $programmes = EpgProgramme::whereIn('epg_channel_id', $epgChannelIds->toArray())
             ->where('start_time', '>=', $cutoff)
-            ->where('title', 'like', '%'.$q.'%')
+            ->where('title', 'ilike', '%'.$q.'%')
             ->limit(500)
             ->get();
 
@@ -3511,6 +3580,8 @@ class XtreamApiController extends Controller
             $results[] = [
                 'normalized_title' => $norm,
                 'display_title' => $group['display_title'],
+                'has_series_rule' => $seriesRuleTitles->has($norm),
+                'series_rule_id' => $seriesRuleTitles[$norm] ?? null,
                 'channel_count' => count($channels),
                 'channels' => $channels,
                 'episode_count' => count($progs),
@@ -3600,14 +3671,40 @@ class XtreamApiController extends Controller
 
     /**
      * Create a series recording rule.
+     *
+     * Accepts the full option set (priority, padding, match mode, series mode,
+     * keep_last). All new optional fields use omit-to-inherit: only fields the
+     * caller actually sends are stored. `priority` falls back to its column
+     * default (50 per the migration) when absent/blank/non-numeric; padding
+     * fields fall back to runtime resolution via
+     * DvrSetting::resolveStartEarlySeconds()/resolveEndLateSeconds(). Blank is
+     * NOT coerced to 0 because 0 is a meaningful value for padding (no padding)
+     * and is NOT the same as "inherit".
+     *
+     * Omitting both `channel_id` and `source_channel_id` is the explicit "any
+     * channel" form — see DvrSchedulerService::resolveSeriesEpgScope() for the
+     * scope resolution. `source_channel_id` is intentionally not accepted from
+     * the API; setting it would narrow scope back to a single channel.
+     *
+     * Returns 409 with `rule_id` + `duplicate: true` when a Series rule for
+     * the same normalized title already exists under this DVR setting (+ auth),
+     * so the client can switch its button to the "rule exists" state rather
+     * than showing a generic failure.
+     *
+     * Scheduling is handled by DvrRecordingRule::boot()'s created hook calling
+     * scheduleRuleImmediately() for enabled rules; this action does NOT dispatch
+     * DvrSchedulerTick (the model's hook already covers the API path).
      */
     private function createDvrSeriesRule(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
     {
-        $channelId = (int) $request->input('channel_id');
+        $rawChannelId = $request->input('channel_id');
+        $channelId = ($rawChannelId === null || $rawChannelId === '')
+            ? null
+            : (int) $rawChannelId;
         $title = trim((string) $request->input('title', ''));
 
-        if (! $channelId || ! $title) {
-            return response()->json(['error' => 'channel_id and title are required'], 400);
+        if (! $title) {
+            return response()->json(['error' => 'title is required'], 400);
         }
 
         $dvrSetting = $playlist->dvrSetting?->enabled ? $playlist->dvrSetting : null;
@@ -3616,16 +3713,43 @@ class XtreamApiController extends Controller
             return response()->json(['error' => 'DVR is not enabled for this playlist'], 422);
         }
 
-        $channel = $playlist->channels()->where('channels.id', $channelId)->first();
-        if (! $channel) {
-            return response()->json(['error' => 'Channel not found'], 404);
+        // Duplicate guard: same dvr_setting, same normalized show title, same auth.
+        // Uses the auto-derived `normalized_title` column that DvrRecordingRule::saving
+        // populates via SeriesKey::normalize — matching the stored column (not
+        // re-computing with a different normalizer) so future EPG matches align.
+        $normalizedTitle = SeriesKey::normalize($title);
+        $existing = DvrRecordingRule::where('dvr_setting_id', $dvrSetting->id)
+            ->where('type', DvrRuleType::Series)
+            ->where('normalized_title', $normalizedTitle)
+            ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
+            ->first();
+
+        if ($existing) {
+            return response()->json([
+                'error' => 'A series rule for this show already exists',
+                'rule_id' => $existing->id,
+                'duplicate' => true,
+            ], 409);
+        }
+
+        if ($channelId !== null) {
+            $channel = $playlist->channels()->where('channels.id', $channelId)->first();
+            if (! $channel) {
+                return response()->json(['error' => 'Channel not found'], 404);
+            }
         }
 
         $matchMode = DvrMatchMode::tryFrom($request->input('match_mode', 'contains')) ?? DvrMatchMode::Contains;
         $seriesMode = DvrSeriesMode::tryFrom($request->input('series_mode', $dvrSetting->default_series_mode?->value ?? 'all')) ?? DvrSeriesMode::All;
-        $keepLast = $request->input('keep_last') !== null ? (int) $request->input('keep_last') : $dvrSetting->default_series_keep_last;
+        // Same blank-vs-meaningful-zero discipline as the new optional fields: a blank
+        // or non-numeric value falls through to the DVR setting default instead of being
+        // coerced to 0 (which would silently disable the keep-last policy).
+        $rawKeepLast = $request->input('keep_last');
+        $keepLast = is_numeric($rawKeepLast)
+            ? (int) $rawKeepLast
+            : $dvrSetting->default_series_keep_last;
 
-        $rule = DvrRecordingRule::create([
+        $createAttrs = [
             'user_id' => $dvrSetting->user_id,
             'dvr_setting_id' => $dvrSetting->id,
             'playlist_auth_id' => $playlistAuth?->id,
@@ -3634,9 +3758,136 @@ class XtreamApiController extends Controller
             'series_title' => $title,
             'match_mode' => $matchMode,
             'series_mode' => $seriesMode,
+            // Keep the legacy `new_only` flag in lockstep with series_mode so the
+            // DvrRecordingRule::saving hook's new_only→series_mode migration (which
+            // rewrites series_mode=new_flag to all when new_only is false) does not
+            // clobber an explicitly-requested new_flag. Must be EXACTLY this
+            // equality: new_only=true alongside series_mode=unique_se would trip the
+            // hook's first branch and clobber unique_se → new_flag.
+            'new_only' => ($seriesMode === DvrSeriesMode::NewFlag),
             'keep_last' => $keepLast,
             'enabled' => true,
+        ];
+
+        // Omit-to-inherit for all three new optional fields. Absent or blank
+        // leaves the key OUT of the create array so the column default (priority=50
+        // per the migration) or runtime resolution via DvrSetting::resolveStartEarly
+        // Seconds()/resolveEndLateSeconds() applies. Critically, blank is NOT
+        // coerced to 0 because 0 is a meaningful value for the padding fields
+        // (no padding) and is NOT the same as "inherit" — see the spec.
+        $rawPriority = $request->input('priority');
+        if (is_numeric($rawPriority)) {
+            $createAttrs['priority'] = max(0, min(100, (int) $rawPriority));
+        }
+
+        $rawStartEarly = $request->input('start_early_seconds');
+        if ($rawStartEarly !== null && $rawStartEarly !== '') {
+            $createAttrs['start_early_seconds'] = (int) $rawStartEarly;
+        }
+        $rawEndLate = $request->input('end_late_seconds');
+        if ($rawEndLate !== null && $rawEndLate !== '') {
+            $createAttrs['end_late_seconds'] = (int) $rawEndLate;
+        }
+
+        $rule = DvrRecordingRule::create($createAttrs);
+
+        return response()->json([
+            'success' => true,
+            'rule_id' => $rule->id,
         ]);
+    }
+
+    /**
+     * Update an existing Series DVR recording rule in place.
+     *
+     * This intentionally does NOT delete-and-recreate: deleting a rule cascades to
+     * its recordings and would destroy recording history and change the rule id.
+     *
+     * **Omit-to-inherit on update** — only fields actually present in the request are
+     * applied; absent fields keep their current value. Nothing is nulled out unless
+     * the request explicitly says so (see `channel_id` below).
+     */
+    private function updateDvrSeriesRule(Request $request, $playlist, ?PlaylistAuth $playlistAuth): \Illuminate\Http\JsonResponse
+    {
+        $ruleId = (int) $request->input('rule_id');
+
+        if (! $ruleId) {
+            return response()->json(['error' => 'rule_id parameter is required'], 400);
+        }
+
+        $dvrSetting = $playlist->dvrSetting;
+
+        if (! $dvrSetting) {
+            return response()->json(['error' => 'DVR not configured for this playlist'], 404);
+        }
+
+        $rule = DvrRecordingRule::where('dvr_setting_id', $dvrSetting->id)
+            ->where('id', $ruleId)
+            ->where('type', DvrRuleType::Series)
+            ->when($playlistAuth, fn ($q) => $q->where('playlist_auth_id', $playlistAuth->id))
+            ->first();
+
+        if (! $rule) {
+            return response()->json(['error' => 'Series rule not found'], 404);
+        }
+
+        // channel_id: present-and-blank means "any channel" (null); present-with-a-value
+        // pins to that channel; absent means "leave unchanged". `$request->has` returns
+        // false for a blank value, so check presence via `$request->input` + `exists`.
+        if ($request->exists('channel_id')) {
+            $rawChannelId = $request->input('channel_id');
+            $channelId = ($rawChannelId === null || $rawChannelId === '')
+                ? null
+                : (int) $rawChannelId;
+
+            if ($channelId !== null) {
+                $channel = $playlist->channels()->where('channels.id', $channelId)->first();
+                if (! $channel) {
+                    return response()->json(['error' => 'Channel not found'], 404);
+                }
+            }
+
+            $rule->channel_id = $channelId;
+        }
+
+        if ($request->has('match_mode')) {
+            $matchMode = DvrMatchMode::tryFrom($request->input('match_mode'));
+            if ($matchMode !== null) {
+                $rule->match_mode = $matchMode;
+            }
+        }
+
+        if ($request->has('series_mode')) {
+            $seriesMode = DvrSeriesMode::tryFrom($request->input('series_mode'));
+            if ($seriesMode !== null) {
+                $rule->series_mode = $seriesMode;
+                // Keep the legacy new_only flag in lockstep with series_mode for the same
+                // saving-hook migration reason as createDvrSeriesRule (task 16).
+                $rule->new_only = ($seriesMode === DvrSeriesMode::NewFlag);
+            }
+        }
+
+        $rawKeepLast = $request->input('keep_last');
+        if (is_numeric($rawKeepLast)) {
+            $rule->keep_last = (int) $rawKeepLast;
+        }
+
+        $rawPriority = $request->input('priority');
+        if (is_numeric($rawPriority)) {
+            $rule->priority = max(0, min(100, (int) $rawPriority));
+        }
+
+        $rawStartEarly = $request->input('start_early_seconds');
+        if ($rawStartEarly !== null && $rawStartEarly !== '') {
+            $rule->start_early_seconds = (int) $rawStartEarly;
+        }
+
+        $rawEndLate = $request->input('end_late_seconds');
+        if ($rawEndLate !== null && $rawEndLate !== '') {
+            $rule->end_late_seconds = (int) $rawEndLate;
+        }
+
+        $rule->save();
 
         return response()->json([
             'success' => true,
@@ -3798,6 +4049,7 @@ class XtreamApiController extends Controller
             'match_mode' => $rule->match_mode->value,
             'series_mode' => $rule->series_mode->value,
             'keep_last' => $rule->keep_last,
+            'priority' => $rule->priority,
             'enabled' => (bool) $rule->enabled,
             'enable_comskip' => (bool) $rule->enable_comskip,
             'start_early_seconds' => $rule->start_early_seconds,

--- a/app/Services/DvrSchedulerService.php
+++ b/app/Services/DvrSchedulerService.php
@@ -231,10 +231,15 @@ class DvrSchedulerService
 
             $query->where('tmdb_id', $rule->tmdb_id);
         } else {
+            // Escape LIKE metacharacters in the user-entered title so a series
+            // named e.g. "50%" or "Under_ground" is matched literally instead
+            // of "50" + any-chars / "Under" + any-single-char.
+            $escapedTitle = addcslashes($title, '\\%_');
+
             [$sql, $binding] = match ($matchMode) {
                 DvrMatchMode::Exact => ['lower(title) = lower(?)', $title],
-                DvrMatchMode::StartsWith => ['lower(title) LIKE lower(?)', $title.'%'],
-                default => ['lower(title) LIKE lower(?)', '%'.$title.'%'],
+                DvrMatchMode::StartsWith => ["lower(title) LIKE lower(?) ESCAPE '\\'", $escapedTitle.'%'],
+                default => ["lower(title) LIKE lower(?) ESCAPE '\\'", '%'.$escapedTitle.'%'],
             };
 
             $query->whereRaw($sql, [$binding]);

--- a/app/Traits/HasDvrMatchedAirings.php
+++ b/app/Traits/HasDvrMatchedAirings.php
@@ -56,10 +56,14 @@ trait HasDvrMatchedAirings
 
             $query->where('tmdb_id', $rule->tmdb_id);
         } else {
+            // Escape LIKE metacharacters in the user-entered title — see the
+            // same treatment in DvrSchedulerService::matchSeriesRule().
+            $escapedTitle = addcslashes($title, '\\%_');
+
             [$sql, $binding] = match ($matchMode) {
                 DvrMatchMode::Exact => ['lower(title) = lower(?)', $title],
-                DvrMatchMode::StartsWith => ['lower(title) LIKE lower(?)', $title.'%'],
-                default => ['lower(title) LIKE lower(?)', '%'.$title.'%'],
+                DvrMatchMode::StartsWith => ["lower(title) LIKE lower(?) ESCAPE '\\'", $escapedTitle.'%'],
+                default => ["lower(title) LIKE lower(?) ESCAPE '\\'", '%'.$escapedTitle.'%'],
             };
 
             $query->whereRaw($sql, [$binding]);

--- a/lang/de.json
+++ b/lang/de.json
@@ -3691,6 +3691,7 @@
     "Russian": "Russisch",
     "S/E": "S/E",
     "S:s E:e of \":title\" has been submitted and is awaiting admin approval.": "S:s E:e von \":title\" wurde eingereicht und wartet auf die Genehmigung des Admins.",
+    "Series rules only match against channels with EPG data mapped. If a rule never records, confirm this channel has an EPG source assigned.": "Serienregeln greifen nur bei Sendern mit zugeordneten EPG-Daten. Wenn eine Regel nie aufzeichnet, prüfen Sie, ob diesem Sender eine EPG-Quelle zugewiesen ist.",
     "SD Progress": "SD-Fortschritt",
     "SHA-256 Checksum": "SHA-256-Prüfsumme",
     "SMTP": "SMTP",

--- a/lang/en.json
+++ b/lang/en.json
@@ -4739,6 +4739,7 @@
     "Russian": "Russian",
     "S/E": "S/E",
     "S:s E:e of \":title\" has been submitted and is awaiting admin approval.": "S:s E:e of \":title\" has been submitted and is awaiting admin approval.",
+    "Series rules only match against channels with EPG data mapped. If a rule never records, confirm this channel has an EPG source assigned.": "Series rules only match against channels with EPG data mapped. If a rule never records, confirm this channel has an EPG source assigned.",
     "SD Progress": "SD Progress",
     "SHA-256 Checksum": "SHA-256 Checksum",
     "SMTP": "SMTP",

--- a/lang/es.json
+++ b/lang/es.json
@@ -3691,6 +3691,7 @@
     "Russian": "ruso",
     "S/E": "S/E",
     "S:s E:e of \":title\" has been submitted and is awaiting admin approval.": "S:s E:e de \":title\" ha sido enviado y está a la espera de aprobación del administrador.",
+    "Series rules only match against channels with EPG data mapped. If a rule never records, confirm this channel has an EPG source assigned.": "Las reglas de serie solo coinciden con canales que tienen datos EPG asignados. Si una regla nunca graba, confirme que este canal tenga una fuente EPG asignada.",
     "SD Progress": "Progreso SD",
     "SHA-256 Checksum": "Suma de comprobación SHA-256",
     "SMTP": "SMTP",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -3691,6 +3691,7 @@
     "Russian": "russe",
     "S/E": "S/E",
     "S:s E:e of \":title\" has been submitted and is awaiting admin approval.": "S:s E:e de \":title\" a été soumis et attend l'approbation de l'administrateur.",
+    "Series rules only match against channels with EPG data mapped. If a rule never records, confirm this channel has an EPG source assigned.": "Les règles de série ne correspondent qu'aux chaînes disposant de données EPG associées. Si une règle n'enregistre jamais, vérifiez qu'une source EPG est bien assignée à cette chaîne.",
     "SD Progress": "Progrès du DD",
     "SHA-256 Checksum": "Somme de contrôle SHA-256",
     "SMTP": "SMTP",

--- a/lang/zh_CN.json
+++ b/lang/zh_CN.json
@@ -3691,6 +3691,7 @@
     "Russian": "俄语",
     "S/E": "S/E",
     "S:s E:e of \":title\" has been submitted and is awaiting admin approval.": "\":title\" 的 S:s E:e 已提交，正在等待管理员批准。",
+    "Series rules only match against channels with EPG data mapped. If a rule never records, confirm this channel has an EPG source assigned.": "剧集规则仅匹配已映射 EPG 数据的频道。如果某条规则从未录制，请确认该频道已分配 EPG 源。",
     "SD Progress": "Schedules Direct 进度",
     "SHA-256 Checksum": "SHA-256 校验和",
     "SMTP": "SMTP",

--- a/tests/Feature/DvrSchedulerServiceTest.php
+++ b/tests/Feature/DvrSchedulerServiceTest.php
@@ -1234,6 +1234,32 @@ it('match_mode contains records titles containing the pattern', function () {
     expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(3);
 });
 
+it('match_mode contains treats a literal % in the series title as a literal character, not a LIKE wildcard', function () {
+    $rule = DvrRecordingRule::factory()
+        ->series()
+        ->for($this->setting, 'dvrSetting')
+        ->for($this->user)
+        ->create([
+            'series_title' => '50%',
+            'match_mode' => DvrMatchMode::Contains,
+        ]);
+
+    EpgProgramme::factory()->upcoming(5)->create([
+        'title' => 'Top 50% Movies',
+        'epg_channel_id' => 'test.channel',
+    ]);
+    // Without escaping the "%" in the rule's title, the LIKE pattern becomes
+    // "%50%%" — equivalent to "%50%" — which would wrongly match this too.
+    EpgProgramme::factory()->upcoming(5)->create([
+        'title' => 'Season 50 Highlights',
+        'epg_channel_id' => 'test.channel',
+    ]);
+
+    $this->service->matchAndSchedule(30);
+
+    expect(DvrRecording::where('dvr_recording_rule_id', $rule->id)->count())->toBe(1);
+});
+
 it('match_mode tmdb records programmes by tmdb_id', function () {
     $rule = DvrRecordingRule::factory()
         ->series()

--- a/tests/Feature/XtreamDvrOwnershipTest.php
+++ b/tests/Feature/XtreamDvrOwnershipTest.php
@@ -24,7 +24,9 @@
  *      advertisement (canAdvertiseDvrFeature).
  */
 
+use App\Enums\DvrMatchMode;
 use App\Enums\DvrRecordingStatus;
+use App\Enums\DvrSeriesMode;
 use App\Models\Channel;
 use App\Models\DvrRecording;
 use App\Models\DvrRecordingRule;
@@ -109,6 +111,122 @@ it('stamps schedule_dvr and create_dvr_series_rule with the requesting credentia
 
     $rule = DvrRecordingRule::find($response->json('rule_id'));
     expect($rule->playlist_auth_id)->toBe($this->authB->id);
+});
+
+it('stores new_flag series_mode as new_flag, not rewriting it to all', function () {
+    // Regression for the legacy new_only→series_mode migration in
+    // DvrRecordingRule::saving: new_only defaults false and the API historically
+    // never set it, so every new_flag rule was rewritten to all on save.
+    $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', 'create_dvr_series_rule'), [
+        'channel_id' => (string) $this->channel->id,
+        'title' => 'New Flag Show',
+        'series_mode' => 'new_flag',
+    ])->assertOk();
+
+    $rule = DvrRecordingRule::find($response->json('rule_id'));
+
+    expect($rule->series_mode)->toBe(DvrSeriesMode::NewFlag);
+    expect($rule->new_only)->toBeTrue();
+});
+
+it('does not let new_only rewrite a unique_se rule to new_flag', function () {
+    $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', 'create_dvr_series_rule'), [
+        'channel_id' => (string) $this->channel->id,
+        'title' => 'Unique Se Show',
+        'series_mode' => 'unique_se',
+    ])->assertOk();
+
+    $rule = DvrRecordingRule::find($response->json('rule_id'));
+
+    expect($rule->series_mode)->toBe(DvrSeriesMode::UniqueSe);
+    expect($rule->new_only)->toBeFalse();
+});
+
+it('updates only fields present on update_dvr_series_rule, leaving others untouched', function () {
+    $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', 'create_dvr_series_rule'), [
+        'channel_id' => (string) $this->channel->id,
+        'title' => 'Editable Show',
+        'series_mode' => 'all',
+        'keep_last' => 3,
+        'priority' => 40,
+    ])->assertOk();
+
+    $rule = DvrRecordingRule::find($response->json('rule_id'));
+    expect($rule->series_mode)->toBe(DvrSeriesMode::All);
+    expect($rule->keep_last)->toBe(3);
+    expect($rule->priority)->toBe(40);
+
+    // Update only series_mode + priority; keep_last/channel/match_mode must be untouched.
+    $update = $this->postJson(dvrActionUrl('credential-a', 'password-a', 'update_dvr_series_rule'), [
+        'rule_id' => (string) $rule->id,
+        'series_mode' => 'new_flag',
+        'priority' => 60,
+    ])->assertOk();
+    expect($update->json('rule_id'))->toBe($rule->id);
+
+    $rule->refresh();
+    expect($rule->series_mode)->toBe(DvrSeriesMode::NewFlag);
+    expect($rule->new_only)->toBeTrue(); // lockstep with series_mode
+    expect($rule->priority)->toBe(60);
+    expect($rule->keep_last)->toBe(3); // unspecified field unchanged
+    expect($rule->channel_id)->toBe($this->channel->id); // unspecified field unchanged
+    expect($rule->match_mode)->toBe(DvrMatchMode::Contains); // unspecified field unchanged
+});
+
+it('updates match_mode and start/end padding on update_dvr_series_rule', function () {
+    $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', 'create_dvr_series_rule'), [
+        'channel_id' => (string) $this->channel->id,
+        'title' => 'Padding Show',
+    ])->assertOk();
+
+    $rule = DvrRecordingRule::find($response->json('rule_id'));
+
+    $this->postJson(dvrActionUrl('credential-a', 'password-a', 'update_dvr_series_rule'), [
+        'rule_id' => (string) $rule->id,
+        'match_mode' => 'exact',
+        'start_early_seconds' => '300',
+        'end_late_seconds' => '600',
+    ])->assertOk();
+
+    $rule->refresh();
+    expect($rule->match_mode)->toBe(DvrMatchMode::Exact);
+    expect($rule->start_early_seconds)->toBe(300);
+    expect($rule->end_late_seconds)->toBe(600);
+});
+
+it('switches a pinned rule to any-channel with a blank channel_id on update', function () {
+    $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', 'create_dvr_series_rule'), [
+        'channel_id' => (string) $this->channel->id,
+        'title' => 'Unpin Show',
+    ])->assertOk();
+
+    $rule = DvrRecordingRule::find($response->json('rule_id'));
+    expect($rule->channel_id)->toBe($this->channel->id);
+
+    $this->postJson(dvrActionUrl('credential-a', 'password-a', 'update_dvr_series_rule'), [
+        'rule_id' => (string) $rule->id,
+        'channel_id' => '',
+    ])->assertOk();
+
+    $rule->refresh();
+    expect($rule->channel_id)->toBeNull();
+});
+
+it('404s update_dvr_series_rule for a rule owned by another credential', function () {
+    $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', 'create_dvr_series_rule'), [
+        'channel_id' => (string) $this->channel->id,
+        'title' => 'Owned Show',
+    ])->assertOk();
+
+    $rule = DvrRecordingRule::find($response->json('rule_id'));
+
+    $this->postJson(dvrActionUrl('credential-b', 'password-b', 'update_dvr_series_rule'), [
+        'rule_id' => (string) $rule->id,
+        'priority' => '90',
+    ])->assertNotFound();
+
+    $rule->refresh();
+    expect($rule->priority)->not->toBe(90);
 });
 
 it('does not let one credential see another credential\'s recordings via get_dvr_recordings', function () {

--- a/tests/Feature/XtreamDvrOwnershipTest.php
+++ b/tests/Feature/XtreamDvrOwnershipTest.php
@@ -26,6 +26,7 @@
 
 use App\Enums\DvrMatchMode;
 use App\Enums\DvrRecordingStatus;
+use App\Enums\DvrRuleType;
 use App\Enums\DvrSeriesMode;
 use App\Models\Channel;
 use App\Models\DvrRecording;
@@ -360,7 +361,7 @@ it('does not let one credential see or delete another credential\'s series rule 
         'user_id' => $this->user->id,
         'dvr_setting_id' => $this->setting->id,
         'playlist_auth_id' => $this->authA->id,
-        'type' => \App\Enums\DvrRuleType::Series,
+        'type' => DvrRuleType::Series,
         'channel_id' => $this->channel->id,
         'series_title' => 'Credential A Show',
         'match_mode' => DvrMatchMode::Contains,
@@ -372,7 +373,7 @@ it('does not let one credential see or delete another credential\'s series rule 
         'user_id' => $this->user->id,
         'dvr_setting_id' => $this->setting->id,
         'playlist_auth_id' => $this->authB->id,
-        'type' => \App\Enums\DvrRuleType::Series,
+        'type' => DvrRuleType::Series,
         'channel_id' => $this->channel->id,
         'series_title' => 'Credential B Show',
         'match_mode' => DvrMatchMode::Contains,

--- a/tests/Feature/XtreamDvrOwnershipTest.php
+++ b/tests/Feature/XtreamDvrOwnershipTest.php
@@ -333,8 +333,10 @@ it('rejects all DVR actions for a PlaylistAuth credential without dvr_enabled', 
 
     $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', $action), [
         'recording_id' => 'does-not-matter',
+        'rule_id' => '1',
         'channel_id' => (string) $this->channel->id,
         'title' => 'Evening News',
+        'q' => 'ne',
         'start_time' => now()->addHour()->toIso8601String(),
         'end_time' => now()->addHours(2)->toIso8601String(),
     ]);
@@ -345,6 +347,47 @@ it('rejects all DVR actions for a PlaylistAuth credential without dvr_enabled', 
     'get_dvr_recording',
     'schedule_dvr',
     'create_dvr_series_rule',
+    'update_dvr_series_rule',
     'cancel_dvr_recording',
     'delete_dvr_recording',
+    'list_dvr_series_rules',
+    'delete_dvr_series_rule',
+    'search_epg_shows',
 ]);
+
+it('does not let one credential see or delete another credential\'s series rule via list/delete_dvr_series_rule', function () {
+    $ruleA = DvrRecordingRule::create([
+        'user_id' => $this->user->id,
+        'dvr_setting_id' => $this->setting->id,
+        'playlist_auth_id' => $this->authA->id,
+        'type' => \App\Enums\DvrRuleType::Series,
+        'channel_id' => $this->channel->id,
+        'series_title' => 'Credential A Show',
+        'match_mode' => DvrMatchMode::Contains,
+        'series_mode' => DvrSeriesMode::All,
+        'enabled' => true,
+    ]);
+
+    DvrRecordingRule::create([
+        'user_id' => $this->user->id,
+        'dvr_setting_id' => $this->setting->id,
+        'playlist_auth_id' => $this->authB->id,
+        'type' => \App\Enums\DvrRuleType::Series,
+        'channel_id' => $this->channel->id,
+        'series_title' => 'Credential B Show',
+        'match_mode' => DvrMatchMode::Contains,
+        'series_mode' => DvrSeriesMode::All,
+        'enabled' => true,
+    ]);
+
+    $response = $this->postJson(dvrActionUrl('credential-a', 'password-a', 'list_dvr_series_rules'))->assertOk();
+    expect($response->json())->toHaveCount(1);
+    expect($response->json('0.series_title'))->toBe('Credential A Show');
+    expect($response->json('0.recording_count'))->toBe(0);
+
+    $this->postJson(dvrActionUrl('credential-a', 'password-a', 'delete_dvr_series_rule'), [
+        'rule_id' => (string) $ruleA->id,
+    ])->assertOk()->assertJson(['success' => true]);
+
+    expect(DvrRecordingRule::find($ruleA->id))->toBeNull();
+});


### PR DESCRIPTION
Server side of series recording from EPG show search. Companion to **m3ue/m3u-tv#180**, which is blocked on this — the client calls these actions and is non-functional without them. This should land first.

## New Xtream actions

| action | purpose |
|---|---|
| `search_epg_shows` | Groups upcoming `EpgProgramme` rows by `SeriesKey`-normalized title across the playlist's EPG-mapped channels. Returns per-show channels, episode count, next airing, recent episodes, and `has_series_rule` / `series_rule_id`. |
| `list_dvr_series_rules` | Enabled Series rules for the playlist, scoped by `playlist_auth` where applicable. |
| `update_dvr_series_rule` | In-place edit of an existing rule. |
| `delete_dvr_series_rule` | Removes a rule by id. |

## `create_dvr_series_rule` extended

Now accepts `priority`, `start_early_seconds` and `end_late_seconds`, and **`channel_id` becomes optional**.

Omitting `channel_id` means *any channel*. `DvrSchedulerService::resolveSeriesEpgScope()` already scopes a rule to every EPG-mapped channel in the playlist when both `channel_id` and `source_channel_id` are null, so neither is set. Note this deliberately differs from the Browse Shows page, whose "any channel" option (`seriesChannelId === 0`) sets `source_channel_id` and therefore *narrows* scope to the browsing channel.

**Omit-to-inherit** is applied consistently: a param that is absent, blank or non-numeric is left out of the create entirely so the `DvrSetting` default applies. Blank is never coerced to `0` — for the padding fields `0` means *no padding*, which is not the same as *inherit*. The same treatment was applied to the pre-existing `keep_last` handling, which turned a blank value into `0`.

## Fix: `series_mode=new_flag` was silently stored as `all`

`DvrRecordingRule::saving` carries a legacy `new_only` → `series_mode` migration:

```php
} elseif (! $rawNewOnly && $rule->series_mode === DvrSeriesMode::NewFlag) {
    $rule->series_mode = DvrSeriesMode::All;
}
```

`new_only` defaults to `false` and the Xtream controller never set it, so **every** rule created through the API with `series_mode=new_flag` was rewritten to `all` on save — "New episodes only" silently became "All episodes". The Browse Shows page escapes this because `recordSeriesWithOptions()` passes both fields.

Fixed by setting `'new_only' => ($seriesMode === DvrSeriesMode::NewFlag)` on create and update. It has to be exactly that equality: setting `new_only = true` alongside `unique_se` trips the hook's *first* branch and clobbers the mode to `new_flag`. **The shared saving hook is deliberately left untouched**, since it is also used by the Filament resources.

Verified across all 12 `series_mode` × `match_mode` combinations against a local container — `new_flag` was the only broken value, and all four match modes always round-tripped correctly.

## Duplicate guard

Creating a second Series rule for the same show now returns **409** with the existing `rule_id` and `duplicate: true`, so a client can show "already recording" instead of a generic failure. Previously the API would happily create unlimited duplicate rules for one show, while the Browse Shows page refused them.

The lookup uses the auto-derived, indexed `normalized_title` column via `SeriesKey::normalize` — matching what the model actually stores and what `search_epg_shows` groups by, rather than `EpgProgrammeNormalizer::cleanForSearch` as the web page uses. Worth noting those two normalizers coexist in the codebase and can disagree.

The guard is intentionally scoped by DVR setting + type + normalized title + auth, and **not** by channel, matching `GuestBrowseShows::createSeriesRule` — a second rule for the same show on a different channel is treated as a duplicate.

## Update semantics

Only fields present in the request are applied, so editing one setting never nulls out unrelated ones. `channel_id` present-but-blank switches a rule to any-channel; absent leaves it unchanged.

Edit is a genuine in-place update rather than delete-and-recreate: deleting cascades to the rule's recordings, which would destroy recording history and change the rule id.

`DvrSchedulerTick` is **not** dispatched — `DvrRecordingRule::boot()`'s `created` hook already calls `DvrSchedulerService::scheduleRuleImmediately()` for enabled rules, so the API path is covered.

## Testing

`tests/Feature/XtreamDvrOwnershipTest.php` — 18 passing / 61 assertions, Pint clean. Covers the new-flag lockstep in both directions (including that `new_only` must not rewrite a `unique_se` rule), present-fields-only updates, blank-channel → any-channel, and cross-credential 404s.

Also exercised end to end against a running container: the full 12-combination matrix, explicit `start_early_seconds=0` persisting as `0` rather than null, blank inheriting, non-numeric `priority` falling back to the column default, the 409 path, and `get_dvr_storage` from #1360 still responding alongside the new actions.

## Notes

- `search_epg_shows` returns `has_series_rule` and `series_rule_id` so a client can render correct toggle state without a second round trip.
- `priority` was added to `formatDvrSeriesRule`, which previously omitted it.
- Also included: the playlist title search in `search_epg_shows` uses `ILIKE` so lowercase queries match capitalised titles (PostgreSQL-specific).
- Per-rule `enable_comskip` is out of scope; the Browse Shows options form does not expose it either.
