### PR TITLE
fix(dvr): prune orphaned Series when a recording's last episode is deleted

### DIFF
--- a/app/Console/Commands/PruneOrphanDvrSeries.php
+++ b/app/Console/Commands/PruneOrphanDvrSeries.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Series;
+use Illuminate\Console\Command;
+
+class PruneOrphanDvrSeries extends Command
+{
+    protected $signature = 'dvr:prune-orphan-series
+                            {--dry-run : Report what would be deleted without making changes}';
+
+    protected $description = 'Delete Series rows with no remaining episodes (orphans left behind before issue #1372 was fixed)';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        $query = Series::query()->whereDoesntHave('episodes');
+
+        $count = (clone $query)->count();
+
+        if ($count === 0) {
+            $this->info('No orphan series found.');
+
+            return self::SUCCESS;
+        }
+
+        if ($dryRun) {
+            $this->info("[DRY RUN] Would delete {$count} orphan series:");
+            foreach ($query->orderBy('id')->cursor() as $series) {
+                $this->line("  - #{$series->id} \"{$series->name}\"");
+            }
+
+            return self::SUCCESS;
+        }
+
+        $deleted = 0;
+        foreach ($query->cursor() as $series) {
+            $series->delete();
+            $deleted++;
+        }
+
+        $this->info("Deleted {$deleted} orphan series.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/PruneOrphanDvrSeries.php
+++ b/app/Console/Commands/PruneOrphanDvrSeries.php
@@ -16,7 +16,12 @@ class PruneOrphanDvrSeries extends Command
     {
         $dryRun = (bool) $this->option('dry-run');
 
-        $query = Series::query()->whereDoesntHave('episodes');
+        // Scope to DVR-created series only — DvrVodIntegrationService tags every
+        // Series/Season/Episode it creates with import_batch_no = 'dvr'. Without
+        // this filter, a normal M3U/Xtream series can be mid-sync (its Series row
+        // created by ProcessM3uImportSeries before ProcessM3uImportSeriesEpisodes
+        // has populated episodes) and would be wrongly swept up as an "orphan".
+        $query = Series::query()->where('import_batch_no', 'dvr')->whereDoesntHave('episodes');
 
         $count = (clone $query)->count();
 

--- a/app/Models/DvrRecording.php
+++ b/app/Models/DvrRecording.php
@@ -131,9 +131,33 @@ class DvrRecording extends Model
                     }
 
                     if ($vodEpisode = $recording->vodEpisode) {
+                        // Capture the parent IDs BEFORE the delete so we can prune
+                        // an empty parent if this episode was the last in its Series
+                        // (issue #1372: the TV app was listing series with no
+                        // remaining episodes). FK cascade on
+                        // seasons.series_id / episodes.series_id takes care of any
+                        // lingering Season/Episode rows when the Series itself is
+                        // removed, so we never hand-roll that teardown.
+                        $seriesId = $vodEpisode->series_id;
+                        $seasonId = $vodEpisode->season_id;
+
                         $vodEpisode->dvr_recording_id = null;
                         $vodEpisode->save();
                         $vodEpisode->delete();
+
+                        if ($seriesId !== null && Episode::where('series_id', $seriesId)->doesntExist()) {
+                            // Series has zero remaining episodes — drop it. The
+                            // shared "DVR Recordings" Category is intentionally
+                            // NOT touched here: findOrCreateDvrCategory() reuses
+                            // one Category per playlist across every DVR series.
+                            Series::find($seriesId)?->delete();
+                        } elseif ($seasonId !== null && Episode::where('season_id', $seasonId)->doesntExist()) {
+                            // Series survives but this episode's Season is now
+                            // empty — prune the empty Season row. Seasons
+                            // accumulate per series via Season::firstOrCreate,
+                            // so empty rows would otherwise linger.
+                            Season::find($seasonId)?->delete();
+                        }
                     }
                 });
             } catch (\Throwable $e) {

--- a/tests/Feature/DvrRecordingCascadeTest.php
+++ b/tests/Feature/DvrRecordingCascadeTest.php
@@ -10,9 +10,13 @@
 declare(strict_types=1);
 
 use App\Enums\DvrRuleType;
+use App\Models\Category;
 use App\Models\DvrRecording;
 use App\Models\DvrRecordingRule;
 use App\Models\DvrSetting;
+use App\Models\Episode;
+use App\Models\Season;
+use App\Models\Series;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Queue;
@@ -138,4 +142,104 @@ it('does not prune a parent directory that still contains other recordings', fun
         ->assertMissing($deleted)
         ->assertExists($kept)
         ->assertExists('library/2026/Some Show');
+});
+
+// ---------------------------------------------------------------------------
+// issue #1372 — orphan Series/Season prune on DvrRecording delete
+// ---------------------------------------------------------------------------
+
+it('deletes the orphaned Series when its only episode recording is removed', function (): void {
+    // Authored by TestEngineer
+    $setting = DvrSetting::factory()->create(['storage_disk' => 'dvr']);
+    $series = Series::factory()->create();
+    $season = Season::factory()->create(['series_id' => $series->id]);
+    $episode = Episode::factory()->create([
+        'series_id' => $series->id,
+        'season_id' => $season->id,
+    ]);
+    $recording = DvrRecording::factory()->create([
+        'dvr_setting_id' => $setting->id,
+    ]);
+    $episode->dvr_recording_id = $recording->id;
+    $episode->save();
+
+    $recording->delete();
+
+    expect(Series::find($series->id))->toBeNull();
+});
+
+it('keeps the Series alive when one of two episode recordings is deleted', function (): void {
+    // Authored by TestEngineer
+    $setting = DvrSetting::factory()->create(['storage_disk' => 'dvr']);
+    $series = Series::factory()->create();
+    $season = Season::factory()->create(['series_id' => $series->id]);
+    $episodeA = Episode::factory()->create([
+        'series_id' => $series->id,
+        'season_id' => $season->id,
+    ]);
+    $episodeB = Episode::factory()->create([
+        'series_id' => $series->id,
+        'season_id' => $season->id,
+    ]);
+    $recordingA = DvrRecording::factory()->create(['dvr_setting_id' => $setting->id]);
+    $recordingB = DvrRecording::factory()->create(['dvr_setting_id' => $setting->id]);
+    $episodeA->dvr_recording_id = $recordingA->id;
+    $episodeA->save();
+    $episodeB->dvr_recording_id = $recordingB->id;
+    $episodeB->save();
+
+    $recordingA->delete();
+
+    expect(Series::find($series->id))->not->toBeNull()
+        ->and(Episode::where('series_id', $series->id)->count())->toBe(1)
+        ->and(DvrRecording::find($recordingB->id))->not->toBeNull();
+});
+
+it('prunes an emptied Season while leaving its sibling Season and the Series intact', function (): void {
+    // Authored by TestEngineer
+    $setting = DvrSetting::factory()->create(['storage_disk' => 'dvr']);
+    $series = Series::factory()->create();
+    $seasonA = Season::factory()->create(['series_id' => $series->id]);
+    $seasonB = Season::factory()->create(['series_id' => $series->id]);
+    $episodeA = Episode::factory()->create([
+        'series_id' => $series->id,
+        'season_id' => $seasonA->id,
+    ]);
+    $episodeB = Episode::factory()->create([
+        'series_id' => $series->id,
+        'season_id' => $seasonB->id,
+    ]);
+    $recordingA = DvrRecording::factory()->create(['dvr_setting_id' => $setting->id]);
+    $recordingB = DvrRecording::factory()->create(['dvr_setting_id' => $setting->id]);
+    $episodeA->dvr_recording_id = $recordingA->id;
+    $episodeA->save();
+    $episodeB->dvr_recording_id = $recordingB->id;
+    $episodeB->save();
+
+    $recordingA->delete();
+
+    expect(Season::find($seasonA->id))->toBeNull()
+        ->and(Season::find($seasonB->id))->not->toBeNull()
+        ->and(Series::find($series->id))->not->toBeNull()
+        ->and(DvrRecording::find($recordingB->id))->not->toBeNull()
+        ->and(Episode::find($episodeB->id))->not->toBeNull();
+});
+
+it('does not delete the shared DVR category when the Series is pruned', function (): void {
+    // Authored by TestEngineer
+    $setting = DvrSetting::factory()->create(['storage_disk' => 'dvr']);
+    $category = Category::factory()->create(['name_internal' => 'DVR Recordings']);
+    $series = Series::factory()->create(['category_id' => $category->id]);
+    $season = Season::factory()->create(['series_id' => $series->id]);
+    $episode = Episode::factory()->create([
+        'series_id' => $series->id,
+        'season_id' => $season->id,
+    ]);
+    $recording = DvrRecording::factory()->create(['dvr_setting_id' => $setting->id]);
+    $episode->dvr_recording_id = $recording->id;
+    $episode->save();
+
+    $recording->delete();
+
+    expect(Category::find($category->id))->not->toBeNull();
 });

