### PR TITLE
fix(epg): enable DVR record button for CustomPlaylist and MergedPlaylist views

### DIFF
--- a/app/Livewire/EpgViewer.php
+++ b/app/Livewire/EpgViewer.php
@@ -70,10 +70,10 @@ class EpgViewer extends Component implements HasActions, HasForms
         $this->record = $record;
         $this->type = class_basename($this->record);
 
-        // Determine DVR enabled state for Playlist records
-        if ($this->type === 'Playlist') {
-            $this->dvrEnabled = (bool) $this->record->dvrSetting?->enabled;
-        }
+        // dvrSetting() exists directly on Playlist, CustomPlaylist, and MergedPlaylist
+        // (via HasPolymorphicPlaylistOwner) — safe to resolve unconditionally; other
+        // record types (e.g. Epg) simply have no such relation and resolve to null.
+        $this->dvrEnabled = (bool) $this->record->dvrSetting?->enabled;
     }
 
     /**

--- a/tests/Feature/EpgViewerDvrButtonTest.php
+++ b/tests/Feature/EpgViewerDvrButtonTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Livewire\EpgViewer;
+use App\Models\CustomPlaylist;
+use App\Models\DvrSetting;
+use App\Models\MergedPlaylist;
+use App\Models\Playlist;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Queue::fake();
+    $this->user = User::factory()->create(['permissions' => ['use_dvr']]);
+    $this->actingAs($this->user);
+});
+
+it('enables the record button for a Playlist with DVR enabled (regression)', function () {
+    $playlist = Playlist::factory()->for($this->user)->create();
+    DvrSetting::factory()->enabled()->for($this->user)->create([
+        'playlist_id' => $playlist->id,
+    ]);
+
+    Livewire::test(EpgViewer::class, ['record' => $playlist])
+        ->assertSet('dvrEnabled', true);
+});
+
+it('does not enable the record button for a Playlist without DVR enabled', function () {
+    $playlist = Playlist::factory()->for($this->user)->create();
+
+    Livewire::test(EpgViewer::class, ['record' => $playlist])
+        ->assertSet('dvrEnabled', false);
+});
+
+it('enables the record button for a CustomPlaylist with its own DVR setting enabled (#1370)', function () {
+    $custom = CustomPlaylist::factory()->for($this->user)->create();
+    DvrSetting::factory()->enabled()->for($this->user)->create([
+        'playlist_id' => null,
+        'custom_playlist_id' => $custom->id,
+    ]);
+
+    Livewire::test(EpgViewer::class, ['record' => $custom])
+        ->assertSet('dvrEnabled', true);
+});
+
+it('does not enable the record button for a CustomPlaylist without a DVR setting', function () {
+    $custom = CustomPlaylist::factory()->for($this->user)->create();
+
+    Livewire::test(EpgViewer::class, ['record' => $custom])
+        ->assertSet('dvrEnabled', false);
+});
+
+it('enables the record button for a MergedPlaylist with its own DVR setting enabled (#1375)', function () {
+    $merged = MergedPlaylist::factory()->for($this->user)->create();
+    DvrSetting::factory()->enabled()->for($this->user)->create([
+        'playlist_id' => null,
+        'merged_playlist_id' => $merged->id,
+    ]);
+
+    Livewire::test(EpgViewer::class, ['record' => $merged])
+        ->assertSet('dvrEnabled', true);
+});
+
+it('does not enable the record button for a MergedPlaylist without a DVR setting', function () {
+    $merged = MergedPlaylist::factory()->for($this->user)->create();
+
+    Livewire::test(EpgViewer::class, ['record' => $merged])
+        ->assertSet('dvrEnabled', false);
+});


### PR DESCRIPTION
## Summary
Fixes #1370, fixes #1375.

`EpgViewer::mount()` only set `$dvrEnabled` when the record's class was literally `Playlist`:

```php
if ($this->type === 'Playlist') {
    $this->dvrEnabled = (bool) $this->record->dvrSetting?->enabled;
}
```

So the record button never appeared for `CustomPlaylist` or `MergedPlaylist` views — even though both models already have their own `dvrSetting()` relation (via `HasPolymorphicPlaylistOwner`), and `handleScheduleProgramme()` already resolves `$dvrSetting` generically via `$this->record->dvrSetting` for any of the three types.

`ViewMergedPlaylist` already embeds `EpgViewer`, so once this gate is fixed both playlist types get the record button — this one fix covers both issues.

The fix is just removing the type check; `dvrSetting` resolves safely to `null` for record types that don't define that relation (e.g. `Epg`), so no other branching is needed.

## Test plan
- [x] `tests/Feature/EpgViewerDvrButtonTest.php` — 6 Pest cases: DVR-enabled and DVR-disabled for each of `Playlist` (regression), `CustomPlaylist`, and `MergedPlaylist`.
- [x] Confirmed each "enabled" case fails when the old type-gated code is temporarily restored, and passes with the fix (mutation check).
- [x] `vendor/bin/pint` clean.
- [x] Neighbor smoke check: `BrowseShowsTest` + `EpgApiControllerTest` — no regressions (46/46 total passing across all three files).