### PR TITLE
Make Horizon worker pool (maxProcesses / memory / maxJobs / maxTime) env-configurable

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -186,10 +186,10 @@ return [
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
             // Set maxProcesses to 1 if using SQLite to avoid database locks
-            'maxProcesses' => env('DB_CONNECTION', 'sqlite') === 'sqlite' ? 1 : 12,
-            'maxTime' => 0,
-            'maxJobs' => 0,
-            'memory' => 512, // MB
+            'maxProcesses' => (int) env('HORIZON_QUEUE_MAX_PROCESSES', env('DB_CONNECTION', 'sqlite') === 'sqlite' ? 1 : 12),
+            'maxTime' => (int) env('HORIZON_QUEUE_MAX_TIME', 0),
+            'maxJobs' => (int) env('HORIZON_QUEUE_MAX_JOBS', 0),
+            'memory' => (int) env('HORIZON_QUEUE_MEMORY', 512), // MB
             'tries' => 3, // Number of times to attempt a job before marking it as failed
             'timeout' => 60 * 125, // Should be longer than the retry_after value set in queue.php
             'nice' => 0,
@@ -203,10 +203,10 @@ return [
             'connection' => 'redis',
             'queue' => ['schedules-direct'],
             'balance' => 'simple',
-            'maxProcesses' => 1,
-            'maxTime' => 0,
-            'maxJobs' => 0,
-            'memory' => 512, // MB
+            'maxProcesses' => (int) env('HORIZON_SD_MAX_PROCESSES', 1),
+            'maxTime' => (int) env('HORIZON_SD_MAX_TIME', 0),
+            'maxJobs' => (int) env('HORIZON_SD_MAX_JOBS', 0),
+            'memory' => (int) env('HORIZON_SD_MEMORY', 512), // MB
             'tries' => 3,
             'timeout' => 60 * 125,
             'nice' => 0,
@@ -218,10 +218,10 @@ return [
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
             // Set maxProcesses to 1 if using SQLite to avoid database locks
-            'maxProcesses' => env('DB_CONNECTION', 'sqlite') === 'sqlite' ? 1 : 4,
-            'maxTime' => 0,
-            'maxJobs' => 0,
-            'memory' => 512, // MB
+            'maxProcesses' => (int) env('HORIZON_DVR_MAX_PROCESSES', env('DB_CONNECTION', 'sqlite') === 'sqlite' ? 1 : 4),
+            'maxTime' => (int) env('HORIZON_DVR_MAX_TIME', 0),
+            'maxJobs' => (int) env('HORIZON_DVR_MAX_JOBS', 0),
+            'memory' => (int) env('HORIZON_DVR_MEMORY', 512), // MB
             'tries' => 2, // DVR jobs get fewer retries to avoid duplicate recordings
             'timeout' => 60 * 60, // 1 hour (long-running recordings)
             'nice' => 5,
@@ -238,10 +238,10 @@ return [
             'connection' => 'redis',
             'queue' => ['aiostreams-resolve'],
             'balance' => 'simple',
-            'maxProcesses' => 2,
-            'maxTime' => 0,
-            'maxJobs' => 0,
-            'memory' => 512, // MB
+            'maxProcesses' => (int) env('HORIZON_AIOSTREAMS_MAX_PROCESSES', 2),
+            'maxTime' => (int) env('HORIZON_AIOSTREAMS_MAX_TIME', 0),
+            'maxJobs' => (int) env('HORIZON_AIOSTREAMS_MAX_JOBS', 0),
+            'memory' => (int) env('HORIZON_AIOSTREAMS_MEMORY', 512), // MB
             'tries' => 1, // jobs handle their own empty-result retry/backoff internally
             'timeout' => 60 * 5,
             'nice' => 5,


### PR DESCRIPTION
## What

Wraps the hardcoded `maxProcesses`, `memory`, `maxJobs`, and `maxTime` values of all four Horizon supervisors in `config/horizon.php` with `env(...)` reads, **keeping the existing values as defaults**. Adds these env vars (per supervisor):

| Supervisor | max processes | memory | max jobs | max time |
|---|---|---|---|---|
| `m3u-editor-queue` | `HORIZON_QUEUE_MAX_PROCESSES` | `HORIZON_QUEUE_MEMORY` | `HORIZON_QUEUE_MAX_JOBS` | `HORIZON_QUEUE_MAX_TIME` |
| `m3u-editor-sd-queue` | `HORIZON_SD_MAX_PROCESSES` | `HORIZON_SD_MEMORY` | `HORIZON_SD_MAX_JOBS` | `HORIZON_SD_MAX_TIME` |
| `dvr-queue` | `HORIZON_DVR_MAX_PROCESSES` | `HORIZON_DVR_MEMORY` | `HORIZON_DVR_MAX_JOBS` | `HORIZON_DVR_MAX_TIME` |
| `aiostreams-queue` | `HORIZON_AIOSTREAMS_MAX_PROCESSES` | `HORIZON_AIOSTREAMS_MEMORY` | `HORIZON_AIOSTREAMS_MAX_JOBS` | `HORIZON_AIOSTREAMS_MAX_TIME` |

## Why

On non-sqlite (Postgres/MySQL) deployments the pool scales to `12 + 1 + 4 + 2 = 19` long-lived PHP workers, each allowed to grow to **512 MB RSS** and **never recycled** (`maxTime = 0`, `maxJobs = 0`). Under `import` / EPG / `file_sync` bursts, `balance: auto` scales the pool up and the spawned workers retain their RSS, so idle memory drifts to **~1 GB+ per instance**.

Operators running many instances (shared hosting, homelab stacks, resource-constrained boxes) currently have to fork the image or edit config inside the container to bound this. This change lets them cap concurrency and enable job/time-based worker recycling purely via env, e.g.:

```
HORIZON_QUEUE_MAX_PROCESSES=4
HORIZON_DVR_MAX_PROCESSES=2
HORIZON_QUEUE_MEMORY=160
HORIZON_QUEUE_MAX_JOBS=500
HORIZON_QUEUE_MAX_TIME=3600
```

## Compatibility

Fully backward-compatible — every new env var **defaults to the current hardcoded value** (the sqlite/non-sqlite `maxProcesses` ternary is preserved as the default), so behaviour is unchanged unless an operator sets the vars. `php -l` clean.