### PR TITLE
Fix series NFO provider IDs and artwork fields

### DIFF
--- a/app/Services/NfoService.php
+++ b/app/Services/NfoService.php
@@ -29,9 +29,9 @@ class NfoService
         try {
             $metadata = $series->metadata ?? [];
 
-            $tmdbId = $this->getScalarValue($metadata['tmdb_id'] ?? $metadata['tmdb'] ?? null);
-            $tvdbId = $this->getScalarValue($metadata['tvdb_id'] ?? $metadata['tvdb'] ?? null);
-            $imdbId = $this->getScalarValue($metadata['imdb_id'] ?? $metadata['imdb'] ?? null);
+            $tmdbId = $this->getSeriesProviderId($series, 'tmdb');
+            $tvdbId = $this->getSeriesProviderId($series, 'tvdb');
+            $imdbId = $this->getSeriesProviderId($series, 'imdb');
 
             $xml = $this->startXml('tvshow');
 
@@ -61,8 +61,10 @@ class NfoService
             $this->appendGenres($xml, $metadata['genres'] ?? null);
             $this->appendNamedList($xml, 'studio', $metadata['networks'] ?? null);
 
-            $this->appendImage($xml, 'thumb', $metadata['poster_path'] ?? null, useProxy: false, attrs: ['aspect' => 'poster']);
-            $this->appendImage($xml, 'fanart', $metadata['backdrop_path'] ?? null);
+            $poster = $this->getFirstUsableImage($series->cover, $metadata['cover'] ?? null, $metadata['poster_path'] ?? null);
+            $backdrop = $this->getFirstUsableImage($series->backdrop_path, $metadata['backdrop_path'] ?? null);
+            $this->appendImage($xml, 'thumb', $poster, useProxy: false, attrs: ['aspect' => 'poster']);
+            $this->appendImage($xml, 'fanart', $backdrop);
 
             // Unique IDs (important for scrapers)
             if (! empty($tmdbId)) {
@@ -111,11 +113,11 @@ class NfoService
     {
         try {
             $info = $episode->info ?? [];
-            $metadata = $series->metadata ?? [];
 
-            $tmdbId = $this->getScalarValue($info['tmdb_id'] ?? $info['tmdb'] ?? $metadata['tmdb_id'] ?? $metadata['tmdb'] ?? null);
-            $tvdbId = $this->getScalarValue($metadata['tvdb_id'] ?? $metadata['tvdb'] ?? null);
-            $imdbId = $this->getScalarValue($metadata['imdb_id'] ?? $metadata['imdb'] ?? null);
+            $tmdbId = $this->getScalarValue($info['tmdb_id'] ?? $info['tmdb'] ?? null)
+                ?: $this->getSeriesProviderId($series, 'tmdb');
+            $tvdbId = $this->getSeriesProviderId($series, 'tvdb');
+            $imdbId = $this->getSeriesProviderId($series, 'imdb');
 
             $xml = $this->startXml('episodedetails');
 
@@ -497,6 +499,36 @@ class NfoService
 
             return false;
         }
+    }
+
+    /**
+     * Get a usable series provider ID from current fields with legacy metadata fallback.
+     */
+    private function getSeriesProviderId(Series $series, string $provider): mixed
+    {
+        $dedicated = $this->getScalarValue($series->getAttribute("{$provider}_id"));
+        if (! empty($dedicated)) {
+            return $dedicated;
+        }
+
+        $metadata = $series->metadata ?? [];
+
+        return $this->getScalarValue($metadata["{$provider}_id"] ?? $metadata[$provider] ?? null);
+    }
+
+    /**
+     * Return the first non-empty scalar image URL or path.
+     */
+    private function getFirstUsableImage(mixed ...$values): ?string
+    {
+        foreach ($values as $value) {
+            $image = $this->getScalarValue($value);
+            if (is_string($image) && trim($image) !== '') {
+                return $image;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Services/NfoService.php
+++ b/app/Services/NfoService.php
@@ -29,9 +29,9 @@ class NfoService
         try {
             $metadata = $series->metadata ?? [];
 
-            $tmdbId = $this->getSeriesProviderId($series, 'tmdb');
-            $tvdbId = $this->getSeriesProviderId($series, 'tvdb');
-            $imdbId = $this->getSeriesProviderId($series, 'imdb');
+            $tmdbId = $this->getSeriesProviderId($series, 'tmdb', $metadata);
+            $tvdbId = $this->getSeriesProviderId($series, 'tvdb', $metadata);
+            $imdbId = $this->getSeriesProviderId($series, 'imdb', $metadata);
 
             $xml = $this->startXml('tvshow');
 
@@ -113,11 +113,12 @@ class NfoService
     {
         try {
             $info = $episode->info ?? [];
+            $metadata = $series->metadata ?? [];
 
             $tmdbId = $this->getScalarValue($info['tmdb_id'] ?? $info['tmdb'] ?? null)
-                ?: $this->getSeriesProviderId($series, 'tmdb');
-            $tvdbId = $this->getSeriesProviderId($series, 'tvdb');
-            $imdbId = $this->getSeriesProviderId($series, 'imdb');
+                ?: $this->getSeriesProviderId($series, 'tmdb', $metadata);
+            $tvdbId = $this->getSeriesProviderId($series, 'tvdb', $metadata);
+            $imdbId = $this->getSeriesProviderId($series, 'imdb', $metadata);
 
             $xml = $this->startXml('episodedetails');
 
@@ -503,28 +504,34 @@ class NfoService
 
     /**
      * Get a usable series provider ID from current fields with legacy metadata fallback.
+     * Deliberately treats falsy dedicated values (0, '') as unset so placeholder data
+     * still falls back to legacy metadata - see NfoServiceTest "keeps legacy metadata
+     * as a fallback". This intentionally differs from Series::getMovieDbIds()'s ??-based
+     * fallback, which serves query scoping/UI code where 0 is a legitimate stored value.
      */
-    private function getSeriesProviderId(Series $series, string $provider): mixed
+    private function getSeriesProviderId(Series $series, string $provider, array $metadata): mixed
     {
         $dedicated = $this->getScalarValue($series->getAttribute("{$provider}_id"));
         if (! empty($dedicated)) {
             return $dedicated;
         }
 
-        $metadata = $series->metadata ?? [];
-
         return $this->getScalarValue($metadata["{$provider}_id"] ?? $metadata[$provider] ?? null);
     }
 
     /**
      * Return the first non-empty scalar image URL or path.
+     * Array values are scanned element by element so a blank entry doesn't
+     * mask a usable one later in the same array.
      */
     private function getFirstUsableImage(mixed ...$values): ?string
     {
         foreach ($values as $value) {
-            $image = $this->getScalarValue($value);
-            if (is_string($image) && trim($image) !== '') {
-                return $image;
+            foreach (is_array($value) ? $value : [$value] as $candidate) {
+                $image = $this->getScalarValue($candidate);
+                if (is_string($image) && trim($image) !== '') {
+                    return $image;
+                }
             }
         }
 

--- a/tests/Unit/NfoServiceTest.php
+++ b/tests/Unit/NfoServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Episode;
+use App\Models\Series;
 use App\Services\NfoService;
 
 describe('NfoService getScalarValue', function () {
@@ -64,6 +66,145 @@ describe('NfoService getScalarValue', function () {
         $result = $method->invokeArgs($service, [$imagePaths]);
 
         expect($result)->toBe('/path/to/image1.jpg');
+    });
+});
+
+describe('NfoService series provider fields', function () {
+    it('writes dedicated provider IDs and artwork before legacy metadata', function () {
+        $path = sys_get_temp_dir().'/nfo-service-'.bin2hex(random_bytes(6));
+        $series = (new Series)->forceFill([
+            'name' => 'Current Fields',
+            'release_date' => '2026-08-20',
+            'tmdb_id' => 220855,
+            'tvdb_id' => 428608,
+            'imdb_id' => 'tt26923358',
+            'cover' => 'https://images.example/current-poster.jpg',
+            'backdrop_path' => ['https://images.example/current-backdrop.jpg'],
+            'metadata' => [
+                'tmdb_id' => 1,
+                'tvdb_id' => 2,
+                'imdb_id' => 'tt0000002',
+                'poster_path' => 'https://images.example/legacy-poster.jpg',
+                'backdrop_path' => 'https://images.example/legacy-backdrop.jpg',
+            ],
+        ]);
+
+        expect((new NfoService)->generateSeriesNfo($series, $path))->toBeTrue();
+
+        $xml = file_get_contents($path.'/tvshow.nfo');
+        expect($xml)
+            ->toContain('<tmdbid>220855</tmdbid>')
+            ->toContain('<tvdbid>428608</tvdbid>')
+            ->toContain('<imdbid>tt26923358</imdbid>')
+            ->toContain('https://images.example/current-poster.jpg')
+            ->toContain('https://images.example/current-backdrop.jpg')
+            ->not->toContain('https://images.example/legacy-poster.jpg')
+            ->not->toContain('https://images.example/legacy-backdrop.jpg');
+
+        unlink($path.'/tvshow.nfo');
+        rmdir($path);
+    });
+
+    it('keeps legacy metadata as a fallback', function () {
+        $path = sys_get_temp_dir().'/nfo-service-'.bin2hex(random_bytes(6));
+        $series = (new Series)->forceFill([
+            'name' => 'Legacy Fields',
+            'tmdb_id' => 0,
+            'tvdb_id' => '',
+            'imdb_id' => '',
+            'cover' => '',
+            'backdrop_path' => [''],
+            'metadata' => [
+                'tmdb_id' => [225467],
+                'tvdb_id' => 436946,
+                'imdb_id' => 'tt27787158',
+                'poster_path' => 'https://images.example/legacy-poster.jpg',
+                'backdrop_path' => 'https://images.example/legacy-backdrop.jpg',
+            ],
+        ]);
+
+        expect((new NfoService)->generateSeriesNfo($series, $path))->toBeTrue();
+
+        $xml = file_get_contents($path.'/tvshow.nfo');
+        expect($xml)
+            ->toContain('<tmdbid>225467</tmdbid>')
+            ->toContain('<tvdbid>436946</tvdbid>')
+            ->toContain('<imdbid>tt27787158</imdbid>')
+            ->toContain('https://images.example/legacy-poster.jpg')
+            ->toContain('https://images.example/legacy-backdrop.jpg');
+
+        unlink($path.'/tvshow.nfo');
+        rmdir($path);
+    });
+
+    it('uses dedicated series provider IDs in episode NFOs', function () {
+        $path = sys_get_temp_dir().'/nfo-service-'.bin2hex(random_bytes(6));
+        mkdir($path);
+        $strmPath = $path.'/episode.strm';
+        touch($strmPath);
+
+        $series = (new Series)->forceFill([
+            'name' => 'Current Fields',
+            'tmdb_id' => 220855,
+            'tvdb_id' => 428608,
+            'imdb_id' => 'tt26923358',
+            'metadata' => [],
+        ]);
+        $episode = (new Episode)->forceFill([
+            'title' => 'Pilot',
+            'season' => 1,
+            'episode_num' => 1,
+            'info' => [],
+        ]);
+
+        expect((new NfoService)->generateEpisodeNfo($episode, $series, $strmPath))->toBeTrue();
+
+        $xml = file_get_contents($path.'/episode.nfo');
+        expect($xml)
+            ->toContain('<uniqueid type="tmdb" default="true">220855</uniqueid>')
+            ->toContain('<uniqueid type="tvdb">428608</uniqueid>')
+            ->toContain('<uniqueid type="imdb">tt26923358</uniqueid>');
+
+        unlink($path.'/episode.nfo');
+        unlink($strmPath);
+        rmdir($path);
+    });
+
+    it('falls back to usable legacy provider IDs in episode NFOs', function () {
+        $path = sys_get_temp_dir().'/nfo-service-'.bin2hex(random_bytes(6));
+        mkdir($path);
+        $strmPath = $path.'/episode.strm';
+        touch($strmPath);
+
+        $series = (new Series)->forceFill([
+            'name' => 'Legacy Fields',
+            'tmdb_id' => 0,
+            'tvdb_id' => '',
+            'imdb_id' => '',
+            'metadata' => [
+                'tmdb_id' => [225467],
+                'tvdb_id' => 436946,
+                'imdb_id' => 'tt27787158',
+            ],
+        ]);
+        $episode = (new Episode)->forceFill([
+            'title' => 'Pilot',
+            'season' => 1,
+            'episode_num' => 1,
+            'info' => [],
+        ]);
+
+        expect((new NfoService)->generateEpisodeNfo($episode, $series, $strmPath))->toBeTrue();
+
+        $xml = file_get_contents($path.'/episode.nfo');
+        expect($xml)
+            ->toContain('<uniqueid type="tmdb" default="true">225467</uniqueid>')
+            ->toContain('<uniqueid type="tvdb">436946</uniqueid>')
+            ->toContain('<uniqueid type="imdb">tt27787158</uniqueid>');
+
+        unlink($path.'/episode.nfo');
+        unlink($strmPath);
+        rmdir($path);
     });
 });
 


### PR DESCRIPTION
## Summary

- use dedicated series provider ID columns before legacy metadata
- use dedicated cover and backdrop fields before legacy artwork metadata
- apply the same provider fallback to episode NFO generation
- preserve compatibility with older metadata-only records

## Verification

- `./vendor/bin/pint --test app/Services/NfoService.php tests/Unit/NfoServiceTest.php`
- `REVERB_APP_ID=test REVERB_APP_KEY=test REVERB_APP_SECRET=test php artisan test tests/Unit/NfoServiceTest.php`
- 17 tests passed with 40 assertions
- regression sabotage confirmed the new provider tests fail against the previous implementation
- `git diff --check`

Closes #1438
