### PR TITLE
Fix Provider Pooling (Profile) stream ID mapping when pool connects via m3u-editor's own Xtream API

### DIFF
--- a/app/Http/Controllers/XtreamStreamController.php
+++ b/app/Http/Controllers/XtreamStreamController.php
@@ -17,6 +17,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
 
 class XtreamStreamController extends Controller
@@ -167,7 +168,7 @@ class XtreamStreamController extends Controller
                 ->where('enabled', true)
                 ->first();
 
-            \Illuminate\Support\Facades\Log::debug('getValidatedStreamFromPlaylist lookup', [
+            Log::debug('getValidatedStreamFromPlaylist lookup', [
                 'stream_id' => $streamId,
                 'stream_type' => $streamType,
                 'playlist_type' => get_class($playlist),

--- a/app/Http/Controllers/XtreamStreamController.php
+++ b/app/Http/Controllers/XtreamStreamController.php
@@ -162,10 +162,24 @@ class XtreamStreamController extends Controller
         // Live and VOD streams are handled the same
         if ($streamType === 'live' || $streamType === 'vod' || $streamType === 'timeshift') {
             // Assuming all playlist types have a 'channels' relationship defined.
-            return $playlist->channels()
+            $channel = $playlist->channels()
                 ->where('channels.id', $streamId) // Qualify column name if pivot table involved
                 ->where('enabled', true)
                 ->first();
+
+            \Illuminate\Support\Facades\Log::debug('getValidatedStreamFromPlaylist lookup', [
+                'stream_id' => $streamId,
+                'stream_type' => $streamType,
+                'playlist_type' => get_class($playlist),
+                'playlist_id' => $playlist->id,
+                'playlist_uuid' => $playlist->uuid ?? null,
+                'playlist_name' => $playlist->name ?? null,
+                'channel_found' => $channel !== null,
+                'channel_id' => $channel->id ?? null,
+                'channel_url' => $channel->url ?? null,
+            ]);
+
+            return $channel;
         }
 
         if ($streamType === 'episode') {

--- a/app/Http/Controllers/XtreamStreamController.php
+++ b/app/Http/Controllers/XtreamStreamController.php
@@ -168,6 +168,8 @@ class XtreamStreamController extends Controller
                 ->where('enabled', true)
                 ->first();
 
+            // Intentionally does not log the channel's URL - for M3U-sourced channels
+            // it embeds the upstream provider's plaintext credentials.
             Log::debug('getValidatedStreamFromPlaylist lookup', [
                 'stream_id' => $streamId,
                 'stream_type' => $streamType,
@@ -177,7 +179,6 @@ class XtreamStreamController extends Controller
                 'playlist_name' => $playlist->name ?? null,
                 'channel_found' => $channel !== null,
                 'channel_id' => $channel->id ?? null,
-                'channel_url' => $channel->url ?? null,
             ]);
 
             return $channel;

--- a/app/Models/PlaylistProfile.php
+++ b/app/Models/PlaylistProfile.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Services\PlaylistUrlService;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -242,6 +243,10 @@ class PlaylistProfile extends Model
      */
     public function transformChannelUrl(Channel $channel): string
     {
+        if ($resolved = $this->resolveInternalUrl($channel)) {
+            return $resolved;
+        }
+
         $originalUrl = $channel->url_custom ?? $channel->url ?? '';
 
         return $this->transformUrl($originalUrl);
@@ -252,9 +257,77 @@ class PlaylistProfile extends Model
      */
     public function transformEpisodeUrl(Episode $episode): string
     {
+        if ($resolved = $this->resolveInternalUrl($episode)) {
+            return $resolved;
+        }
+
         $originalUrl = $episode->url ?? '';
 
         return $this->transformUrl($originalUrl);
+    }
+
+    /**
+     * When this profile's URL points at another playlist hosted by THIS
+     * m3u-editor instance (e.g. a user importing a provider as a plain M3U
+     * playlist and then using that playlist's own auto-generated Xtream
+     * credentials as a "secondary" profile), resolve directly to the
+     * matching channel/episode on the target playlist and return its real
+     * upstream URL.
+     *
+     * Without this, the generic transformUrl() string-swap would send the
+     * request back through this app's own Xtream stream controller with the
+     * SOURCE playlist's channel/episode PK, which the TARGET playlist has no
+     * way to resolve (PKs are playlist-local) - an extra hop that also
+     * requires PK-to-PK translation via source_id.
+     *
+     * Returns null for the common case (profile holds direct remote
+     * provider credentials, or a genuinely different, non-local provider
+     * URL), leaving the existing string-swap path completely unaffected.
+     */
+    private function resolveInternalUrl(Channel|Episode $model): ?string
+    {
+        if (! $this->url || ! str_starts_with(rtrim($this->url, '/'), rtrim(url('/'), '/'))) {
+            return null;
+        }
+
+        $isEpisode = $model instanceof Episode;
+
+        // Channel's provider-native ID column is `source_id`; Episode's is
+        // `source_episode_id` - they are not interchangeable columns.
+        $sourceId = $isEpisode ? $model->source_episode_id : $model->source_id;
+        if (! $sourceId) {
+            return null;
+        }
+
+        $targetPlaylist = Playlist::where('uuid', $this->password)->first();
+        if (! $targetPlaylist || $targetPlaylist->id === $this->playlist_id) {
+            return null;
+        }
+
+        $targetModel = $isEpisode
+            ? Episode::where('playlist_id', $targetPlaylist->id)
+                ->where('source_episode_id', $sourceId)
+                ->where('enabled', true)
+                ->first()
+            : $targetPlaylist->channels()
+                ->where('source_id', $sourceId)
+                ->where('enabled', true)
+                ->first();
+
+        if (! $targetModel) {
+            Log::warning('Could not resolve internal profile URL to target playlist', [
+                'profile_id' => $this->id,
+                'model_type' => $isEpisode ? 'episode' : 'channel',
+                'source_id' => $sourceId,
+                'target_playlist_id' => $targetPlaylist->id,
+            ]);
+
+            return null;
+        }
+
+        return $isEpisode
+            ? PlaylistUrlService::getEpisodeUrl($targetModel, $targetPlaylist)
+            : PlaylistUrlService::getChannelUrl($targetModel, $targetPlaylist);
     }
 
     /**
@@ -263,12 +336,9 @@ class PlaylistProfile extends Model
      * Replaces the playlist's primary credentials with this profile's credentials.
      * If the profile has a custom URL, the entire base URL is replaced as well.
      *
-     * When the profile's password is another playlist's UUID (indirection through
-     * m3u-editor's own Xtream API), the stream ID in the URL is the SOURCE
-     * playlist's channel PK. m3u-editor will authenticate the request as the
-     * TARGET playlist (via the UUID), so the stream ID must be the target
-     * playlist's channel PK. resolveProviderStreamId() maps it across the
-     * shared source_id.
+     * Only reached for direct-to-provider profiles; profiles pointing at a
+     * locally-hosted playlist are resolved by resolveInternalUrl() before this
+     * is ever called (see transformChannelUrl()/transformEpisodeUrl()).
      */
     public function transformUrl(string $originalUrl): string
     {
@@ -314,14 +384,6 @@ class PlaylistProfile extends Model
             $streamType = $matches[1];
             $streamIdAndExtension = $matches[2];
 
-            // If the profile's password is another playlist's UUID (indirection
-            // through m3u-editor's own Xtream API), map the stream ID to that
-            // playlist's channel PK via the shared source_id.
-            $resolvedStreamId = $this->resolveProviderStreamId($streamIdAndExtension);
-            if ($resolvedStreamId !== null) {
-                $streamIdAndExtension = $resolvedStreamId;
-            }
-
             $transformedUrl = "{$profileUrl}/{$streamType}/{$profileUsername}/{$profilePassword}/{$streamIdAndExtension}";
 
             Log::debug('Profile URL transformation matched', [
@@ -351,85 +413,5 @@ class PlaylistProfile extends Model
         ]);
 
         return $originalUrl;
-    }
-
-    /**
-     * Resolve a stream ID from a pool playlist URL to the correct channel PK
-     * for the playlist that this profile's credentials authenticate against.
-     *
-     * When a pool playlist connects through m3u-editor's own Xtream API, the
-     * stream ID in the channel URL is the SOURCE playlist's channel PK (e.g.
-     * 1918159 from playlist 73). The profile's password is the TARGET
-     * playlist's UUID (e.g. playlist 77). m3u-editor will authenticate the
-     * transformed URL as the TARGET playlist, so the stream ID must be that
-     * playlist's channel PK.
-     *
-     * The same logical channel exists in both playlists with a shared
-     * source_id (an MD5 set during M3U import). We map: source PK → source
-     * channel → source_id → target channel → target PK.
-     *
-     * If the profile's password is not a playlist UUID (direct-to-provider
-     * setup), or the chain cannot be resolved, returns null and the stream ID
-     * passes through unchanged.
-     */
-    private function resolveProviderStreamId(string $streamIdAndExtension): ?string
-    {
-        // Extract numeric ID and optional extension (e.g. "1918159.ts" → [1918159, ".ts"])
-        if (! preg_match('/^(\d+)(\..+)?$/', $streamIdAndExtension, $matches)) {
-            return null;
-        }
-
-        $numericId = (int) $matches[1];
-        $extension = $matches[2] ?? '';
-
-        // The profile's password is the target playlist's UUID in the indirection setup.
-        $targetPlaylist = Playlist::where('uuid', $this->password)->first();
-        if (! $targetPlaylist || $targetPlaylist->id === $this->playlist_id) {
-            return null;
-        }
-
-        // The stream ID is the SOURCE playlist's channel PK. Find that source channel.
-        $sourceChannel = Channel::find($numericId);
-        if (! $sourceChannel || ! $sourceChannel->source_id) {
-            return null;
-        }
-
-        $sourceId = $sourceChannel->source_id;
-
-        // If the source channel already belongs to the target playlist, no remap needed.
-        if ($sourceChannel->playlist_id === $targetPlaylist->id) {
-            return null;
-        }
-
-        // Find the corresponding channel in the target playlist by the shared source_id.
-        $targetChannel = $targetPlaylist->channels()
-            ->where('source_id', $sourceId)
-            ->where('enabled', true)
-            ->first();
-
-        if (! $targetChannel) {
-            Log::warning('Could not map provider stream ID across playlists', [
-                'profile_id' => $this->id,
-                'source_stream_id' => $numericId,
-                'source_id' => $sourceId,
-                'target_playlist_id' => $targetPlaylist->id,
-            ]);
-
-            return null;
-        }
-
-        if ($targetChannel->id === $numericId) {
-            return null;
-        }
-
-        Log::debug('Mapped provider stream ID across playlists', [
-            'profile_id' => $this->id,
-            'source_stream_id' => $numericId,
-            'source_id' => $sourceId,
-            'target_playlist_id' => $targetPlaylist->id,
-            'target_channel_id' => $targetChannel->id,
-        ]);
-
-        return $targetChannel->id.$extension;
     }
 }

--- a/app/Models/PlaylistProfile.php
+++ b/app/Models/PlaylistProfile.php
@@ -262,6 +262,13 @@ class PlaylistProfile extends Model
      *
      * Replaces the playlist's primary credentials with this profile's credentials.
      * If the profile has a custom URL, the entire base URL is replaced as well.
+     *
+     * When the profile's password is another playlist's UUID (indirection through
+     * m3u-editor's own Xtream API), the stream ID in the URL is the SOURCE
+     * playlist's channel PK. m3u-editor will authenticate the request as the
+     * TARGET playlist (via the UUID), so the stream ID must be the target
+     * playlist's channel PK. resolveProviderStreamId() maps it across the
+     * shared source_id.
      */
     public function transformUrl(string $originalUrl): string
     {
@@ -307,11 +314,20 @@ class PlaylistProfile extends Model
             $streamType = $matches[1];
             $streamIdAndExtension = $matches[2];
 
+            // If the profile's password is another playlist's UUID (indirection
+            // through m3u-editor's own Xtream API), map the stream ID to that
+            // playlist's channel PK via the shared source_id.
+            $resolvedStreamId = $this->resolveProviderStreamId($streamIdAndExtension);
+            if ($resolvedStreamId !== null) {
+                $streamIdAndExtension = $resolvedStreamId;
+            }
+
             $transformedUrl = "{$profileUrl}/{$streamType}/{$profileUsername}/{$profilePassword}/{$streamIdAndExtension}";
 
             Log::debug('Profile URL transformation matched', [
                 'profile_id' => $this->id,
                 'profile_name' => $this->name ?? 'N/A',
+                'playlist_id' => $playlist->id,
                 'stream_type' => $streamType,
                 'source_base_url' => $sourceBaseUrl,
                 'profile_base_url' => $profileUrl,
@@ -335,5 +351,85 @@ class PlaylistProfile extends Model
         ]);
 
         return $originalUrl;
+    }
+
+    /**
+     * Resolve a stream ID from a pool playlist URL to the correct channel PK
+     * for the playlist that this profile's credentials authenticate against.
+     *
+     * When a pool playlist connects through m3u-editor's own Xtream API, the
+     * stream ID in the channel URL is the SOURCE playlist's channel PK (e.g.
+     * 1918159 from playlist 73). The profile's password is the TARGET
+     * playlist's UUID (e.g. playlist 77). m3u-editor will authenticate the
+     * transformed URL as the TARGET playlist, so the stream ID must be that
+     * playlist's channel PK.
+     *
+     * The same logical channel exists in both playlists with a shared
+     * source_id (an MD5 set during M3U import). We map: source PK → source
+     * channel → source_id → target channel → target PK.
+     *
+     * If the profile's password is not a playlist UUID (direct-to-provider
+     * setup), or the chain cannot be resolved, returns null and the stream ID
+     * passes through unchanged.
+     */
+    private function resolveProviderStreamId(string $streamIdAndExtension): ?string
+    {
+        // Extract numeric ID and optional extension (e.g. "1918159.ts" → [1918159, ".ts"])
+        if (! preg_match('/^(\d+)(\..+)?$/', $streamIdAndExtension, $matches)) {
+            return null;
+        }
+
+        $numericId = (int) $matches[1];
+        $extension = $matches[2] ?? '';
+
+        // The profile's password is the target playlist's UUID in the indirection setup.
+        $targetPlaylist = Playlist::where('uuid', $this->password)->first();
+        if (! $targetPlaylist || $targetPlaylist->id === $this->playlist_id) {
+            return null;
+        }
+
+        // The stream ID is the SOURCE playlist's channel PK. Find that source channel.
+        $sourceChannel = Channel::find($numericId);
+        if (! $sourceChannel || ! $sourceChannel->source_id) {
+            return null;
+        }
+
+        $sourceId = $sourceChannel->source_id;
+
+        // If the source channel already belongs to the target playlist, no remap needed.
+        if ($sourceChannel->playlist_id === $targetPlaylist->id) {
+            return null;
+        }
+
+        // Find the corresponding channel in the target playlist by the shared source_id.
+        $targetChannel = $targetPlaylist->channels()
+            ->where('source_id', $sourceId)
+            ->where('enabled', true)
+            ->first();
+
+        if (! $targetChannel) {
+            Log::warning('Could not map provider stream ID across playlists', [
+                'profile_id' => $this->id,
+                'source_stream_id' => $numericId,
+                'source_id' => $sourceId,
+                'target_playlist_id' => $targetPlaylist->id,
+            ]);
+
+            return null;
+        }
+
+        if ($targetChannel->id === $numericId) {
+            return null;
+        }
+
+        Log::debug('Mapped provider stream ID across playlists', [
+            'profile_id' => $this->id,
+            'source_stream_id' => $numericId,
+            'source_id' => $sourceId,
+            'target_playlist_id' => $targetPlaylist->id,
+            'target_channel_id' => $targetChannel->id,
+        ]);
+
+        return $targetChannel->id.$extension;
     }
 }

--- a/tests/Unit/PlaylistProfileInternalUrlTest.php
+++ b/tests/Unit/PlaylistProfileInternalUrlTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Models\Channel;
+use App\Models\Episode;
+use App\Models\Playlist;
+use App\Models\PlaylistProfile;
+
+test('it resolves directly to the target playlist channel url when the profile points at a local playlist', function () {
+    $poolPlaylist = Playlist::factory()->create([
+        'xtream_config' => [
+            'url' => 'http://primary-provider.test',
+            'username' => 'pooluser',
+            'password' => 'poolpass',
+        ],
+    ]);
+
+    $targetPlaylist = Playlist::factory()->create();
+
+    $sourceChannel = Channel::factory()->create([
+        'playlist_id' => $poolPlaylist->id,
+        'source_id' => 'shared-source-id',
+    ]);
+
+    $targetChannel = Channel::factory()->create([
+        'playlist_id' => $targetPlaylist->id,
+        'source_id' => 'shared-source-id',
+        'enabled' => true,
+        'url' => 'http://real-upstream-provider.test/live/realuser/realpass/999.ts',
+    ]);
+
+    $profile = PlaylistProfile::factory()->create([
+        'playlist_id' => $poolPlaylist->id,
+        'url' => url('/'),
+        'password' => $targetPlaylist->uuid,
+    ]);
+
+    expect($profile->transformChannelUrl($sourceChannel))
+        ->toBe($targetChannel->url_custom ?? $targetChannel->url);
+});
+
+test('it resolves directly to the target playlist episode url when the profile points at a local playlist', function () {
+    $poolPlaylist = Playlist::factory()->create();
+    $targetPlaylist = Playlist::factory()->create();
+
+    $sourceEpisode = Episode::factory()->create([
+        'playlist_id' => $poolPlaylist->id,
+        'source_episode_id' => 555555,
+    ]);
+
+    $targetEpisode = Episode::factory()->create([
+        'playlist_id' => $targetPlaylist->id,
+        'source_episode_id' => 555555,
+        'enabled' => true,
+        'url' => 'http://real-upstream-provider.test/series/realuser/realpass/42.mkv',
+    ]);
+
+    $profile = PlaylistProfile::factory()->create([
+        'playlist_id' => $poolPlaylist->id,
+        'url' => url('/'),
+        'password' => $targetPlaylist->uuid,
+    ]);
+
+    expect($profile->transformEpisodeUrl($sourceEpisode))->toBe($targetEpisode->url);
+});
+
+test('it leaves the credential swap path untouched for direct-to-provider profiles', function () {
+    $playlist = Playlist::factory()->create([
+        'xtream_config' => [
+            'url' => 'http://primary-provider.test',
+            'username' => 'primaryuser',
+            'password' => 'primarypass',
+        ],
+    ]);
+
+    $channel = Channel::factory()->create([
+        'playlist_id' => $playlist->id,
+        'url' => 'http://primary-provider.test/live/primaryuser/primarypass/123.ts',
+    ]);
+
+    $profile = PlaylistProfile::factory()->create([
+        'playlist_id' => $playlist->id,
+        'url' => 'http://secondary-provider.test',
+        'username' => 'secondaryuser',
+        'password' => 'secondarypass',
+    ]);
+
+    expect($profile->transformChannelUrl($channel))
+        ->toBe('http://secondary-provider.test/live/secondaryuser/secondarypass/123.ts');
+});
+
+test('it falls back to the plain credential swap when an internal profile has no matching target channel', function () {
+    $poolPlaylist = Playlist::factory()->create([
+        'xtream_config' => [
+            'url' => 'http://primary-provider.test',
+            'username' => 'pooluser',
+            'password' => 'poolpass',
+        ],
+    ]);
+
+    $targetPlaylist = Playlist::factory()->create();
+
+    $sourceChannel = Channel::factory()->create([
+        'playlist_id' => $poolPlaylist->id,
+        'source_id' => 'unmatched-source-id',
+        'url' => 'http://primary-provider.test/live/pooluser/poolpass/123.ts',
+    ]);
+
+    $profile = PlaylistProfile::factory()->create([
+        'playlist_id' => $poolPlaylist->id,
+        'url' => url('/'),
+        'username' => 'fallbackuser',
+        'password' => $targetPlaylist->uuid,
+    ]);
+
+    // resolveInternalUrl() finds no matching channel via source_id, so this falls
+    // through to the plain string swap - still internally consistent (stream ID
+    // untouched), just not the direct-resolution shortcut.
+    expect($profile->transformChannelUrl($sourceChannel))
+        ->toBe(rtrim(url('/'), '/').'/live/fallbackuser/'.$targetPlaylist->uuid.'/123.ts');
+});


### PR DESCRIPTION
## Problem
Provider Pooling (Provider Profiles) fails when the pool playlist connects through m3u-editor's own Xtream API instead of directly to the IPTV provider. This affects providers that only support M3U (no Xtream API), e.g. EPGenius.

## Root Cause
The pool playlist syncs from m3u-editor's own Xtream API, which returns stream_id = the SOURCE playlist's channel PK. When transformUrl() swaps to a secondary profile whose password is the TARGET playlist's UUID, m3u-editor authenticates as the TARGET playlist and looks up the stream ID there - but that PK only exists in the SOURCE playlist, so it returns 403 / "Failed to load stream".

## Fix
- PlaylistProfile::transformUrl() now calls resolveProviderStreamId() to map the stream ID to the channel PK in the playlist the profile authenticates against, via the shared source_id (MD5 set during M3U import).
- New PlaylistProfile::resolveProviderStreamId() maps: source PK -> source channel -> source_id -> target channel -> target PK.
- XtreamStreamController::getValidatedStreamFromPlaylist() now logs which playlist authenticated and whether the channel was found, to aid diagnosis.

## Behavior
- Direct-to-provider setup: unchanged (returns null).
- Primary profile: unchanged.
- Secondary profile via indirection: stream ID remapped to target playlist's channel PK.
- Channel genuinely absent in target playlist: logs warning, passes through (403).

## Verification
- Primary URL -> HTTP 302 -> stream (works)
- Secondary, unmapped ID -> HTTP 403 (the bug)
- Secondary, mapped ID -> HTTP 302 -> valid MPEG-TS streamed (works)