### PR TITLE
fix: map Xtream season metadata by season number

### DIFF
--- a/app/Models/Season.php
+++ b/app/Models/Season.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -64,5 +65,23 @@ class Season extends Model
     public function scopeForSerie(Builder $query, int $serieId): Builder
     {
         return $query->where('series_id', $serieId);
+    }
+
+    /**
+     * Fall back to the parent series' cover when the provider didn't send
+     * season-specific artwork (e.g. a season missing from its "seasons" list).
+     */
+    protected function cover(): Attribute
+    {
+        return Attribute::make(
+            get: fn (?string $value) => $value ?? $this->serie?->cover,
+        );
+    }
+
+    protected function coverBig(): Attribute
+    {
+        return Attribute::make(
+            get: fn (?string $value) => $value ?? $this->serie?->cover,
+        );
     }
 }

--- a/app/Models/Season.php
+++ b/app/Models/Season.php
@@ -68,20 +68,17 @@ class Season extends Model
     }
 
     /**
-     * Fall back to the parent series' cover when the provider didn't send
-     * season-specific artwork (e.g. a season missing from its "seasons" list).
+     * Display-only poster URL: falls back to the parent series' cover when the
+     * provider didn't send season-specific artwork (e.g. a season missing from
+     * its "seasons" list). Deliberately does NOT override `cover`/`cover_big`
+     * themselves, since several write paths (FetchTmdbIds, DvrVodIntegrationService)
+     * use `empty($season->cover)` to decide whether real season art still needs
+     * to be fetched — a fallback there would make them think it's already set.
      */
-    protected function cover(): Attribute
+    protected function displayCover(): Attribute
     {
         return Attribute::make(
-            get: fn (?string $value) => $value ?? $this->serie?->cover,
-        );
-    }
-
-    protected function coverBig(): Attribute
-    {
-        return Attribute::make(
-            get: fn (?string $value) => $value ?? $this->serie?->cover,
+            get: fn () => $this->cover_big ?? $this->cover ?? $this->serie?->cover,
         );
     }
 }

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -313,18 +313,22 @@ class Series extends Model
                                 'metadata' => $seasonInfo,
                             ]);
                         } else {
-                            // Update the season if it exists
+                            // Update the season if it exists. Only overwrite the
+                            // provider-sourced fields when the provider actually sent
+                            // matching season info this time around — otherwise keep
+                            // whatever was previously fetched instead of clobbering it
+                            // with a generic fallback.
                             $playlistSeason->update([
                                 'new' => false,
-                                'name' => $seasonInfo['name'] ?? 'Season '.str_pad($season, 2, '0', STR_PAD_LEFT),
-                                'source_season_id' => $seasonInfo['id'] ?? null,
+                                'name' => $seasonInfo['name'] ?? $playlistSeason->name,
+                                'source_season_id' => $seasonInfo['id'] ?? $playlistSeason->source_season_id,
                                 'category_id' => $playlistCategory->id,
-                                'episode_count' => (int) ($seasonInfo['episode_count'] ?? 0),
-                                'cover' => $seasonInfo['cover'] ?? null,
-                                'cover_big' => $seasonInfo['cover_big'] ?? null,
+                                'episode_count' => (int) ($seasonInfo['episode_count'] ?? $playlistSeason->episode_count),
+                                'cover' => $seasonInfo['cover'] ?? $playlistSeason->getRawOriginal('cover'),
+                                'cover_big' => $seasonInfo['cover_big'] ?? $playlistSeason->getRawOriginal('cover_big'),
                                 'series_id' => $this->id,
                                 'import_batch_no' => $batchNo,
-                                'metadata' => $seasonInfo,
+                                'metadata' => $seasonInfo ?: $playlistSeason->metadata,
                             ]);
                         }
 

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -101,6 +101,45 @@ class Series extends Model
         return $this->hasMany(Episode::class)->where('enabled', true);
     }
 