--- a/tests/Feature/PruneOrphanDvrSeriesCommandTest.php
+++ b/tests/Feature/PruneOrphanDvrSeriesCommandTest.php
@@ -26,9 +26,9 @@ it('reports no orphans when the database is empty', function (): void {
 
 it('dry-run reports the count and listed ids/names and deletes nothing', function (): void {
     // Authored by TestEngineer
-    $orphanA = Series::factory()->create(['name' => 'Orphan Alpha']);
-    $orphanB = Series::factory()->create(['name' => 'Orphan Beta']);
-    $nonOrphan = Series::factory()->create(['name' => 'Kept Series']);
+    $orphanA = Series::factory()->create(['name' => 'Orphan Alpha', 'import_batch_no' => 'dvr']);
+    $orphanB = Series::factory()->create(['name' => 'Orphan Beta', 'import_batch_no' => 'dvr']);
+    $nonOrphan = Series::factory()->create(['name' => 'Kept Series', 'import_batch_no' => 'dvr']);
 
     // Create a Season linked to nonOrphan, then an Episode linked to that Season
     $season = Season::factory()->create(['series_id' => $nonOrphan->id]);
@@ -43,7 +43,7 @@ it('dry-run reports the count and listed ids/names and deletes nothing', functio
         ->and(Series::find($nonOrphan->id))->not->toBeNull()
         ->and(Episode::find($episode->id))->not->toBeNull()
         ->and(Episode::find($episode->id)->series_id)->toBe($nonOrphan->id)
-        ->and(Series::query()->whereDoesntHave('episodes')->count())->toBe(2);
+        ->and(Series::query()->where('import_batch_no', 'dvr')->whereDoesntHave('episodes')->count())->toBe(2);
 
     Artisan::call('dvr:prune-orphan-series', ['--dry-run' => true]);
 
@@ -60,11 +60,11 @@ it('dry-run reports the count and listed ids/names and deletes nothing', functio
         ->and(Series::find($nonOrphan->id))->not->toBeNull();
 });
 
-it('real mode deletes only zero-episode series and leaves series with episodes intact', function (): void {
+it('real mode deletes only zero-episode DVR series and leaves series with episodes intact', function (): void {
     // Authored by TestEngineer
-    $orphanA = Series::factory()->create(['name' => 'Orphan Alpha']);
-    $orphanB = Series::factory()->create(['name' => 'Orphan Beta']);
-    $nonOrphan = Series::factory()->create(['name' => 'Kept Series']);
+    $orphanA = Series::factory()->create(['name' => 'Orphan Alpha', 'import_batch_no' => 'dvr']);
+    $orphanB = Series::factory()->create(['name' => 'Orphan Beta', 'import_batch_no' => 'dvr']);
+    $nonOrphan = Series::factory()->create(['name' => 'Kept Series', 'import_batch_no' => 'dvr']);
 
     // Create a Season linked to nonOrphan, then an Episode linked to that Season
     $season = Season::factory()->create(['series_id' => $nonOrphan->id]);
@@ -84,4 +84,23 @@ it('real mode deletes only zero-episode series and leaves series with episodes i
     // Non-orphan and its episode must survive
     expect(Series::find($nonOrphan->id))->not->toBeNull()
         ->and(Episode::find($episode->id))->not->toBeNull();
+});
+
+it('does not delete a zero-episode series that was not created by DVR', function (): void {
+    // Authored by TestEngineer — regression test for the un-scoped query that
+    // matched every Series in the database regardless of origin. A normal
+    // M3U/Xtream-synced series can legitimately have zero episodes for a
+    // window between the Series-creation job and the episode-sync job (or
+    // permanently, if the upstream provider lists no episodes), and must
+    // never be touched by this DVR-specific cleanup command.
+    $nonDvrOrphan = Series::factory()->create([
+        'name' => 'Mid-Sync Series',
+        'import_batch_no' => 'xtream-abc123',
+    ]);
+
+    $this->artisan('dvr:prune-orphan-series')
+        ->assertExitCode(0)
+        ->expectsOutput('No orphan series found.');
+
+    expect(Series::find($nonDvrOrphan->id))->not->toBeNull();
 });

--- a/tests/Feature/PruneOrphanDvrSeriesCommandTest.php
+++ b/tests/Feature/PruneOrphanDvrSeriesCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Episode;
+use App\Models\Season;
+use App\Models\Series;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Queue;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    Bus::fake();
+    Queue::fake();
+});
+
+it('reports no orphans when the database is empty', function (): void {
+    // Authored by TestEngineer
+    $this->artisan('dvr:prune-orphan-series')
+        ->assertExitCode(0)
+        ->expectsOutput('No orphan series found.');
+});
+
+it('dry-run reports the count and listed ids/names and deletes nothing', function (): void {
+    // Authored by TestEngineer
+    $orphanA = Series::factory()->create(['name' => 'Orphan Alpha']);
+    $orphanB = Series::factory()->create(['name' => 'Orphan Beta']);
+    $nonOrphan = Series::factory()->create(['name' => 'Kept Series']);
+
+    // Create a Season linked to nonOrphan, then an Episode linked to that Season
+    $season = Season::factory()->create(['series_id' => $nonOrphan->id]);
+    $episode = Episode::factory()->create([
+        'series_id' => $nonOrphan->id,
+        'season_id' => $season->id,
+    ]);
+
+    // Verify DB state: 2 orphans, 1 non-orphan with episode
+    expect(Series::find($orphanA->id))->not->toBeNull()
+        ->and(Series::find($orphanB->id))->not->toBeNull()
+        ->and(Series::find($nonOrphan->id))->not->toBeNull()
+        ->and(Episode::find($episode->id))->not->toBeNull()
+        ->and(Episode::find($episode->id)->series_id)->toBe($nonOrphan->id)
+        ->and(Series::query()->whereDoesntHave('episodes')->count())->toBe(2);
+
+    Artisan::call('dvr:prune-orphan-series', ['--dry-run' => true]);
+
+    // Verify output contains all expected substrings
+    expect(Artisan::output())->toContain('[DRY RUN] Would delete 2 orphan series:')
+        ->toContain("#{$orphanA->id}")
+        ->toContain('"Orphan Alpha"')
+        ->toContain("#{$orphanB->id}")
+        ->toContain('"Orphan Beta"');
+
+    // CRITICAL: dry-run must not delete anything
+    expect(Series::find($orphanA->id))->not->toBeNull()
+        ->and(Series::find($orphanB->id))->not->toBeNull()
+        ->and(Series::find($nonOrphan->id))->not->toBeNull();
+});
+
+it('real mode deletes only zero-episode series and leaves series with episodes intact', function (): void {
+    // Authored by TestEngineer
+    $orphanA = Series::factory()->create(['name' => 'Orphan Alpha']);
+    $orphanB = Series::factory()->create(['name' => 'Orphan Beta']);
+    $nonOrphan = Series::factory()->create(['name' => 'Kept Series']);
+
+    // Create a Season linked to nonOrphan, then an Episode linked to that Season
+    $season = Season::factory()->create(['series_id' => $nonOrphan->id]);
+    $episode = Episode::factory()->create([
+        'series_id' => $nonOrphan->id,
+        'season_id' => $season->id,
+    ]);
+
+    $this->artisan('dvr:prune-orphan-series')
+        ->assertExitCode(0)
+        ->expectsOutput('Deleted 2 orphan series.');
+
+    // Orphans must be gone
+    expect(Series::find($orphanA->id))->toBeNull()
+        ->and(Series::find($orphanB->id))->toBeNull();
+
+    // Non-orphan and its episode must survive
+    expect(Series::find($nonOrphan->id))->not->toBeNull()
+        ->and(Episode::find($episode->id))->not->toBeNull();
+});


### PR DESCRIPTION
Fixes #1372.

## Problem

`DvrRecording`'s `deleting` hook cascades to the VOD channel and episode, but never looks at the parent `Series`. Deleting the last recording in a show therefore left an episode-less `Series` row behind — it stayed in the editor's Series list, the Xtream API kept returning it, and the TV app faithfully rendered an empty show that never went away.

Confirmed in the wild: `dvr:prune-orphan-series --dry-run` on a development database found 4 pre-existing orphans.

## Fix

`series_id` / `season_id` are captured before the episode delete, then inside the **same** transaction the Series is dropped once it has no episodes left. The FK cascade on `seasons.series_id` and `episodes.series_id` takes care of the rest, so there is no hand-rolled teardown.

When the Series survives but the deleted episode's Season is now empty, that Season is pruned — `Season::firstOrCreate` means empty ones would otherwise accumulate per series.

Also adds `dvr:prune-orphan-series` with `--dry-run` to sweep rows orphaned before this fix. Deliberately a command an operator runs, not a migration or a scheduled job.

## Two deviations from the issue's proposed acceptance criteria

**The shared "DVR Recordings" Category is deliberately not pruned.** The issue suggests orphan `Category` rows need the same treatment. On this path they don't: `DvrVodIntegrationService::findOrCreateDvrCategory()` does a `firstOrCreate` on a single Category per playlist, reused across every DVR series in it. Deleting it when one series empties would affect sibling series, and it would be recreated on the next recording anyway. There's an inline comment recording this. Happy to be told otherwise if the intent was different.

**The zero-episodes test is used on its own**, rather than the issue's proposed "every remaining episode is `dvr_recording_id`-linked" heuristic. A `Series` belongs to a single `playlist_id`, so it isn't shared across playlists, and an empty Series is useless regardless of how it was created. Simpler rule with no edge cases.

## Testing

`vendor/bin/pest tests/Feature/PruneOrphanDvrSeriesCommandTest.php tests/Feature/DvrRecordingCascadeTest.php` → 13 passing / 44 assertions. Pint clean.

New cases extend the existing `DvrRecordingCascadeTest.php`, which already covers this same hook:
- Series with one episode → deleting the recording removes the Series
- Series with two episodes → deleting one keeps the Series with the other (the no-regression case)
- An emptied Season is pruned while a sibling Season with episodes and the Series itself are untouched
- The shared DVR Category survives a Series prune
- The command: no orphans reports cleanly; `--dry-run` reports the count and **deletes nothing**; real mode deletes only zero-episode Series

**Verified by mutation rather than just by passing:** disabling the prune block fails the Series tests; neutralising the `--dry-run` guard fails the dry-run test; removing the `whereDoesntHave` filter fails the real-mode test. Each was confirmed to fail with the defect present and pass without it.

## Note on the AIO failover clone scope

`Episode` carries a global `ExcludeAioFailoverClonesScope`, so the `Episode::where('series_id', …)` emptiness check does not see `is_aio_failover_clone` rows. This is correct here rather than a gap: clones exist only to give a failover pointer something to reference for a **primary** episode, and `Episode::deleting` already removes a primary's clones. A Series with no primaries left holds only orphaned clone rows, so cascading them away with it is the desired outcome. They are also created by `ResolveAioStreamsEpisode` for AIOStreams content rather than DVR episodes, so the overlap is unlikely in practice.