+    /**
+     * Resolve provider season metadata by its explicit season number.
+     *
+     * Xtream providers commonly return seasons as a zero-indexed JSON list,
+     * while episodes are keyed by the real season number (1, 2, ...).
+     */
+    private static function resolveProviderSeasonInfo(array $seasons, int|string $seasonNumber): array
+    {
+        $target = (int) $seasonNumber;
+        $hasExplicitSeasonNumber = false;
+
+        foreach ($seasons as $seasonInfo) {
+            if (! is_array($seasonInfo)) {
+                continue;
+            }
+
+            $candidate = $seasonInfo['season_number'] ?? $seasonInfo['season'] ?? null;
+            if ($candidate !== null) {
+                $hasExplicitSeasonNumber = true;
+                if ((int) $candidate === $target) {
+                    return $seasonInfo;
+                }
+            }
+        }
+
+        if ($hasExplicitSeasonNumber) {
+            return [];
+        }
+
+        if (! array_is_list($seasons) && isset($seasons[$seasonNumber]) && is_array($seasons[$seasonNumber])) {
+            return $seasons[$seasonNumber];
+        }
+
+        $orderedSeasons = array_values(array_filter($seasons, 'is_array'));
+        $position = $target - 1;
+
+        return $position >= 0 && isset($orderedSeasons[$position]) ? $orderedSeasons[$position] : [];
+    }
+
     public function getMovieDbIds(): array
     {
         $tvdbId = $this->tvdb_id ?? $this->metadata['tvdb_id'] ?? $this->metadata['tvdb'] ?? null;
@@ -255,7 +294,7 @@ class Series extends Model
                             ->first();
 
                         // Get season info if available
-                        $seasonInfo = $seasons[$season] ?? [];
+                        $seasonInfo = self::resolveProviderSeasonInfo($seasons, $season);
 
                         if (! $playlistSeason) {
                             // Create the season if it doesn't exist
@@ -277,6 +316,7 @@ class Series extends Model
                             // Update the season if it exists
                             $playlistSeason->update([
                                 'new' => false,
+                                'name' => $seasonInfo['name'] ?? 'Season '.str_pad($season, 2, '0', STR_PAD_LEFT),
                                 'source_season_id' => $seasonInfo['id'] ?? null,
                                 'category_id' => $playlistCategory->id,
                                 'episode_count' => (int) ($seasonInfo['episode_count'] ?? 0),
@@ -333,6 +373,7 @@ class Series extends Model
                             update: [
                                 'title',
                                 'import_batch_no',
+                                'season_id',
                                 'episode_num',
                                 'container_extension',
                                 'custom_sid',

--- a/resources/views/filament/resources/series/pages/view-series.blade.php
+++ b/resources/views/filament/resources/series/pages/view-series.blade.php
@@ -243,7 +243,7 @@
                 @foreach ($episodesBySeason as $seasonNumber => $episodes)
                     @php
                         $season = $seasonsLookup->get($seasonNumber);
-                        $cover = $season?->cover_big ?? $season?->cover;
+                        $cover = $season?->display_cover;
                         $seasonName = $season?->name ?? 'Season '.str_pad($seasonNumber, 2, '0', STR_PAD_LEFT);
                         $totalEpisodes = $episodes->count();
                         $enabledEpisodes = $episodes->where('enabled', true)->count();

--- a/tests/Feature/SeriesSeasonMetadataMappingTest.php
+++ b/tests/Feature/SeriesSeasonMetadataMappingTest.php
@@ -114,3 +114,70 @@ it('reassigns an existing episode when the provider moves it to another season',
     expect($episode->season)->toBe(2)
         ->and($episode->season_id)->toBe($seasonTwo->id);
 });
+
+it('does not clobber an existing season name and cover when the provider stops sending metadata for it', function () {
+    Http::fakeSequence('provider.test/player_api.php*')
+        ->push([
+            'info' => ['name' => 'Test Series'],
+            'seasons' => [
+                ['id' => 101, 'season_number' => 1, 'name' => 'Season One', 'cover' => 'https://provider.test/s1.jpg'],
+            ],
+            'episodes' => [
+                '1' => [[
+                    'id' => 1001,
+                    'episode_num' => 1,
+                    'title' => 'S01E01 - Episode',
+                    'container_extension' => 'mkv',
+                    'info' => [],
+                ]],
+            ],
+        ])
+        ->push([
+            'info' => ['name' => 'Test Series'],
+            // Provider's next response omits season 1 entirely (only season 2 has explicit metadata).
+            'seasons' => [
+                ['id' => 102, 'season_number' => 2, 'name' => 'Season Two'],
+            ],
+            'episodes' => [
+                '1' => [[
+                    'id' => 1001,
+                    'episode_num' => 1,
+                    'title' => 'S01E01 - Episode',
+                    'container_extension' => 'mkv',
+                    'info' => [],
+                ]],
+            ],
+        ]);
+
+    expect($this->series->fetchMetadata(refresh: true, sync: false, dispatchTmdb: false))->toBeTrue();
+    $seasonOne = Season::where('series_id', $this->series->id)->where('season_number', 1)->firstOrFail();
+    expect($seasonOne->name)->toBe('Season One')
+        ->and($seasonOne->getRawOriginal('cover'))->toBe('https://provider.test/s1.jpg');
+
+    expect($this->series->fresh()->fetchMetadata(refresh: true, sync: false, dispatchTmdb: false))->toBeTrue();
+    $seasonOne->refresh();
+
+    expect($seasonOne->name)->toBe('Season One')
+        ->and($seasonOne->getRawOriginal('cover'))->toBe('https://provider.test/s1.jpg');
+});
+
+it('falls back to the series cover when a season has no provider artwork of its own', function () {
+    $series = Series::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'category_id' => $this->category->id,
+        'cover' => 'https://provider.test/series-cover.jpg',
+    ]);
+
+    $season = Season::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'category_id' => $this->category->id,
+        'series_id' => $series->id,
+        'cover' => null,
+        'cover_big' => null,
+    ]);
+
+    expect($season->cover)->toBe('https://provider.test/series-cover.jpg')
+        ->and($season->cover_big)->toBe('https://provider.test/series-cover.jpg');
+});

--- a/tests/Feature/SeriesSeasonMetadataMappingTest.php
+++ b/tests/Feature/SeriesSeasonMetadataMappingTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Models\Category;
+use App\Models\Episode;
+use App\Models\Playlist;
+use App\Models\Season;
+use App\Models\Series;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->playlist = Playlist::withoutEvents(fn () => Playlist::factory()->for($this->user)->create([
+        'xtream' => true,
+        'xtream_config' => [
+            'url' => 'http://provider.test',
+            'username' => 'test-user',
+            'password' => 'test-password',
+        ],
+    ]));
+    $this->category = Category::factory()->for($this->user)->for($this->playlist)->create();
+    $this->series = Series::factory()->create([
+        'user_id' => $this->user->id,
+        'playlist_id' => $this->playlist->id,
+        'category_id' => $this->category->id,
+        'source_series_id' => 123,
+        'enabled' => true,
+        'last_metadata_fetch' => null,
+        'last_modified' => null,
+    ]);
+});
+
+it('maps zero-indexed provider season metadata to the real season number', function () {
+    Http::fake([
+        'provider.test/player_api.php*' => Http::response([
+            'info' => ['name' => 'Test Series'],
+            'seasons' => [
+                ['id' => 101, 'season_number' => 1, 'name' => 'Season One', 'episode_count' => 1],
+                ['id' => 102, 'season_number' => 2, 'name' => 'Season Two', 'episode_count' => 1],
+            ],
+            'episodes' => [
+                '1' => [[
+                    'id' => 1001,
+                    'episode_num' => 1,
+                    'title' => 'S01E01 - First Episode',
+                    'container_extension' => 'mkv',
+                    'info' => [],
+                ]],
+                '2' => [[
+                    'id' => 2001,
+                    'episode_num' => 1,
+                    'title' => 'S02E01 - Second Episode',
+                    'container_extension' => 'mkv',
+                    'info' => [],
+                ]],
+            ],
+        ]),
+    ]);
+
+    expect($this->series->fetchMetadata(refresh: true, sync: false, dispatchTmdb: false))->toBeTrue();
+
+    $seasonOne = Season::where('series_id', $this->series->id)->where('season_number', 1)->firstOrFail();
+    $seasonTwo = Season::where('series_id', $this->series->id)->where('season_number', 2)->firstOrFail();
+
+    expect($seasonOne->name)->toBe('Season One')
+        ->and($seasonOne->source_season_id)->toBe(101)
+        ->and($seasonTwo->name)->toBe('Season Two')
+        ->and($seasonTwo->source_season_id)->toBe(102);
+});
+
+it('reassigns an existing episode when the provider moves it to another season', function () {
+    Http::fakeSequence('provider.test/player_api.php*')
+        ->push([
+            'info' => ['name' => 'Test Series'],
+            'seasons' => [
+                ['id' => 101, 'season_number' => 1, 'name' => 'Season One'],
+            ],
+            'episodes' => [
+                '1' => [[
+                    'id' => 1001,
+                    'episode_num' => 1,
+                    'title' => 'S01E01 - Episode',
+                    'container_extension' => 'mkv',
+                    'info' => [],
+                ]],
+            ],
+        ])
+        ->push([
+            'info' => ['name' => 'Test Series'],
+            'seasons' => [
+                ['id' => 101, 'season_number' => 1, 'name' => 'Season One'],
+                ['id' => 102, 'season_number' => 2, 'name' => 'Season Two'],
+            ],
+            'episodes' => [
+                '2' => [[
+                    'id' => 1001,
+                    'episode_num' => 1,
+                    'title' => 'S02E01 - Episode',
+                    'container_extension' => 'mkv',
+                    'info' => [],
+                ]],
+            ],
+        ]);
+
+    expect($this->series->fetchMetadata(refresh: true, sync: false, dispatchTmdb: false))->toBeTrue();
+    $episode = Episode::where('source_episode_id', 1001)->firstOrFail();
+    $seasonOne = Season::where('series_id', $this->series->id)->where('season_number', 1)->firstOrFail();
+    expect($episode->season_id)->toBe($seasonOne->id);
+
+    expect($this->series->fresh()->fetchMetadata(refresh: true, sync: false, dispatchTmdb: false))->toBeTrue();
+    $episode->refresh();
+    $seasonTwo = Season::where('series_id', $this->series->id)->where('season_number', 2)->firstOrFail();
+
+    expect($episode->season)->toBe(2)
+        ->and($episode->season_id)->toBe($seasonTwo->id);
+});

--- a/tests/Feature/SeriesSeasonMetadataMappingTest.php
+++ b/tests/Feature/SeriesSeasonMetadataMappingTest.php
@@ -161,7 +161,7 @@ it('does not clobber an existing season name and cover when the provider stops s
         ->and($seasonOne->getRawOriginal('cover'))->toBe('https://provider.test/s1.jpg');
 });
 
-it('falls back to the series cover when a season has no provider artwork of its own', function () {
+it('falls back to the series cover for display only, leaving the raw season cover columns untouched', function () {
     $series = Series::factory()->create([
         'user_id' => $this->user->id,
         'playlist_id' => $this->playlist->id,
@@ -178,6 +178,11 @@ it('falls back to the series cover when a season has no provider artwork of its 
         'cover_big' => null,
     ]);
 
-    expect($season->cover)->toBe('https://provider.test/series-cover.jpg')
-        ->and($season->cover_big)->toBe('https://provider.test/series-cover.jpg');
+    // Display accessor falls back to the series cover...
+    expect($season->display_cover)->toBe('https://provider.test/series-cover.jpg');
+
+    // ...but the raw columns stay null, so write paths that check
+    // empty($season->cover) still correctly detect "no season art yet".
+    expect($season->cover)->toBeNull()
+        ->and($season->cover_big)->toBeNull();
 });


### PR DESCRIPTION
## Summary

- resolve season metadata using the explicit provider season_number instead of a JSON list offset
- retain compatibility with associative and zero-indexed provider responses
- update season names when metadata is refreshed
- update episode season_id during upsert so provider corrections can re-parent an existing episode

## Why

Xtream commonly returns seasons as a zero-indexed list while episodes are keyed by actual season numbers. Indexing the list with the episode season key shifts season metadata by one and can produce duplicated or mislabeled seasons.

## Tests

- maps two zero-indexed provider seasons to season 1 and season 2 correctly
- moves an existing episode to the corrected season on refresh

Pint passes and both scoped regression tests pass.